### PR TITLE
fix: Resolve MRP double-counting of SO and PO demand

### DIFF
--- a/backend/app/api/v1/endpoints/items.py
+++ b/backend/app/api/v1/endpoints/items.py
@@ -890,10 +890,7 @@ async def get_low_stock_items(
             else:
                 aggregated_requirements[key]["gross_quantity"] += req.gross_quantity
 
-        # Calculate net requirements
-        # Pass source_production_order_ids so MRP adds back their allocations
-        # (since their demand is already in gross_quantity, we don't want to
-        # double-count by also subtracting their allocations from available)
+        # Calculate net requirements (uses on_hand, not available, to avoid double-counting)
         if aggregated_requirements:
             from app.services.mrp import ComponentRequirement
             component_reqs = []


### PR DESCRIPTION
## Summary
- Uses `on_hand` instead of `available` in MRP net shortage calculation to prevent double-counting (allocations represent the same demand being calculated)
- Removes the complex `source_production_order_ids` allocation adjustment mechanism (no longer needed with the simpler on_hand approach)

Cherry-picked from the original `fix/mrp-double-counting` branch which diverged before v3.0.0 Core extraction. This v2 branch is clean and based on current main.

Closes the original MRP double-counting issue where shortage showed 8180G instead of correct 3590G.

## Test plan
- [ ] Verify MRP shortage calculations with SOs that have linked POs
- [ ] Verify low-stock endpoint returns correct demand figures
- [ ] Run existing MRP tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Net requirements now use on-hand + incoming + safety stock for more reliable low-stock detection.
  * Removed per-order allocation adjustments from netting logic, improving consistency of inventory recommendations.

* **Refactor**
  * Streamlined netting flow and terminology, simplifying calculations and reducing complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->