### PR TITLE
feat: Add reusable StatCard component with brand-aligned colors

### DIFF
--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -1,0 +1,97 @@
+/**
+ * Reusable StatCard component for displaying metrics across admin pages.
+ *
+ * Brand-aligned color scheme:
+ * - primary: Emerald/cyan (brand colors)
+ * - secondary: Cyan variant
+ * - success: Green (positive metrics)
+ * - warning: Amber/yellow (caution)
+ * - danger: Red (needs attention)
+ * - neutral: Gray/white (default)
+ *
+ * Supports two variants:
+ * - "gradient" (default): Dashboard-style with gradient background and optional icon
+ * - "simple": Flat card with colored value text
+ */
+
+const colorClasses = {
+  // Gradient variant colors (background gradients)
+  gradient: {
+    // Brand colors
+    primary: "from-emerald-600/20 to-cyan-600/10 border-emerald-500/30",
+    secondary: "from-cyan-600/20 to-blue-600/10 border-cyan-500/30",
+    // Semantic colors
+    success: "from-green-600/20 to-green-600/5 border-green-500/30",
+    warning: "from-amber-600/20 to-amber-600/5 border-amber-500/30",
+    danger: "from-red-600/20 to-red-600/5 border-red-500/30",
+    neutral: "from-gray-600/20 to-gray-600/5 border-gray-500/30",
+    // Legacy support (map to new names)
+    emerald: "from-emerald-600/20 to-cyan-600/10 border-emerald-500/30",
+    cyan: "from-cyan-600/20 to-blue-600/10 border-cyan-500/30",
+    green: "from-green-600/20 to-green-600/5 border-green-500/30",
+    orange: "from-amber-600/20 to-amber-600/5 border-amber-500/30",
+    red: "from-red-600/20 to-red-600/5 border-red-500/30",
+    blue: "from-cyan-600/20 to-blue-600/10 border-cyan-500/30",
+    purple: "from-emerald-600/20 to-cyan-600/10 border-emerald-500/30",
+    yellow: "from-amber-600/20 to-amber-600/5 border-amber-500/30",
+    white: "from-gray-600/20 to-gray-600/5 border-gray-500/30",
+  },
+  // Simple variant colors (text colors for value)
+  simple: {
+    // Brand colors
+    primary: "text-emerald-400",
+    secondary: "text-cyan-400",
+    // Semantic colors
+    success: "text-green-400",
+    warning: "text-amber-400",
+    danger: "text-red-400",
+    neutral: "text-white",
+    // Legacy support
+    emerald: "text-emerald-400",
+    cyan: "text-cyan-400",
+    green: "text-green-400",
+    orange: "text-amber-400",
+    red: "text-red-400",
+    blue: "text-cyan-400",
+    purple: "text-emerald-400",
+    yellow: "text-amber-400",
+    white: "text-white",
+  },
+};
+
+export default function StatCard({
+  title,
+  value,
+  subtitle,
+  color = "white",
+  icon,
+  variant = "gradient",
+}) {
+  if (variant === "simple") {
+    return (
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+        <p className="text-gray-400 text-sm">{title}</p>
+        <p className={`text-2xl font-bold ${colorClasses.simple[color] || colorClasses.simple.white}`}>
+          {value}
+        </p>
+        {subtitle && <p className="text-gray-500 text-xs mt-1">{subtitle}</p>}
+      </div>
+    );
+  }
+
+  // Gradient variant (default)
+  return (
+    <div
+      className={`bg-gradient-to-br ${colorClasses.gradient[color] || colorClasses.gradient.white} border rounded-xl p-6`}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-gray-400 text-sm font-medium">{title}</p>
+          <p className="text-3xl font-bold text-white mt-1">{value}</p>
+          {subtitle && <p className="text-gray-500 text-xs mt-1">{subtitle}</p>}
+        </div>
+        {icon && <div className="text-gray-500">{icon}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { API_URL } from "../../config/api";
 import { useToast } from "../../components/Toast";
+import StatCard from "../../components/StatCard";
 
 // Status options
 const STATUS_OPTIONS = [
@@ -209,27 +210,15 @@ export default function AdminCustomers() {
 
       {/* Stats */}
       <div className="grid grid-cols-4 gap-4">
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-sm">Total Customers</p>
-          <p className="text-2xl font-bold text-white">{stats.total}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-sm">Active</p>
-          <p className="text-2xl font-bold text-green-400">{stats.active}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-sm">With Orders</p>
-          <p className="text-2xl font-bold text-blue-400">{stats.withOrders}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-          <p className="text-gray-400 text-sm">Total Revenue</p>
-          <p className="text-2xl font-bold text-emerald-400">
-            $
-            {stats.totalRevenue.toLocaleString("en-US", {
-              minimumFractionDigits: 2,
-            })}
-          </p>
-        </div>
+        <StatCard variant="simple" title="Total Customers" value={stats.total} color="neutral" />
+        <StatCard variant="simple" title="Active" value={stats.active} color="success" />
+        <StatCard variant="simple" title="With Orders" value={stats.withOrders} color="secondary" />
+        <StatCard
+          variant="simple"
+          title="Total Revenue"
+          value={`$${stats.totalRevenue.toLocaleString("en-US", { minimumFractionDigits: 2 })}`}
+          color="primary"
+        />
       </div>
 
       {/* Filters */}

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -1,33 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { API_URL } from "../../config/api";
-
-// Stat Card Component
-function StatCard({ title, value, subtitle, color, icon }) {
-  const colorClasses = {
-    blue: "from-blue-600/20 to-blue-600/5 border-blue-500/30",
-    green: "from-green-600/20 to-green-600/5 border-green-500/30",
-    purple: "from-purple-600/20 to-purple-600/5 border-purple-500/30",
-    orange: "from-orange-600/20 to-orange-600/5 border-orange-500/30",
-    red: "from-red-600/20 to-red-600/5 border-red-500/30",
-    cyan: "from-cyan-600/20 to-cyan-600/5 border-cyan-500/30",
-  };
-
-  return (
-    <div
-      className={`bg-gradient-to-br ${colorClasses[color]} border rounded-xl p-6`}
-    >
-      <div className="flex items-start justify-between">
-        <div>
-          <p className="text-gray-400 text-sm font-medium">{title}</p>
-          <p className="text-3xl font-bold text-white mt-1">{value}</p>
-          {subtitle && <p className="text-gray-500 text-xs mt-1">{subtitle}</p>}
-        </div>
-        <div className="text-gray-500">{icon}</div>
-      </div>
-    </div>
-  );
-}
+import StatCard from "../../components/StatCard";
 
 // Module Card Component
 function ModuleCard({ title, description, to, icon, stats }) {

--- a/frontend/src/pages/admin/AdminItems.jsx
+++ b/frontend/src/pages/admin/AdminItems.jsx
@@ -3,6 +3,7 @@ import ItemForm from "../../components/ItemForm";
 import MaterialForm from "../../components/MaterialForm";
 import BOMEditor from "../../components/BOMEditor";
 import RoutingEditor from "../../components/RoutingEditor";
+import StatCard from "../../components/StatCard";
 import { API_URL } from "../../config/api";
 import { useToast } from "../../components/Toast";
 
@@ -518,40 +519,12 @@ export default function AdminItems() {
 
         {/* Stats */}
         <div className="grid grid-cols-6 gap-4">
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Total Items</p>
-            <p className="text-2xl font-bold text-white">{stats.total}</p>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Finished Goods</p>
-            <p className="text-2xl font-bold text-blue-400">
-              {stats.finishedGoods}
-            </p>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Components</p>
-            <p className="text-2xl font-bold text-purple-400">
-              {stats.components}
-            </p>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Filaments</p>
-            <p className="text-2xl font-bold text-orange-400">
-              {stats.filaments}
-            </p>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Supplies</p>
-            <p className="text-2xl font-bold text-yellow-400">
-              {stats.supplies}
-            </p>
-          </div>
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-            <p className="text-gray-400 text-sm">Needs Reorder</p>
-            <p className="text-2xl font-bold text-red-400">
-              {stats.needsReorder}
-            </p>
-          </div>
+          <StatCard variant="simple" title="Total Items" value={stats.total} color="neutral" />
+          <StatCard variant="simple" title="Finished Goods" value={stats.finishedGoods} color="primary" />
+          <StatCard variant="simple" title="Components" value={stats.components} color="secondary" />
+          <StatCard variant="simple" title="Filaments" value={stats.filaments} color="primary" />
+          <StatCard variant="simple" title="Supplies" value={stats.supplies} color="warning" />
+          <StatCard variant="simple" title="Needs Reorder" value={stats.needsReorder} color="danger" />
         </div>
 
         {/* Error */}


### PR DESCRIPTION
## Summary
- Create reusable `StatCard` component supporting gradient and simple variants
- Implement brand-aligned color palette matching emerald/cyan logo colors
- Reduce duplicate stat card markup across admin pages

## Changes

### New Component: `StatCard.jsx`
- **Variants**: `gradient` (Dashboard-style) and `simple` (flat cards)
- **Brand Colors**:
  - `primary`: Emerald (brand color)
  - `secondary`: Cyan
  - `success`: Green
  - `warning`: Amber
  - `danger`: Red
  - `neutral`: White/gray

### Updated Pages
- **AdminDashboard**: Import shared StatCard (removes 25-line duplicate component)
- **AdminItems**: Replace 36 lines of inline markup with 6 StatCard calls
- **AdminCustomers**: Replace 22 lines of inline markup with 4 StatCard calls

## Visual Changes
Colors now align with the FilaOps brand:
- Primary metrics use emerald/cyan tones (matches logo gradient)
- Semantic colors reserved for specific meanings (green=success, red=danger)

## Test plan
- [ ] Verify AdminDashboard stat cards render correctly
- [ ] Verify AdminItems stat cards show correct colors
- [ ] Verify AdminCustomers stat cards show correct colors
- [ ] Check both gradient and simple variants work
- [ ] Confirm colors match brand aesthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new StatCard component for displaying metrics with two visual variants: gradient and simple. Supports multiple color options for flexible styling.

* **Refactor**
  * Consolidated stat card implementations across admin pages to use the new reusable StatCard component, improving code consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->