### PR TITLE
feat: Security audit auto-fix improvements

### DIFF
--- a/frontend/src/pages/admin/AdminSecurity.jsx
+++ b/frontend/src/pages/admin/AdminSecurity.jsx
@@ -51,6 +51,7 @@ const REMEDIABLE_CHECKS = [
   "dependencies_secure",
   "rate_limiting_enabled",
   "backup_configured",
+  "env_file_not_exposed",
 ];
 
 const getStatusIcon = (status) => {


### PR DESCRIPTION
## Summary
- Add auto-fix button for `.env` file exposure that updates Caddyfile with blocking rules
- Fix pip-audit detection to check JSON output instead of exit code (pip-audit returns 1 when it finds vulns)
- Fix pip self-upgrade to use `python -m pip` (pip can't upgrade itself directly)
- Add `env_file_not_exposed` to remediable security checks

## Technical Details
The dotfile blocking uses explicit `handle` blocks in Caddy which must come BEFORE the catch-all `handle {}` block:
```
handle /.env {
    respond 404
}
```

## Test plan
- [x] Tested dotfile blocking fix - .env now returns 404
- [x] Tested pip-audit detection - correctly shows WARN when CVEs found
- [x] Tested pip upgrade via Fix This button - successfully upgrades pip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic dotfile blocking capability to prevent unauthorized access to sensitive configuration files.
  * Introduced remediation guidance for environment file exposure protection.

* **Improvements**
  * Enhanced remediation tooling with improved access controls for admin operations.
  * Improved security audit reporting with more reliable vulnerability detection.
  * Optimized package dependency upgrade handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->