### PR TITLE
fix: Resolve MRP double-counting of SO and PO demand

### DIFF
--- a/backend/app/api/v1/endpoints/items.py
+++ b/backend/app/api/v1/endpoints/items.py
@@ -762,11 +762,18 @@ async def get_low_stock_items(
     # 2. Get MRP shortages from active sales orders (if enabled)
     if include_mrp_shortages:
         from app.models.sales_order import SalesOrder, SalesOrderLine
+        from app.models.production_order import ProductionOrder
         from app.services.mrp import MRPService
 
-        # Get all active sales orders (not cancelled, not completed)
+        # Get active sales orders that DON'T have linked production orders
+        # (POs already account for their demand via inventory allocations)
+        so_ids_with_po = db.query(ProductionOrder.sales_order_id).filter(
+            ProductionOrder.sales_order_id.isnot(None)
+        ).distinct()
+
         active_orders = db.query(SalesOrder).filter(
             SalesOrder.status.notin_(["cancelled", "completed", "delivered"]),
+            ~SalesOrder.id.in_(so_ids_with_po),
         ).all()
 
         mrp_service = MRPService(db)
@@ -794,7 +801,7 @@ async def get_low_stock_items(
                         except Exception:
                             # Skip if BOM explosion fails (no BOM, etc.)
                             continue
-            elif order.order_type == "quote_based" and hasattr(order, 'quote_id') and order.quote_id:
+            elif order.order_type == "quote" and hasattr(order, 'quote_id') and order.quote_id:
                 # For quote-based orders, get product from quote
                 from app.models.quote import Quote
                 quote = db.query(Quote).filter(Quote.id == order.quote_id).first()
@@ -810,7 +817,30 @@ async def get_low_stock_items(
                     except Exception:
                         # Skip if BOM explosion fails
                         continue
-        
+
+        # Also get demand from active Production Orders
+        # (POs that have sales_order_id are already excluded from SO processing above)
+        active_pos = db.query(ProductionOrder).filter(
+            ProductionOrder.status.in_(["draft", "released", "in_progress"]),
+        ).all()
+
+        for po in active_pos:
+            if po.product_id:
+                try:
+                    # Calculate remaining quantity (ordered - completed)
+                    remaining_qty = Decimal(str(po.quantity_ordered or 0)) - Decimal(str(po.quantity_completed or 0))
+                    if remaining_qty > 0:
+                        requirements = mrp_service.explode_bom(
+                            product_id=po.product_id,
+                            quantity=remaining_qty,
+                            source_demand_type="production_order",
+                            source_demand_id=po.id
+                        )
+                        all_requirements.extend(requirements)
+                except Exception:
+                    # Skip if BOM explosion fails
+                    continue
+
         # Aggregate requirements by product_id (sum quantities)
         aggregated_requirements = {}
         


### PR DESCRIPTION
## Summary

Fixes multiple issues in the MRP/purchasing demand calculation that caused material shortages to show 2x the actual need:

- **Quote-based orders not processed**: Fixed `order_type` check from `"quote_based"` to `"quote"` 
- **SO/PO double-counting**: Exclude SOs with linked Production Orders from SO-based demand
- **Allocation double-counting**: Use `on_hand` (not `available`) for MRP net shortage calculation

## Root Cause

When a Sales Order has a linked Production Order:
1. The PO allocates material (reduces `available_quantity`)
2. The low-stock endpoint was also exploding the SO's BOM
3. Net shortage formula: `gross - available` = `4590 - (-3590)` = **8180G** (wrong!)

## Fix Architecture

```
Before: SO demand + (PO allocation effect) = 2x demand
After:  PO demand only, using on_hand for supply = correct demand
```

- SOs without POs → demand from SO BOM explosion
- SOs with POs → demand from PO BOM explosion (not both)
- Net shortage = `Gross - On_hand - Incoming + Safety_stock`

## Test Results

| Scenario | Before | After |
|----------|--------|-------|
| PO demand: 4590G, On-hand: 1000G | 8180G shortage | 3590G shortage ✓ |

## Files Changed

- `backend/app/api/v1/endpoints/items.py` - Low-stock endpoint fixes
- `backend/app/services/mrp.py` - MRP service fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MRP shortage calculations to exclude items already allocated to production orders, reducing false shortage alerts.
  * Fixed order type classification for accurate demand analysis.

* **New Features**
  * Enhanced demand forecasting by incorporating active production orders for more comprehensive inventory analysis.
  * Added shortage classification summary with critical/urgent/low counts and total shortfall value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->