### PR TITLE
fix: Resolve frontend build failure and improve order workflow UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,9 +160,9 @@ cli_config_fixed.json
 # Batch files (local only)
 *.bat
 
-# Temp HTML
+# Temp HTML (but NOT frontend/index.html which is required for Vite)
 *.html
-!frontend/
+!frontend/index.html
 
 # ===========================================
 # SECURITY - Prevent accidental secret commits

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FilaOps</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -31,6 +31,8 @@ export default function AdminManufacturing() {
   const [showRoutingModal, setShowRoutingModal] = useState(false);
   const [editingWorkCenter, setEditingWorkCenter] = useState(null);
   const [editingResource, setEditingResource] = useState(null);
+  const [editingRouting, setEditingRouting] = useState(null);
+  const [routingProductId, setRoutingProductId] = useState(null);
   const [selectedWorkCenter, setSelectedWorkCenter] = useState(null);
 
   const token = localStorage.getItem("adminToken");

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -166,6 +166,19 @@ export default function AdminOrders() {
     return flow[currentStatus];
   };
 
+  const getStatusLabel = (status) => {
+    const labels = {
+      pending: "Pending",
+      confirmed: "Confirmed",
+      in_production: "In Production",
+      ready_to_ship: "Ready to Ship",
+      shipped: "Shipped",
+      completed: "Completed",
+      cancelled: "Cancelled",
+    };
+    return labels[status] || status?.replace(/_/g, " ");
+  };
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -338,8 +351,9 @@ export default function AdminOrders() {
                           )
                         }
                         className="text-green-400 hover:text-green-300 text-sm"
+                        title={`Advance to: ${getStatusLabel(getNextStatus(order.status))}`}
                       >
-                        Advance
+                        → {getStatusLabel(getNextStatus(order.status))}
                       </button>
                     )}
                   </td>

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -415,10 +415,19 @@ export default function AdminShipping() {
                     </p>
                   </div>
                 ) : (
-                  <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-4">
-                    <p className="text-yellow-400 text-sm">
-                      No shipping address on file
+                  <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
+                    <p className="text-red-400 text-sm font-medium mb-1">
+                      ⚠ Shipping Address Required
                     </p>
+                    <p className="text-red-300 text-xs mb-2">
+                      Cannot create shipping label without a valid shipping address.
+                    </p>
+                    <button
+                      onClick={() => navigate(`/admin/orders/${selectedOrder.id}`)}
+                      className="text-xs text-blue-400 hover:text-blue-300 underline"
+                    >
+                      Edit Order to Add Address →
+                    </button>
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary

This PR addresses a **critical bug** preventing new users from building the frontend Docker container, plus several UX improvements for the order-to-ship workflow.

### Critical Fix (Issue #40)
- **Problem**: `frontend/index.html` was being ignored by `.gitignore` rule `*.html`
- **Impact**: Fresh clones couldn't build frontend: `Could not resolve entry module "index.html"`
- **Fix**: Updated `.gitignore` to exclude `frontend/index.html` and added the file to the repository

### UX Improvements

| Component | Issue | Fix |
|-----------|-------|-----|
| AdminManufacturing | Crash when opening routing modal | Added missing `editingRouting` and `routingProductId` state variables |
| AdminOrders | "Advance" button unclear | Now shows target status: `→ Confirmed`, `→ In Production`, etc. |
| AdminShipping | Missing address error unclear | Red error banner with link to edit order |

## Test plan

- [ ] Clone repo fresh and run `docker-compose up -d` - frontend should build successfully
- [ ] Go to Orders page - verify "Advance" buttons show target status
- [ ] Go to Manufacturing > Routings tab - click "Create Routing" - modal should open without crash
- [ ] Go to Shipping, select order without address - verify red error with edit link appears

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation prompt to quickly add missing shipping addresses directly from the shipping page.

* **Improvements**
  * Order advancement button now displays the target status label clearly.
  * Enhanced shipping address warning with more prominent visual styling and messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a critical build failure that prevented fresh clones from building the frontend, plus adds several UX improvements to the order workflow.

**Critical Fix:**
- Fixed `.gitignore` rule that was blocking `frontend/index.html` from being tracked
- Added the missing `index.html` file required by Vite build process
- Without this fix, new users encounter "Could not resolve entry module" error

**UX Improvements:**
- **AdminManufacturing**: Added missing state variables (`editingRouting`, `routingProductId`) that caused crashes when opening routing modal
- **AdminOrders**: Changed generic "Advance" button to show target status (e.g., "→ Confirmed") for better clarity
- **AdminShipping**: Enhanced missing address error from yellow warning to red banner with actionable "Edit Order to Add Address →" link

All changes are straightforward, well-tested per the test plan, and directly address the reported issues.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it fixes critical bugs and improves UX without introducing new risks
- Score of 5 reflects: (1) the critical build fix is correct and necessary, (2) all UX improvements are simple UI changes with no logic risks, (3) the AdminManufacturing fix properly adds missing state that's already being used elsewhere in the component, and (4) comprehensive test plan covers all changes
- No files require special attention - all changes are straightforward and correct

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .gitignore | 5/5 | Fixed critical gitignore rule that was preventing `frontend/index.html` from being tracked - now explicitly excludes it from the `*.html` ignore pattern |
| frontend/index.html | 5/5 | Added standard Vite entry HTML file that was missing from repository, required for frontend build process |
| frontend/src/pages/admin/AdminManufacturing.jsx | 5/5 | Added missing state variables `editingRouting` and `routingProductId` that prevented routing modal from opening |
| frontend/src/pages/admin/AdminOrders.jsx | 5/5 | Improved "Advance" button UX by showing target status (e.g., "→ Confirmed") instead of generic label, includes tooltip |
| frontend/src/pages/admin/AdminShipping.jsx | 5/5 | Enhanced missing address error from yellow warning to red error banner with actionable link to edit order and add address |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Docker
    participant Git
    participant Vite
    participant AdminOrders
    participant AdminManufacturing
    participant AdminShipping
    participant Backend

    Note over User,Vite: Critical Fix - Build Process
    User->>Git: git clone repository
    Git-->>User: Clone without index.html (blocked by .gitignore)
    User->>Docker: docker-compose up -d
    Docker->>Vite: npm run build
    Vite--XUser: ERROR: Could not resolve entry module "index.html"
    
    Note over Git,Vite: After PR Fix
    Git-->>User: Clone WITH index.html (gitignore fixed)
    Docker->>Vite: npm run build
    Vite-->>Docker: ✓ Build successful
    
    Note over User,Backend: UX Improvements - Order Workflow
    User->>AdminOrders: View orders page
    AdminOrders->>Backend: Fetch orders
    Backend-->>AdminOrders: Return orders list
    AdminOrders->>User: Show "→ Confirmed" button (was "Advance")
    User->>AdminOrders: Click advance button
    AdminOrders->>Backend: Update order status
    Backend-->>AdminOrders: Status updated
    
    Note over User,Backend: Manufacturing - Routing Modal
    User->>AdminManufacturing: Navigate to Routings tab
    User->>AdminManufacturing: Click "Create Routing"
    AdminManufacturing->>AdminManufacturing: setEditingRouting(null), setRoutingProductId(null)
    AdminManufacturing->>User: Open RoutingEditor modal (no crash)
    
    Note over User,Backend: Shipping - Missing Address
    User->>AdminShipping: Select order without address
    AdminShipping->>User: Show red error banner with edit link
    User->>AdminShipping: Click "Edit Order to Add Address →"
    AdminShipping->>AdminOrders: navigate(`/admin/orders/${orderId}`)
    AdminOrders->>User: Open order editor
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->