### PR TITLE
refactor(ARCHITECT-002): split ItemWizard — extract inline forms + constants

### DIFF
--- a/frontend/src/components/ItemWizard.jsx
+++ b/frontend/src/components/ItemWizard.jsx
@@ -1,22 +1,9 @@
 import { useState, useEffect, useMemo } from "react";
 import { API_URL } from "../config/api";
 import Modal from "./Modal";
-
-// Item type options
-const ITEM_TYPES = [
-  { value: "finished_good", label: "Finished Good", color: "blue", defaultProcurement: "make" },
-  { value: "component", label: "Component", color: "purple", defaultProcurement: "buy" },
-  { value: "supply", label: "Supply", color: "orange", defaultProcurement: "buy" },
-  { value: "service", label: "Service", color: "green", defaultProcurement: "buy" },
-  { value: "material", label: "Material (Filament)", color: "yellow", defaultProcurement: "buy" },
-];
-
-// Procurement type options (Make vs Buy)
-const PROCUREMENT_TYPES = [
-  { value: "make", label: "Make (Manufactured)", color: "green", needsBom: true, description: "Produced in-house with BOM & routing" },
-  { value: "buy", label: "Buy (Purchased)", color: "blue", needsBom: false, description: "Purchased from suppliers" },
-  { value: "make_or_buy", label: "Make or Buy", color: "yellow", needsBom: true, description: "Flexible sourcing" },
-];
+import { ITEM_TYPES, PROCUREMENT_TYPES } from "./item-wizard/constants";
+import MaterialWizardForm from "./item-wizard/MaterialWizardForm";
+import SubComponentWizardForm from "./item-wizard/SubComponentWizardForm";
 
 /**
  * ItemWizard - Reusable item creation wizard with BOM builder
@@ -759,137 +746,30 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
 
                 {/* Material Wizard */}
                 {showMaterialWizard && (
-                  <div className="bg-pink-900/20 border border-pink-500/30 rounded-lg p-4 mb-3 space-y-3">
-                    <div className="flex justify-between items-center">
-                      <span className="text-pink-400 font-medium text-sm">Add Filament to Inventory</span>
-                      <button type="button" onClick={() => setShowMaterialWizard(false)} className="text-gray-400 hover:text-white text-xs">Cancel</button>
-                    </div>
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Material Type *</label>
-                        <select
-                          value={newMaterial.material_type_code}
-                          onChange={(e) => {
-                            const code = e.target.value;
-                            setNewMaterial({ ...newMaterial, material_type_code: code, color_code: "" });
-                            fetchColorsForType(code);
-                          }}
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        >
-                          <option value="">Select material...</option>
-                          {materialTypes.map(mt => (
-                            <option key={mt.code} value={mt.code}>{mt.name}</option>
-                          ))}
-                        </select>
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Color *</label>
-                        <select
-                          value={newMaterial.color_code}
-                          onChange={(e) => setNewMaterial({ ...newMaterial, color_code: e.target.value })}
-                          disabled={!newMaterial.material_type_code}
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm disabled:opacity-50"
-                        >
-                          <option value="">{newMaterial.material_type_code ? "Select color..." : "Select material first"}</option>
-                          {allColors.map(c => (
-                            <option key={c.code} value={c.code}>{c.name}</option>
-                          ))}
-                        </select>
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Quantity (kg)</label>
-                        <input
-                          type="number"
-                          step="0.1"
-                          value={newMaterial.quantity_kg}
-                          onChange={(e) => setNewMaterial({ ...newMaterial, quantity_kg: parseFloat(e.target.value) || 1.0 })}
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Cost per kg ($)</label>
-                        <input
-                          type="number"
-                          step="0.01"
-                          value={newMaterial.cost_per_kg || ""}
-                          onChange={(e) => setNewMaterial({ ...newMaterial, cost_per_kg: parseFloat(e.target.value) || null })}
-                          placeholder="Auto from material"
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        />
-                      </div>
-                    </div>
-                    <div className="flex justify-end">
-                      <button
-                        type="button"
-                        onClick={handleCreateMaterial}
-                        disabled={loading || !newMaterial.material_type_code || !newMaterial.color_code}
-                        className="px-3 py-1.5 bg-pink-600 text-white text-sm rounded hover:bg-pink-500 disabled:opacity-50"
-                      >
-                        {loading ? "Creating..." : "Add to Inventory & BOM"}
-                      </button>
-                    </div>
-                  </div>
+                  <MaterialWizardForm
+                    materialTypes={materialTypes}
+                    allColors={allColors}
+                    newMaterial={newMaterial}
+                    loading={loading}
+                    onMaterialChange={setNewMaterial}
+                    onColorTypeChange={(code) => {
+                      setNewMaterial({ ...newMaterial, material_type_code: code, color_code: "" });
+                      fetchColorsForType(code);
+                    }}
+                    onCreateMaterial={handleCreateMaterial}
+                    onCancel={() => setShowMaterialWizard(false)}
+                  />
                 )}
 
                 {/* Sub-Component Wizard */}
                 {showSubComponentWizard && (
-                  <div className="bg-purple-900/20 border border-purple-500/30 rounded-lg p-4 mb-3 space-y-3">
-                    <div className="flex justify-between items-center">
-                      <span className="text-purple-400 font-medium text-sm">New Component</span>
-                      <button type="button" onClick={() => setShowSubComponentWizard(false)} className="text-gray-400 hover:text-white text-xs">Cancel</button>
-                    </div>
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Component Name *</label>
-                        <input
-                          type="text"
-                          value={subComponent.name}
-                          onChange={(e) => setSubComponent({ ...subComponent, name: e.target.value })}
-                          placeholder="e.g. M3 Heat Insert"
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">SKU</label>
-                        <input
-                          type="text"
-                          value={subComponent.sku}
-                          onChange={(e) => setSubComponent({ ...subComponent, sku: e.target.value.toUpperCase() })}
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm font-mono"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Unit Cost ($)</label>
-                        <input
-                          type="number"
-                          step="0.01"
-                          value={subComponent.standard_cost || ""}
-                          onChange={(e) => setSubComponent({ ...subComponent, standard_cost: parseFloat(e.target.value) || null })}
-                          placeholder="0.00"
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-400 mb-1">Unit</label>
-                        <input
-                          type="text"
-                          value={subComponent.unit}
-                          onChange={(e) => setSubComponent({ ...subComponent, unit: e.target.value.toUpperCase() })}
-                          className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
-                        />
-                      </div>
-                    </div>
-                    <div className="flex justify-end">
-                      <button
-                        type="button"
-                        onClick={handleSaveSubComponent}
-                        disabled={loading || !subComponent.name}
-                        className="px-3 py-1.5 bg-purple-600 text-white text-sm rounded hover:bg-purple-500 disabled:opacity-50"
-                      >
-                        {loading ? "Creating..." : "Create & Add to BOM"}
-                      </button>
-                    </div>
-                  </div>
+                  <SubComponentWizardForm
+                    subComponent={subComponent}
+                    loading={loading}
+                    onSubComponentChange={setSubComponent}
+                    onSave={handleSaveSubComponent}
+                    onCancel={() => setShowSubComponentWizard(false)}
+                  />
                 )}
 
                 {/* Component Dropdown */}

--- a/frontend/src/components/item-wizard/MaterialWizardForm.jsx
+++ b/frontend/src/components/item-wizard/MaterialWizardForm.jsx
@@ -1,0 +1,85 @@
+/**
+ * MaterialWizardForm - Inline form for adding filament to inventory & BOM.
+ *
+ * Extracted from ItemWizard.jsx (ARCHITECT-002)
+ */
+
+export default function MaterialWizardForm({
+  materialTypes,
+  allColors,
+  newMaterial,
+  loading,
+  onMaterialChange,
+  onColorTypeChange,
+  onCreateMaterial,
+  onCancel,
+}) {
+  return (
+    <div className="bg-pink-900/20 border border-pink-500/30 rounded-lg p-4 mb-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <span className="text-pink-400 font-medium text-sm">Add Filament to Inventory</span>
+        <button type="button" onClick={onCancel} className="text-gray-400 hover:text-white text-xs">Cancel</button>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Material Type *</label>
+          <select
+            value={newMaterial.material_type_code}
+            onChange={(e) => onColorTypeChange(e.target.value)}
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          >
+            <option value="">Select material...</option>
+            {materialTypes.map(mt => (
+              <option key={mt.code} value={mt.code}>{mt.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Color *</label>
+          <select
+            value={newMaterial.color_code}
+            onChange={(e) => onMaterialChange({ ...newMaterial, color_code: e.target.value })}
+            disabled={!newMaterial.material_type_code}
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm disabled:opacity-50"
+          >
+            <option value="">{newMaterial.material_type_code ? "Select color..." : "Select material first"}</option>
+            {allColors.map(c => (
+              <option key={c.code} value={c.code}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Quantity (kg)</label>
+          <input
+            type="number"
+            step="0.1"
+            value={newMaterial.quantity_kg}
+            onChange={(e) => onMaterialChange({ ...newMaterial, quantity_kg: parseFloat(e.target.value) || 1.0 })}
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Cost per kg ($)</label>
+          <input
+            type="number"
+            step="0.01"
+            value={newMaterial.cost_per_kg || ""}
+            onChange={(e) => onMaterialChange({ ...newMaterial, cost_per_kg: parseFloat(e.target.value) || null })}
+            placeholder="Auto from material"
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          />
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onCreateMaterial}
+          disabled={loading || !newMaterial.material_type_code || !newMaterial.color_code}
+          className="px-3 py-1.5 bg-pink-600 text-white text-sm rounded hover:bg-pink-500 disabled:opacity-50"
+        >
+          {loading ? "Creating..." : "Add to Inventory & BOM"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/item-wizard/SubComponentWizardForm.jsx
+++ b/frontend/src/components/item-wizard/SubComponentWizardForm.jsx
@@ -1,0 +1,73 @@
+/**
+ * SubComponentWizardForm - Inline form for creating a new component and adding to BOM.
+ *
+ * Extracted from ItemWizard.jsx (ARCHITECT-002)
+ */
+
+export default function SubComponentWizardForm({
+  subComponent,
+  loading,
+  onSubComponentChange,
+  onSave,
+  onCancel,
+}) {
+  return (
+    <div className="bg-purple-900/20 border border-purple-500/30 rounded-lg p-4 mb-3 space-y-3">
+      <div className="flex justify-between items-center">
+        <span className="text-purple-400 font-medium text-sm">New Component</span>
+        <button type="button" onClick={onCancel} className="text-gray-400 hover:text-white text-xs">Cancel</button>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Component Name *</label>
+          <input
+            type="text"
+            value={subComponent.name}
+            onChange={(e) => onSubComponentChange({ ...subComponent, name: e.target.value })}
+            placeholder="e.g. M3 Heat Insert"
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">SKU</label>
+          <input
+            type="text"
+            value={subComponent.sku}
+            onChange={(e) => onSubComponentChange({ ...subComponent, sku: e.target.value.toUpperCase() })}
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm font-mono"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Unit Cost ($)</label>
+          <input
+            type="number"
+            step="0.01"
+            value={subComponent.standard_cost || ""}
+            onChange={(e) => onSubComponentChange({ ...subComponent, standard_cost: parseFloat(e.target.value) || null })}
+            placeholder="0.00"
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Unit</label>
+          <input
+            type="text"
+            value={subComponent.unit}
+            onChange={(e) => onSubComponentChange({ ...subComponent, unit: e.target.value.toUpperCase() })}
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm"
+          />
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={loading || !subComponent.name}
+          className="px-3 py-1.5 bg-purple-600 text-white text-sm rounded hover:bg-purple-500 disabled:opacity-50"
+        >
+          {loading ? "Creating..." : "Create & Add to BOM"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/item-wizard/constants.js
+++ b/frontend/src/components/item-wizard/constants.js
@@ -1,0 +1,21 @@
+/**
+ * ItemWizard constants — shared across item-wizard components.
+ *
+ * Extracted from ItemWizard.jsx (ARCHITECT-002)
+ */
+
+// Item type options
+export const ITEM_TYPES = [
+  { value: "finished_good", label: "Finished Good", color: "blue", defaultProcurement: "make" },
+  { value: "component", label: "Component", color: "purple", defaultProcurement: "buy" },
+  { value: "supply", label: "Supply", color: "orange", defaultProcurement: "buy" },
+  { value: "service", label: "Service", color: "green", defaultProcurement: "buy" },
+  { value: "material", label: "Material (Filament)", color: "yellow", defaultProcurement: "buy" },
+];
+
+// Procurement type options (Make vs Buy)
+export const PROCUREMENT_TYPES = [
+  { value: "make", label: "Make (Manufactured)", color: "green", needsBom: true, description: "Produced in-house with BOM & routing" },
+  { value: "buy", label: "Buy (Purchased)", color: "blue", needsBom: false, description: "Purchased from suppliers" },
+  { value: "make_or_buy", label: "Make or Buy", color: "yellow", needsBom: true, description: "Flexible sourcing" },
+];


### PR DESCRIPTION
## Summary
- Extract `MaterialWizardForm` component (filament inventory inline form) to `components/item-wizard/MaterialWizardForm.jsx`
- Extract `SubComponentWizardForm` component (new component inline form) to `components/item-wizard/SubComponentWizardForm.jsx`
- Extract `ITEM_TYPES` and `PROCUREMENT_TYPES` constants to `components/item-wizard/constants.js`
- ItemWizard.jsx: **1135 → 1015 lines**

Part of ARCHITECT-002 (Split God Files). This is the final frontend candidate — remaining wizard step JSX shares too much state to benefit from further extraction.

## Test plan
- [ ] Verify item creation wizard opens and all 3 steps work (Basic Info → BOM → Pricing)
- [ ] Verify "Add Filament" inline form creates material and adds to BOM
- [ ] Verify "Create Component" inline form creates component and adds to BOM
- [ ] Verify item type and procurement type selectors work correctly
- [ ] `npm run build` passes
- [ ] `npx eslint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Material Wizard and Sub-Component Wizard forms with improved organization and validation.
  * Centralized item type and procurement configuration for consistency.
  * Enhanced form UI with better input handling, responsive layout, and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->