### PR TITLE
feat: Add QC (Quality Control) inspection workflow

### DIFF
--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -57,6 +57,12 @@ class ProductionOrder(Base):
     # Status: draft, released, in_progress, complete, cancelled, on_hold
     status = Column(String(50), default='draft', nullable=False, index=True)
 
+    # QC Status: not_required, pending, passed, failed
+    qc_status = Column(String(50), default='not_required', nullable=False)
+    qc_notes = Column(Text, nullable=True)
+    qc_inspected_by = Column(String(100), nullable=True)
+    qc_inspected_at = Column(DateTime, nullable=True)
+
     # Priority: 1 (highest) to 5 (lowest)
     priority = Column(Integer, default=3, nullable=False)
 

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -40,6 +40,14 @@ class OperationStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class QCStatus(str, Enum):
+    """Quality Control status"""
+    NOT_REQUIRED = "not_required"
+    PENDING = "pending"
+    PASSED = "passed"
+    FAILED = "failed"
+
+
 # ============================================================================
 # Production Order Operation Schemas
 # ============================================================================
@@ -186,6 +194,9 @@ class ProductionOrderListResponse(BaseModel):
     priority: int
     source: str
 
+    # QC Status
+    qc_status: str = "not_required"
+
     due_date: Optional[date] = None
     scheduled_start: Optional[datetime] = None
     scheduled_end: Optional[datetime] = None
@@ -231,6 +242,12 @@ class ProductionOrderResponse(BaseModel):
     source: str
     status: str
     priority: int
+
+    # QC Status
+    qc_status: str = "not_required"
+    qc_notes: Optional[str] = None
+    qc_inspected_by: Optional[str] = None
+    qc_inspected_at: Optional[datetime] = None
 
     # Scheduling
     due_date: Optional[date] = None
@@ -472,3 +489,41 @@ class ScrapReasonsResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+# ============================================================================
+# QC Inspection Schemas
+# ============================================================================
+
+class QCInspectionRequest(BaseModel):
+    """Request to perform QC inspection on a production order"""
+    result: QCStatus = Field(
+        ...,
+        description="QC result: 'passed' or 'failed'"
+    )
+    notes: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="Inspector notes about the QC inspection"
+    )
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "result": "passed",
+                "notes": "All units inspected. Surface finish acceptable."
+            }
+        }
+
+
+class QCInspectionResponse(BaseModel):
+    """Response from QC inspection"""
+    production_order_id: int
+    production_order_code: str
+    qc_status: str
+    qc_notes: Optional[str] = None
+    qc_inspected_by: Optional[str] = None
+    qc_inspected_at: Optional[datetime] = None
+    sales_order_updated: bool = False
+    sales_order_status: Optional[str] = None
+    message: str

--- a/backend/migrations/versions/012_add_qc_workflow_fields.py
+++ b/backend/migrations/versions/012_add_qc_workflow_fields.py
@@ -1,0 +1,69 @@
+"""Add QC workflow fields to production orders
+
+Revision ID: 012_add_qc_workflow
+Revises: 011_add_scrap_reasons
+Create Date: 2025-12-16
+
+Adds Quality Control (QC) tracking fields to production orders:
+- qc_status: Track QC state (not_required, pending, passed, failed)
+- qc_notes: Inspector notes
+- qc_inspected_by: Who performed QC
+- qc_inspected_at: When QC was performed
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = '012_add_qc_workflow'
+down_revision = '011_add_scrap_reasons'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add QC workflow fields to production_orders table"""
+
+    # Add qc_status column with default 'not_required'
+    op.add_column(
+        'production_orders',
+        sa.Column('qc_status', sa.String(50), nullable=False, server_default='not_required')
+    )
+
+    # Add qc_notes column
+    op.add_column(
+        'production_orders',
+        sa.Column('qc_notes', sa.Text(), nullable=True)
+    )
+
+    # Add qc_inspected_by column
+    op.add_column(
+        'production_orders',
+        sa.Column('qc_inspected_by', sa.String(100), nullable=True)
+    )
+
+    # Add qc_inspected_at column
+    op.add_column(
+        'production_orders',
+        sa.Column('qc_inspected_at', sa.DateTime(), nullable=True)
+    )
+
+    # Create index on qc_status for filtering
+    op.create_index(
+        'ix_production_orders_qc_status',
+        'production_orders',
+        ['qc_status']
+    )
+
+
+def downgrade():
+    """Remove QC workflow fields from production_orders table"""
+
+    # Drop index
+    op.drop_index('ix_production_orders_qc_status', table_name='production_orders')
+
+    # Drop columns
+    op.drop_column('production_orders', 'qc_inspected_at')
+    op.drop_column('production_orders', 'qc_inspected_by')
+    op.drop_column('production_orders', 'qc_notes')
+    op.drop_column('production_orders', 'qc_status')

--- a/frontend/src/components/QCInspectionModal.jsx
+++ b/frontend/src/components/QCInspectionModal.jsx
@@ -1,0 +1,289 @@
+import { useState } from "react";
+import { API_URL } from "../config/api";
+import { useToast } from "./Toast";
+
+export default function QCInspectionModal({
+  productionOrder,
+  onClose,
+  onComplete,
+}) {
+  const toast = useToast();
+  const [result, setResult] = useState("passed");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const token = localStorage.getItem("adminToken");
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/qc`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            result,
+            notes: notes.trim() || null,
+          }),
+        }
+      );
+
+      if (res.ok) {
+        const data = await res.json();
+        if (result === "passed") {
+          toast.success(data.message || "QC inspection passed");
+        } else {
+          toast.warning(data.message || "QC inspection failed");
+        }
+        onComplete();
+      } else {
+        const err = await res.json();
+        toast.error(err.detail || "Failed to submit QC inspection");
+      }
+    } catch (err) {
+      toast.error(err.message || "Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-lg p-6">
+        <div className="flex justify-between items-center mb-6">
+          <div>
+            <h2 className="text-xl font-bold text-white">QC Inspection</h2>
+            <p className="text-gray-400 text-sm mt-1">
+              {productionOrder.code} -{" "}
+              {productionOrder.product_name || productionOrder.product_sku}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white text-xl"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Order Details */}
+        <div className="bg-gray-800/50 rounded-lg p-4 mb-6">
+          <div className="flex justify-between text-sm mb-2">
+            <span className="text-gray-400">Quantity Completed:</span>
+            <span className="text-white font-medium">
+              {productionOrder.quantity_completed || productionOrder.quantity_ordered} units
+            </span>
+          </div>
+          <div className="flex justify-between text-sm mb-2">
+            <span className="text-gray-400">Status:</span>
+            <span className="text-green-400 font-medium">
+              {productionOrder.status}
+            </span>
+          </div>
+          {productionOrder.completed_at && (
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-400">Completed:</span>
+              <span className="text-white">
+                {new Date(productionOrder.completed_at).toLocaleString()}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* QC Result Selection */}
+        <div className="mb-6">
+          <label className="block text-sm text-gray-400 mb-3">
+            Inspection Result *
+          </label>
+          <div className="grid grid-cols-2 gap-4">
+            <button
+              type="button"
+              onClick={() => setResult("passed")}
+              className={`p-4 rounded-lg border-2 transition-all ${
+                result === "passed"
+                  ? "border-green-500 bg-green-500/10"
+                  : "border-gray-700 bg-gray-800 hover:border-gray-600"
+              }`}
+            >
+              <div className="flex items-center justify-center gap-2">
+                <svg
+                  className={`w-6 h-6 ${
+                    result === "passed" ? "text-green-400" : "text-gray-400"
+                  }`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <span
+                  className={`font-medium ${
+                    result === "passed" ? "text-green-400" : "text-gray-300"
+                  }`}
+                >
+                  Pass
+                </span>
+              </div>
+              <p
+                className={`text-xs mt-2 ${
+                  result === "passed" ? "text-green-400/70" : "text-gray-500"
+                }`}
+              >
+                Quality acceptable
+              </p>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setResult("failed")}
+              className={`p-4 rounded-lg border-2 transition-all ${
+                result === "failed"
+                  ? "border-red-500 bg-red-500/10"
+                  : "border-gray-700 bg-gray-800 hover:border-gray-600"
+              }`}
+            >
+              <div className="flex items-center justify-center gap-2">
+                <svg
+                  className={`w-6 h-6 ${
+                    result === "failed" ? "text-red-400" : "text-gray-400"
+                  }`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+                <span
+                  className={`font-medium ${
+                    result === "failed" ? "text-red-400" : "text-gray-300"
+                  }`}
+                >
+                  Fail
+                </span>
+              </div>
+              <p
+                className={`text-xs mt-2 ${
+                  result === "failed" ? "text-red-400/70" : "text-gray-500"
+                }`}
+              >
+                Quality issues found
+              </p>
+            </button>
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div className="mb-6">
+          <label className="block text-sm text-gray-400 mb-2">
+            Inspection Notes {result === "failed" ? "(Recommended)" : "(Optional)"}
+          </label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder={
+              result === "failed"
+                ? "Describe the quality issues found (e.g., surface defects, dimensional issues, etc.)"
+                : "Add any notes about the inspection"
+            }
+            rows={3}
+            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white resize-none"
+          />
+        </div>
+
+        {/* Warning for failed QC */}
+        {result === "failed" && (
+          <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mb-6">
+            <div className="flex gap-3">
+              <svg
+                className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              <div>
+                <p className="text-red-400 font-medium">QC Failed</p>
+                <p className="text-red-400/80 text-sm">
+                  After marking as failed, you can scrap this order and create a
+                  remake if needed.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Success info for passed QC */}
+        {result === "passed" && productionOrder.sales_order_id && (
+          <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-4 mb-6">
+            <div className="flex gap-3">
+              <svg
+                className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div>
+                <p className="text-green-400 font-medium">Ready to Ship</p>
+                <p className="text-green-400/80 text-sm">
+                  Once QC passes, the linked sales order will be ready for shipping.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className={`flex-1 px-4 py-2 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
+              result === "passed"
+                ? "bg-green-600 hover:bg-green-500"
+                : "bg-red-600 hover:bg-red-500"
+            }`}
+          >
+            {submitting
+              ? "Submitting..."
+              : result === "passed"
+              ? "Mark as Passed"
+              : "Mark as Failed"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Quality Control (QC) inspection step to the production workflow. Orders now require QC approval before advancing to shipping.

### New Workflow
```
Production Complete → QC Pending → QC Pass/Fail → Ready to Ship
```

### Changes

**Backend:**
- Add `qc_status` field to ProductionOrder (`pending`, `passed`, `failed`, `not_required`)
- Add `qc_notes`, `qc_inspected_by`, `qc_inspected_at` tracking fields
- New endpoint: `POST /production-orders/{id}/qc` for QC inspection
- Updated completion flow: sets `qc_status='pending'` instead of auto-advancing to ready_to_ship
- Sales order only advances to `ready_to_ship` after ALL production orders pass QC

**Frontend:**
- New `QCInspectionModal` component with pass/fail selection and notes
- QC status badges on completed orders (yellow=pending, green=passed, red=failed)
- "Perform QC Inspection" button appears for pending/failed orders
- Visual distinction for orders awaiting QC (yellow border)

**Database:**
- Migration `012_add_qc_workflow_fields.py` adds QC columns with index

### Test Plan

- [ ] Create a production order from a sales order
- [ ] Complete the production order - verify qc_status becomes "pending"
- [ ] Verify sales order does NOT advance to ready_to_ship yet
- [ ] Open QC modal, mark as passed - verify sales order advances
- [ ] Test QC failure flow - verify order can be re-inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Quality Control (QC) inspection workflow for production orders with status tracking (pending, passed, failed)
  * Sales orders now advance to ready-to-ship only after QC passes, providing stricter quality gate before shipment
  * New QC inspection interface for admins to validate orders and document results with optional notes and dynamic status badges

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->