### PR TITLE
perf: fix N+1 queries in dashboard and BOM endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/admin/bom.py
+++ b/backend/app/api/v1/endpoints/admin/bom.py
@@ -199,9 +199,52 @@ def build_line_response(line: BOMLine, component: Optional[Product], comp_cost: 
 
 def build_bom_response(bom: BOM, db: Session) -> dict:
     """Build a full BOM response with product info and lines"""
+    from sqlalchemy import func
+
+    # Batch-fetch all components for this BOM's lines
+    component_ids = [line.component_id for line in bom.lines]
+    components_by_id = {}
+    if component_ids:
+        components = db.query(Product).filter(Product.id.in_(component_ids)).all()
+        components_by_id = {c.id: c for c in components}
+
+    # Batch-fetch inventory for all components
+    inventory_by_id = {}
+    if component_ids:
+        inv_rows = (
+            db.query(
+                Inventory.product_id,
+                func.sum(Inventory.on_hand_quantity).label("on_hand"),
+                func.sum(Inventory.allocated_quantity).label("allocated"),
+                func.sum(Inventory.available_quantity).label("available"),
+            )
+            .filter(Inventory.product_id.in_(component_ids))
+            .group_by(Inventory.product_id)
+            .all()
+        )
+        inventory_by_id = {
+            row.product_id: {
+                "on_hand": float(row.on_hand or 0),
+                "allocated": float(row.allocated or 0),
+                "available": float(row.available or 0),
+            }
+            for row in inv_rows
+        }
+
+    # Batch-check which components have active BOMs (sub-assemblies)
+    components_with_bom = set()
+    if component_ids:
+        sub_bom_rows = (
+            db.query(BOM.product_id)
+            .filter(BOM.product_id.in_(component_ids), BOM.active.is_(True))
+            .distinct()
+            .all()
+        )
+        components_with_bom = {row.product_id for row in sub_bom_rows}
+
     lines = []
     for line in bom.lines:
-        component = db.query(Product).filter(Product.id == line.component_id).first()
+        component = components_by_id.get(line.component_id)
         component_cost = get_effective_cost(component) if component else Decimal("0")
 
         # Calculate effective quantity including scrap factor
@@ -209,9 +252,9 @@ def build_bom_response(bom: BOM, db: Session) -> dict:
         scrap = line.scrap_factor or Decimal("0")
         effective_qty = qty * (1 + scrap / 100)
 
-        # Get inventory status
-        inventory = get_component_inventory(line.component_id, db)
-        
+        # Get inventory status from batch-loaded data
+        inventory = inventory_by_id.get(line.component_id, {"on_hand": 0, "allocated": 0, "available": 0})
+
         # Convert effective_qty to inventory unit for comparison if needed
         qty_needed_in_inventory_unit = float(effective_qty)
         component_unit = component.unit if component else None
@@ -220,34 +263,25 @@ def build_bom_response(bom: BOM, db: Session) -> dict:
             and component_unit
             and line.unit != component_unit
         ):
-            # Convert effective_qty from line.unit to component.unit (inventory unit)
-            # E.g., 25 G -> 0.025 KG
-            # Use _safe variant to handle empty UOM table with inline fallbacks
             converted_qty, success = convert_quantity_safe(db, effective_qty, line.unit, component_unit)
             if success:
                 qty_needed_in_inventory_unit = float(converted_qty)
-        
+
         is_available = inventory["available"] >= qty_needed_in_inventory_unit
         shortage = max(0, qty_needed_in_inventory_unit - inventory["available"])
 
-        # Check if component has its own BOM (is a sub-assembly)
-        component_has_bom = db.query(BOM).filter(
-            BOM.product_id == line.component_id,
-            BOM.active.is_(True)
-        ).first() is not None
-
         # Build base line response using helper
         line_dict = build_line_response(line, component, component_cost, db)
-        
+
         # Add inventory and sub-assembly info specific to this endpoint
         line_dict.update({
             "inventory_on_hand": inventory["on_hand"],
             "inventory_available": inventory["available"],
             "is_available": is_available,
             "shortage": shortage,
-            "has_bom": component_has_bom,
+            "has_bom": line.component_id in components_with_bom,
         })
-        
+
         lines.append(line_dict)
 
     product = bom.product
@@ -273,10 +307,17 @@ def build_bom_response(bom: BOM, db: Session) -> dict:
 def recalculate_bom_cost(bom: BOM, db: Session) -> Decimal:
     """Recalculate total BOM cost from component costs, with UOM conversion"""
     from app.services.inventory_helpers import is_material
-    
+
+    # Batch-fetch all components for this BOM's lines
+    component_ids = [line.component_id for line in bom.lines]
+    components_by_id = {}
+    if component_ids:
+        components = db.query(Product).filter(Product.id.in_(component_ids)).all()
+        components_by_id = {c.id: c for c in components}
+
     total = Decimal("0")
     for line in bom.lines:
-        component = db.query(Product).filter(Product.id == line.component_id).first()
+        component = components_by_id.get(line.component_id)
         if component:
             cost = get_effective_cost(component)
             if cost > 0:
@@ -349,16 +390,26 @@ async def list_boms(
     query = query.order_by(desc(BOM.created_at))
     boms = query.offset(skip).limit(limit).all()
 
+    # Batch-fetch active routings for all BOM products
+    product_ids = [bom.product_id for bom in boms]
+    routings_by_product = {}
+    if product_ids:
+        routings = db.query(Routing).filter(
+            Routing.product_id.in_(product_ids),
+            Routing.is_active.is_(True)
+        ).all()
+        for r in routings:
+            # Keep first (or only) active routing per product
+            if r.product_id not in routings_by_product:
+                routings_by_product[r.product_id] = r
+
     result = []
     for bom in boms:
         product = bom.product
         material_cost = bom.total_cost or Decimal("0")
 
-        # Get routing process cost for this product
-        routing = db.query(Routing).filter(
-            Routing.product_id == bom.product_id,
-            Routing.is_active.is_(True)
-        ).first()
+        # Get routing process cost from batch-loaded data
+        routing = routings_by_product.get(bom.product_id)
         process_cost = routing.total_cost if routing and routing.total_cost else Decimal("0")
 
         # Combined total
@@ -876,10 +927,17 @@ async def recalculate_bom(
 
     # Calculate line costs for response (with UOM conversion)
     from app.services.inventory_helpers import is_material
-    
+
+    # Batch-fetch all components for this BOM's lines
+    component_ids = [line.component_id for line in bom.lines]
+    components_by_id = {}
+    if component_ids:
+        components = db.query(Product).filter(Product.id.in_(component_ids)).all()
+        components_by_id = {c.id: c for c in components}
+
     line_costs = []
     for line in bom.lines:
-        component = db.query(Product).filter(Product.id == line.component_id).first()
+        component = components_by_id.get(line.component_id)
         component_cost = get_effective_cost(component) if component else Decimal("0")
         
         if component and component_cost and component_cost > 0:
@@ -1345,11 +1403,31 @@ async def get_cost_rollup(
     if not bom:
         raise HTTPException(status_code=404, detail="BOM not found")
 
+    # Batch-fetch all components for this BOM's lines
+    component_ids = [line.component_id for line in bom.lines]
+    components_by_id = {}
+    if component_ids:
+        components = db.query(Product).filter(Product.id.in_(component_ids)).all()
+        components_by_id = {c.id: c for c in components}
+
+    # Batch-fetch active sub-BOMs for all components
+    sub_boms_by_product = {}
+    if component_ids:
+        sub_boms = (
+            db.query(BOM)
+            .filter(BOM.product_id.in_(component_ids), BOM.active.is_(True))
+            .order_by(desc(BOM.version))
+            .all()
+        )
+        for sb in sub_boms:
+            if sb.product_id not in sub_boms_by_product:
+                sub_boms_by_product[sb.product_id] = sb
+
     breakdown = []
     total = Decimal("0")
 
     for line in bom.lines:
-        component = db.query(Product).filter(Product.id == line.component_id).first()
+        component = components_by_id.get(line.component_id)
         if not component:
             continue
 
@@ -1357,13 +1435,8 @@ async def get_cost_rollup(
         scrap = line.scrap_factor or Decimal("0")
         effective_qty = qty * (1 + scrap / 100)
 
-        # Check for sub-BOM
-        sub_bom = (
-            db.query(BOM)
-            .filter(BOM.product_id == component.id, BOM.active.is_(True))  # noqa: E712
-            .order_by(desc(BOM.version))
-            .first()
-        )
+        # Check for sub-BOM from batch-loaded data
+        sub_bom = sub_boms_by_product.get(component.id)
 
         if sub_bom:
             sub_cost = calculate_rolled_up_cost(sub_bom.id, db)
@@ -1520,9 +1593,27 @@ async def validate_bom(
             "message": "BOM has no components"
         })
 
+    # Batch-fetch all components for validation
+    component_ids = [line.component_id for line in bom.lines]
+    components_by_id = {}
+    if component_ids:
+        components = db.query(Product).filter(Product.id.in_(component_ids)).all()
+        components_by_id = {c.id: c for c in components}
+
+    # Batch-check which components have active BOMs (sub-assemblies)
+    components_with_bom = set()
+    if component_ids:
+        sub_bom_rows = (
+            db.query(BOM.product_id)
+            .filter(BOM.product_id.in_(component_ids), BOM.active.is_(True))
+            .distinct()
+            .all()
+        )
+        components_with_bom = {row.product_id for row in sub_bom_rows}
+
     # Check each line
     for line in bom.lines:
-        component = db.query(Product).filter(Product.id == line.component_id).first()
+        component = components_by_id.get(line.component_id)
 
         if not component:
             issues.append({
@@ -1537,12 +1628,9 @@ async def validate_bom(
         component_cost = get_effective_cost(component)
         if not component_cost or component_cost <= 0:
             # Check if it's a sub-assembly
-            sub_bom = db.query(BOM).filter(
-                BOM.product_id == component.id,
-                BOM.active.is_(True)
-            ).first()
+            has_sub_bom = component.id in components_with_bom
 
-            if not sub_bom:
+            if not has_sub_bom:
                 issues.append({
                     "severity": "warning",
                     "code": "missing_cost",

--- a/backend/app/api/v1/endpoints/admin/dashboard.py
+++ b/backend/app/api/v1/endpoints/admin/dashboard.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from datetime import datetime, timezone, timedelta
 
 from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, desc, or_
 from pydantic import BaseModel
 
@@ -264,6 +264,7 @@ async def get_dashboard(
     pending_bom_query = (
         db.query(BOM)
         .join(Product)
+        .options(joinedload(BOM.product), joinedload(BOM.lines))
         .filter(
             Product.type == "custom",
             BOM.active.is_(True),  # noqa: E712
@@ -348,7 +349,6 @@ async def get_dashboard_summary(
     # Use the same logic as /items/low-stock endpoint - just get the count
     from app.models.inventory import Inventory
     from collections import defaultdict
-    from app.models.sales_order import SalesOrderLine
     from app.services.mrp import MRPService, ComponentRequirement
     
     # 1. Get items below reorder point (count unique products)
@@ -385,18 +385,16 @@ async def get_dashboard_summary(
     # 2. Get MRP shortages from active sales orders
     active_orders = db.query(SalesOrder).filter(
         SalesOrder.status.notin_(["cancelled", "completed", "delivered"])
-    ).all()
-    
+    ).options(joinedload(SalesOrder.lines)).all()
+
     mrp_shortage_products = set()
     if active_orders:
         mrp_service = MRPService(db)
         all_requirements = []
-        
+
         for order in active_orders:
             if order.order_type == "line_item":
-                lines = db.query(SalesOrderLine).filter(
-                    SalesOrderLine.sales_order_id == order.id
-                ).all()
+                lines = order.lines
                 for line in lines:
                     if line.product_id:
                         try:
@@ -465,53 +463,72 @@ async def get_dashboard_summary(
     
     # Production orders ready to start (materials available)
     # Get released/pending production orders and check material availability
-    from app.models.bom import BOMLine
     from app.models.inventory import Inventory
     
     ready_to_start_count = 0
     released_orders = db.query(ProductionOrder).filter(
         ProductionOrder.status.in_(["pending", "released"])
     ).all()
-    
+
+    # Batch-load BOMs with lines for all released orders
+    bom_ids = [po.bom_id for po in released_orders if po.bom_id]
+    boms_by_id = {}
+    if bom_ids:
+        boms_loaded = (
+            db.query(BOM)
+            .options(joinedload(BOM.lines))
+            .filter(BOM.id.in_(bom_ids))
+            .all()
+        )
+        boms_by_id = {b.id: b for b in boms_loaded}
+
+    # Batch-load inventory availability for all components
+    all_component_ids = set()
+    for bom in boms_by_id.values():
+        for line in bom.lines:
+            if not line.is_cost_only:
+                all_component_ids.add(line.component_id)
+
+    inventory_by_product = {}
+    if all_component_ids:
+        inv_rows = (
+            db.query(
+                Inventory.product_id,
+                func.sum(Inventory.available_quantity).label("total")
+            )
+            .filter(Inventory.product_id.in_(all_component_ids))
+            .group_by(Inventory.product_id)
+            .all()
+        )
+        inventory_by_product = {row.product_id: Decimal(str(row.total or 0)) for row in inv_rows}
+
     for po in released_orders:
         if not po.bom_id:
-            # No BOM = no materials needed, ready to start
             ready_to_start_count += 1
             continue
-        
-        bom = db.query(BOM).filter(BOM.id == po.bom_id).first()
+
+        bom = boms_by_id.get(po.bom_id)
         if not bom:
             continue
-        
-        bom_lines = db.query(BOMLine).filter(BOMLine.bom_id == bom.id).all()
+
         all_available = True
-        
         qty_multiplier = Decimal(str(po.quantity_ordered or 1))
-        
-        for line in bom_lines:
+
+        for line in bom.lines:
             if line.is_cost_only:
                 continue
-            
-            component = db.query(Product).filter(Product.id == line.component_id).first()
-            if not component:
-                continue
-            
-            # Calculate required quantity
+
             base_qty = Decimal(str(line.quantity or 0))
             scrap_factor = Decimal(str(line.scrap_factor or 0)) / Decimal("100")
             qty_with_scrap = base_qty * (Decimal("1") + scrap_factor)
             required_qty = qty_with_scrap * qty_multiplier
-            
-            # Check available inventory
-            inv_result = db.query(
-                func.sum(Inventory.available_quantity)
-            ).filter(Inventory.product_id == line.component_id).scalar()
-            available_qty = Decimal(str(inv_result or 0))
-            
+
+            available_qty = inventory_by_product.get(line.component_id, Decimal("0"))
+
             if available_qty < required_qty:
                 all_available = False
                 break
-        
+
         if all_available:
             ready_to_start_count += 1
     
@@ -567,6 +584,7 @@ async def get_recent_orders(
     """
     orders = (
         db.query(SalesOrder)
+        .options(joinedload(SalesOrder.user))
         .order_by(desc(SalesOrder.created_at))
         .limit(limit)
         .all()
@@ -599,6 +617,7 @@ async def get_pending_bom_reviews(
     """
     boms = (
         db.query(BOM)
+        .options(joinedload(BOM.lines))
         .filter(BOM.active.is_(True))  # noqa: E712
         .order_by(desc(BOM.created_at))
         .limit(limit)


### PR DESCRIPTION
## Summary
- **ARCHITECT-001**: Fix N+1 queries in dashboard — eager-load `SalesOrder.user`, `BOM.lines`, batch-load BOMs/inventory for ready-to-start check, remove unused imports
- **ARCHITECT-005**: Fix N+1 queries in BOM — batch-fetch components, inventory, sub-assembly status, routings across `build_bom_response()`, `recalculate_bom_cost()`, `list_boms()`, `cost-rollup`, and `validate` endpoints

## Changes
- **dashboard.py**: Added `joinedload(SalesOrder.user)` to recent-orders, `joinedload(BOM.lines)` to pending-bom-reviews, batch-loaded BOMs + inventory for production ready-to-start, cleaned up unused imports
- **bom.py**: Replaced per-line `db.query(Product)` calls with batch `.in_()` queries in 5 functions, batch-fetched Routing records in `list_boms()`, batch-checked sub-assembly status

## Test plan
- [x] ruff lint passes on both files
- [x] All 237 BOM and dashboard tests pass
- [x] 1969 tests pass overall (33 pre-existing test isolation failures unrelated to this PR)

Closes #126
Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized BOM (Bill of Materials) operations to reduce database load and improve response times
  * Enhanced dashboard queries for faster data retrieval and rendering
  * Improved efficiency of inventory and cost calculations across administrative features
  * Dashboard now provides more comprehensive related data without performance degradation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->