### PR TITLE
docs: add comprehensive user guide for all FilaOps modules

### DIFF
--- a/docs/user-guide/accounting-module.md
+++ b/docs/user-guide/accounting-module.md
@@ -1,147 +1,1197 @@
-# Accounting Module User Guide
+# Accounting Module Guide
+
+This guide covers FilaOps' built-in accounting system, including the General Ledger, journal entries, fiscal periods, inventory valuation, tax reporting, and financial dashboards.
 
 ## Overview
 
-The Accounting Module provides financial visibility into your 3D print farm operations. It automatically creates GL journal entries for inventory transactions, ensuring your books stay in sync with physical operations.
+FilaOps includes a **double-entry bookkeeping** system that automatically records financial transactions as your business operates. When you receive inventory, ship orders, or consume materials in production, the GL stays in sync.
 
-## Accessing the Module
+**Key Features:**
+- Double-entry General Ledger with balance verification
+- Automatic journal entries from inventory transactions
+- Fiscal period management (open/close)
+- Trial Balance and Transaction Ledger reports
+- Inventory valuation with GL reconciliation
+- COGS tracking and gross margin analysis
+- Tax collection and reporting
+- Revenue recognition at shipment (GAAP accrual basis)
+- Schedule C line mapping for sole proprietor tax filing
+- Full audit trail (who created, posted, voided every entry)
 
-1. Navigate to **Admin** → **Accounting**
-2. Requires **Pro** or **Enterprise** tier for GL Reports and Period Management
-
-## Available Reports
-
-### GL Reports Tab
-
-#### Trial Balance
-Shows all General Ledger account balances as of a specific date.
-
-- **Debit Balance**: Normal for Assets (1xxx) and Expenses (5xxx)
-- **Credit Balance**: Normal for Liabilities (2xxx) and Revenue (4xxx)
-- **Is Balanced**: ✓ means total debits = total credits (healthy books)
-
-**Tip:** Click any account row to view its transaction ledger. If books are unbalanced, check for incomplete transactions or manual adjustments.
-
-#### Inventory Valuation
-Compares physical inventory value to GL account balances.
-
-| Category | GL Account | Description |
-|----------|------------|-------------|
-| Raw Materials | 1200 | Filament, components |
-| WIP | 1210 | In-progress production |
-| Finished Goods | 1220 | Completed products |
-| Packaging | 1230 | Boxes, labels |
-
-**Variance** indicates a discrepancy between what's physically on hand and what's recorded in the GL. Common causes:
-- Manual inventory adjustments without GL entry
-- Incomplete transactions
-- Timing differences
-- Inventory that existed before GL system was implemented
-
-#### Transaction Ledger
-Detailed transaction history for a specific GL account.
-
-- Enter an account code (e.g., 1200) to view all journal entries affecting that account
-- Shows running balance after each transaction
-- Links back to source documents (PO, SO, Production Order)
-
-### Periods Tab
-
-Manage fiscal periods to control when entries can be posted.
-
-#### Closing a Period
-1. Click **Close** on an open period
-2. System validates all entries are balanced
-3. Once closed, no new entries can be backdated to that period
-
-#### Reopening a Period
-- Use with caution - allows modifications to historical data
-- Typically used to correct errors discovered after close
-- Requires admin privileges
-
-## GL Account Reference
-
-| Code | Name | Type | Normal Balance |
-|------|------|------|----------------|
-| 1200 | Raw Materials Inventory | Asset | Debit |
-| 1210 | Work in Process | Asset | Debit |
-| 1220 | Finished Goods Inventory | Asset | Debit |
-| 1230 | Packaging Inventory | Asset | Debit |
-| 2000 | Accounts Payable | Liability | Credit |
-| 5000 | Cost of Goods Sold | Expense | Debit |
-| 5010 | Shipping Expense | Expense | Debit |
-| 5020 | Scrap Expense | Expense | Debit |
-| 5030 | Inventory Adjustment | Expense | Debit |
-
-## Transaction Flow
-
-### Purchase Order Receipt
+**Accounting Flow:**
 ```
-DR 1200 Raw Materials
-   CR 2000 Accounts Payable
+Purchase Receipt → GL Entry (DR Inventory, CR AP)
+Production Consumption → GL Entry (DR WIP, CR Raw Materials)
+Finished Goods Receipt → GL Entry (DR FG Inventory, CR WIP)
+Customer Shipment → GL Entry (DR COGS, CR FG Inventory)
 ```
 
-### Material Issue to Production
+**Who Uses This Module:**
+- **Administrators** - Full access to all accounting features
+- **Operators** - No access to accounting
+
+---
+
+## Table of Contents
+
+1. [Chart of Accounts](#1-chart-of-accounts)
+2. [Journal Entries](#2-journal-entries)
+3. [Trial Balance](#3-trial-balance)
+4. [Inventory Valuation](#4-inventory-valuation)
+5. [Transaction Ledger](#5-transaction-ledger)
+6. [Fiscal Periods](#6-fiscal-periods)
+7. [Accounting Dashboard](#7-accounting-dashboard)
+8. [COGS and Gross Margin](#8-cogs-and-gross-margin)
+9. [Tax Reporting](#9-tax-reporting)
+10. [Revenue and Payments](#10-revenue-and-payments)
+11. [Schedule C Integration](#11-schedule-c-integration)
+12. [Data Export](#12-data-export)
+13. [Common Workflows](#13-common-workflows)
+14. [Best Practices](#14-best-practices)
+15. [Troubleshooting](#15-troubleshooting)
+16. [Quick Reference](#16-quick-reference)
+
+---
+
+## 1. Chart of Accounts
+
+### 1.1 What is the Chart of Accounts?
+
+The **Chart of Accounts** is the master list of all financial accounts used to categorize transactions. Every journal entry posts to one or more of these accounts.
+
+FilaOps ships with a default chart of accounts designed for 3D print farm operations.
+
+### 1.2 Default Accounts
+
+**Assets (1xxx) - Normal Balance: Debit**
+
+| Code | Name | Purpose |
+|------|------|---------|
+| 1000 | Cash | Bank account / cash on hand |
+| 1100 | Accounts Receivable | Money owed by customers |
+| 1200 | Raw Materials Inventory | Filament, components (unconsumed) |
+| 1210 | Work in Process (WIP) | Materials allocated to production |
+| 1220 | Finished Goods Inventory | Completed products ready to sell |
+| 1230 | Packaging Inventory | Boxes, bags, labels |
+
+**Liabilities (2xxx) - Normal Balance: Credit**
+
+| Code | Name | Purpose |
+|------|------|---------|
+| 2000 | Accounts Payable | Money owed to vendors |
+| 2100 | Sales Tax Payable | Tax collected, owed to government |
+
+**Revenue (4xxx) - Normal Balance: Credit**
+
+| Code | Name | Purpose |
+|------|------|---------|
+| 4000 | Sales Revenue | Income from product sales |
+| 4010 | Shipping Revenue | Shipping charges collected |
+
+**Expenses (5xxx) - Normal Balance: Debit**
+
+| Code | Name | Purpose |
+|------|------|---------|
+| 5000 | Cost of Goods Sold (COGS) | Material + labor cost of sold items |
+| 5010 | Shipping Expense | Cost of shipping to customers |
+| 5020 | Scrap Expense | Cost of scrapped/failed production |
+| 5030 | Inventory Adjustment | Cost of cycle count corrections |
+| 5100 | COGS - Materials | Material portion of COGS |
+
+### 1.3 Account Types
+
+| Type | Normal Balance | Increases With | Decreases With |
+|------|---------------|----------------|----------------|
+| **Asset** | Debit | Debit | Credit |
+| **Liability** | Credit | Credit | Debit |
+| **Equity** | Credit | Credit | Debit |
+| **Revenue** | Credit | Credit | Debit |
+| **Expense** | Debit | Debit | Credit |
+
+### 1.4 System Accounts
+
+Accounts marked as **system accounts** cannot be deleted. These are the core accounts needed for automatic transaction posting. You can rename them or add sub-accounts, but the codes must remain.
+
+### 1.5 Sub-Accounts
+
+Accounts support **parent-child hierarchy** for detailed tracking:
+
 ```
-DR 1210 WIP
-   CR 1200 Raw Materials
+5000 - Cost of Goods Sold (parent)
+  5010 - Shipping Expense
+  5020 - Scrap Expense
+  5030 - Inventory Adjustment
+  5100 - COGS - Materials
 ```
 
-### Finished Goods Receipt (QC Pass)
+---
+
+## 2. Journal Entries
+
+### 2.1 What is a Journal Entry?
+
+A **Journal Entry** records a financial transaction using double-entry bookkeeping. Every entry has:
+
+- At least **two lines** (minimum one debit and one credit)
+- **Total debits must equal total credits** (balanced)
+- A **source reference** linking to the originating document (PO, SO, etc.)
+
+**Entry Number Format:** `JE-2026-0001` (auto-generated)
+
+### 2.2 Journal Entry Statuses
+
+| Status | Meaning | Editable? | In Reports? |
+|--------|---------|-----------|-------------|
+| **draft** | Created, not yet finalized | Yes | No |
+| **posted** | Finalized and locked | No | Yes |
+| **voided** | Cancelled with reason | No | No |
+
+### 2.3 How Entries Are Created
+
+**Most journal entries are created automatically** by inventory transactions:
+
+**Purchase Order Receipt:**
 ```
-DR 1220 Finished Goods
-   CR 1210 WIP
+DR 1200 Raw Materials Inventory    $125.00
+   CR 2000 Accounts Payable                $125.00
+   (Received 5 KG PLA @ $25/KG)
 ```
 
-### Shipment to Customer
+**Material Issue to Production:**
 ```
-DR 5000 COGS
-   CR 1220 Finished Goods
-DR 5010 Shipping Expense
-   CR 1230 Packaging
-```
-
-### Scrap (QC Fail)
-```
-DR 5020 Scrap Expense
-   CR 1210 WIP
+DR 1210 Work in Process            $11.25
+   CR 1200 Raw Materials Inventory          $11.25
+   (450 G PLA consumed for PO-2026-0042)
 ```
 
-## Troubleshooting
+**Finished Goods Receipt (QC Pass):**
+```
+DR 1220 Finished Goods Inventory   $50.00
+   CR 1210 Work in Process                  $50.00
+   (10 EA Phone Stands completed)
+```
+
+**Shipment to Customer:**
+```
+DR 5000 Cost of Goods Sold         $50.00
+   CR 1220 Finished Goods Inventory         $50.00
+DR 5010 Shipping Expense           $0.10
+   CR 1230 Packaging Inventory              $0.10
+   (Shipped SO-2026-0042)
+```
+
+**Scrap (QC Failure):**
+```
+DR 5020 Scrap Expense              $5.00
+   CR 1210 Work in Process                  $5.00
+   (2 units scrapped - adhesion failure)
+```
+
+**Inventory Adjustment:**
+```
+DR 5030 Inventory Adjustment       $1.25
+   CR 1200 Raw Materials Inventory          $1.25
+   (Cycle count correction: -50 G PLA)
+```
+
+### 2.4 Manual Journal Entries
+
+For transactions not covered by automatic posting, create manual entries:
+
+**Navigation:** Accounting → Journal Entries → **+ New Entry**
+
+**Step 1: Entry Header**
+```
+Description: "Write-off damaged inventory"
+Entry Date: 2026-02-07
+```
+
+**Step 2: Add Lines**
+```
+Line 1: DR 5030 Inventory Adjustment   $25.00
+Line 2: CR 1200 Raw Materials                   $25.00
+```
+
+**Step 3: Verify Balance**
+- System shows: Total Debits = $25.00, Total Credits = $25.00
+- Status: Balanced
+
+**Step 4: Save as Draft or Post**
+- **Save Draft** - Can edit later
+- **Post** - Locks entry, includes in reports
+
+### 2.5 Posting Journal Entries
+
+**From "draft" to "posted":**
+
+1. Open the journal entry
+2. Verify all lines are correct
+3. Confirm the entry is balanced (debits = credits)
+4. Click **Post Entry**
+5. Entry is locked and included in financial reports
+
+**What Happens:**
+- `posted_by` and `posted_at` are recorded
+- Entry becomes read-only
+- Balances update in Trial Balance
+- Entry visible in Transaction Ledger
+
+### 2.6 Voiding Journal Entries
+
+**For posted entries that need correction:**
+
+1. Open the journal entry
+2. Click **Void Entry**
+3. Enter void reason: "Duplicate entry" or "Incorrect amount"
+4. Confirm
+
+**What Happens:**
+- Entry status changes to "voided"
+- `voided_by`, `voided_at`, and `void_reason` are recorded
+- Entry excluded from reports
+- To correct: create a new entry with the right amounts
+
+**You cannot edit a posted entry** - void and recreate instead.
+
+### 2.7 Source Tracking
+
+Every journal entry can link to its source document:
+
+| Source Type | Example | Auto-Created? |
+|-------------|---------|---------------|
+| Purchase Order | PO-2026-010 | Yes (on receipt) |
+| Sales Order | SO-2026-042 | Yes (on shipment) |
+| Production Order | PO-2026-005 | Yes (on completion) |
+| Inventory Adjustment | ADJ-001 | Yes (on adjustment) |
+| Payment | PAY-001 | Yes (on payment record) |
+| Manual | - | No (manual entry) |
+
+Click the source reference in any entry to navigate to the originating document.
+
+---
+
+## 3. Trial Balance
+
+### 3.1 What is a Trial Balance?
+
+The **Trial Balance** is the foundational accounting report. It lists all GL accounts with their debit and credit balances as of a specific date. If total debits equal total credits, the books are **balanced**.
+
+### 3.2 Viewing the Trial Balance
+
+**Navigation:** Accounting → **GL Reports** → **Trial Balance**
+
+**Parameters:**
+- **As of Date** - Report date (defaults to today)
+- **Include Zero Balances** - Show accounts with no activity
+
+**Report Output:**
+
+```
+Trial Balance as of 2026-02-07
+═══════════════════════════════════════════════════════════
+Account   Name                          Debit      Credit
+═══════════════════════════════════════════════════════════
+1000      Cash                       $12,450.00
+1100      Accounts Receivable         $2,350.00
+1200      Raw Materials Inventory     $3,128.50
+1210      Work in Process               $450.00
+1220      Finished Goods Inventory    $1,755.00
+1230      Packaging Inventory           $425.00
+2000      Accounts Payable                        $1,850.00
+2100      Sales Tax Payable                         $312.50
+4000      Sales Revenue                          $15,250.00
+5000      Cost of Goods Sold          $6,854.00
+═══════════════════════════════════════════════════════════
+TOTAL                               $27,412.50  $27,412.50
+                                     ✓ BALANCED
+```
+
+### 3.3 Understanding Normal Balances
+
+Each account type has a **normal balance** side:
+
+- **Assets** (1xxx) - Normally show a **debit** balance
+- **Liabilities** (2xxx) - Normally show a **credit** balance
+- **Revenue** (4xxx) - Normally show a **credit** balance
+- **Expenses** (5xxx) - Normally show a **debit** balance
+
+If an account shows the opposite of its normal balance, investigate (e.g., negative inventory value suggests over-consumption).
+
+### 3.4 When to Review
+
+- **Weekly** - Quick check that books are balanced
+- **Month-end** - Before closing fiscal period
+- **Quarter-end** - Before tax filing preparation
+- **Year-end** - Before annual close and tax preparation
+
+---
+
+## 4. Inventory Valuation
+
+### 4.1 What is Inventory Valuation?
+
+The **Inventory Valuation** report compares the value of physical inventory (from the inventory module) against GL account balances. Any difference is a **variance** that needs investigation.
+
+### 4.2 Viewing Inventory Valuation
+
+**Navigation:** Accounting → **GL Reports** → **Inventory Valuation**
+
+**Report Output:**
+
+```
+Inventory Valuation Report
+═══════════════════════════════════════════════════════════════════
+Category          GL Account   Physical Value   GL Balance   Variance
+═══════════════════════════════════════════════════════════════════════
+Raw Materials     1200         $3,128.50        $3,128.50    $0.00 ✓
+Work in Process   1210           $450.00          $450.00    $0.00 ✓
+Finished Goods    1220         $1,755.00        $1,755.00    $0.00 ✓
+Packaging         1230           $425.00          $425.00    $0.00 ✓
+═══════════════════════════════════════════════════════════════════════
+TOTAL                          $5,758.50        $5,758.50    $0.00 ✓
+```
+
+### 4.3 Understanding Categories
+
+| Category | GL Account | What It Includes |
+|----------|-----------|-----------------|
+| **Raw Materials** | 1200 | Filament, components, hardware not yet in production |
+| **Work in Process** | 1210 | Materials allocated/consumed by active production orders |
+| **Finished Goods** | 1220 | Completed products in inventory, ready to sell |
+| **Packaging** | 1230 | Boxes, bags, labels, packing materials |
+
+**SKU Mapping Logic:**
+- SKUs starting with `MAT-` map to Raw Materials (1200)
+- SKUs starting with `PRD-` or finished goods map to Finished Goods (1220)
+- SKUs starting with `PKG-` map to Packaging (1230)
+- Active production order materials map to WIP (1210)
+
+### 4.4 Investigating Variances
+
+**Common causes of variance:**
+
+1. **Manual inventory adjustments** without corresponding GL entries
+2. **Incomplete transactions** (receipt recorded but GL entry failed)
+3. **Timing differences** (physical count at different time than GL snapshot)
+4. **Pre-existing inventory** (stock existed before the GL system was configured)
+
+**Resolution steps:**
+1. Note the variance amount and category
+2. Check recent inventory transactions for the category
+3. Look for manual adjustments without GL postings
+4. Create a correcting journal entry if needed
+5. Document the cause for audit trail
+
+---
+
+## 5. Transaction Ledger
+
+### 5.1 What is the Transaction Ledger?
+
+The **Transaction Ledger** shows all journal entry lines for a specific GL account, with a **running balance** after each transaction. It's the detailed view of how an account balance was built up over time.
+
+### 5.2 Viewing the Ledger
+
+**Navigation:** Accounting → **GL Reports** → **Transaction Ledger**
+
+**Parameters:**
+- **Account Code** - The GL account to view (e.g., 1200)
+- **Start Date** / **End Date** - Date range filter
+- **Limit** / **Offset** - Pagination
+
+**Report Output:**
+
+```
+Transaction Ledger: 1200 - Raw Materials Inventory
+Period: 2026-02-01 to 2026-02-07
+═══════════════════════════════════════════════════════════════════════════
+Date       Entry #        Description                 Debit    Credit   Balance
+═══════════════════════════════════════════════════════════════════════════
+           Opening Balance                                              $2,500.00
+2026-02-03 JE-2026-0021   PO-2026-010 Receipt       $125.00            $2,625.00
+2026-02-05 JE-2026-0024   PO-2026-005 Consumption            $11.25    $2,613.75
+2026-02-06 JE-2026-0025   PO-2026-008 Consumption            $8.50     $2,605.25
+2026-02-07 JE-2026-0027   ADJ-001 Cycle Count                $1.25     $2,604.00
+═══════════════════════════════════════════════════════════════════════════
+                           Period Activity           $125.00  $21.00
+                           Closing Balance                              $2,604.00
+```
+
+### 5.3 Using the Ledger
+
+**Click any entry** to view the full journal entry details.
+
+**Common uses:**
+- Trace how inventory value changed over a period
+- Find specific transactions by source reference
+- Verify costs were recorded correctly
+- Prepare for audits or tax filing
+- Debug inventory valuation variances
+
+---
+
+## 6. Fiscal Periods
+
+### 6.1 What is a Fiscal Period?
+
+A **Fiscal Period** represents a month in your fiscal year. Periods control when journal entries can be posted:
+
+- **Open period** - New entries allowed
+- **Closed period** - No new entries (historical data locked)
+
+### 6.2 Period Structure
+
+```
+Fiscal Year 2026
+├── Period 1  (Jan 2026)  - Closed ✓
+├── Period 2  (Feb 2026)  - Open (current)
+├── Period 3  (Mar 2026)  - Open
+├── ...
+└── Period 12 (Dec 2026)  - Open
+```
+
+### 6.3 Viewing Fiscal Periods
+
+**Navigation:** Accounting → **Periods**
+
+**Columns:**
+- Year and period number
+- Start date and end date
+- Status (open / closed)
+- Entry count
+- Total debits and credits
+- Closed by / closed at (if closed)
+
+### 6.4 Closing a Period
+
+**Navigation:** Accounting → Periods → Select period → **Close**
+
+**Pre-Close Validation:**
+1. System checks all entries in the period are balanced
+2. Displays summary: entry count, total debits/credits
+3. Warns of any unposted draft entries
+4. Requires confirmation
+
+**Closing Process:**
+1. Click **Close Period**
+2. Review the summary
+3. Confirm closure
+4. Period status changes to "closed"
+5. `closed_by` and `closed_at` recorded
+
+**After Closing:**
+- No new journal entries can be dated in this period
+- Existing entries remain visible (read-only)
+- Reports reflect final numbers
+- Prevents accidental modification of historical data
+
+### 6.5 Reopening a Period
+
+**Use with caution** - only for correcting errors discovered after close.
+
+**Navigation:** Accounting → Periods → Select closed period → **Reopen**
+
+1. Click **Reopen Period**
+2. Confirm the action
+3. Period status changes back to "open"
+4. New entries can now be posted to this period
+5. **Remember to re-close** after making corrections
+
+**When to Reopen:**
+- Discovered a missed invoice from previous month
+- Need to correct a posting error
+- Auditor requires an adjustment
+
+---
+
+## 7. Accounting Dashboard
+
+### 7.1 Dashboard Overview
+
+**Navigation:** Accounting → **Dashboard** (or the summary widget on the main dashboard)
+
+The accounting dashboard provides a real-time financial snapshot.
+
+### 7.2 Key Metrics
+
+**Inventory Value:**
+
+| Category | Value | % of Total |
+|----------|-------|------------|
+| Raw Materials | $3,128.50 | 54% |
+| Work in Process | $450.00 | 8% |
+| Finished Goods | $1,755.00 | 30% |
+| Packaging | $425.00 | 7% |
+| **Total** | **$5,758.50** | **100%** |
+
+**Current Period:**
+- Period: February 2026
+- Status: Open
+- Entries this period: 42
+
+**Activity Metrics:**
+- Entries today: 5
+- Entries this week: 18
+- Entries this month: 42
+
+**Books Status:**
+- Balanced: Yes (DR = CR)
+
+### 7.3 Revenue Metrics
+
+**Month-to-Date (MTD):**
+- Revenue: $4,250.00 (recognized at shipment)
+- Payments Received: $3,800.00
+- Outstanding: $450.00
+
+**Year-to-Date (YTD):**
+- Revenue: $15,250.00
+- Payments Received: $14,100.00
+- Outstanding: $1,150.00
+
+### 7.4 Recent Entries
+
+Shows the last 10 journal entries:
+- Entry number
+- Date
+- Description
+- Total amount
+- Source reference
+
+Click any entry to view full details.
+
+---
+
+## 8. COGS and Gross Margin
+
+### 8.1 Understanding COGS
+
+**Cost of Goods Sold (COGS)** includes only the direct costs of producing items that were shipped:
+
+| Component | Included in COGS? | GL Account |
+|-----------|-------------------|------------|
+| Material cost | Yes | 5100 |
+| Labor cost | Yes | 5000 |
+| Packaging cost | Yes | 5000 |
+| Shipping to customer | **No** (operating expense) | 5010 |
+| Overhead | Depends on setup | 5000 |
+
+**GAAP Rule:** COGS is recognized when goods are **shipped** to the customer, not when produced or ordered.
+
+### 8.2 COGS Summary
+
+**Navigation:** Accounting → **COGS Summary**
+
+**Parameters:**
+- Date range (defaults to last 30 days)
+
+**Report Output:**
+
+```
+COGS Summary: Feb 1-7, 2026
+═══════════════════════════════════════════════
+Component                Amount      % of COGS
+═══════════════════════════════════════════════
+Materials               $1,825.00      67%
+Labor                     $580.00      21%
+Packaging                 $325.00      12%
+───────────────────────────────────────────────
+Total COGS              $2,730.00     100%
+
+Revenue                 $4,250.00
+Gross Profit            $1,520.00
+Gross Margin               35.8%
+═══════════════════════════════════════════════
+```
+
+### 8.3 Order-Level Cost Breakdown
+
+**Navigation:** Accounting → **Order Cost Breakdown** → Select order
+
+View COGS for a specific sales order:
+
+```
+Order: SO-2026-0042
+═══════════════════════════════════════════════
+Material Cost:          $112.50
+  - PLA Black (450 G × 10): $112.50
+Labor Cost:              $40.00
+  - Print time (2.5 hrs × 10): $40.00
+Packaging Cost:           $1.00
+  - Poly bags (10 EA): $1.00
+───────────────────────────────────────────────
+Total COGS:             $153.50
+
+Revenue:                $250.00
+Shipping Charged:        $12.00
+Tax Collected:           $20.63
+
+Gross Profit:            $96.50
+Gross Margin:             38.6%
+═══════════════════════════════════════════════
+```
+
+**Note:** Shipping charges are operational revenue/expense, not part of COGS.
+
+### 8.4 Monitoring Gross Margin
+
+**Target margins for 3D printing:**
+
+| Product Type | Target Margin | Typical Range |
+|-------------|---------------|---------------|
+| Standard products | 40-60% | Predictable cost, volume pricing |
+| Custom orders | 30-50% | Variable print time, unique designs |
+| Rush orders | 50-70% | Premium pricing offsets rush costs |
+
+**If margin drops below target:**
+1. Check material costs (vendor price increases?)
+2. Review scrap rates (high failure = higher COGS)
+3. Analyze labor costs (inefficient operations?)
+4. Review pricing (selling too cheap?)
+
+---
+
+## 9. Tax Reporting
+
+### 9.1 Tax Summary
+
+**Navigation:** Accounting → **Tax Summary**
+
+**Parameters:**
+- Date range
+- Export to CSV option
+
+**Report Output:**
+
+```
+Tax Summary: January 2026
+═══════════════════════════════════════════════
+Taxable Sales:          $12,500.00
+Non-Taxable Sales:       $2,750.00
+  (Tax-exempt customers)
+───────────────────────────────────────────────
+Total Sales:            $15,250.00
+
+Tax Collected:
+  Sales Tax (8.25%):     $1,031.25
+
+Pending (not yet shipped):
+  Taxable Orders:        $3,200.00
+  Estimated Tax:           $264.00
+═══════════════════════════════════════════════
+```
+
+### 9.2 Monthly Tax Breakdown
+
+The tax summary includes a monthly breakdown for quarterly filing:
+
+```
+Month        Taxable Sales    Tax Collected
+───────────────────────────────────────────
+January      $12,500.00       $1,031.25
+February      $4,250.00         $350.63
+March          (in progress)
+───────────────────────────────────────────
+Q1 Total     $16,750.00       $1,381.88
+```
+
+### 9.3 Tax-Exempt Customers
+
+Customers marked as **Tax Exempt** in their profile are excluded from tax calculations. Their sales appear in the "Non-Taxable Sales" line.
+
+**To mark a customer as tax-exempt:**
+1. Navigate to Sales → Customers → Select customer
+2. Enable **Tax Exempt**
+3. All future orders for this customer skip tax
+
+### 9.4 Tax Configuration
+
+**Navigation:** Settings → Company → Tax
+
+```
+Tax Enabled: Yes
+Tax Rate: 0.0825 (decimal = 8.25%)
+Tax Name: "Sales Tax"
+Tax Registration Number: XX-1234567
+```
+
+**Important:** The tax rate is a **decimal**, not a percentage. Enter 0.0825, not 8.25.
+
+---
+
+## 10. Revenue and Payments
+
+### 10.1 Revenue Recognition
+
+FilaOps follows **GAAP accrual accounting** for revenue recognition:
+
+- **Revenue is recognized when goods are shipped** (not when ordered or paid)
+- The `shipped_at` timestamp on the sales order drives recognition
+- Tax is a **liability** (2100 Sales Tax Payable), not revenue
+
+**Example Timeline:**
+```
+Feb 1: Customer places order (SO-2026-042)      → No revenue
+Feb 3: Payment received ($250.00)               → No revenue (deposit)
+Feb 5: Production completes                      → No revenue
+Feb 7: Order shipped                             → Revenue: $250.00 ✓
+```
+
+### 10.2 Sales Journal
+
+**Navigation:** Accounting → **Sales Journal**
+
+**Parameters:**
+- Date range
+- Export to CSV option
+
+**Shows all shipped orders with financial breakdown:**
+
+```
+Sales Journal: February 2026
+═══════════════════════════════════════════════════════════════
+Order #        Customer        Shipped    Subtotal  Tax     Total
+═══════════════════════════════════════════════════════════════
+SO-2026-038    Acme Corp      Feb 03     $150.00   $12.38  $162.38
+SO-2026-039    Beta LLC       Feb 05     $320.00   $26.40  $346.40
+SO-2026-042    Delta Inc      Feb 07     $250.00   $20.63  $270.63
+═══════════════════════════════════════════════════════════════
+TOTAL                                    $720.00   $59.41  $779.41
+```
+
+### 10.3 Payments Journal
+
+**Navigation:** Accounting → **Payments Journal**
+
+**Tracks all completed payments:**
+
+```
+Payments Journal: February 2026
+═══════════════════════════════════════════════════════════════
+Date       Order #        Customer     Method        Amount
+═══════════════════════════════════════════════════════════════
+Feb 01     SO-2026-038    Acme Corp   Credit Card   $162.38
+Feb 03     SO-2026-039    Beta LLC    PayPal        $346.40
+Feb 05     SO-2026-042    Delta Inc   Credit Card   $270.63
+═══════════════════════════════════════════════════════════════
+TOTAL                                               $779.41
+
+By Payment Method:
+  Credit Card:    $433.01  (55%)
+  PayPal:         $346.40  (45%)
+  Manual:           $0.00   (0%)
+```
+
+### 10.4 Outstanding Payments
+
+**Dashboard widget shows:**
+- Orders shipped but not paid
+- Orders with partial payment
+- Overdue payments (past due date)
+
+---
+
+## 11. Schedule C Integration
+
+### 11.1 What is Schedule C?
+
+**IRS Schedule C** (Profit or Loss From Business) is the tax form used by sole proprietors to report business income and expenses. FilaOps maps GL accounts to Schedule C lines to simplify tax preparation.
+
+### 11.2 Account Mapping
+
+Each GL account can be mapped to a Schedule C line:
+
+| GL Account | Schedule C Line | Description |
+|-----------|----------------|-------------|
+| 4000 Sales Revenue | Line 1 | Gross receipts |
+| 5000 COGS | Line 4 | Cost of goods sold |
+| 5010 Shipping Expense | Line 27a | Other expenses |
+| 5020 Scrap Expense | Part III | COGS detail |
+
+### 11.3 Generating Schedule C Report
+
+**Navigation:** Accounting → **Reports** → **Schedule C**
+
+**Output:**
+```
+Schedule C Summary: Tax Year 2025
+═══════════════════════════════════════
+Line 1  - Gross Receipts:    $85,000
+Line 4  - Cost of Goods Sold: $42,500
+Line 5  - Gross Profit:      $42,500
+Line 27 - Other Expenses:     $8,500
+Line 31 - Net Profit:        $34,000
+═══════════════════════════════════════
+```
+
+**Use this report** when preparing your annual tax return or handing data to your accountant.
+
+---
+
+## 12. Data Export
+
+### 12.1 Available Exports
+
+| Report | Format | Navigation |
+|--------|--------|-----------|
+| Sales Journal | CSV | Accounting → Sales Journal → Export |
+| Tax Summary | CSV | Accounting → Tax Summary → Export |
+| Payments Journal | CSV | Accounting → Payments → Export |
+| Trial Balance | Screen | Accounting → GL Reports → Trial Balance |
+| Transaction Ledger | Screen | Accounting → GL Reports → Ledger |
+
+### 12.2 Sales Export for Tax
+
+**Navigation:** Accounting → **Export** → **Sales**
+
+Generates a CSV with all shipped sales orders:
+
+```csv
+order_number,customer,shipped_date,subtotal,tax,shipping,total
+SO-2026-038,Acme Corp,2026-02-03,150.00,12.38,8.00,170.38
+SO-2026-039,Beta LLC,2026-02-05,320.00,26.40,12.00,358.40
+```
+
+**Useful for:**
+- Importing into QuickBooks or other accounting software
+- Providing to your accountant at tax time
+- Reconciling with bank statements
+
+---
+
+## 13. Common Workflows
+
+### Workflow 1: Month-End Close
+
+```
+1. Review Trial Balance
+   - Verify books are balanced (DR = CR)
+   - Investigate any anomalies
+
+2. Review Inventory Valuation
+   - Compare physical to GL balances
+   - Resolve any variances
+
+3. Review COGS Summary
+   - Verify gross margin is reasonable
+   - Check for unusual cost entries
+
+4. Post Draft Entries
+   - Find any unposted draft entries
+   - Review and post or void them
+
+5. Generate Reports
+   - Tax Summary (for quarterly filing)
+   - Sales Journal (for records)
+   - Payments Journal (reconcile with bank)
+
+6. Close Period
+   - Navigate to Periods
+   - Close the current month
+   - Confirm closure
+
+7. Archive
+   - Export reports to CSV for backup
+   - File with monthly financial records
+```
+
+**Time estimate:** 30-60 minutes
+
+### Workflow 2: Quarterly Tax Filing
+
+```
+1. Generate Tax Summary for the quarter
+   - Set date range: Q1 (Jan 1 - Mar 31)
+   - Note total taxable sales and tax collected
+
+2. Export to CSV
+   - Download sales journal CSV
+   - Download tax summary CSV
+
+3. Reconcile
+   - Compare tax collected to bank deposits
+   - Verify payment method totals
+
+4. File
+   - Submit quarterly sales tax return
+   - Pay tax liability to state/local authority
+
+5. Record Payment (optional manual JE)
+   DR 2100 Sales Tax Payable    $1,381.88
+      CR 1000 Cash                       $1,381.88
+   (Quarterly tax payment)
+```
+
+### Workflow 3: Investigating a Variance
+
+```
+1. Run Inventory Valuation report
+   - Notice: Raw Materials GL = $3,128.50, Physical = $3,078.50
+   - Variance: $50.00
+
+2. Check Transaction Ledger for account 1200
+   - Review recent entries
+   - Look for missing or duplicate entries
+
+3. Cross-reference with Inventory Transactions
+   - Compare GL entries to inventory transaction log
+   - Find the discrepancy:
+     "Manual adjustment of -50 G PLA on Feb 6
+      did not create corresponding GL entry"
+
+4. Create correcting entry
+   DR 5030 Inventory Adjustment  $1.25
+      CR 1200 Raw Materials               $1.25
+   (Correct for missing GL entry from inventory adjustment)
+
+5. Post the entry
+
+6. Re-run Inventory Valuation
+   - Verify variance is now $0.00
+```
+
+### Workflow 4: Year-End Close
+
+```
+1. Complete all month-end closes for the year
+   - Close Periods 1-12
+
+2. Generate annual reports
+   - Full-year Trial Balance
+   - Full-year COGS Summary
+   - Full-year Tax Summary
+   - Schedule C report
+
+3. Reconcile
+   - Compare to bank statements
+   - Verify all payments accounted for
+   - Check for outstanding receivables
+
+4. Export everything
+   - Sales Journal (full year)
+   - Tax Summary (full year)
+   - Payments Journal (full year)
+
+5. Provide to accountant
+   - CSV exports
+   - Schedule C summary
+   - Any notes on unusual transactions
+
+6. Start new fiscal year
+   - New periods auto-created
+   - Opening balances carry forward
+```
+
+---
+
+## 14. Best Practices
+
+### General Accounting
+
+- **Do:** Post entries promptly (don't let drafts accumulate)
+- **Do:** Close periods monthly to protect historical data
+- **Do:** Review Trial Balance weekly for balance verification
+- **Do:** Investigate variances immediately (they get harder to trace over time)
+- **Do:** Keep source references on all manual entries
+
+- **Don't:** Leave periods open indefinitely
+- **Don't:** Void entries without documenting the reason
+- **Don't:** Ignore "books unbalanced" warnings
+- **Don't:** Reopen closed periods without good reason
+
+### Inventory Valuation
+
+- **Do:** Run valuation report after each cycle count
+- **Do:** Reconcile GL to physical inventory monthly
+- **Do:** Create correcting entries for variances
+
+- **Don't:** Adjust inventory without corresponding GL entries
+- **Don't:** Ignore small variances (they compound)
+
+### Tax Compliance
+
+- **Do:** Export tax summary quarterly for filing
+- **Do:** Keep CSV exports as backup records
+- **Do:** Verify tax-exempt customer designations annually
+- **Do:** Enter tax rate as a decimal (0.0825), not percentage (8.25)
+
+- **Don't:** Mix up tax rate format (0.0825 vs 8.25)
+- **Don't:** Forget to file quarterly returns
+- **Don't:** Ignore the difference between tax collected and tax owed
+
+---
+
+## 15. Troubleshooting
 
 ### Books Not Balanced
-1. Check Trial Balance for the variance amount
+
+**Symptom:** Trial Balance shows total debits != total credits
+
+**Cause:** A journal entry was posted with unequal debits and credits, or a system error occurred.
+
+**Solution:**
+1. Note the variance amount from Trial Balance
 2. Use Transaction Ledger to find recent entries
 3. Look for entries with only one side (missing DR or CR)
+4. Create a correcting entry to balance
+5. Investigate root cause (software bug? manual entry error?)
 
 ### Inventory Valuation Variance
-1. Compare physical count to system on-hand
-2. Check for manual inventory adjustments
-3. Verify all PO receipts have been recorded
-4. Note: Inventory that existed before the GL system was implemented will show as variance
+
+**Symptom:** Physical inventory value differs from GL balance
+
+**Common Causes:**
+- Manual inventory adjustments without GL entries
+- Incomplete receiving transactions
+- Timing differences between physical count and report
+- Inventory that existed before the GL system was implemented
+
+**Solution:**
+1. Compare physical count to system on-hand quantities
+2. Review recent inventory transactions
+3. Check for manual adjustments in the inventory module
+4. Create correcting journal entries for true variances
+5. Note: Pre-existing inventory (before GL implementation) will always show as variance until a one-time correcting entry is made
 
 ### Cannot Post Entry to Closed Period
+
+**Symptom:** "Cannot post to closed period" error
+
+**Solution:**
 1. Check Periods tab for period status
-2. If needed, reopen the period (admin only)
-3. Post entry, then re-close period
+2. If you need to post to a closed period:
+   - Reopen the period (admin only)
+   - Post the entry
+   - Re-close the period
+3. Or post the entry to the current open period with a note
 
-## Tier Differences
+### COGS Showing $0
 
-| Feature | Community | Pro | Enterprise |
-|---------|-----------|-----|------------|
-| Basic Inventory | ✓ | ✓ | ✓ |
-| GL Reports | - | ✓ | ✓ |
-| Period Management | - | ✓ | ✓ |
-| Transaction Ledger | - | ✓ | ✓ |
-| Audit Trail | - | - | ✓ |
+**Symptom:** COGS Summary shows zero even though orders were shipped
 
-## Dashboard Widgets
+**Cause:** COGS is calculated from shipped orders only. Check:
+- Are orders marked as "shipped"? (not just "completed")
+- Do the products have standard_cost set?
+- Were production orders properly closed (inventory consumed)?
 
-The Accounting Dashboard provides a quick overview:
+**Solution:**
+1. Verify sales orders have `shipped_at` timestamps
+2. Check product cost fields are populated
+3. Review production order closing process
+4. COGS entries should auto-create when orders ship
 
-- **Total Inventory Value**: Sum of all inventory categories
-- **Inventory by Category**: Breakdown by Raw Materials, WIP, Finished Goods, Packaging
-- **Current Period**: Active fiscal period with status
-- **Entry Activity**: Counts for today, this week, and this month
-- **Books Balanced**: Quick indicator if DR = CR
-- **Recent Entries**: Last 10 journal entries with amounts
+### Tax Amount Shows $0
+
+**Symptom:** Orders have no tax calculated
+
+**Cause:**
+- Tax not enabled in company settings
+- Tax rate set to 0
+- Customer marked as tax-exempt
+
+**Solution:**
+1. Settings → Company → Tax → Verify enabled and rate set
+2. Check customer profile for tax-exempt flag
+3. Rate must be decimal: 0.0825 (not 8.25)
+
+---
+
+## 16. Quick Reference
+
+### Transaction Flow Diagram
+
+```
+Purchase Receipt:        DR 1200 Raw Materials    → CR 2000 AP
+Material to Production:  DR 1210 WIP              → CR 1200 Raw Materials
+Finished Goods:          DR 1220 FG Inventory     → CR 1210 WIP
+Ship to Customer:        DR 5000 COGS             → CR 1220 FG Inventory
+Packaging Used:          DR 5010 Shipping Expense  → CR 1230 Packaging
+Scrap:                   DR 5020 Scrap Expense     → CR 1210 WIP
+Inventory Adjustment:    DR 5030 Adj Expense       → CR 1200 Raw Materials
+```
+
+### Journal Entry Lifecycle
+
+```
+draft → posted → (voided if needed)
+```
+
+### Fiscal Period Lifecycle
+
+```
+open → closed → (reopened if needed) → closed
+```
+
+### Key Formulas
+
+**Gross Profit:**
+```
+Gross Profit = Revenue - COGS
+```
+
+**Gross Margin:**
+```
+Gross Margin = (Gross Profit / Revenue) × 100%
+```
+
+**COGS (per order):**
+```
+COGS = Material Cost + Labor Cost + Packaging Cost
+```
+
+**Inventory Value:**
+```
+Total Value = Sum(On-Hand Qty × Unit Cost) for all items
+```
+
+### API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/accounting/trial-balance` | GET | Trial Balance report |
+| `/api/v1/accounting/inventory-valuation` | GET | Inventory vs GL comparison |
+| `/api/v1/accounting/ledger/{account_code}` | GET | Transaction Ledger |
+| `/api/v1/accounting/periods` | GET | List fiscal periods |
+| `/api/v1/accounting/periods/{id}/close` | POST | Close a period |
+| `/api/v1/accounting/periods/{id}/reopen` | POST | Reopen a period |
+| `/api/v1/accounting/summary` | GET | Dashboard summary |
+| `/api/v1/accounting/recent-entries` | GET | Recent journal entries |
+| `/api/v1/admin/accounting/dashboard` | GET | Full accounting dashboard |
+| `/api/v1/admin/accounting/cogs-summary` | GET | COGS breakdown |
+| `/api/v1/admin/accounting/sales-journal` | GET | Sales transaction journal |
+| `/api/v1/admin/accounting/tax-summary` | GET | Tax reporting data |
+| `/api/v1/admin/accounting/payments-journal` | GET | Payment tracking |
+| `/api/v1/admin/accounting/export/sales` | GET | CSV export for tax |
+| `/api/v1/admin/accounting/order-cost-breakdown/{id}` | GET | Per-order COGS |
+
+### Account Type Quick Reference
+
+| Code Range | Type | Normal Balance | Examples |
+|-----------|------|---------------|----------|
+| 1xxx | Asset | Debit | Cash, Inventory, AR |
+| 2xxx | Liability | Credit | AP, Tax Payable |
+| 3xxx | Equity | Credit | Owner's Equity |
+| 4xxx | Revenue | Credit | Sales, Shipping Revenue |
+| 5xxx | Expense | Debit | COGS, Shipping, Scrap |
+
+---
+
+## Related Guides
+
+- **[Getting Started](getting-started.md)** - Initial setup and environment configuration
+- **[Inventory Management](inventory-management.md)** - Physical inventory that feeds GL transactions
+- **[Manufacturing](manufacturing.md)** - Production costs, COGS, and WIP tracking
+- **[Purchasing](purchasing.md)** - Vendor payments and AP entries
+- **[Sales & Quotes](sales-and-quotes.md)** - Revenue, tax, and payment tracking
+- **[Settings & Admin](settings-and-admin.md)** - Tax rate and fiscal year configuration
+
+---
+
+**Need Help?**
+- Consult the [API Reference](../API-REFERENCE.md) for integration details
+- Report issues on [GitHub](https://github.com/Blb3D/filaops/issues)
+- See [Getting Started](getting-started.md) for initial setup
+
+---
+
+*Last Updated: February 2026 | FilaOps v3.0.0*

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,0 +1,410 @@
+# Getting Started with FilaOps
+
+Welcome to FilaOps! This guide will walk you through installing and setting up FilaOps for the first time.
+
+## What is FilaOps?
+
+FilaOps is an open-source ERP system designed specifically for 3D print farm operations. It manages:
+
+- **Inventory** - Track filament spools, hardware, packaging, and finished goods
+- **Manufacturing** - Production orders, BOMs, routings, and MRP
+- **Sales** - Quotes, sales orders, and fulfillment
+- **Purchasing** - Vendor management and purchase orders
+- **Accounting** - General ledger, journal entries, and basic financial reports
+- **Printer Integration** - MQTT monitoring for Bambu Lab printer fleets
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+| Software | Minimum Version | Download |
+|----------|----------------|----------|
+| **Python** | 3.11+ | [python.org](https://www.python.org/downloads/) |
+| **Node.js** | 18+ | [nodejs.org](https://nodejs.org/) |
+| **PostgreSQL** | 15+ | [postgresql.org](https://www.postgresql.org/download/) |
+| **Git** | 2.0+ | [git-scm.com](https://git-scm.com/downloads/) |
+
+**Note:** FilaOps requires PostgreSQL - SQLite is not supported due to the use of PostgreSQL-specific features (JSONB, arrays).
+
+## Installation
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/Blb3D/filaops.git
+cd filaops
+```
+
+### 2. Create PostgreSQL Database
+
+Connect to PostgreSQL and create a database:
+
+```bash
+# Using psql
+psql -U postgres
+
+# In psql:
+CREATE DATABASE filaops;
+\q
+```
+
+Or using a GUI tool like pgAdmin, create a database named `filaops`.
+
+### 3. Configure Environment Variables
+
+Create a `.env` file in the `backend/` directory:
+
+```bash
+cd backend
+cp .env.example .env  # If .env.example exists, otherwise create new .env
+```
+
+Edit `backend/.env` with your database connection details:
+
+```ini
+# Database Configuration
+DATABASE_URL=postgresql+psycopg://postgres:your_password@localhost:5432/filaops
+
+# Security
+SECRET_KEY=your-secret-key-here-change-in-production
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=43200
+
+# Environment
+ENVIRONMENT=development
+
+# Optional: CORS (if frontend runs on different port)
+CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+```
+
+**⚠️ Important:** Change `your_password` to your PostgreSQL password, and generate a secure `SECRET_KEY` for production:
+
+```bash
+# Generate a secure secret key (Linux/Mac):
+openssl rand -hex 32
+
+# Or in Python:
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+### 4. Set Up Backend
+
+```bash
+cd backend
+
+# Create virtual environment
+python -m venv venv
+
+# Activate virtual environment
+# On Windows:
+.\venv\Scripts\Activate
+# On Linux/Mac:
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Run database migrations
+alembic upgrade head
+```
+
+**Expected output:** You should see migration messages ending with "Running upgrade ... -> ..., [migration description]"
+
+### 5. Set Up Frontend
+
+Open a **new terminal window** (keep the backend terminal open):
+
+```bash
+cd frontend
+
+# Install dependencies
+npm install
+
+# Optional: Check for vulnerabilities
+npm audit
+```
+
+### 6. Start the Application
+
+**Terminal 1 - Backend:**
+```bash
+cd backend
+.\venv\Scripts\Activate  # or source venv/bin/activate on Linux/Mac
+uvicorn app.main:app --reload
+```
+
+**You should see:**
+```
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process
+INFO:     Started server process
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+**Terminal 2 - Frontend:**
+```bash
+cd frontend
+npm run dev
+```
+
+**You should see:**
+```
+VITE v5.x.x  ready in xxx ms
+
+➜  Local:   http://localhost:5173/
+➜  Network: use --host to expose
+```
+
+## First-Time Setup
+
+### 1. Access the Setup Wizard
+
+Open your browser and navigate to:
+
+```
+http://localhost:5173
+```
+
+If this is your first time running FilaOps (no users exist), you'll be automatically redirected to the **Setup Wizard**.
+
+### 2. Create Admin Account
+
+Fill in the setup form:
+
+- **Email:** Your admin email (used for login)
+- **Password:** Minimum 8 characters, must meet strength requirements
+- **Full Name:** Your name (e.g., "John Smith")
+- **Company Name:** Optional (e.g., "Acme 3D Printing")
+
+Click **Create Admin Account**.
+
+**✅ Success:** You'll be automatically logged in and taken to the dashboard.
+
+### 3. Seed Example Data (Optional but Recommended)
+
+To help you explore FilaOps, we recommend seeding example data. This creates:
+
+- Example items in each category (finished goods, packaging, hardware)
+- Material types (PLA, PETG, ABS, TPU, etc.)
+- Basic colors (Black, White, Gray, Red, Blue, etc.)
+- Material-color combinations for common filaments
+
+**To seed data:**
+
+1. After creating your admin account, you'll be logged in
+2. Make a POST request to the seed endpoint (requires admin authentication):
+
+**Using curl:**
+```bash
+# First, get your access token (it's automatically stored in the frontend)
+# The seed endpoint is admin-only, so call it through the API:
+
+# Using the frontend console:
+# Open browser DevTools (F12) → Console → Run:
+fetch('/api/v1/setup/seed-example-data', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer ' + localStorage.getItem('access_token')
+  }
+}).then(r => r.json()).then(console.log)
+```
+
+**Or using a REST client like Postman:**
+- Method: `POST`
+- URL: `http://localhost:8000/api/v1/setup/seed-example-data`
+- Headers: `Authorization: Bearer YOUR_ACCESS_TOKEN`
+
+**✅ Success:** You'll see a response like:
+```json
+{
+  "message": "Example data seeded successfully!",
+  "items_created": 10,
+  "items_skipped": 0,
+  "materials_created": 18,
+  "colors_created": 15,
+  "links_created": 24,
+  "material_products_created": 0
+}
+```
+
+Now your system has example data to explore!
+
+## Exploring FilaOps
+
+### Dashboard Overview
+
+After logging in, you'll see the **Admin Dashboard** with:
+
+- **Sales Chart:** Visual of recent sales orders
+- **Production Pipeline:** Current production orders by status
+- **Recent Orders:** Latest sales orders
+- **Quick Actions:** Buttons to create new records
+
+### Navigation Menu
+
+The left sidebar provides access to all modules:
+
+| Icon | Module | What It Does |
+|------|--------|--------------|
+| 📊 | Dashboard | Overview and quick actions |
+| 📦 | Items | Product catalog, BOMs, categories |
+| 🏭 | Production | Production orders, operations, capacity |
+| 📋 | MRP | Material Requirements Planning |
+| 🛒 | Purchasing | Vendors, purchase orders, receiving |
+| 💰 | Sales | Quotes, sales orders, customers |
+| 🖨️ | Printers | MQTT fleet monitoring (Bambu Lab) |
+| 📒 | Accounting | General ledger, journal entries, reports |
+| ⚙️ | Settings | Company settings, users, locations |
+
+## Creating Your First Sales Order
+
+Let's walk through creating a complete sales order:
+
+### 1. Create a Customer
+
+**Navigation:** Sales → Customers → **+ New Customer**
+
+Fill in:
+- **Name:** "Acme Corporation"
+- **Email:** customer@example.com
+- **Phone:** (optional)
+- **Address:** (optional)
+
+Click **Save**. Customer code (e.g., `CUST-00001`) is auto-generated.
+
+### 2. Create a Sales Order
+
+**Navigation:** Sales → Sales Orders → **+ New Sales Order**
+
+**Step 1: Customer Selection**
+- Select customer: "Acme Corporation"
+- Order date: (defaults to today)
+- Due date: (optional)
+
+**Step 2: Add Line Items**
+- Click **+ Add Line**
+- Select a product (e.g., "Example Standard Product")
+- Quantity: 5
+- Unit price: (auto-filled from product's selling price, or enter custom price)
+- Click **Add**
+
+**Step 3: Review and Submit**
+- Review order total
+- Add notes (optional)
+- Click **Create Sales Order**
+
+**✅ Success:** Your first sales order is created with status "Draft"!
+
+### 3. View the Sales Order
+
+The order appears in **Sales → Sales Orders** with:
+- Auto-generated SO number (e.g., `SO-2026-00001`)
+- Customer name
+- Total amount
+- Status: "Draft"
+
+**Next steps:**
+- Click **Confirm** to change status to "Confirmed"
+- When ready to ship, mark as "Shipped"
+- When payment received, mark as "Completed"
+
+## What's Next?
+
+Now that FilaOps is running, explore these guides:
+
+| Guide | Learn About |
+|-------|-------------|
+| **Sales & Quotes** | Quote workflow, converting quotes to orders, pricing |
+| **Inventory Management** | Stock adjustments, cycle counting, spool tracking |
+| **Manufacturing** | Production orders, BOMs, routings, operations |
+| **Purchasing** | Creating POs, receiving inventory, vendor management |
+| **MRP** | Running MRP, planned orders, firming and releasing |
+| **Accounting** | Chart of accounts, journal entries, reports |
+
+## Verification Checklist
+
+✅ **Backend running:** http://127.0.0.1:8000 shows "FilaOps API is running"
+✅ **Frontend running:** http://localhost:5173 loads the application
+✅ **Database connected:** No connection errors in backend terminal
+✅ **Admin account created:** You can log in
+✅ **Example data seeded:** (optional) Items and materials visible in UI
+✅ **First sales order created:** Order appears in Sales Orders list
+
+## Common Issues
+
+### "Module not found" errors (Backend)
+
+**Problem:** Missing Python dependencies
+
+**Solution:**
+```bash
+cd backend
+.\venv\Scripts\Activate
+pip install -r requirements.txt
+```
+
+### "Cannot connect to database" error
+
+**Problem:** PostgreSQL not running or wrong credentials in `.env`
+
+**Solution:**
+- Check PostgreSQL is running: `psql -U postgres -c "SELECT version();"`
+- Verify DATABASE_URL in `backend/.env` matches your PostgreSQL credentials
+- Ensure database `filaops` exists: `psql -U postgres -c "CREATE DATABASE filaops;"`
+
+### Frontend shows "Network Error"
+
+**Problem:** Backend not running or CORS misconfiguration
+
+**Solution:**
+- Ensure backend is running on http://127.0.0.1:8000
+- Check `backend/.env` has `CORS_ORIGINS=http://localhost:5173`
+- Restart backend after changing `.env`
+
+### "Setup already complete" when trying to seed data
+
+**Problem:** The `/setup/initial-admin` endpoint is disabled after first user is created
+
+**Solution:** This is expected. The seed data endpoint is at `/setup/seed-example-data` and requires admin authentication (see "Seed Example Data" section above).
+
+### Migrations fail with "relation already exists"
+
+**Problem:** Database schema conflicts from previous installation
+
+**Solution:**
+```bash
+# Drop and recreate database (⚠️ loses all data!)
+psql -U postgres -c "DROP DATABASE filaops;"
+psql -U postgres -c "CREATE DATABASE filaops;"
+
+# Re-run migrations
+cd backend
+alembic upgrade head
+```
+
+## Getting Help
+
+- **Documentation:** See other guides in `docs/user-guide/`
+- **API Reference:** `docs/API-REFERENCE.md`
+- **Issues:** [GitHub Issues](https://github.com/Blb3D/filaops/issues)
+- **Contributing:** See `CONTRIBUTING.md`
+
+## Development vs. Production
+
+This guide covers **development setup**. For production deployment:
+
+- Use a production-grade WSGI server (Gunicorn, uWSGI)
+- Serve frontend as static build (`npm run build`)
+- Use a reverse proxy (Nginx, Caddy)
+- Enable HTTPS
+- Use environment-specific `.env` files
+- Set strong `SECRET_KEY` and `DATABASE_URL`
+- Configure backups for PostgreSQL
+
+See deployment guides (coming soon) for production setup.
+
+---
+
+**🎉 Congratulations!** You've successfully installed FilaOps and created your first sales order. Explore the other modules and see the power of an ERP built for 3D printing.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,67 @@
+# FilaOps User Guide
+
+Welcome to the FilaOps User Guide. This documentation covers all modules of the FilaOps open-source ERP system for 3D print farm operations.
+
+## Quick Start
+
+New to FilaOps? Start here:
+
+1. **[Getting Started](getting-started.md)** - Installation, setup, and your first sales order
+
+## Module Guides
+
+| Guide | Description |
+|-------|-------------|
+| **[Getting Started](getting-started.md)** | Installation, database setup, first-time wizard, creating your first sales order |
+| **[Sales & Quotes](sales-and-quotes.md)** | Quote creation and approval, sales order lifecycle, customers, pricing, fulfillment |
+| **[Inventory Management](inventory-management.md)** | Items, stock levels, transactions, spool tracking, UOM system, cycle counting |
+| **[Manufacturing](manufacturing.md)** | Production orders, BOMs, routings, work centers, QC, scrap and rework |
+| **[Purchasing](purchasing.md)** | Vendors, purchase orders, receiving inventory, documents, cost tracking |
+| **[MRP](mrp.md)** | Material Requirements Planning, planned orders, firming, releasing, BOM explosion |
+| **[Printers & Fleet](printers-and-fleet.md)** | Multi-brand printer management, network discovery, MQTT monitoring, maintenance |
+| **[Accounting](accounting-module.md)** | General Ledger, journal entries, trial balance, COGS, tax reporting, fiscal periods |
+| **[Settings & Admin](settings-and-admin.md)** | Company settings, users, locations, materials, work centers, AI configuration |
+
+## Typical Workflow
+
+```
+1. Set Up (once)
+   Getting Started → Settings & Admin
+
+2. Daily Operations
+   Sales & Quotes → Manufacturing → Inventory → Purchasing
+
+3. Planning
+   MRP → Purchasing → Manufacturing
+
+4. Monitoring
+   Printers & Fleet → Manufacturing Dashboard
+
+5. Financial
+   Accounting → Tax Reporting → Month-End Close
+```
+
+## How Modules Connect
+
+```
+Sales & Quotes
+  └→ Manufacturing (production orders from sales orders)
+       ├→ Inventory (material consumption and finished goods)
+       ├→ Printers & Fleet (printer assignment and monitoring)
+       └→ MRP (material shortage detection)
+            └→ Purchasing (purchase orders from MRP)
+                 └→ Inventory (receiving updates stock)
+
+Accounting ← (automatic GL entries from all modules)
+Settings ← (configuration used by all modules)
+```
+
+## Getting Help
+
+- **API Reference:** See `docs/API-REFERENCE.md`
+- **Issues:** [GitHub Issues](https://github.com/Blb3D/filaops/issues)
+- **Contributing:** See `CONTRIBUTING.md` in the repository root
+
+---
+
+*FilaOps v3.0.0 | February 2026*

--- a/docs/user-guide/inventory-management.md
+++ b/docs/user-guide/inventory-management.md
@@ -1,0 +1,1084 @@
+# Inventory Management Guide
+
+This guide covers FilaOps' inventory management system, including stock tracking, adjustments, spool management, and the unique unit of measure (UOM) system for 3D printing materials.
+
+## Overview
+
+FilaOps tracks inventory for all physical items:
+
+- **Filament / Materials** - Raw materials consumed in production (PLA, PETG, ABS, TPU, etc.)
+- **Finished Goods** - Products you sell to customers
+- **Components** - Parts used in assemblies (hardware, inserts, etc.)
+- **Supplies** - Consumables (packaging, labels, etc.)
+
+**Key Features:**
+- ✅ Multi-location inventory tracking
+- ✅ Unit of measure conversions (grams ↔ kilograms)
+- ✅ Material spool tracking with weight management
+- ✅ Cycle counting and physical inventory adjustments
+- ✅ Automatic transactions from production and shipping
+- ✅ Reorder points and safety stock
+- ✅ Cost tracking (FIFO, average, standard)
+
+---
+
+## Part 1: Items (Products)
+
+### What is an Item?
+
+An **Item** (also called **Product**) represents anything tracked in inventory. Each item has:
+
+- **SKU** (Stock Keeping Unit) - Unique identifier (e.g., `MAT-PLA-BASIC-BLK`)
+- **Name** - Human-readable description
+- **Category** - Organizational grouping (FILAMENT > PLA)
+- **Item Type** - Classification (finished_good, component, supply, service)
+- **Unit** - Storage/consumption unit (G for filament, EA for hardware)
+
+### Item Types
+
+| Type | Description | Examples |
+|------|-------------|----------|
+| **finished_good** | Products sold to customers | Phone Stand, Custom Bracket |
+| **component** | Parts used in BOMs | M3 Inserts, Magnets, Screws |
+| **supply** | Consumables not sold | Poly Bags, Shipping Boxes |
+| **service** | Non-physical items | Machine Time, Labor |
+
+### Creating Items
+
+**Navigation:** Items → Products → **+ New Item**
+
+**Step 1: Basic Information**
+
+```
+SKU: BRACKET-001 (auto-generated or manual)
+Name: Desk Mounting Bracket
+Description: "Adjustable bracket for monitor arms"
+
+Item Type: finished_good
+Procurement Type: make (options: make, buy, make_or_buy)
+Category: FINISHED_GOODS > Standard Products
+
+Active: ✓ (items can be deactivated without deletion)
+```
+
+**Step 2: Unit of Measure**
+
+**For Standard Items (Hardware, Finished Goods):**
+```
+Unit: EA (each)
+Purchase UOM: EA
+Purchase Factor: 1
+```
+
+**For Materials (Filament):**
+```
+Unit: G (grams - storage/consumption)
+Purchase UOM: KG (kilograms - how vendors sell)
+Purchase Factor: 1000 (1 KG = 1000 G)
+```
+
+**⚠️ Critical: Material UOM System**
+
+FilaOps uses a dual-unit system for materials:
+- **Storage/Consumption:** Grams (G) for precision
+- **Purchasing:** Kilograms (KG) for vendor pricing
+- **Cost Basis:** $/KG (standard market pricing)
+
+**Why this matters:**
+- Inventory shows: 500 G on hand
+- Purchase order shows: Buy 3 KG @ $25/KG
+- Inventory transaction records: +3000 G @ $0.025/G = $75 total
+
+**See:** [UOM System Deep Dive](#part-7-unit-of-measure-uom-system) below
+
+**Step 3: Costs**
+
+```
+Cost Method: average (options: standard, average, fifo, last)
+
+Standard Cost: $5.00 (fixed cost for manufactured items)
+Average Cost: $4.85 (running average - system calculated)
+Last Cost: $4.75 (most recent purchase)
+Selling Price: $15.00 (customer price)
+```
+
+**Cost Methods:**
+- **standard** - Fixed cost (for manufactured items with set costs)
+- **average** - Weighted average (default, for purchased items)
+- **fifo** - First in, first out (uses last_cost as approximation)
+- **last** - Most recent purchase price
+
+**Step 4: Inventory Settings**
+
+```
+Stocking Policy: on_demand (options: stocked, on_demand)
+  - stocked: Keep minimum on hand, reorder proactively
+  - on_demand: Only order when MRP shows demand
+
+Reorder Point: 100 (when to trigger PO)
+Safety Stock: 50 (buffer for demand variability)
+Lead Time (days): 7 (supplier delivery time)
+
+Min Order Qty: 10 (minimum purchase quantity)
+Preferred Vendor: (select from dropdown)
+```
+
+**Step 5: Physical Properties** (optional)
+
+```
+Weight (oz): 2.5
+Length (in): 4.0
+Width (in): 2.0
+Height (in): 1.0
+
+UPC: 123456789012 (barcode)
+```
+
+**Step 6: Save**
+
+Click **Create Item** → Item is saved and ready for inventory tracking
+
+### Item Categories
+
+**Hierarchical structure** for organization:
+
+```
+FILAMENT
+  ├── PLA
+  ├── PETG
+  ├── ABS
+  └── TPU
+
+PACKAGING
+  ├── Boxes
+  └── Bags
+
+HARDWARE
+  ├── Fasteners
+  └── Inserts
+
+FINISHED_GOODS
+  ├── Standard Products
+  └── Custom Products
+```
+
+**Creating Categories:**
+
+**Navigation:** Items → Categories → **+ New Category**
+
+```
+Code: PLA (unique identifier)
+Name: PLA Filament
+Parent: FILAMENT (optional - for subcategories)
+Sort Order: 10 (display order)
+Active: ✓
+```
+
+---
+
+## Part 2: Inventory Locations
+
+### What is a Location?
+
+A **Location** is a physical or logical place where inventory is stored:
+
+- Warehouse A
+- Shelf B3
+- Bin 5
+- Main Production Floor
+- Shipping Dock
+
+**Locations enable:**
+- Multi-site inventory tracking
+- Warehouse management
+- Transfer tracking between locations
+- Location-specific cycle counts
+
+### Creating Locations
+
+**Navigation:** Settings → Locations → **+ New Location**
+
+```
+Code: WH-A-B3-05 (unique identifier)
+Name: Warehouse A - Shelf B3 - Bin 5
+Type: bin (options: warehouse, shelf, bin, zone, floor)
+
+Parent Location: WH-A-B3 (hierarchical)
+Active: ✓
+```
+
+**Example Hierarchy:**
+```
+Warehouse A (WH-A)
+  ├── Shelf B1 (WH-A-B1)
+  │   ├── Bin 01 (WH-A-B1-01)
+  │   └── Bin 02 (WH-A-B1-02)
+  └── Shelf B2 (WH-A-B2)
+      ├── Bin 01 (WH-A-B2-01)
+      └── Bin 02 (WH-A-B2-02)
+```
+
+### Default Location
+
+When first setting up FilaOps:
+1. One default location is created (e.g., "Main Warehouse")
+2. All inventory defaults to this location
+3. You can create additional locations as needed
+
+---
+
+## Part 3: Stock Levels
+
+### Viewing Inventory
+
+**Navigation:** Items → Inventory
+
+**Columns:**
+- **SKU** - Item identifier
+- **Name** - Item description
+- **Category** - Category path
+- **Location** - Storage location
+- **On Hand** - Physical quantity in stock
+- **Allocated** - Quantity reserved for orders
+- **Available** - On Hand - Allocated = Available for new orders
+- **Unit** - Storage unit (G, EA, etc.)
+- **Value** - Inventory value ($)
+
+**Example:**
+```
+SKU: MAT-PLA-BASIC-BLK
+Name: PLA Basic - Black
+Location: Main Warehouse
+On Hand: 5,000 G
+Allocated: 450 G (reserved for active production orders)
+Available: 4,550 G
+Unit: G
+Value: $125.00 (5000 G × $0.025/G)
+```
+
+### Understanding Quantities
+
+**On Hand Quantity:**
+- Physical stock in location
+- Includes allocated items (they're still physically present)
+
+**Allocated Quantity:**
+- Reserved for production orders
+- Cannot be used for new orders until released
+- Automatically allocated when production order created
+- Automatically released when production completed or cancelled
+
+**Available Quantity:**
+- Available = On Hand - Allocated
+- What MRP sees as "available for new orders"
+- Computed field (not stored, calculated on-the-fly)
+
+**Example Flow:**
+```
+Starting: 1000 G on hand, 0 allocated, 1000 available
+
+Create Production Order for 200 G:
+  → 1000 G on hand, 200 G allocated, 800 G available
+
+Complete Production Order:
+  → 800 G on hand, 0 allocated, 800 G available
+  (200 G consumed, allocation released)
+```
+
+---
+
+## Part 4: Inventory Transactions
+
+### What is a Transaction?
+
+An **Inventory Transaction** records every inventory movement:
+
+- **Receipt** - Receiving inventory from vendor
+- **Issue** - Removing inventory (non-production)
+- **Consumption** - Used in manufacturing
+- **Adjustment** - Correcting discrepancies
+- **Transfer** - Moving between locations
+- **Reservation** - Allocating for production
+- **Scrap** - Damaged/waste material
+
+**All transactions are immutable** - once created, they cannot be edited (only reversed with a new transaction).
+
+### Transaction Types
+
+| Type | Direction | Use Case | Example |
+|------|-----------|----------|---------|
+| **receipt** | + | Receiving from vendor | PO received |
+| **issue** | - | Non-production removal | Sample given away |
+| **consumption** | - | Manufacturing usage | Filament used in print |
+| **adjustment** | ± | Cycle count correction | Physical count shows 980 G vs 1000 G |
+| **transfer** | ± | Moving between locations | WH-A → WH-B |
+| **reservation** | (allocate) | Reserve for production | PO created |
+| **scrap** | - | Damaged/waste | Failed print scrap |
+| **shipment** | - | Customer shipment | SO shipped |
+
+### Viewing Transaction History
+
+**Navigation:** Items → Inventory → Select item → **Transaction History**
+
+**Columns:**
+- **Date** - When transaction occurred
+- **Type** - Transaction type
+- **Quantity** - Amount (+ or -)
+- **Unit** - Unit of measure
+- **Cost** - Cost per unit
+- **Total Cost** - Quantity × Cost
+- **Location** - Storage location
+- **Reference** - Order/PO number
+- **Notes** - Description
+
+**Example History:**
+```
+Date       Type        Qty      Unit  Cost/Unit  Total   Reference    Notes
+---------- ----------- -------- ----- ---------- ------- ------------ -----
+2026-02-05 receipt     +3000 G  G     $0.025     $75.00  PO-2026-010  Received from Vendor A
+2026-02-06 consumption -450 G   G     $0.025     $11.25  PO-2026-005  Production Order
+2026-02-07 adjustment  -50 G    G     $0.025     $1.25   ADJ-001      Cycle count correction
+```
+
+---
+
+## Part 5: Manual Inventory Adjustments
+
+### When to Adjust Inventory
+
+**Common scenarios:**
+- 🔢 **Cycle counting** - Physical count differs from system
+- 📦 **Lost/damaged inventory** - Items broken or misplaced
+- 🔄 **Opening balances** - Setting up initial inventory
+- ✏️ **Data entry errors** - Correcting past mistakes
+
+### Creating Adjustments
+
+**Navigation:** Items → Inventory → **Adjust Inventory**
+
+**Method 1: Single Item Adjustment**
+
+```
+Select Item: MAT-PLA-BASIC-BLK
+Location: Main Warehouse
+
+Current Quantity: 5,000 G
+New Quantity: 4,950 G (physical count)
+
+Reason: Cycle count adjustment
+Notes: "Physical count on 2026-02-07"
+
+Cost per Unit: $0.025/G (auto-filled from item cost)
+```
+
+Click **Submit** → Transaction created:
+- Type: `adjustment`
+- Quantity: -50 G (difference)
+- Total Cost: -$1.25 (inventory value reduction)
+
+**Method 2: Batch Adjustment (Cycle Counting)**
+
+For counting multiple items at once:
+
+**Navigation:** Items → Inventory → **Batch Adjust**
+
+Upload CSV or enter data:
+```csv
+sku,location_code,physical_count
+MAT-PLA-BASIC-BLK,WH-A,4950
+MAT-PETG-HF-WHT,WH-A,3200
+BRACKET-001,WH-A,45
+```
+
+System compares to current quantities and creates adjustment transactions for all differences.
+
+### Negative Inventory
+
+**FilaOps allows negative inventory with approval:**
+
+When a transaction would cause negative stock:
+- Transaction flagged with `requires_approval: true`
+- Reason required: "Emergency production order - PO on the way"
+- Admin must approve
+- Transaction recorded as `negative_adjustment` type
+
+**View pending approvals:** Items → Inventory → **Pending Adjustments**
+
+---
+
+## Part 6: Material Spool Tracking
+
+### What is a Spool?
+
+A **Material Spool** represents a physical roll of filament with:
+
+- **Spool Number** - Unique ID (e.g., `SPOOL-PLA-BLK-001`)
+- **Material** - Link to material product (SKU)
+- **Weight Tracking** - Initial weight → Current weight
+- **Status** - active, empty, expired, damaged
+- **Lot Number** - Vendor's lot/batch (for traceability)
+- **Location** - Where stored
+
+**Why track spools?**
+- ✅ **Traceability** - Know which spool used in which order
+- ✅ **Weight management** - Track remaining material accurately
+- ✅ **Shelf life** - Monitor expiration dates (TPU, Nylon)
+- ✅ **Quality control** - Identify problematic batches
+
+### Creating Spools
+
+**Navigation:** Items → Spools → **+ New Spool**
+
+**When receiving filament:**
+
+```
+Spool Number: SPOOL-PLA-BLK-001 (auto-generated)
+Material: MAT-PLA-BASIC-BLK
+
+Initial Weight: 1.000 kg (full roll)
+Current Weight: 1.000 kg (same at creation)
+
+Status: active
+Received Date: 2026-02-05
+Expiry Date: (optional - for hygroscopic materials)
+
+Location: WH-A-B1-03
+Supplier Lot Number: LOT-2026-0205 (vendor's batch)
+
+Notes: "Arrived sealed, good condition"
+```
+
+**Result:**
+- Spool created and tracked
+- Links to material SKU for cost/properties
+- Available for production order assignment
+
+### Spool Consumption Tracking
+
+**During Production:**
+
+When a production order uses material:
+1. Assign spool to production order
+2. Record weight consumed (e.g., 450 G)
+3. Update spool current weight:
+   - Initial: 1000 G
+   - Consumed: 450 G
+   - Current: 550 G (1000 - 450)
+4. Link spool to production order for traceability
+
+**Low Spool Alert:**
+- When spool < 10% remaining → Status shows "Low"
+- When spool < 50 G → Automatically marked "empty"
+
+**View Spool History:**
+
+**Navigation:** Items → Spools → Select spool → **History**
+
+Shows all production orders that used this spool:
+```
+PO-2026-005 → 450 G consumed → Customer Order SO-2026-042
+PO-2026-008 → 320 G consumed → Customer Order SO-2026-044
+PO-2026-012 → 180 G consumed → Customer Order SO-2026-051
+```
+
+**Result:** Full traceability from raw material spool → production order → sales order → customer
+
+---
+
+## Part 7: Unit of Measure (UOM) System
+
+### The Dual-Unit Challenge
+
+**Problem:** Vendors sell filament in **kilograms**, but production consumes in **grams**.
+
+**FilaOps Solution:** Dual-unit system with automatic conversion.
+
+### How It Works
+
+**Material Product Setup:**
+```
+Product: MAT-PLA-BASIC-BLK
+  unit: G (grams - storage/consumption)
+  purchase_uom: KG (kilograms - purchasing)
+  purchase_factor: 1000 (1 KG = 1000 G)
+  standard_cost: $25.00 (per KG)
+```
+
+**Purchase Order:**
+```
+PO Line: 3 KG @ $25/KG = $75.00
+```
+
+**Inventory Transaction (Receipt):**
+```
+Quantity: 3000 G (converted from 3 KG × 1000)
+Cost per Unit: $0.025/G (converted from $25/KG ÷ 1000)
+Total Cost: $75.00 (3000 G × $0.025/G)
+Unit: G (stored for display)
+```
+
+**Inventory Display:**
+```
+On Hand: 3000 G
+Value: $75.00 (3000 G × $0.025/G)
+```
+
+**Production Consumption:**
+```
+BOM requires: 450 G
+Transaction: -450 G @ $0.025/G = $11.25 COGS
+```
+
+### Cost Storage Rule
+
+**⚠️ CRITICAL: Costs are stored as $/KG (purchase UOM), not $/G**
+
+**Product.standard_cost:** $25.00 (per KG)
+**Product.average_cost:** $24.50 (per KG)
+**Product.last_cost:** $24.75 (per KG)
+
+**When calculating inventory value:**
+```
+Inventory Value = Quantity (G) × (Cost per KG ÷ 1000)
+                = 3000 G × ($25/KG ÷ 1000)
+                = 3000 × $0.025
+                = $75.00
+```
+
+**System handles this automatically** - you never manually calculate.
+
+### UOM for Non-Material Items
+
+**Standard Items (Hardware, Finished Goods):**
+```
+unit: EA
+purchase_uom: EA
+purchase_factor: 1
+```
+
+**No conversion needed** - simple 1:1 relationship.
+
+### UOM Best Practices
+
+✅ **Do:**
+- Let the system handle all UOM conversions
+- Enter purchase orders in vendor's units (KG)
+- Trust inventory displays in storage units (G)
+- Use spool tracking for accurate weight management
+
+❌ **Don't:**
+- Manually convert units (system does this)
+- Change purchase_factor after transactions exist
+- Mix units within same material (always G/KG/1000)
+
+---
+
+## Part 8: Cycle Counting
+
+### What is Cycle Counting?
+
+**Cycle counting** is a periodic physical inventory check:
+- Count subset of inventory regularly (daily/weekly)
+- Compare physical count to system quantity
+- Adjust discrepancies immediately
+- Rotate through all items over time
+
+**Benefits:**
+- ✅ Maintain inventory accuracy without full shutdowns
+- ✅ Identify shrinkage/theft
+- ✅ Catch data entry errors early
+- ✅ Improve trust in system data
+
+### Cycle Count Workflow
+
+**Step 1: Generate Count Sheet**
+
+**Navigation:** Items → Inventory → **Cycle Count**
+
+Select items to count:
+```
+Filter by:
+  - Category: FILAMENT
+  - Location: WH-A
+  - Last Counted: > 30 days ago
+  - Value: > $500 (ABC analysis - count high-value items more often)
+```
+
+**Generate Count Sheet** → Download CSV or print:
+```csv
+sku,name,location,expected_qty,unit,counted_qty
+MAT-PLA-BASIC-BLK,PLA Basic - Black,WH-A,5000,G,
+MAT-PETG-HF-WHT,PETG HF - White,WH-A,3500,G,
+BRACKET-001,Desk Bracket,WH-A,48,EA,
+```
+
+**Step 2: Physical Count**
+
+- Print count sheet
+- Walk warehouse with sheet
+- Count physical inventory
+- Record counts in `counted_qty` column
+
+**Step 3: Enter Counts**
+
+**Navigation:** Items → Inventory → **Batch Adjust**
+
+Upload completed count sheet:
+```csv
+sku,name,location,expected_qty,unit,counted_qty
+MAT-PLA-BASIC-BLK,PLA Basic - Black,WH-A,5000,G,4950
+MAT-PETG-HF-WHT,PETG HF - White,WH-A,3500,G,3500
+BRACKET-001,Desk Bracket,WH-A,48,EA,47
+```
+
+**Step 4: Review Discrepancies**
+
+System shows differences:
+```
+MAT-PLA-BASIC-BLK: Expected 5000 G, Counted 4950 G → Variance: -50 G (-1.0%)
+BRACKET-001: Expected 48 EA, Counted 47 EA → Variance: -1 EA (-2.1%)
+```
+
+**Step 5: Approve Adjustments**
+
+- Review variances
+- Add notes (reason for discrepancy)
+- Click **Submit Adjustments**
+
+**Result:**
+- Adjustment transactions created
+- Inventory quantities updated
+- `last_counted` field updated to today
+- Inventory value recalculated
+
+### ABC Analysis for Cycle Counting
+
+**Prioritize high-value items:**
+
+| Class | Criteria | Count Frequency |
+|-------|----------|-----------------|
+| **A** | Top 20% by value | Weekly |
+| **B** | Next 30% by value | Monthly |
+| **C** | Bottom 50% by value | Quarterly |
+
+**Example:**
+- Class A: Expensive materials (PAHT-CF, PC) → Count weekly
+- Class B: Standard materials (PLA, PETG) → Count monthly
+- Class C: Low-cost supplies (bags, labels) → Count quarterly
+
+---
+
+## Part 9: Reorder Points and MRP Integration
+
+### Setting Reorder Points
+
+**Reorder Point** = When to trigger purchase order
+
+**Formula:**
+```
+Reorder Point = (Daily Usage × Lead Time) + Safety Stock
+```
+
+**Example:**
+```
+Material: PLA Basic Black
+Daily Usage: 500 G/day (average)
+Lead Time: 7 days
+Safety Stock: 1000 G (buffer)
+
+Reorder Point = (500 G/day × 7 days) + 1000 G
+              = 3500 G + 1000 G
+              = 4500 G
+
+When inventory drops to 4500 G → Create PO
+```
+
+**Setting in System:**
+
+**Navigation:** Items → Products → Select item → Edit
+
+```
+Stocking Policy: stocked
+Reorder Point: 4500 G
+Safety Stock: 1000 G
+Lead Time: 7 days
+Min Order Qty: 5 KG (5000 G)
+```
+
+### Automatic Reorder via MRP
+
+**MRP (Material Requirements Planning) automates reordering:**
+
+1. MRP runs daily (or on-demand)
+2. Calculates net requirements:
+   ```
+   Net Required = Demand - On Hand + Safety Stock - On Order
+   ```
+3. Generates **Planned Orders** for items below reorder point
+4. User reviews and converts to Purchase Orders
+
+**See:** [MRP Guide](mrp.md) for full MRP workflow
+
+---
+
+## Part 10: Integration with Manufacturing
+
+### Production Consumption
+
+**When production order completes:**
+
+1. **Material Consumption** - Automatic transactions:
+   ```
+   BOM Line: 450 G PLA Basic Black
+   → Transaction: -450 G (consumption)
+   → Cost: $11.25 (450 G × $0.025/G)
+   → Reduce on_hand by 450 G
+   → Release allocation (if reserved)
+   ```
+
+2. **Finished Goods Receipt** - Automatic transactions:
+   ```
+   Production Order Output: 10 EA Phone Stands
+   → Transaction: +10 EA (receipt from production)
+   → Cost: $50.00 (based on BOM + labor)
+   → Add to finished goods inventory
+   ```
+
+**All automatic** - no manual inventory entries needed for production.
+
+### Allocation System
+
+**When production order created:**
+```
+BOM requires: 450 G PLA Basic Black
+Current inventory: 5000 G on hand, 0 allocated
+
+Action: Reserve 450 G
+Result: 5000 G on hand, 450 G allocated, 4550 G available
+```
+
+**Available quantity drops** so MRP knows those 450 G are spoken for.
+
+**When production completes/cancels:**
+- Material consumed: -450 G from on_hand, -450 G from allocated
+- Final: 4550 G on hand, 0 allocated, 4550 G available
+
+---
+
+## Part 11: Inventory Reports
+
+### Stock Status Report
+
+**Navigation:** Items → Inventory → **Reports** → Stock Status
+
+**Columns:**
+- SKU, Name, Category
+- On Hand, Allocated, Available
+- Unit, Unit Cost
+- Inventory Value
+- Reorder Point
+- Days of Stock (on hand ÷ daily usage)
+
+**Filters:**
+- Location
+- Category
+- Item Type
+- Below Reorder Point (alerts)
+- Negative Inventory (issues)
+
+### Inventory Valuation
+
+**Total inventory value by category:**
+
+```
+Category            Items   Qty         Value      % of Total
+FILAMENT            87      125,450 G   $3,128.50  62%
+PACKAGING           12      850 EA      $425.00    8%
+HARDWARE            34      2,340 EA    $585.00    12%
+FINISHED_GOODS      45      234 EA      $1,755.00  35%
+──────────────────────────────────────────────────────────
+TOTAL               178                 $5,893.50  100%
+```
+
+### Transaction History Report
+
+**View all transactions by date range:**
+
+**Navigation:** Items → Inventory → **Reports** → Transaction History
+
+**Filters:**
+- Date Range
+- Transaction Type
+- Location
+- SKU
+
+**Export to CSV** for analysis in Excel/spreadsheet.
+
+---
+
+## Part 12: Best Practices
+
+### Inventory Accuracy
+
+✅ **Do:**
+- Perform cycle counts regularly
+- Investigate variances > 2%
+- Update costs when purchasing
+- Use spool tracking for materials
+- Keep locations organized and labeled
+
+❌ **Don't:**
+- Ignore small discrepancies (they compound)
+- Skip recording scrap/waste
+- Manually adjust without reason/notes
+- Change reorder points without data analysis
+
+### Material Management
+
+✅ **Do:**
+- Track spools from receipt to consumption
+- Rotate stock (FIFO) for materials with shelf life
+- Store hygroscopic materials (Nylon, TPU) properly
+- Label spools with received date and lot number
+- Monitor low spool alerts
+
+❌ **Don't:**
+- Mix spools of same material without tracking
+- Use expired materials (check expiry_date)
+- Store materials in humid conditions
+- Leave spools on printers when not in use
+
+### Cost Management
+
+✅ **Do:**
+- Update standard costs when vendor prices change
+- Review average costs quarterly
+- Use standard costing for manufactured items
+- Use average costing for purchased materials
+- Track cost variances
+
+❌ **Don't:**
+- Leave cost fields blank (breaks valuation)
+- Change cost method after many transactions
+- Forget to update costs after price increases
+
+---
+
+## Part 13: Common Workflows
+
+### Workflow 1: Receiving Filament
+
+```
+1. Vendor ships 5 KG of PLA Basic Black
+2. Receive shipment
+3. Create spool records:
+   - SPOOL-PLA-BLK-010 (1 KG)
+   - SPOOL-PLA-BLK-011 (1 KG)
+   - SPOOL-PLA-BLK-012 (1 KG)
+   - SPOOL-PLA-BLK-013 (1 KG)
+   - SPOOL-PLA-BLK-014 (1 KG)
+4. Each spool shows:
+   - Initial Weight: 1.000 kg
+   - Current Weight: 1.000 kg
+   - Status: active
+5. Inventory updated:
+   - +5000 G (5 KG × 1000)
+   - Cost: $125.00 (5000 G × $0.025/G)
+```
+
+### Workflow 2: Production Consumption
+
+```
+1. Production order created for 10 phone stands
+2. BOM requires: 450 G PLA per unit = 4500 G total
+3. System reserves 4500 G (allocated)
+4. Production order assigned spool: SPOOL-PLA-BLK-010
+5. Production completes
+6. System records:
+   - Material consumption: -4500 G
+   - Spool updated: 1000 G → 550 G remaining
+   - Finished goods receipt: +10 EA
+7. Allocation released
+```
+
+### Workflow 3: Cycle Count Correction
+
+```
+1. Generate count sheet for FILAMENT category
+2. Physical count shows: 4950 G (expected 5000 G)
+3. Enter counted quantity: 4950 G
+4. System creates adjustment: -50 G
+5. Investigate:
+   - Check scrap records
+   - Review recent production
+   - Ask operators
+6. Document reason: "Unrecorded test prints"
+7. Approve adjustment
+8. Inventory updated to 4950 G
+```
+
+---
+
+## Part 14: Troubleshooting
+
+### Inventory Shows Negative Quantity
+
+**Problem:** Item shows -50 G on hand
+
+**Cause:**
+- Consumption transaction recorded before receipt
+- Manual adjustment error
+- Production order consumed more than available
+
+**Solution:**
+1. Review transaction history for item
+2. Identify incorrect transaction
+3. Create correction adjustment to fix
+4. Update processes to prevent recurrence
+
+### Available Quantity Incorrect
+
+**Problem:** Available = 500 G, but should be 1000 G
+
+**Cause:**
+- Allocated quantity not released after PO cancellation
+- Reservation transaction orphaned
+
+**Solution:**
+1. Check allocated_quantity field
+2. Find orphaned reservations:
+   ```
+   Items → Inventory → Item detail → Allocations
+   ```
+3. Release orphaned allocations manually
+4. Verify production orders associated
+
+### Spool Weight Tracking Off
+
+**Problem:** Spool shows 800 G remaining, but scale shows 600 G
+
+**Cause:**
+- Manual consumption not recorded
+- Production order didn't update spool
+- Spool used for test prints
+
+**Solution:**
+1. Weigh spool physically
+2. Adjust spool weight to match scale
+3. Investigate missing transactions
+4. Update production recording process
+
+### Cost per Unit Shows $0.00
+
+**Problem:** Transaction shows no cost
+
+**Cause:**
+- Product has no cost fields set
+- Cost not entered on receipt
+- New product without initial cost
+
+**Solution:**
+1. Edit product → Set standard_cost
+2. Re-run inventory valuation
+3. Future transactions will have cost
+4. Past transactions remain $0 (historical)
+
+---
+
+## Part 15: Advanced Features
+
+### Multi-Location Transfers
+
+**Transfer inventory between locations:**
+
+**Navigation:** Items → Inventory → **Transfer**
+
+```
+Item: MAT-PLA-BASIC-BLK
+From Location: WH-A
+To Location: WH-B
+Quantity: 1000 G
+Reason: "Rebalancing inventory"
+```
+
+**Result:**
+- Transaction 1: -1000 G @ WH-A (issue)
+- Transaction 2: +1000 G @ WH-B (receipt)
+- Net inventory unchanged, location changed
+
+### Lot/Serial Tracking
+
+**Track batches for quality control:**
+
+```
+Lot Number: LOT-2026-0205 (vendor's batch)
+Serial Number: SERIAL-001 (unique item)
+```
+
+**Used for:**
+- Material lot traceability (which batch had defects?)
+- Warranty tracking (which serial returned?)
+- Recall management (which lots affected?)
+
+**View items by lot:**
+
+**Navigation:** Items → Inventory → **By Lot/Serial**
+
+Shows all inventory quantities by lot number for recall scenarios.
+
+### Inventory Alerts
+
+**Automated notifications for:**
+
+- ⚠️ **Below Reorder Point** - Time to purchase
+- 🔴 **Negative Inventory** - Investigation needed
+- 📉 **Low Spools** - < 10% remaining
+- 📅 **Expiring Materials** - Nylon/TPU approaching expiry
+- 💰 **High Value Variances** - Cycle count differences > $100
+
+**Configure alerts:** Settings → Notifications → Inventory Alerts
+
+---
+
+## Next Steps
+
+Now that you understand inventory management, explore these related guides:
+
+| Guide | Learn About |
+|-------|-------------|
+| **Manufacturing** | How production consumes materials, BOMs, routings |
+| **MRP** | Automatic reorder point calculations, planned orders |
+| **Purchasing** | Creating POs, receiving inventory, vendor management |
+| **Accounting** | COGS calculation, inventory valuation, financial reports |
+
+## Quick Reference
+
+### Transaction Types Quick Guide
+
+| Type | On Hand | Allocated | Available | Use Case |
+|------|---------|-----------|-----------|----------|
+| **receipt** | + | - | + | Receiving from vendor |
+| **consumption** | - | - (if released) | - | Manufacturing usage |
+| **adjustment** | ± | - | ± | Cycle count correction |
+| **reservation** | - | + | - | Allocate for production |
+| **reservation_release** | - | - | + | Cancel allocation |
+
+### UOM Conversion Quick Reference
+
+```
+Purchase: 3 KG @ $25/KG
+  ↓ (× 1000 for quantity, ÷ 1000 for cost)
+Inventory: 3000 G @ $0.025/G = $75.00
+```
+
+### Keyboard Shortcuts
+
+- `n` - New item
+- `a` - Adjust inventory
+- `t` - Transfer
+- `r` - Refresh list
+- `/` - Search
+
+---
+
+**🎉 Congratulations!** You now understand FilaOps inventory management, including the critical UOM system for 3D printing materials. Set up your locations, create items, and start tracking inventory!

--- a/docs/user-guide/manufacturing.md
+++ b/docs/user-guide/manufacturing.md
@@ -1,0 +1,1222 @@
+# Manufacturing Guide
+
+This guide covers FilaOps' manufacturing system for 3D print production, including production orders, BOMs, routings, work centers, and quality control.
+
+## Overview
+
+FilaOps manufacturing system manages the entire production workflow:
+
+- **Production Orders** - Work orders to manufacture products
+- **BOMs (Bill of Materials)** - What components/materials are needed
+- **Routings** - How to make the product (process steps)
+- **Work Centers** - Where production happens (printer pools, stations)
+- **Resources** - Individual machines/printers
+- **Operations** - Individual steps in the manufacturing process
+- **Quality Control** - QC inspection and approval workflow
+
+**Manufacturing Flow:**
+```
+Sales Order → Production Order → Allocate Materials →
+Release to Production → Execute Operations → QC Inspection →
+Receive Finished Goods → Ship to Customer
+```
+
+---
+
+## Part 1: Production Orders
+
+### What is a Production Order?
+
+A **Production Order** (also called **Manufacturing Order** or **Work Order**) is an instruction to manufacture a specific quantity of a product.
+
+**Production orders can be created from:**
+- Sales orders (make-to-order)
+- MRP planned orders (make-to-stock)
+- Manual entry (ad-hoc production)
+
+**Each production order tracks:**
+- What to make (product)
+- How much to make (quantity)
+- When it's due (due date)
+- How to make it (BOM + routing)
+- Current status (draft → in_progress → completed)
+- Material consumption
+- Labor hours
+- Costs
+
+### Production Order Statuses
+
+| Status | Meaning | Next Actions |
+|--------|---------|--------------|
+| **draft** | Created but not ready | Review and release |
+| **released** | Materials allocated, ready to schedule | Assign to work center |
+| **scheduled** | Assigned to printer/work center, queued | Start production |
+| **in_progress** | Job actively running | Monitor, complete |
+| **completed** | Manufacturing finished, awaiting QC | QC inspection |
+| **qc_hold** | QC failed, needs decision | Scrap or rework |
+| **closed** | Parts accepted, inventory updated | Archive |
+| **cancelled** | Order terminated | No further action |
+| **on_hold** | Production paused | Resume or cancel |
+
+### Production Order Lifecycle
+
+**Standard Flow:**
+```
+draft → released → scheduled → in_progress → completed → closed
+```
+
+**QC Flow (if required):**
+```
+completed → [QC pending] → [QC passed] → closed
+          ↓
+    [QC failed] → qc_hold → (scrap + remake) OR (rework)
+```
+
+### Creating Production Orders
+
+**Navigation:** Manufacturing → Production Orders → **+ New Production Order**
+
+**Step 1: Product Selection**
+
+```
+Product: Select from dropdown
+  - Shows products with procurement_type = 'make'
+  - Must have BOM and/or Routing
+
+Quantity: 10 (units to produce)
+
+Source: manual (options: manual, sales_order, mrp_planned)
+Order Type: MAKE_TO_ORDER (options: MAKE_TO_ORDER, MAKE_TO_STOCK)
+  - MTO: For specific customer order, ships when complete
+  - MTS: For inventory stock, sits on shelf until sold
+```
+
+**Step 2: BOM Selection**
+
+```
+BOM: BOM-001 v1 (Bill of Materials)
+  - Auto-selects active BOM for product
+  - Shows material requirements
+  - Example:
+    Line 1: 450 G PLA Basic Black (filament)
+    Line 2: 1 EA M3 Insert (hardware)
+    Line 3: 1 EA Poly Bag (packaging)
+```
+
+**Step 3: Routing Selection**
+
+```
+Routing: ROUTING-001 v1 (Manufacturing Process)
+  - Auto-selects active routing for product
+  - Shows operations sequence
+  - Example:
+    OP-10: Print (FDM Pool, 2.5 hrs)
+    OP-20: Insert Hardware (Assembly, 5 min)
+    OP-30: QC Inspection (QC Station, 5 min)
+    OP-40: Pack (Shipping, 3 min)
+```
+
+**Step 4: Scheduling**
+
+```
+Due Date: 2026-02-15 (when customer needs it)
+Priority: 3 (1=highest, 5=lowest)
+
+Assigned To: (operator name, optional)
+```
+
+**Step 5: Sales Order Link** (optional)
+
+```
+Sales Order: SO-2026-0042 (links to customer order)
+  - Auto-fills when creating from sales order
+  - Tracks which customer order this fulfills
+```
+
+**Step 6: Submit**
+
+Click **Create Production Order** → PO number generated (e.g., `PO-2026-0001`)
+
+**✅ Result:** Production order created with status "draft"
+
+### Releasing Production Orders
+
+**From "draft" → "released":**
+
+When you release a production order:
+1. System validates BOM and routing exist
+2. **Inventory Allocated** - Materials reserved:
+   ```
+   450 G PLA Basic Black
+   1 EA M3 Insert
+   1 EA Poly Bag
+   ```
+   Available inventory reduced by allocated amounts
+3. Operations copied from routing to production order
+4. Production order ready for scheduling
+5. Status changes to "released"
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Release Order**
+
+**⚠️ Cannot release if:**
+- Insufficient inventory (shows shortage)
+- No BOM or routing assigned
+- Product inactive
+
+**If insufficient inventory:**
+- Option 1: Reduce quantity
+- Option 2: Run MRP to generate purchase orders
+- Option 3: Override (requires approval)
+
+### Executing Production
+
+**From "released" → "in_progress" → "completed":**
+
+**Step 1: Start Production**
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Start Production**
+
+- Assign to specific resource (printer)
+- Record actual start time
+- Status → "in_progress"
+
+**Step 2: Execute Operations**
+
+Each operation tracks separately:
+```
+OP-10: Print
+  Status: pending → running → complete
+  Planned Time: 2.5 hrs
+  Actual Time: 2.6 hrs (tracked)
+  Materials Used: 450 G PLA (recorded)
+  Spool Used: SPOOL-PLA-BLK-010 (traceability)
+
+OP-20: Insert Hardware
+  Status: pending → running → complete
+  Planned Time: 5 min
+  Actual Time: 4 min
+
+OP-30: QC Inspection
+  Status: pending → running → complete
+  QC Result: Passed ✓
+
+OP-40: Pack
+  Status: pending → running → complete
+  Materials Used: 1 EA Poly Bag
+```
+
+**Step 3: Complete Production**
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Complete Order**
+
+- Mark all operations complete
+- Record actual end time
+- Enter quantity completed: 10 EA
+- Enter quantity scrapped: 0 EA
+- Status → "completed"
+
+### Quality Control
+
+**QC Status values:**
+- **not_required** - Auto-pass (trusted products, internal orders)
+- **pending** - Awaiting QC assignment
+- **in_progress** - Inspector reviewing parts
+- **passed** - Parts accepted ✓
+- **failed** - Parts rejected ✗
+- **waived** - Failed but accepted anyway (document reason)
+
+**QC Workflow:**
+
+1. **Production Completes** → QC Status: "pending"
+2. **Assign QC Inspector** → QC Status: "in_progress"
+3. **Inspector Reviews Parts:**
+   - Check dimensions, finish, strength
+   - Test functionality
+   - Document findings in notes
+4. **Inspector Passes/Fails:**
+   - **Pass** → QC Status: "passed", PO ready to close
+   - **Fail** → QC Status: "failed", PO Status: "qc_hold"
+
+**If QC Fails:**
+
+**Option 1: Scrap and Remake**
+```
+1. Mark PO as "scrapped"
+2. Enter scrap reason: "Poor layer adhesion"
+3. Create remake order:
+   - Links to original PO (remake_of_id)
+   - Same quantity, same product
+   - Starts as "draft"
+```
+
+**Option 2: Rework**
+```
+1. Keep PO in "qc_hold"
+2. Add rework operation
+3. Re-execute problematic step
+4. Re-submit to QC
+```
+
+**Option 3: Waive (Accept as-is)**
+```
+1. QC Status → "waived"
+2. Document reason in QC notes: "Cosmetic issue only, customer accepts"
+3. PO ready to close
+```
+
+### Closing Production Orders
+
+**From "completed" → "closed":**
+
+**Requirements:**
+- ✅ All operations complete
+- ✅ QC passed (or not required/waived)
+- ✅ Quantity completed ≥ Quantity ordered
+
+**Closing process:**
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Close Order**
+
+**System actions:**
+1. **Material Consumption** - Inventory transactions:
+   ```
+   -450 G PLA Basic Black ($11.25 COGS)
+   -1 EA M3 Insert ($0.25 COGS)
+   -1 EA Poly Bag ($0.10 COGS)
+   ────────────────────────────────
+   Total Material Cost: $11.60
+   ```
+
+2. **Finished Goods Receipt** - Inventory transaction:
+   ```
+   +10 EA Phone Stand
+   Cost: $50.00 (material $11.60 + labor $3.40/unit)
+   Value: $50.00
+   ```
+
+3. **Allocations Released** - Available inventory updated
+
+4. **Sales Order Updated** (if linked):
+   - SO Status → "ready_to_ship"
+   - Customer notified (if configured)
+
+5. **Cost Accounting** - COGS recorded to GL
+
+**✅ Result:** Production order closed, finished goods in inventory
+
+---
+
+## Part 2: Bill of Materials (BOM)
+
+### What is a BOM?
+
+A **Bill of Materials** defines **what components** are needed to make a product.
+
+**BOM contains:**
+- List of components (materials, hardware, packaging)
+- Quantities required per unit
+- When to consume (production vs shipping)
+- Cost estimates
+
+**Example BOM:**
+```
+Product: Phone Stand
+BOM: BOM-001 v1
+
+Line 1: PLA Basic Black - 450 G (consume: production)
+Line 2: M3 Heat Set Insert - 2 EA (consume: production)
+Line 3: Poly Bag - 1 EA (consume: shipping)
+Line 4: Instruction Card - 1 EA (consume: shipping)
+────────────────────────────────────────────────
+Total Cost: $12.25 per unit
+```
+
+### Creating BOMs
+
+**Navigation:** Manufacturing → BOMs → **+ New BOM**
+
+**Step 1: BOM Header**
+
+```
+Product: Phone Stand (select product)
+Code: BOM-STAND-001 (optional identifier)
+Name: Phone Stand Assembly (descriptive)
+
+Version: 1 (auto-incremented)
+Revision: 1.0 (engineering revision)
+Active: ✓ (only one active BOM per product)
+
+Assembly Time: 10 minutes (manual assembly time)
+Effective Date: 2026-02-01 (when to start using)
+
+Notes: "Updated to use stronger insert size"
+```
+
+**Step 2: Add BOM Lines**
+
+Click **+ Add Line** for each component:
+
+**Line 1 - Filament:**
+```
+Component: MAT-PLA-BASIC-BLK
+Quantity: 450
+Unit: G (grams)
+Consume Stage: production (consumed during print)
+Scrap Factor: 5% (waste/support material)
+Notes: "Print with 0.2mm layer height"
+```
+
+**Line 2 - Hardware:**
+```
+Component: INSERT-M3
+Quantity: 2
+Unit: EA (each)
+Consume Stage: production (installed during assembly)
+Scrap Factor: 0% (no waste)
+```
+
+**Line 3 - Packaging:**
+```
+Component: BAG-POLY-4X6
+Quantity: 1
+Unit: EA
+Consume Stage: shipping (consumed when packing order)
+Scrap Factor: 0%
+```
+
+**Step 3: Review Costs**
+
+System calculates total cost:
+```
+Line 1: 450 G × $0.025/G × 1.05 = $11.81 (with 5% scrap)
+Line 2: 2 EA × $0.15/EA = $0.30
+Line 3: 1 EA × $0.10/EA = $0.10
+────────────────────────────────────────────────
+Total Material Cost: $12.21
+Assembly Time: 10 min × $24/hr = $4.00
+────────────────────────────────────────────────
+Total BOM Cost: $16.21 per unit
+```
+
+**Step 4: Save**
+
+Click **Create BOM** → BOM is saved and can be assigned to production orders
+
+### BOM Versions
+
+**Multiple versions per product:**
+- Version 1: Original design
+- Version 2: Cost-reduced (cheaper material)
+- Version 3: Strength-improved (thicker walls)
+
+**Only one active BOM per product** - the active BOM is used for new production orders.
+
+**Version control:**
+- When editing BOM, option to "Create New Version"
+- Previous versions archived (historical record)
+- Production orders reference specific BOM version (locked)
+
+### Consume Stages
+
+**production** - Consumed during manufacturing:
+- Filament/materials (used in print)
+- Hardware (installed in assembly)
+- Labels (applied to product)
+
+**shipping** - Consumed during packing/shipment:
+- Boxes
+- Poly bags
+- Packing material
+- Shipping labels
+
+**Why separate?**
+- Accurate COGS timing (production COGS vs shipping expense)
+- Inventory allocation (production materials reserved, shipping materials allocated at ship time)
+- GL accounting (different expense accounts)
+
+### Cost-Only Lines
+
+**For costing without inventory consumption:**
+
+```
+Line 5: Machine Time - 2.5 HR @ $10/HR = $25.00
+  is_cost_only: ✓
+  (Includes in BOM cost, doesn't allocate inventory)
+```
+
+**Use cases:**
+- Machine depreciation
+- Overhead allocation
+- Energy costs
+- Setup time
+
+---
+
+## Part 3: Routings
+
+### What is a Routing?
+
+A **Routing** defines **how to make** a product - the sequence of operations.
+
+**Routing contains:**
+- List of operations (Print, QC, Pack, etc.)
+- Work center assignments
+- Time estimates
+- Material requirements per operation
+- Operation dependencies
+
+**Example Routing:**
+```
+Product: Phone Stand
+Routing: ROUTING-001 v1
+
+OP-10: Print (Work Center: FDM-POOL)
+  Time: 2.5 hrs
+  Material: 450 G PLA Basic Black
+
+OP-20: Install Inserts (Work Center: ASSEMBLY)
+  Time: 5 min
+  Material: 2 EA M3 Inserts
+  Dependency: After OP-10
+
+OP-30: QC Inspection (Work Center: QC)
+  Time: 5 min
+  Dependency: After OP-20
+
+OP-40: Pack (Work Center: SHIPPING)
+  Time: 3 min
+  Material: 1 EA Poly Bag
+  Dependency: After OP-30
+────────────────────────────────────────────────
+Total Time: 2 hrs 43 min
+Total Cost: $27.50 (material + labor)
+```
+
+### Creating Routings
+
+**Navigation:** Manufacturing → Routings → **+ New Routing**
+
+**Step 1: Routing Header**
+
+```
+Product: Phone Stand
+Code: ROUTING-STAND-001
+Name: Standard Phone Stand Process
+
+Version: 1
+Revision: 1.0
+Active: ✓
+
+Effective Date: 2026-02-01
+Notes: "Optimized for Bambu X1C printers"
+```
+
+**Step 2: Add Operations**
+
+Click **+ Add Operation** for each step:
+
+**Operation 1 - Print:**
+```
+Sequence: 10
+Operation Code: PRINT
+Operation Name: 3D Print Base
+
+Work Center: FDM-POOL (printer pool)
+
+Setup Time: 5 min (bed prep, filament load)
+Run Time: 150 min (2.5 hrs actual print)
+Wait Time: 10 min (cool down)
+Move Time: 5 min (remove from bed)
+
+Units per Cycle: 1 (1 part per print)
+Scrap Rate: 5% (expected failures)
+
+Materials:
+  - PLA Basic Black: 450 G per unit
+```
+
+**Operation 2 - Install Inserts:**
+```
+Sequence: 20
+Operation Code: ASSEMBLE
+Operation Name: Install Heat Set Inserts
+
+Work Center: ASSEMBLY
+
+Setup Time: 0 min
+Run Time: 5 min
+Wait Time: 0 min
+Move Time: 0 min
+
+Predecessor Operation: OP-10 (must complete print first)
+Can Overlap: No
+
+Materials:
+  - M3 Insert: 2 EA per unit
+```
+
+**Operation 3 - QC:**
+```
+Sequence: 30
+Operation Code: QC
+Operation Name: Quality Inspection
+
+Work Center: QC
+
+Setup Time: 0 min
+Run Time: 5 min
+
+Predecessor Operation: OP-20
+```
+
+**Operation 4 - Pack:**
+```
+Sequence: 40
+Operation Code: PACK
+Operation Name: Package Product
+
+Work Center: SHIPPING
+
+Setup Time: 0 min
+Run Time: 3 min
+
+Predecessor Operation: OP-30
+
+Materials:
+  - Poly Bag: 1 EA per unit
+```
+
+**Step 3: Review Totals**
+
+System calculates:
+```
+Total Setup Time: 5 min
+Total Run Time: 163 min (2 hrs 43 min)
+Total Cost: $27.50 (based on work center rates)
+```
+
+**Step 4: Save**
+
+Click **Create Routing** → Routing saved and ready for production orders
+
+### Routing Templates
+
+**Create reusable routing templates:**
+
+```
+Template: TRUE (no product assigned)
+Code: TEMPLATE-STANDARD-PRINT
+Name: Standard 3D Print Process
+
+Operations:
+  OP-10: Print (FDM-POOL)
+  OP-20: QC (QC)
+  OP-30: Pack (SHIPPING)
+
+Use: Assign to multiple products with similar process
+```
+
+**Assign template to product:**
+1. Navigate to product
+2. Select "Copy from Template"
+3. Choose template
+4. Routing created with operations pre-filled
+5. Customize as needed
+
+---
+
+## Part 4: Work Centers & Resources
+
+### What is a Work Center?
+
+A **Work Center** is a logical production area where operations are performed.
+
+**Examples:**
+- **FDM-POOL** - Pool of FDM 3D printers
+- **POST-PRINT** - Post-processing station (sanding, painting)
+- **ASSEMBLY** - Manual assembly station
+- **QC** - Quality control inspection station
+- **SHIPPING** - Packing and shipping area
+
+**Work centers contain:**
+- Resources (individual machines/printers)
+- Capacity (hours per day)
+- Hourly rates (for cost calculation)
+- Scheduling priority
+
+### Creating Work Centers
+
+**Navigation:** Manufacturing → Work Centers → **+ New Work Center**
+
+```
+Code: FDM-POOL
+Name: FDM 3D Printer Pool
+Description: "Pool of Bambu Lab FDM printers"
+
+Center Type: machine (options: machine, station, production)
+  - machine: Has resources (printers)
+  - station: Single workstation
+  - production: Generic production area
+
+Capacity: 160 hours/day (8 printers × 20 hrs/day each)
+
+Costing:
+  Machine Rate: $8.00/hr (depreciation, maintenance)
+  Labor Rate: $16.00/hr (operator wages)
+  Overhead Rate: $4.00/hr (facility, utilities)
+  ──────────────────────────────────────────────
+  Total Rate: $28.00/hr
+
+Is Bottleneck: ✓ (constrains overall throughput)
+Scheduling Priority: 1 (highest)
+
+Active: ✓
+```
+
+### What is a Resource?
+
+A **Resource** is an individual machine or printer within a work center.
+
+**Example:**
+```
+Work Center: FDM-POOL
+  Resource 1: Leonardo (X1C)
+  Resource 2: Donatello (X1C)
+  Resource 3: Michelangelo (P1S)
+  Resource 4: Raphael (P1S)
+```
+
+### Creating Resources
+
+**Navigation:** Manufacturing → Work Centers → Select WC → **+ Add Resource**
+
+```
+Code: LEONARDO
+Name: Leonardo (X1C Printer)
+
+Work Center: FDM-POOL
+
+Machine Type: X1C
+Serial Number: 01P00A123456789
+Printer Class: enclosed (required for ABS/ASA/PC)
+
+Bambu Integration:
+  Device ID: 01P00A123456789
+  IP Address: 192.168.1.100
+
+Capacity Override: 20 hrs/day (from WC default)
+
+Status: available (options: available, busy, maintenance, offline)
+Active: ✓
+```
+
+**Printer Classes:**
+- **open** - Open frame (A1, A1 Mini) - PLA, PETG, TPU only
+- **enclosed** - Enclosed chamber (P1S, X1C) - ABS, ASA, PC capable
+
+**Scheduling logic:**
+- ABS/ASA/PC orders → Only assigned to enclosed printers
+- PLA/PETG orders → Can use any printer
+
+---
+
+## Part 5: Production Scheduling
+
+### Scheduling Overview
+
+**FilaOps scheduling approach:**
+
+1. **Work Center Assignment** - Operations assigned to work centers
+2. **Resource Dispatch** - Work centers dispatch to specific resources
+3. **Priority-Based** - Higher priority orders scheduled first
+4. **Capacity-Aware** - Respects work center capacity limits
+
+### Manual Scheduling
+
+**Assign production order to printer:**
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Assign to Printer**
+
+```
+Operation: OP-10 Print
+Work Center: FDM-POOL
+Resource: Leonardo (X1C)
+
+Scheduled Start: 2026-02-08 10:00 AM
+Scheduled End: 2026-02-08 12:30 PM (2.5 hrs)
+
+Status: scheduled → ready to start
+```
+
+### Automatic Scheduling (via MRP)
+
+**MRP generates planned orders** with due dates:
+
+1. MRP calculates requirements
+2. Creates planned production orders
+3. Assigns due dates based on lead time
+4. User reviews and converts to production orders
+5. Scheduler assigns to work centers/resources
+
+**See:** [MRP Guide](mrp.md) for planning details
+
+### Production Schedule View
+
+**Navigation:** Manufacturing → Schedule
+
+**Gantt chart showing:**
+- All production orders
+- Resource assignments
+- Timeline (hourly/daily/weekly)
+- Bottlenecks highlighted
+- Late orders flagged
+
+**Drag-and-drop rescheduling:**
+- Move orders between resources
+- Adjust start times
+- Re-sequence priorities
+
+---
+
+## Part 6: Scrap and Rework
+
+### Recording Scrap
+
+**During production:**
+
+**Navigation:** Manufacturing → Production Orders → Select PO → **Record Scrap**
+
+```
+Quantity Scrapped: 2 EA (out of 10 ordered)
+Scrap Reason: adhesion (dropdown)
+  - adhesion (bed adhesion failure)
+  - layer_shift (layer misalignment)
+  - stringing (excess material stringing)
+  - warping (part warping/curling)
+  - nozzle_clog (clogged nozzle)
+  - other (describe in notes)
+
+Notes: "First layer failed due to dirty bed"
+
+Update Quantity Ordered:
+  Option 1: Keep 10 EA ordered (make 8 good + 2 scrapped)
+  Option 2: Increase to 12 EA ordered (make 10 good + 2 scrapped)
+```
+
+**Result:**
+- Scrap recorded in quantity_scrapped
+- Material cost written off
+- Scrap reason tracked for analysis
+
+### Creating Remake Orders
+
+**After scrap:**
+
+**Navigation:** Manufacturing → Production Orders → Select scrapped PO → **Create Remake**
+
+```
+Remake for: PO-2026-0005 (links to original)
+Quantity: 2 EA (replace scrapped units)
+Priority: 1 (urgent - customer waiting)
+
+Same product, same BOM, same routing
+Status: draft (ready to release)
+```
+
+**Result:**
+- Remake order created
+- Links to original PO (remake_of_id)
+- Tracks replacement production
+
+### Scrap Analysis
+
+**Navigation:** Manufacturing → Reports → **Scrap Analysis**
+
+**Shows:**
+```
+Scrap by Reason (Last 30 Days):
+
+Adhesion:       15 units (35%) → Clean beds more often
+Layer Shift:    10 units (23%) → Check belt tension
+Warping:         8 units (19%) → Increase bed temp for ABS
+Nozzle Clog:     6 units (14%) → Preventive maintenance
+Stringing:       4 units (9%)  → Adjust retraction settings
+────────────────────────────────────────────────
+Total:          43 units (100%)
+
+Scrap Rate: 4.3% (43 scrapped / 1000 completed)
+Target: < 3%
+```
+
+---
+
+## Part 7: Integration with Sales Orders
+
+### Creating Production from Sales Order
+
+**Method 1: Manual Creation**
+
+**Navigation:** Sales → Sales Orders → Select SO → **Create Production Order**
+
+```
+Sales Order: SO-2026-0042
+Product: Phone Stand
+Quantity: 10 EA
+
+Auto-fills:
+  - Links sales_order_id
+  - Sets order_type: MAKE_TO_ORDER
+  - Sets due_date from SO due_date
+  - Sets priority from SO rush_level
+```
+
+**Method 2: Automatic from MRP**
+
+MRP analyzes sales orders → Creates planned production orders → User converts to production orders
+
+### Production Status Updates Sales Order
+
+**Automatic status sync:**
+
+```
+PO Status          →  SO Status
+────────────────────────────────────────
+released           →  confirmed
+in_progress        →  in_production
+completed (QC pass)→  ready_to_ship
+closed             →  (no change - ready to ship)
+cancelled          →  on_hold (with notification)
+```
+
+---
+
+## Part 8: Manufacturing Reports
+
+### Production Order List
+
+**Navigation:** Manufacturing → Production Orders
+
+**Filter by:**
+- Status (all, draft, released, in_progress, completed, closed)
+- Date range
+- Product
+- Work center
+- Due date
+
+**Columns:**
+- PO Number
+- Product
+- Quantity (Ordered / Completed / Scrapped)
+- Status
+- Due Date
+- Priority
+- Assigned To
+
+### Work Center Utilization
+
+**Navigation:** Manufacturing → Reports → **Work Center Utilization**
+
+**Shows:**
+```
+Work Center: FDM-POOL
+Period: Last 7 Days
+
+Total Capacity: 1,120 hrs (160 hrs/day × 7 days)
+Scheduled: 945 hrs (84%)
+Actual: 920 hrs (82%)
+Idle: 200 hrs (18%)
+
+Efficiency: 97% (920 actual / 945 scheduled)
+Utilization: 82% (920 actual / 1,120 capacity)
+
+Target Utilization: 85%
+Status: ✓ Good
+```
+
+### Production Costs
+
+**Navigation:** Manufacturing → Reports → **Production Costs**
+
+**Shows:**
+```
+Period: Last 30 Days
+
+Total Production Orders: 125
+Total Units Produced: 1,450 EA
+
+Material Cost: $18,250 (avg $12.59/unit)
+Labor Cost: $5,800 (avg $4.00/unit)
+Overhead: $2,900 (avg $2.00/unit)
+────────────────────────────────────────
+Total Cost: $26,950 (avg $18.59/unit)
+
+Scrap Cost: $1,150 (4.3% of material)
+```
+
+---
+
+## Part 9: Best Practices
+
+### BOM Management
+
+✅ **Do:**
+- Keep one active BOM per product
+- Include all materials (filament, hardware, packaging)
+- Set realistic scrap factors (5-10% for filament)
+- Separate production vs shipping materials
+- Update costs when vendor prices change
+
+❌ **Don't:**
+- Forget to include packaging in BOM
+- Use outdated material costs
+- Set scrap factor too low (causes shortages)
+- Have multiple active BOMs per product
+
+### Routing Design
+
+✅ **Do:**
+- Break down into logical operations
+- Set realistic time estimates (add buffer)
+- Define clear operation dependencies
+- Assign correct work centers
+- Include QC steps where needed
+
+❌ **Don't:**
+- Create overly detailed routings (too many ops)
+- Forget setup and move time
+- Skip QC for critical products
+- Assign operations to wrong work centers
+
+### Production Planning
+
+✅ **Do:**
+- Release orders in batches (not one-by-one)
+- Schedule high-priority orders first
+- Monitor bottleneck work centers
+- Plan for material lead times
+- Use MRP for make-to-stock items
+
+❌ **Don't:**
+- Release without checking inventory
+- Ignore capacity constraints
+- Schedule conflicting operations
+- Forget to update due dates
+
+### Quality Control
+
+✅ **Do:**
+- Require QC for customer-facing products
+- Document QC failures with photos/notes
+- Analyze scrap reasons monthly
+- Train operators on quality standards
+- Set clear pass/fail criteria
+
+❌ **Don't:**
+- Waive QC failures without documentation
+- Ignore recurring scrap reasons
+- Ship failed parts (even if "close enough")
+- Skip QC to save time
+
+---
+
+## Part 10: Common Workflows
+
+### Workflow 1: Simple Make-to-Order
+
+```
+1. Sales order received: 10 Phone Stands, due Feb 15
+2. Create production order from SO
+   - Product: Phone Stand
+   - Quantity: 10
+   - Due: Feb 15
+   - Status: draft
+3. Review BOM and routing (auto-assigned)
+4. Release order:
+   - Allocate materials (450 G PLA × 10 = 4500 G)
+   - Status: released
+5. Assign to printer Leonardo (X1C)
+   - Status: scheduled
+6. Start production:
+   - Leonardo starts print
+   - Status: in_progress
+7. Complete operations:
+   - OP-10 Print: Complete (2.5 hrs)
+   - OP-20 Assembly: Complete (5 min)
+   - OP-30 QC: Passed ✓
+   - OP-40 Pack: Complete
+   - Status: completed
+8. Close production order:
+   - Materials consumed
+   - Finished goods received (+10 EA)
+   - Status: closed
+9. Ship to customer:
+   - SO status: shipped
+```
+
+**Time estimate:** 3-4 hours (print time + operations)
+
+### Workflow 2: Batch Production (Make-to-Stock)
+
+```
+1. MRP suggests: Make 100 Brackets for inventory
+2. Create production order:
+   - Product: Bracket
+   - Quantity: 100
+   - Order Type: MAKE_TO_STOCK
+   - Due: End of week
+3. Release order (allocate 45 KG filament)
+4. Split into 10 batches:
+   - PO-001-A: 10 units (Leonardo)
+   - PO-001-B: 10 units (Donatello)
+   - ...
+   - PO-001-J: 10 units (Raphael)
+5. Schedule across printer pool (parallel production)
+6. Monitor progress:
+   - 5 complete
+   - 3 in progress
+   - 2 queued
+7. QC batch inspect (sample 10%)
+8. Close all orders:
+   - 100 units to inventory
+   - Ready for sale
+```
+
+**Time estimate:** 1 day (parallel production)
+
+### Workflow 3: Scrap and Remake
+
+```
+1. Production order in progress: 10 Phone Stands
+2. Print completes, QC inspection finds issues:
+   - 2 units: Poor layer adhesion (scrap)
+   - 8 units: Pass ✓
+3. Record scrap:
+   - Quantity Scrapped: 2 EA
+   - Reason: adhesion
+   - Cost: $25 written off
+4. Create remake order:
+   - Quantity: 2 EA (replace scrapped)
+   - Links to original PO
+   - Priority: 1 (urgent)
+5. Release and produce remake:
+   - Clean bed thoroughly
+   - Increase bed temp
+   - Complete successfully
+6. Close both orders:
+   - Original: 8 good + 2 scrapped
+   - Remake: 2 good
+   - Total delivered: 10 EA
+```
+
+---
+
+## Part 11: Advanced Features
+
+### Multi-Operation Parallel Processing
+
+**Operations can overlap:**
+
+```
+Operation 1: Print Part A (3 hrs)
+Operation 2: Print Part B (2 hrs) [can start immediately]
+Operation 3: Assemble A+B (10 min) [depends on Op1 and Op2]
+
+Timeline:
+0:00 - Start Op1 and Op2 simultaneously
+2:00 - Op2 completes
+3:00 - Op1 completes, start Op3
+3:10 - Op3 completes, order done
+
+Total Time: 3 hrs 10 min (vs 5 hrs 10 min sequential)
+```
+
+### Operation-Level Material Tracking
+
+**Materials consumed per operation:**
+
+```
+OP-10: Print
+  Material: 450 G PLA Basic Black
+  Consumed: At operation complete
+  Cost: $11.25
+
+OP-40: Pack
+  Material: 1 EA Poly Bag
+  Consumed: At operation complete
+  Cost: $0.10
+
+Total Material Cost: $11.35
+(Allocated at release, consumed at operation complete)
+```
+
+### Resource-Specific Routing
+
+**Different routings for different resources:**
+
+```
+Product: Large Part
+
+Routing A (X1C Printer - Large bed):
+  OP-10: Print (1 unit per print)
+  Time: 8 hrs
+
+Routing B (P1S Printer - Standard bed):
+  OP-10: Print Part 1 (4 hrs)
+  OP-20: Print Part 2 (4 hrs)
+  OP-30: Glue Assembly (10 min)
+  Time: 8 hrs 10 min
+
+Use Routing A for X1C, Routing B for P1S
+```
+
+---
+
+## Next Steps
+
+Now that you understand manufacturing, explore these related guides:
+
+| Guide | Learn About |
+|-------|-------------|
+| **Inventory Management** | Material tracking, spool management, stock levels |
+| **MRP** | Material requirements planning, automatic order generation |
+| **Sales & Quotes** | How sales orders create production orders |
+| **Accounting** | COGS calculation, production costing, variance analysis |
+
+## Quick Reference
+
+### Production Order Status Flow
+
+```
+draft → released → scheduled → in_progress → completed → closed
+                                                ↓
+                                           qc_hold → scrap + remake
+```
+
+### QC Status Values
+
+- `not_required` - Auto-pass
+- `pending` - Awaiting QC
+- `in_progress` - Under inspection
+- `passed` - Accepted ✓
+- `failed` - Rejected ✗
+- `waived` - Accepted with notes
+
+### Common Scrap Reasons
+
+- adhesion - Bed adhesion failure
+- layer_shift - Layer misalignment
+- stringing - Excess material
+- warping - Part curling
+- nozzle_clog - Nozzle blockage
+
+### Keyboard Shortcuts
+
+- `n` - New production order
+- `r` - Release order
+- `s` - Start production
+- `c` - Complete order
+- `/` - Search
+
+---
+
+**🎉 Congratulations!** You now understand the complete FilaOps manufacturing system. Create your first production order and see how BOMs, routings, and work centers come together!

--- a/docs/user-guide/mrp.md
+++ b/docs/user-guide/mrp.md
@@ -1,0 +1,1353 @@
+# MRP (Material Requirements Planning)
+
+## Overview
+
+Material Requirements Planning (MRP) is an automated planning system that ensures you have the right materials at the right time to fulfill your production and sales commitments. FilaOps' MRP system analyzes your production orders, explodes Bills of Materials (BOMs), and automatically generates planned purchase orders and production orders for any material shortages.
+
+**What MRP Does:**
+- **Demand Analysis** - Identifies all material requirements from production orders (and optionally sales orders)
+- **BOM Explosion** - Recursively expands multi-level BOMs to calculate component needs
+- **Inventory Netting** - Compares requirements against available inventory and incoming supply
+- **Planned Order Generation** - Creates suggested purchase orders (for raw materials) or production orders (for sub-assemblies)
+- **Supply/Demand Timeline** - Projects when shortages will occur
+
+**MRP Formula:**
+```
+Net Requirement = Gross Requirement - On-Hand Inventory - Incoming Supply + Safety Stock
+```
+
+**When to Use MRP:**
+- Weekly or daily to proactively identify material shortages
+- After creating new production orders
+- When planning for upcoming production
+- To answer "what materials do I need to order?"
+
+---
+
+## Table of Contents
+
+1. [Understanding MRP Concepts](#1-understanding-mrp-concepts)
+2. [Running MRP](#2-running-mrp)
+3. [Reviewing MRP Results](#3-reviewing-mrp-results)
+4. [Managing Planned Orders](#4-managing-planned-orders)
+5. [Firming Planned Orders](#5-firming-planned-orders)
+6. [Releasing Planned Orders](#6-releasing-planned-orders)
+7. [BOM Explosion and Requirements](#7-bom-explosion-and-requirements)
+8. [Supply/Demand Timeline](#8-supplydemand-timeline)
+9. [MRP Configuration](#9-mrp-configuration)
+10. [Best Practices](#10-best-practices)
+11. [Complete Workflows](#11-complete-workflows)
+12. [Troubleshooting](#12-troubleshooting)
+13. [Quick Reference](#13-quick-reference)
+
+---
+
+## 1. Understanding MRP Concepts
+
+### 1.1 Core MRP Components
+
+**MRP Run**
+- A single execution of the MRP calculation
+- Analyzes all open production orders within planning horizon
+- Creates an audit trail with statistics
+- Can be re-run to refresh planned orders
+
+**Planned Order**
+- MRP's suggestion to order material
+- Two types: `purchase` (raw materials) or `production` (sub-assemblies)
+- Lifecycle: `planned` → `firmed` → `released`
+- Can be deleted automatically by next MRP run (unless firmed)
+
+**Planning Horizon**
+- How far ahead MRP looks (default: 30 days)
+- Production orders with due dates within horizon are analyzed
+- Balances planning visibility vs computational cost
+
+**Gross Requirements**
+- Total quantity of a component needed across all production orders
+- Before considering inventory or supply
+
+**Net Requirements**
+- Actual shortage after inventory netting
+- `Net = Gross - On-Hand - Incoming + Safety Stock`
+
+### 1.2 Make vs. Buy Decision
+
+MRP automatically determines whether to create a purchase order or production order:
+
+| Condition | Order Type | Meaning |
+|-----------|-----------|---------|
+| `has_bom = False` | **Purchase** | Raw material or purchased part — buy it |
+| `has_bom = True` | **Production** | Manufactured sub-assembly — make it |
+
+**Example:**
+- **Filament** (no BOM) → Purchase Order to vendor
+- **Circuit Board Sub-Assembly** (has BOM with resistors, capacitors) → Production Order to manufacture
+- **Custom 3D Printed Component** (has BOM with filament) → Production Order
+
+### 1.3 BOM Explosion
+
+**Single-Level BOM:**
+```
+Widget (Qty: 10)
+├─ Component A (Qty: 2 each) → Need 20
+├─ Component B (Qty: 1 each) → Need 10
+└─ Component C (Qty: 3 each) → Need 30
+```
+
+**Multi-Level BOM (Recursive):**
+```
+Widget (Qty: 10)
+├─ Sub-Assembly X (Qty: 2 each) → Need 20
+│   ├─ Component A (Qty: 3 each) → Need 60 total
+│   └─ Component B (Qty: 1 each) → Need 20 total
+└─ Component C (Qty: 5 each) → Need 50
+```
+
+MRP recursively explodes BOMs to calculate ALL component requirements at all levels.
+
+### 1.4 Material Sources
+
+**Primary Source: Routing Operation Materials**
+- Modern approach for 3D printing
+- Materials defined at operation level (e.g., filament at Print operation, boxes at Ship operation)
+- Takes precedence if defined
+
+**Fallback Source: BOM Lines**
+- Legacy BOM components table
+- Used only if no routing materials exist
+- Maintains backward compatibility
+
+### 1.5 Planned Order Lifecycle
+
+```
+[MRP Run] → [PLANNED] → [FIRMED] → [RELEASED] → [Actual PO/MO Created]
+              ↓           ↓           ↓
+         Can be deleted  Locked in   Converted
+         by next MRP    by MRP      to real order
+```
+
+**Status Meanings:**
+- **Planned** - MRP suggestion, not committed, will be deleted on next MRP run
+- **Firmed** - User confirmed, locked, won't be deleted by MRP
+- **Released** - Converted to actual Purchase Order or Production Order
+- **Cancelled** - No longer needed, user cancelled
+
+---
+
+## 2. Running MRP
+
+### 2.1 Manual MRP Run
+
+**Navigation:** MRP → **Run MRP**
+
+**Configuration:**
+1. **Planning Horizon** (default: 30 days)
+   - How far ahead to look for production orders
+   - Example: 30 days = analyze all POs due within next month
+
+2. **Include Draft Orders** (default: Yes)
+   - Include production orders with status `draft`
+   - Recommended: Yes (plan for all upcoming work)
+
+3. **Regenerate Planned Orders** (default: Yes)
+   - Delete unfirmed planned orders before running
+   - Creates fresh plan based on current data
+   - Firmed orders are NOT deleted
+
+**Click "Run MRP"**
+
+### 2.2 MRP Run Results
+
+After running, you'll see:
+
+```
+✅ MRP Run #42 Completed
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Orders Processed:        15 production orders
+Components Analyzed:     47 unique components
+Shortages Found:         8 materials below reorder point
+Planned Orders Created:  8 (5 purchase, 3 production)
+Run Time:               2024-02-07 14:32:15
+Status:                 completed
+```
+
+**What This Means:**
+- MRP analyzed 15 production orders within horizon
+- Found 47 unique components needed
+- 8 components have shortages (need to order)
+- Created 8 planned orders to resolve shortages
+
+### 2.3 Viewing MRP History
+
+**Navigation:** MRP → **MRP Runs**
+
+See all past MRP runs with:
+- Run date and time
+- Planning horizon used
+- Components analyzed
+- Shortages found
+- Planned orders created
+- Status (running, completed, failed)
+
+**Click on a run** to see which planned orders it created.
+
+---
+
+## 3. Reviewing MRP Results
+
+### 3.1 Understanding the Requirements View
+
+After MRP runs, review **Requirements Summary**:
+
+**Navigation:** MRP → **Requirements** (or results page after run)
+
+**Columns:**
+| Column | Meaning |
+|--------|---------|
+| **Product SKU/Name** | Component needed |
+| **Gross Qty** | Total quantity needed across all orders |
+| **On-Hand** | Current inventory |
+| **Allocated** | Already reserved for other orders |
+| **Available** | On-Hand - Allocated |
+| **Incoming** | On open purchase orders |
+| **Safety Stock** | Minimum buffer quantity |
+| **Net Shortage** | How much to order (if > 0) |
+| **Has BOM** | Make (production) or Buy (purchase) |
+
+### 3.2 Example Requirements
+
+**Scenario: 3 Production Orders Need PLA Filament**
+
+| Component | Gross | On-Hand | Incoming | Safety Stock | Net Shortage | Action |
+|-----------|-------|---------|----------|--------------|--------------|--------|
+| PLA Black 1kg | 12000 G | 3000 G | 5000 G | 2000 G | **6000 G** | 🛒 Order 6 KG |
+| PETG Red 1kg | 8000 G | 10000 G | 0 G | 2000 G | **0 G** | ✅ In stock |
+| Poly Mailer 6x9 | 25 EA | 50 EA | 0 EA | 10 EA | **0 G** | ✅ In stock |
+
+**Calculation for PLA Black:**
+```
+Net Shortage = Gross - On-Hand - Incoming + Safety Stock
+             = 12000 - 3000 - 5000 + 2000
+             = 6000 G (6 KG)
+```
+
+**MRP Action:** Create Planned Purchase Order for 6 KG of PLA Black
+
+### 3.3 Identifying Shortages
+
+**Color Coding (in UI):**
+- 🔴 **Red** - Critical shortage (net shortage > 0)
+- 🟡 **Yellow** - Below reorder point but still have stock
+- 🟢 **Green** - Sufficient inventory
+
+**Priority:**
+1. Items with earliest due dates
+2. Items with largest shortage quantities
+3. Items with long lead times
+
+---
+
+## 4. Managing Planned Orders
+
+### 4.1 Viewing Planned Orders
+
+**Navigation:** MRP → **Planned Orders**
+
+**List View Shows:**
+- Order type (Purchase or Production)
+- Product SKU and name
+- Quantity to order
+- Due date (when material is needed)
+- Start date (when to start ordering, accounting for lead time)
+- Status (planned, firmed, released, cancelled)
+- Source demand (which production order triggered this)
+
+**Filters:**
+- Status (planned, firmed, released)
+- Type (purchase, production)
+- Product
+
+### 4.2 Planned Order Details
+
+**Click on a planned order** to see:
+
+**General Info:**
+- Order type (purchase or production)
+- Product details (SKU, name, cost)
+- Quantity to order
+
+**Timing:**
+- **Due Date** - When material must be available
+- **Start Date** - When to initiate order (due date - lead time)
+- Lead time days (from product master)
+
+**Pegging (Demand Tracing):**
+- What triggered this planned order?
+- Source: production_order, sales_order, or mrp_calculation
+- Source ID and code (e.g., PO-2026-0042)
+
+**Status & Actions:**
+- Current status
+- Available actions (Firm, Release, Cancel)
+- Conversion tracking (if released, shows actual PO/MO number)
+
+### 4.3 Understanding Lead Times
+
+**Lead Time** = Time between order initiation and receipt
+
+**Example:**
+- Product: PLA Black Filament
+- Lead time: 7 days
+- Due date: 2026-02-20 (when production order needs it)
+- **Start date**: 2026-02-13 (due date - 7 days)
+
+**Start Date Logic:**
+- MRP calculates start date by subtracting lead time from due date
+- If start date is in the past, it uses today (order ASAP)
+- If due date is also in the past, preserves lead time by shifting both forward
+
+### 4.4 Editing Planned Orders
+
+You **cannot** directly edit planned orders. Instead:
+
+1. **To change quantity/date:**
+   - Cancel this planned order
+   - Adjust the underlying production order
+   - Re-run MRP
+
+2. **To lock it in:**
+   - Firm the order (see next section)
+
+3. **To create the actual order:**
+   - Release the order (converts to PO/MO)
+
+---
+
+## 5. Firming Planned Orders
+
+### 5.1 What is Firming?
+
+**Firming** = Locking a planned order so MRP won't delete it.
+
+**When MRP runs with "Regenerate Planned Orders":**
+- **Unfirmed (status: planned)** orders are deleted and recreated
+- **Firmed orders** are preserved
+
+**Use Cases:**
+- You've reviewed and approved the order
+- You're planning to create PO soon
+- You want to lock in timing while you find a vendor
+- You don't want next MRP run to change/delete it
+
+### 5.2 How to Firm a Planned Order
+
+**Method 1: From Planned Orders List**
+1. Navigate to MRP → Planned Orders
+2. Find the order
+3. Click **Firm** button
+4. Add optional notes
+5. Click **Confirm**
+
+**Method 2: From Planned Order Detail**
+1. Open planned order details
+2. Click **Firm Order** button
+3. Add notes (optional)
+4. Submit
+
+**Result:**
+- Status changes: `planned` → `firmed`
+- `firmed_at` timestamp recorded
+- Order appears in "Firmed Orders" filter
+- Will NOT be deleted by next MRP run
+
+### 5.3 When to Firm vs. Release
+
+**Firm** when you:
+- Approve the order but aren't ready to create PO yet
+- Want to lock timing
+- Need to find vendor or review pricing
+
+**Release** when you:
+- Ready to create actual Purchase Order or Production Order
+- Have selected vendor (for purchase orders)
+- Ready to commit
+
+---
+
+## 6. Releasing Planned Orders
+
+### 6.1 What is Releasing?
+
+**Releasing** = Converting a planned order into an actual Purchase Order or Production Order.
+
+**Process:**
+1. Planned order (suggestion) → Actual order (committed)
+2. For **purchase** orders: Creates draft PO with selected vendor
+3. For **production** orders: Creates draft manufacturing order
+
+### 6.2 Releasing a Purchase Order
+
+**Navigation:** MRP → Planned Orders → (select purchase order) → **Release**
+
+**Steps:**
+1. **Select Vendor** (required for purchase orders)
+   - Choose from your vendor list
+   - Vendor will receive this PO
+
+2. **Review Details:**
+   - Product, quantity, due date
+   - Unit cost (from product's standard or last cost)
+
+3. **Add Notes** (optional)
+   - Any special instructions
+
+4. **Click "Release Order"**
+
+**Result:**
+```
+✅ Purchase Order Created: PO-2026-0123
+   Vendor: Acme Filament Supply
+   Product: PLA Black 1kg
+   Quantity: 6.0 KG
+   Unit Cost: $25.00/KG
+   Total: $150.00
+   Status: Draft
+   Expected Date: 2026-02-20
+```
+
+**Next Steps:**
+1. Go to Purchasing → Purchase Orders → PO-2026-0123
+2. Review the PO
+3. Mark as "Ordered" when you send it to vendor
+4. Receive inventory when it arrives
+
+### 6.3 Releasing a Production Order
+
+**Navigation:** MRP → Planned Orders → (select production order) → **Release**
+
+**Steps:**
+1. **Review Details:**
+   - Product to manufacture (must have BOM)
+   - Quantity
+   - Due date
+
+2. **Add Notes** (optional)
+
+3. **Click "Release Order"**
+
+**Result:**
+```
+✅ Production Order Created: PO-2026-0042
+   Product: Widget Sub-Assembly
+   Quantity: 10 EA
+   BOM: v2.0
+   Status: Draft
+   Due Date: 2026-02-18
+```
+
+**Next Steps:**
+1. Go to Production → Production Orders → PO-2026-0042
+2. Review components needed (BOM)
+3. Release the production order
+4. Schedule and manufacture
+
+### 6.4 Bulk Releasing Orders
+
+To release multiple planned orders:
+
+**Option 1: Release Individually**
+- Good when you need different vendors
+- Good when you want to review each
+
+**Option 2: Group by Vendor, Then Release**
+1. Filter planned orders by vendor (use product's preferred vendor)
+2. Release all orders for Vendor A
+3. Release all orders for Vendor B
+4. etc.
+
+**Best Practice:** Release all orders for same vendor together so you can consolidate shipments and negotiate pricing.
+
+---
+
+## 7. BOM Explosion and Requirements
+
+### 7.1 Understanding BOM Explosion
+
+**What is BOM Explosion?**
+- Recursively expanding a Bill of Materials to calculate ALL component requirements
+- Handles multi-level BOMs (assemblies with sub-assemblies)
+- Accounts for scrap factors and UOM conversions
+
+**Example: Single-Level BOM**
+
+Product: **3D Printed Phone Stand**
+- Quantity Needed: 10 EA
+
+BOM:
+```
+3D Printed Phone Stand (1 EA)
+├─ PLA Black Filament: 35 G
+├─ Rubber Feet (4-pack): 1 EA
+└─ Poly Mailer 6x9: 1 EA
+```
+
+**Explosion for 10 EA:**
+```
+Gross Requirements:
+- PLA Black Filament: 350 G (35 G × 10)
+- Rubber Feet: 10 EA (1 × 10)
+- Poly Mailer: 10 EA (1 × 10)
+```
+
+**Example: Multi-Level BOM**
+
+Product: **Custom Enclosure Assembly**
+- Quantity Needed: 5 EA
+
+BOM (2 levels):
+```
+Custom Enclosure Assembly (1 EA)
+├─ 3D Printed Enclosure Shell (1 EA)  [Has BOM - Level 1]
+│   ├─ PETG Gray Filament: 120 G
+│   └─ Threaded Inserts M3: 4 EA
+├─ Circuit Board Sub-Assembly (1 EA)  [Has BOM - Level 1]
+│   ├─ PCB: 1 EA
+│   ├─ Resistor 10K: 3 EA
+│   └─ Capacitor 100nF: 2 EA
+└─ Screws M3x8: 4 EA
+```
+
+**Explosion for 5 EA:**
+```
+Gross Requirements (all levels):
+- PETG Gray Filament: 600 G (120 × 5)
+- Threaded Inserts M3: 20 EA (4 × 5)
+- PCB: 5 EA (1 × 5)
+- Resistor 10K: 15 EA (3 × 5)
+- Capacitor 100nF: 10 EA (2 × 5)
+- Screws M3x8: 20 EA (4 × 5)
+```
+
+### 7.2 Viewing BOM Explosion
+
+**Manual BOM Explosion:**
+
+**Navigation:** MRP → **Explode BOM**
+
+**Steps:**
+1. Select product (must have BOM)
+2. Enter quantity to explode (e.g., 10)
+3. Click **Explode**
+
+**Result:**
+```
+BOM Explosion for: Widget Assembly (Qty: 10)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Level 0 (Direct Components):
+  - Component A: 20 EA
+  - Sub-Assembly X: 10 EA
+  - Component C: 30 EA
+
+Level 1 (Sub-Components of Sub-Assembly X):
+  - Component B: 30 EA (from Sub-Assembly X)
+  - Component D: 10 EA (from Sub-Assembly X)
+
+Total Components: 5 unique items
+```
+
+**Use Cases:**
+- Understand what materials a product needs
+- Verify BOM accuracy before running MRP
+- Estimate material costs for quotes
+- Plan material purchases before creating production orders
+
+### 7.3 Requirements Analysis
+
+**Navigation:** MRP → **Requirements** → Filter by Production Order
+
+**View Requirements for Specific Production Order:**
+
+**Example: PO-2026-0042 (Widget, Qty: 10)**
+
+```
+Requirements for PO-2026-0042
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Component A
+  Gross Required:  20 EA
+  On-Hand:        15 EA
+  Incoming:        0 EA
+  Safety Stock:    5 EA
+  Net Shortage:   10 EA  ⚠️ Need to order
+
+Sub-Assembly X
+  Gross Required:  10 EA
+  On-Hand:         0 EA
+  Incoming:        0 EA
+  Safety Stock:    2 EA
+  Net Shortage:   12 EA  ⚠️ Need to manufacture
+
+Component C
+  Gross Required:  30 EA
+  On-Hand:        50 EA
+  Incoming:        0 EA
+  Safety Stock:    5 EA
+  Net Shortage:    0 EA  ✅ In stock
+```
+
+---
+
+## 8. Supply/Demand Timeline
+
+### 8.1 What is Supply/Demand Timeline?
+
+A **chronological view** of:
+- **Supply Events** - When inventory arrives (POs, planned orders, production completions)
+- **Demand Events** - When inventory is consumed (production orders, sales orders)
+- **Running Balance** - Projected inventory level over time
+
+**Purpose:**
+- Identify **when** shortages will occur
+- Calculate **days of supply** remaining
+- Validate MRP planned order timing
+
+### 8.2 Viewing Timeline
+
+**Navigation:** MRP → **Supply/Demand** → Select Product
+
+**Timeline Display:**
+
+```
+Supply/Demand Timeline: PLA Black Filament
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Current Status:
+  On-Hand:          5000 G
+  Available:        3000 G (allocated: 2000 G)
+  Safety Stock:     2000 G
+  Days of Supply:   8 days
+
+Projected Events:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Date       Type    Source              Qty       Balance
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2026-02-07 On-Hand Current Inventory   +3000 G   3000 G  ✅
+2026-02-10 Demand  PO-2026-0038        -1500 G   1500 G  ⚠️ Below reorder
+2026-02-12 Demand  PO-2026-0039        -2000 G   -500 G  🔴 SHORTAGE
+2026-02-14 Supply  PO-2026-0101        +5000 G   4500 G  ✅
+2026-02-18 Demand  PO-2026-0041        -3000 G   1500 G  ⚠️
+2026-02-20 Supply  Planned-Purchase-42 +6000 G   7500 G  ✅
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⚠️ Projected Shortage Date: 2026-02-12
+```
+
+**Insights:**
+- Shortage will occur on 2026-02-12 (in 5 days)
+- Incoming supply on 2026-02-14 will arrive too late
+- MRP's planned purchase for 2026-02-20 will restore safety stock
+- **Action:** Expedite PO-2026-0101 or release planned order earlier
+
+### 8.3 Interpreting Timeline
+
+**Event Types:**
+
+| Type | Meaning | Impact |
+|------|---------|--------|
+| **On-Hand** | Starting inventory | Baseline |
+| **Demand** | Material consumed by production | Decreases balance |
+| **Supply** | Material received from PO | Increases balance |
+
+**Balance Colors:**
+- 🟢 **Green** (> Safety Stock) - Healthy inventory
+- 🟡 **Yellow** (< Reorder Point) - Order soon
+- 🔴 **Red** (< 0) - Shortage, production at risk
+
+**Days of Supply:**
+```
+Days of Supply = Available Inventory / Average Daily Demand
+
+Example:
+  Available: 3000 G
+  Demand next 30 days: 12000 G
+  Average Daily: 400 G/day
+  Days of Supply: 3000 / 400 = 7.5 days
+```
+
+---
+
+## 9. MRP Configuration
+
+### 9.1 MRP Settings
+
+**Location:** `backend/.env`
+
+**Key Settings:**
+
+```ini
+# Sales Order Integration
+INCLUDE_SALES_ORDERS_IN_MRP=false
+# Set to 'true' to include sales orders as demand
+# Default: false (only production orders analyzed)
+
+# Auto-MRP Triggers
+AUTO_MRP_ON_ORDER_CREATE=false
+AUTO_MRP_ON_CONFIRMATION=false
+AUTO_MRP_ON_SHIPMENT=false
+# Automatically run MRP when events occur
+# Default: false (manual MRP runs only)
+
+# Sub-Assembly Lead Time Cascading
+MRP_ENABLE_SUB_ASSEMBLY_CASCADING=false
+# Calculate sub-assembly due dates based on parent due dates
+# Default: false (all orders due ASAP)
+
+# Validation
+MRP_VALIDATION_STRICT_MODE=true
+# Strict validation of BOMs and product data
+# Default: true (catch data issues)
+```
+
+### 9.2 Including Sales Orders in MRP
+
+**Default Behavior:** MRP only analyzes production orders
+
+**When to Enable:**
+Enable `INCLUDE_SALES_ORDERS_IN_MRP=true` if you:
+- Have sales orders NOT yet converted to production orders
+- Want MRP to plan for confirmed sales
+- Use make-to-order workflow where SOs drive production directly
+
+**What Changes:**
+- MRP analyzes sales orders within planning horizon
+- Explodes BOMs for quoted products
+- Includes shipping materials (packaging, labels) if consume_stage='shipping'
+
+**Example:**
+```
+Sales Order: SO-2026-00042
+  Customer: Acme Corp
+  Product: Widget
+  Quantity: 10
+  Status: Confirmed
+  Estimated Delivery: 2026-02-20
+
+MRP will:
+1. Explode BOM for Widget (qty: 10)
+2. Calculate material requirements
+3. Create planned orders if shortages exist
+4. Account for packaging materials (boxes, mailers)
+```
+
+### 9.3 Sub-Assembly Lead Time Cascading
+
+**Default Behavior:** All planned orders due ASAP (earliest safe date)
+
+**With Cascading Enabled:**
+- Sub-assembly due dates calculated backwards from parent due date
+- Preserves lead time buffers between levels
+- More realistic timeline
+
+**Example Without Cascading:**
+```
+Parent Product: Custom Enclosure (Due: 2026-02-25)
+  Sub-Assembly: 3D Printed Shell (Due: 2026-02-15) ← ASAP
+    Material: PETG Filament (Due: 2026-02-08) ← ASAP
+```
+
+**Example With Cascading:**
+```
+Parent Product: Custom Enclosure (Due: 2026-02-25)
+  Sub-Assembly: 3D Printed Shell (Due: 2026-02-23) ← 2 days before parent
+    Material: PETG Filament (Due: 2026-02-16) ← 7 days before sub-assy
+```
+
+**Enable:** Set `MRP_ENABLE_SUB_ASSEMBLY_CASCADING=true`
+
+**Use When:**
+- You have multi-level BOMs with sub-assemblies
+- You want realistic lead time offsets
+- You're planning far ahead (30+ days)
+
+---
+
+## 10. Best Practices
+
+### 10.1 MRP Run Frequency
+
+**Recommended Schedule:**
+
+| Business Size | Frequency | Why |
+|--------------|-----------|-----|
+| **Small** (1-5 production orders/week) | Weekly | Monday morning to plan week |
+| **Medium** (5-20 orders/week) | 2-3x per week | Monday, Wednesday, Friday |
+| **Large** (20+ orders/week) | Daily | Every morning before production meeting |
+
+**Trigger MRP When:**
+- ✅ New production orders created
+- ✅ Production schedules change
+- ✅ Large sales orders confirmed
+- ✅ Inventory levels change significantly (after receiving shipments)
+
+### 10.2 Maintaining Accurate Data
+
+**MRP Quality = Data Quality**
+
+**Critical Data to Maintain:**
+
+1. **BOMs** ✅
+   - Keep BOMs accurate and up-to-date
+   - Include ALL components (filament, hardware, packaging)
+   - Set correct quantities and units
+   - Use routing operation materials for 3D printing
+
+2. **Lead Times** ✅
+   - Set realistic lead times on products
+   - Update as vendor performance changes
+   - Account for shipping time + receiving + inspection
+
+3. **Safety Stock** ✅
+   - Set safety stock for critical materials
+   - Formula: `Safety Stock = Daily Usage × Lead Time × Buffer Factor`
+   - Example: 100 G/day × 7 days × 1.5 = 1050 G safety stock
+
+4. **Reorder Points** ✅
+   - Set reorder points to trigger orders
+   - Formula: `Reorder Point = (Daily Usage × Lead Time) + Safety Stock`
+   - MRP will suggest orders when on-hand drops below reorder point
+
+5. **Minimum Order Quantities** ✅
+   - Set min order qty for bulk materials
+   - Example: Filament vendor requires 5 KG minimum
+   - MRP will round up to min qty
+
+### 10.3 Firming Strategy
+
+**When to Firm Planned Orders:**
+
+✅ **Firm Immediately:**
+- Critical materials with long lead times
+- Items already approved by purchasing manager
+- Orders matching existing PO consolidation opportunities
+
+✅ **Firm After Review:**
+- High-value items (review pricing first)
+- New suppliers (verify vendor reliability)
+- Large quantities (negotiate better pricing)
+
+❌ **Don't Firm:**
+- Uncertain demand (production order might cancel)
+- Speculative orders (wait for confirmation)
+- Short lead time items (can order quickly if needed)
+
+### 10.4 Reviewing Planned Orders
+
+**Weekly Review Checklist:**
+
+1. **Planned Purchase Orders:**
+   - [ ] Review quantities (reasonable based on usage?)
+   - [ ] Check vendors (correct supplier selected?)
+   - [ ] Verify due dates (timing makes sense?)
+   - [ ] Consolidate orders (combine orders for same vendor?)
+   - [ ] Firm or release approved orders
+
+2. **Planned Production Orders:**
+   - [ ] Verify product has BOM
+   - [ ] Check sub-assembly quantities
+   - [ ] Ensure materials available for sub-assemblies
+   - [ ] Sequence production (dependencies?)
+   - [ ] Release orders ready to manufacture
+
+### 10.5 Handling Exceptions
+
+**Material Substitutions:**
+- MRP doesn't auto-substitute (uses exact BOM components)
+- If substituting: Cancel planned order, adjust BOM, re-run MRP
+
+**Expediting Orders:**
+- Use Supply/Demand Timeline to identify urgent needs
+- Release planned orders with shorter lead times
+- Manually adjust due dates in released POs
+
+**Cancelling Production Orders:**
+- If a production order cancels, re-run MRP
+- MRP will remove related planned orders
+
+---
+
+## 11. Complete Workflows
+
+### Workflow 1: Weekly MRP Cycle
+
+**Monday Morning Routine**
+
+**Step 1: Prepare for MRP (5 minutes)**
+```
+1. Review upcoming production orders (next 30 days)
+2. Confirm any new sales orders are converted to production orders
+3. Update any BOM changes from last week
+4. Receive any weekend deliveries into inventory
+```
+
+**Step 2: Run MRP (2 minutes)**
+```
+1. Navigate to MRP → Run MRP
+2. Planning Horizon: 30 days
+3. Include Draft Orders: Yes
+4. Regenerate Planned Orders: Yes
+5. Click "Run MRP"
+```
+
+**Step 3: Review Results (10 minutes)**
+```
+1. Check shortages found: 8 materials
+2. Review requirements:
+   - Critical shortages (negative on-hand)
+   - Low stock warnings (below safety stock)
+   - Items with long lead times
+3. Check planned orders:
+   - 5 purchase orders
+   - 3 production orders (sub-assemblies)
+```
+
+**Step 4: Process Purchase Orders (15 minutes)**
+```
+For each planned purchase order:
+1. Review quantity and vendor
+2. Check pricing (standard cost reasonable?)
+3. Consolidate orders (combine orders to same vendor)
+4. Firm high-priority orders
+5. Release orders ready to send:
+   - Select vendor
+   - Confirm quantity and due date
+   - Release → Creates PO-2026-XXXX
+```
+
+**Step 5: Process Production Orders (10 minutes)**
+```
+For each planned production order:
+1. Verify product has BOM
+2. Check material availability for sub-assembly
+3. Coordinate with production lead
+4. Release orders to manufacturing
+```
+
+**Step 6: Send Purchase Orders (10 minutes)**
+```
+1. Go to Purchasing → Purchase Orders
+2. Filter: Status = Draft, Created Today
+3. For each PO:
+   - Review and finalize
+   - Mark as "Ordered"
+   - Send to vendor (email, portal, EDI)
+```
+
+**Total Time: ~50 minutes per week**
+
+---
+
+### Workflow 2: Handling Rush Order
+
+**Scenario:** Customer needs 50 widgets by Friday (4 days away)
+
+**Step 1: Create Production Order (2 minutes)**
+```
+1. Navigate to Production → Production Orders → New
+2. Product: Widget
+3. Quantity: 50
+4. Due Date: 2026-02-11 (Friday)
+5. Priority: High
+6. Save as Draft
+```
+
+**Step 2: Run MRP for This Order (1 minute)**
+```
+1. Navigate to MRP → Requirements
+2. Select: Production Order PO-2026-0042
+3. Click "Calculate Requirements"
+4. View component needs
+```
+
+**Step 3: Check Results (2 minutes)**
+```
+Components Needed:
+- PLA Black Filament: 1750 G
+  On-Hand: 800 G
+  Shortage: 950 G (need 1 KG spool)
+
+- Rubber Feet: 50 EA
+  On-Hand: 200 EA
+  Shortage: 0 EA ✅
+
+- Poly Mailers: 50 EA
+  On-Hand: 25 EA
+  Shortage: 25 EA
+```
+
+**Step 4: Expedite Materials (10 minutes)**
+```
+PLA Black Filament (Shortage: 1 KG):
+  Option A: Order from fast vendor (1-day delivery) ← BEST
+  Option B: Use different color in stock
+  Action: Create manual PO to fast vendor, mark RUSH
+
+Poly Mailers (Shortage: 25 EA):
+  Option A: Order from Amazon (2-day Prime)
+  Option B: Re-use existing mailers from returns
+  Action: Order from Amazon, expedite shipping
+```
+
+**Step 5: Adjust Production Schedule (5 minutes)**
+```
+1. Release production order
+2. Schedule for Friday morning
+3. Ensure filament arrives Wednesday (buffer day)
+4. Block printer capacity
+5. Notify production team of rush order
+```
+
+**Total Time: ~20 minutes**
+
+---
+
+### Workflow 3: Month-End Planning
+
+**Scenario:** Plan material needs for next month
+
+**Step 1: Extended Horizon MRP (5 minutes)**
+```
+1. Navigate to MRP → Run MRP
+2. Planning Horizon: 60 days (2 months)
+3. Include Draft Orders: Yes
+4. Regenerate: Yes
+5. Run MRP
+```
+
+**Step 2: Analyze Long-Term Needs (15 minutes)**
+```
+1. Review planned orders for next month
+2. Group by vendor:
+   - Vendor A: 5 orders, $1,250 total
+   - Vendor B: 3 orders, $450 total
+   - Vendor C: 2 orders, $800 total
+
+3. Identify opportunities:
+   - Consolidate orders to reduce shipping
+   - Negotiate volume discounts
+   - Adjust timing to spread cash flow
+```
+
+**Step 3: Firm Strategic Orders (10 minutes)**
+```
+For critical materials:
+1. Review lead times (8-15 days typical)
+2. Firm all orders due >30 days out
+3. Lock in timing for long-lead items
+```
+
+**Step 4: Budget Review (10 minutes)**
+```
+Calculate monthly material spend:
+- Total planned purchases: $2,500
+- Compare to budget: $3,000 budgeted
+- Review variances and adjust plan
+```
+
+**Step 5: Supplier Communication (15 minutes)**
+```
+1. Email Vendor A with forecast: ~$5K next quarter
+2. Negotiate better pricing for increased volume
+3. Schedule vendor meeting for new products
+```
+
+**Total Time: ~55 minutes**
+
+---
+
+## 12. Troubleshooting
+
+### Issue 1: MRP Found No Shortages (but you expect some)
+
+**Symptoms:**
+- MRP run shows "0 shortages found"
+- You know you need materials
+
+**Causes & Solutions:**
+
+**Cause:** No production orders within planning horizon
+```
+Solution:
+1. Check production orders exist
+2. Verify due dates are within next 30 days
+3. Include draft orders in MRP settings
+```
+
+**Cause:** Production orders have no BOMs
+```
+Solution:
+1. Go to production order
+2. Check if product has active BOM
+3. Assign BOM if missing
+4. Re-run MRP
+```
+
+**Cause:** Safety stock not set
+```
+Solution:
+MRP only creates orders for shortages or safety stock needs
+1. Set safety stock on critical materials
+2. Re-run MRP
+```
+
+### Issue 2: Planned Order Quantity Seems Wrong
+
+**Symptoms:**
+- Planned order suggests 100 KG but you only need 10 KG
+
+**Causes & Solutions:**
+
+**Cause:** Minimum order quantity set too high
+```
+Solution:
+1. Go to product master (e.g., Filament)
+2. Check "Min Order Qty" field
+3. Adjust to realistic minimum (e.g., 1 KG)
+4. Re-run MRP
+```
+
+**Cause:** BOM quantities incorrect
+```
+Solution:
+1. Review BOM for production order
+2. Check component quantities
+3. Fix BOM (e.g., 100 G not 100 KG)
+4. Re-run MRP
+```
+
+**Cause:** UOM mismatch (grams vs kilograms)
+```
+Solution:
+1. Check BOM line unit (should be G for filament)
+2. Check product unit (should be G for inventory)
+3. Verify purchase_uom (KG) and purchase_factor (1000)
+4. See Inventory Management guide, Part 7 (UOM system)
+```
+
+### Issue 3: MRP Creating Duplicate Orders
+
+**Symptoms:**
+- Multiple planned orders for same product
+- Dates are same or very close
+
+**Causes & Solutions:**
+
+**Cause:** Multiple production orders need same component
+```
+Solution:
+This is NORMAL behavior.
+MRP creates separate planned orders for each demand source.
+Action: Consolidate when releasing:
+  1. Select all planned orders for same product/vendor
+  2. Release together
+  3. Creates single PO with combined quantity
+```
+
+**Cause:** MRP run multiple times without "Regenerate"
+```
+Solution:
+1. Run MRP with "Regenerate Planned Orders" = Yes
+2. This deletes old unfirmed planned orders
+3. Creates fresh plan
+```
+
+### Issue 4: Can't Release Planned Order
+
+**Symptoms:**
+- "Release" button disabled or fails
+
+**Causes & Solutions:**
+
+**Cause:** Order already released
+```
+Solution:
+Check status - if "released", it's already converted
+Find created PO/MO using the conversion tracking fields
+```
+
+**Cause:** Product doesn't exist
+```
+Solution:
+1. Check product_id is valid
+2. Verify product not deleted
+3. Re-run MRP to refresh data
+```
+
+**Cause:** Missing vendor (for purchase orders)
+```
+Solution:
+Release requires vendor selection
+1. Click Release
+2. Select vendor from dropdown
+3. Confirm
+```
+
+**Cause:** Product has no BOM (for production orders)
+```
+Solution:
+If product has has_bom=True but no active BOM:
+1. Create BOM for product
+2. Set as active
+3. Try release again
+```
+
+### Issue 5: MRP Run Failed
+
+**Symptoms:**
+- MRP status shows "failed"
+- Error message in results
+
+**Causes & Solutions:**
+
+**Cause:** Circular BOM reference
+```
+Error: "Circular BOM detected: Product A → Product B → Product A"
+Solution:
+1. Review BOMs for products mentioned
+2. Remove circular reference
+3. BOMs should be hierarchical (tree), not circular (loop)
+```
+
+**Cause:** Missing product data
+```
+Error: "Product 123 not found"
+Solution:
+1. Check production orders for invalid product_id
+2. Fix or delete invalid orders
+3. Re-run MRP
+```
+
+**Cause:** Database connection issue
+```
+Error: "Database timeout" or "Connection failed"
+Solution:
+1. Check database is running
+2. Verify connection in backend logs
+3. Retry MRP run
+```
+
+---
+
+## 13. Quick Reference
+
+### MRP Calculation Formula
+
+```
+Net Shortage = Gross Requirement - On-Hand - Incoming + Safety Stock
+
+If Net Shortage > 0:
+  - Create Planned Order (Purchase or Production)
+  - Quantity = max(Net Shortage, Min Order Qty)
+  - Due Date = When material needed
+  - Start Date = Due Date - Lead Time
+```
+
+### Planned Order Lifecycle
+
+```
+[MRP Run] → PLANNED → FIRMED → RELEASED → CANCELLED
+             ↓          ↓         ↓
+        Auto-deleted  Locked   Converted to PO/MO
+        by next MRP  by user
+```
+
+### Key Terminology
+
+| Term | Definition |
+|------|------------|
+| **Planning Horizon** | How far ahead MRP looks (days) |
+| **Gross Requirement** | Total component qty needed before netting |
+| **Net Requirement** | Shortage after considering inventory |
+| **Planned Order** | MRP's suggestion to order material |
+| **Firmed Order** | User-approved planned order (locked) |
+| **Released Order** | Converted to actual PO or MO |
+| **BOM Explosion** | Recursive expansion of multi-level BOMs |
+| **Pegging** | Tracing demand back to source order |
+| **Lead Time** | Days from order to receipt |
+| **Safety Stock** | Minimum buffer inventory |
+| **Reorder Point** | Level that triggers new order |
+
+### API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/mrp/run` | POST | Run MRP calculation |
+| `/api/v1/mrp/runs` | GET | List MRP run history |
+| `/api/v1/mrp/planned-orders` | GET | List planned orders |
+| `/api/v1/mrp/planned-orders/{id}` | GET | Get planned order details |
+| `/api/v1/mrp/planned-orders/{id}/firm` | POST | Firm a planned order |
+| `/api/v1/mrp/planned-orders/{id}/release` | POST | Release to PO/MO |
+| `/api/v1/mrp/planned-orders/{id}` | DELETE | Cancel planned order |
+| `/api/v1/mrp/requirements` | GET | View material requirements |
+| `/api/v1/mrp/supply-demand/{product_id}` | GET | Supply/demand timeline |
+| `/api/v1/mrp/explode-bom/{product_id}` | GET | Explode BOM manually |
+
+### Status Values
+
+**MRP Run Status:**
+- `running` - In progress
+- `completed` - Successfully finished
+- `failed` - Error occurred
+- `cancelled` - User cancelled
+
+**Planned Order Status:**
+- `planned` - MRP suggestion, can be auto-deleted
+- `firmed` - User confirmed, locked
+- `released` - Converted to actual order
+- `cancelled` - No longer needed
+
+**Planned Order Type:**
+- `purchase` - Raw material or purchased part (has_bom=False)
+- `production` - Manufactured sub-assembly (has_bom=True)
+
+### Common Calculations
+
+**Days of Supply:**
+```
+Days of Supply = Available Inventory / Average Daily Demand
+```
+
+**Safety Stock:**
+```
+Safety Stock = Daily Usage × Lead Time × Buffer Factor (1.5-2.0)
+```
+
+**Reorder Point:**
+```
+Reorder Point = (Daily Usage × Lead Time) + Safety Stock
+```
+
+**Lead Time Offset:**
+```
+Start Date = Due Date - Lead Time Days
+```
+
+---
+
+## Related Guides
+
+- **[Inventory Management](inventory-management.md)** - Managing inventory levels, safety stock, and reorder points
+- **[Manufacturing](manufacturing.md)** - Production orders, BOMs, and routing operation materials
+- **[Purchasing](purchasing.md)** - Converting planned purchase orders to actual POs and receiving
+- **[Sales & Quotes](sales-and-quotes.md)** - Understanding how sales orders drive production and MRP demand
+
+---
+
+**Need Help?**
+- Consult the [API Reference](../API-REFERENCE.md) for integration details
+- Report issues on [GitHub](https://github.com/Blb3D/filaops/issues)
+- See [Getting Started](getting-started.md) for initial setup
+
+---
+
+*Last Updated: February 2026 | FilaOps v3.0.0*

--- a/docs/user-guide/printers-and-fleet.md
+++ b/docs/user-guide/printers-and-fleet.md
@@ -1,0 +1,1193 @@
+# Printers & Fleet Monitoring Guide
+
+This guide covers FilaOps' printer management system, including multi-brand printer registration, network discovery, MQTT monitoring, maintenance tracking, and fleet dashboard capabilities.
+
+## Overview
+
+FilaOps provides a **brand-agnostic printer management system** designed for 3D print farms of any size. Whether you run 2 printers or 200, FilaOps can register, monitor, and schedule work across your fleet.
+
+**Key Features:**
+- Multi-brand support (Bambu Lab, Klipper, OctoPrint, Prusa, Creality, Generic)
+- Automatic network discovery (SSDP, mDNS)
+- Real-time MQTT monitoring for Bambu Lab printers
+- Connection testing and diagnostics
+- Preventive maintenance tracking and scheduling
+- Work center integration for production scheduling
+- Print job tracking with time and material variance
+- Bulk CSV import for large fleets
+- Camera and AMS (Auto Material System) support detection
+
+**Fleet Management Flow:**
+```
+Register Printers → Configure Connections → Monitor Status →
+Assign to Work Centers → Schedule Production → Track Maintenance
+```
+
+**Who Uses This Module:**
+- **Administrators** - Full access to printer management and configuration
+- **Operators** - Full access to monitoring and operational features
+
+---
+
+## Table of Contents
+
+1. [Supported Printer Brands](#1-supported-printer-brands)
+2. [Adding Printers](#2-adding-printers)
+3. [Network Discovery](#3-network-discovery)
+4. [Connection Testing](#4-connection-testing)
+5. [Printer Status and Monitoring](#5-printer-status-and-monitoring)
+6. [MQTT Monitoring (Bambu Lab)](#6-mqtt-monitoring-bambu-lab)
+7. [Fleet Dashboard](#7-fleet-dashboard)
+8. [Print Job Tracking](#8-print-job-tracking)
+9. [Maintenance Tracking](#9-maintenance-tracking)
+10. [Work Center Integration](#10-work-center-integration)
+11. [Bulk Import](#11-bulk-import)
+12. [Tier Limits](#12-tier-limits)
+13. [Common Workflows](#13-common-workflows)
+14. [Best Practices](#14-best-practices)
+15. [Troubleshooting](#15-troubleshooting)
+16. [Quick Reference](#16-quick-reference)
+
+---
+
+## 1. Supported Printer Brands
+
+### 1.1 Brand Overview
+
+FilaOps uses a **pluggable adapter architecture** that supports multiple 3D printer brands:
+
+| Brand | Connection | Discovery | Monitoring | Camera |
+|-------|-----------|-----------|------------|--------|
+| **Bambu Lab** | MQTT / LAN | SSDP (auto) | Real-time telemetry | Yes |
+| **Klipper** | Moonraker HTTP | mDNS (auto) | Status polling | Webcam |
+| **OctoPrint** | REST API | HTTP probe | Status polling | Webcam |
+| **Prusa** | PrusaLink | Manual | Basic status | Varies |
+| **Creality** | Network | Manual | Basic status | Varies |
+| **Generic** | Manual | N/A | Manual updates | N/A |
+
+### 1.2 Bambu Lab Printers
+
+**Supported Models:**
+- X1 Carbon (X1C) - Enclosed, multi-material AMS
+- P1S - Enclosed, AMS optional
+- P1P - Open frame
+- A1 - Open frame, AMS Lite
+- A1 Mini - Compact, AMS Lite
+
+**Connection Requirements:**
+- Same local network as FilaOps server
+- LAN mode enabled on printer
+- Access code (from printer settings)
+- Serial number (for MQTT topic)
+
+**Features:**
+- Real-time status via MQTT
+- Print progress percentage
+- Temperature monitoring (nozzle, bed, chamber)
+- AMS filament slot tracking
+- Camera feed (if supported)
+
+### 1.3 Klipper Printers
+
+**Connection Requirements:**
+- Moonraker API running (default port 7125)
+- API key (if authentication enabled)
+- Network accessible from FilaOps server
+
+**Features:**
+- Print status and progress
+- Temperature monitoring
+- Webcam support (via Moonraker)
+
+### 1.4 OctoPrint Printers
+
+**Connection Requirements:**
+- OctoPrint server running (default port 5000 or 80)
+- API key from OctoPrint settings
+- Network accessible from FilaOps server
+
+**Features:**
+- Print status and progress
+- Temperature monitoring
+- Webcam support
+
+### 1.5 Generic Printers
+
+For printers without network connectivity or unsupported brands:
+- Manual status updates only
+- No automatic monitoring
+- Used for tracking and scheduling purposes
+
+---
+
+## 2. Adding Printers
+
+### 2.1 Manual Registration
+
+**Navigation:** Settings → **Printers** → **+ New Printer**
+
+**Step 1: Basic Information**
+
+```
+Code: PRT-001 (auto-generated or custom)
+Name: Leonardo (descriptive name)
+Brand: bambulab
+Model: X1C (from brand's model list)
+Serial Number: 01P00A123456789 (for tracking)
+```
+
+**Step 2: Network Configuration**
+
+```
+IP Address: 192.168.1.100
+MQTT Topic: (auto-derived from serial for Bambu Lab)
+
+Connection Config (brand-specific):
+  Bambu Lab:
+    Access Code: 12345678 (from printer LCD)
+    Serial: 01P00A123456789
+
+  Klipper:
+    Port: 7125
+    API Key: (if required)
+
+  OctoPrint:
+    Port: 80
+    API Key: abc123def456...
+```
+
+**Step 3: Capabilities**
+
+```
+Bed Size: 256 x 256 x 256 mm
+Heated Bed: Yes
+Enclosure: Yes (required for ABS/ASA/PC)
+AMS Slots: 4 (Bambu Lab AMS)
+Camera: Yes
+Max Nozzle Temp: 300 C
+Max Bed Temp: 120 C
+```
+
+**Step 4: Organization**
+
+```
+Location: "Rack A, Shelf 2" (physical location description)
+Work Center: FDM-POOL (production area assignment)
+Notes: "Dedicated to PETG production"
+```
+
+**Step 5: Save**
+
+Click **Create Printer** → Printer registered and ready for monitoring
+
+### 2.2 Auto-Generated Codes
+
+If you leave the code blank, FilaOps generates one automatically:
+
+| Brand | Prefix | Example |
+|-------|--------|---------|
+| Bambu Lab | BAM | BAM-001 |
+| Klipper | KLP | KLP-001 |
+| OctoPrint | OCT | OCT-001 |
+| Generic | PRT | PRT-001 |
+
+**To generate a code manually:**
+
+**Navigation:** Settings → Printers → **Generate Code**
+- Select prefix (e.g., "PRT")
+- System returns next available code (PRT-003)
+
+---
+
+## 3. Network Discovery
+
+### 3.1 Automatic Discovery
+
+FilaOps can automatically find printers on your local network.
+
+**Navigation:** Settings → Printers → **Discover**
+
+**Step 1: Configure Discovery**
+
+```
+Brands to Scan:
+  ☑ Bambu Lab (SSDP on port 1990)
+  ☑ Klipper (mDNS / Moonraker)
+  ☐ OctoPrint (HTTP probe)
+
+Timeout: 5 seconds (1-30 seconds)
+```
+
+**Step 2: Run Discovery**
+
+Click **Start Discovery** → System scans the network
+
+**Step 3: Review Results**
+
+```
+Discovery Results (scanned in 4.2 seconds)
+═══════════════════════════════════════════════════════════
+Found  Brand      Model  IP Address      Serial          Status
+═══════════════════════════════════════════════════════════
+✅ New  Bambu Lab  X1C   192.168.1.100   01P00A123456   Not registered
+✅ New  Bambu Lab  P1S   192.168.1.101   01P00B789012   Not registered
+⚠️ Dup  Bambu Lab  A1    192.168.1.102   01P00C345678   Already registered
+✅ New  Klipper    -     192.168.1.110   -              Not registered
+═══════════════════════════════════════════════════════════
+Found: 4 printers (3 new, 1 duplicate)
+```
+
+**Step 4: Add Discovered Printers**
+
+- Click **Add** next to each new printer
+- Pre-fills brand, model, IP address, serial number
+- Review and customize name, code, location
+- Click **Save**
+
+### 3.2 IP Probe
+
+For Docker deployments or when SSDP/mDNS doesn't work, probe a specific IP:
+
+**Navigation:** Settings → Printers → **Probe IP**
+
+```
+IP Address: 192.168.1.100
+
+Result:
+  Open Ports:
+    ✅ 8883 (MQTT - Bambu Lab)
+    ✅ 80 (HTTP)
+    ❌ 7125 (Moonraker - not found)
+    ❌ 5000 (OctoPrint - not found)
+
+  Detected Brand: Bambu Lab
+  Suggested Code: BAM-003
+```
+
+**Use Cases:**
+- Printer not found by automatic discovery
+- Running FilaOps in Docker (SSDP doesn't cross container boundaries)
+- Confirming a specific printer's network presence
+
+### 3.3 Discovery Protocol Details
+
+| Brand | Protocol | Port | Method |
+|-------|----------|------|--------|
+| Bambu Lab | SSDP | 1990 | UDP multicast broadcast |
+| Klipper | mDNS | 7125 | DNS service discovery |
+| OctoPrint | HTTP | 5000/80 | HTTP API probe |
+| Prusa | Manual | - | Not auto-discoverable |
+| Creality | Manual | - | Not auto-discoverable |
+
+---
+
+## 4. Connection Testing
+
+### 4.1 Testing a Printer Connection
+
+Before relying on monitoring, verify the connection works.
+
+**Navigation:** Settings → Printers → Select printer → **Test Connection**
+
+**Or before adding:** Settings → Printers → **Test Connection** (standalone)
+
+**Input:**
+```
+IP Address: 192.168.1.100
+Brand: bambulab
+Connection Config:
+  Access Code: 12345678
+  Serial: 01P00A123456789
+```
+
+**Output (Success):**
+```
+✅ Connection Successful
+  Response Time: 42ms
+  Printer Status: Idle
+  Model: X1C
+  Firmware: 01.07.00.00
+```
+
+**Output (Failure):**
+```
+❌ Connection Failed
+  Error: Connection timed out after 5000ms
+  Suggestion: Check IP address and network connectivity
+```
+
+### 4.2 Common Connection Issues
+
+| Error | Cause | Solution |
+|-------|-------|---------|
+| Connection timeout | Wrong IP or printer offline | Verify IP, check printer power/WiFi |
+| Authentication failed | Wrong access code or API key | Re-enter credentials from printer |
+| Port not open | Firewall blocking | Check firewall rules for required ports |
+| MQTT connection refused | LAN mode not enabled | Enable LAN mode on Bambu Lab printer |
+
+---
+
+## 5. Printer Status and Monitoring
+
+### 5.1 Printer Status Values
+
+| Status | Meaning | Indicator | Auto-Detected? |
+|--------|---------|-----------|---------------|
+| **offline** | Not seen in 5+ minutes | Gray | Yes |
+| **idle** | Connected, no job running | Green | Yes |
+| **printing** | Active print in progress | Blue | Yes |
+| **paused** | Print paused | Yellow | Yes |
+| **error** | Error state | Red | Yes |
+| **maintenance** | Under maintenance | Orange | Manual only |
+
+### 5.2 Online Detection
+
+A printer is considered **online** if it was last seen within **5 minutes**. The `last_seen` timestamp updates whenever:
+
+- MQTT telemetry is received (Bambu Lab)
+- API poll returns successfully (Klipper, OctoPrint)
+- Manual status update is performed
+
+### 5.3 Updating Status Manually
+
+For printers without automatic monitoring (Generic brand or network issues):
+
+**Navigation:** Settings → Printers → Select printer → **Update Status**
+
+```
+New Status: maintenance
+Notes: "Nozzle replacement scheduled"
+```
+
+**Or via API:**
+```
+PATCH /api/v1/printers/{id}/status
+Body: { "status": "maintenance" }
+```
+
+### 5.4 Printer List View
+
+**Navigation:** Settings → **Printers** (or Printers module in sidebar)
+
+**Columns:**
+- Code (PRT-001, BAM-001, etc.)
+- Name
+- Brand and Model
+- IP Address
+- Status (with color indicator)
+- Online (last seen timestamp)
+- Work Center
+- Location
+
+**Filters:**
+- Search (name, code, model, location)
+- Brand
+- Status
+- Active only
+
+---
+
+## 6. MQTT Monitoring (Bambu Lab)
+
+### 6.1 How MQTT Monitoring Works
+
+For Bambu Lab printers, FilaOps connects via MQTT (Message Queuing Telemetry Transport) for real-time monitoring:
+
+```
+Bambu Lab Printer
+    │
+    ├── MQTT Broker (port 8883 TLS)
+    │
+    ▼
+FilaOps MQTT Service
+    │
+    ├── Telemetry Events (temperature, progress, status)
+    ├── Print Job Status (started, progress, completed, failed)
+    └── AMS Filament Info (slot, material, color)
+```
+
+### 6.2 Enabling MQTT Monitoring
+
+**Prerequisites:**
+1. Bambu Lab printer on same LAN as FilaOps server
+2. LAN mode enabled on printer
+3. Access code obtained from printer settings
+4. Printer registered in FilaOps with correct serial number
+
+**The MQTT monitor service starts automatically** when the FilaOps backend starts. It:
+1. Loads all active Bambu Lab printers from the database
+2. Establishes MQTT connections to each printer
+3. Receives telemetry events in real-time
+4. Queues events for processing (up to 1,000 events)
+5. Periodically flushes status updates to the database
+
+### 6.3 Telemetry Data
+
+**Available data from MQTT telemetry:**
+
+| Data Point | Description | Update Frequency |
+|-----------|-------------|-----------------|
+| Print Status | Idle, printing, paused, error | On change |
+| Print Progress | 0-100% completion | Every few seconds |
+| Nozzle Temperature | Current/target nozzle temp | Every few seconds |
+| Bed Temperature | Current/target bed temp | Every few seconds |
+| Chamber Temperature | Enclosed chamber temp | Every few seconds |
+| Print Speed | Current speed profile | On change |
+| Layer Progress | Current layer / total layers | On layer change |
+| Remaining Time | Estimated minutes remaining | Periodically |
+| AMS Status | Filament type/color per slot | On change |
+
+### 6.4 Event Processing
+
+The MQTT service processes events through an **event queue**:
+
+1. **Receive** - MQTT message arrives from printer
+2. **Parse** - Extract telemetry data
+3. **Queue** - Add to event queue (max 1,000 events)
+4. **Process** - Update in-memory printer state
+5. **Flush** - Periodically write status to database
+
+**This architecture ensures:**
+- No missed events during high-frequency updates
+- Database isn't overwhelmed with writes
+- Real-time display in the UI
+- Historical data recorded at reasonable intervals
+
+---
+
+## 7. Fleet Dashboard
+
+### 7.1 Fleet Overview
+
+**Navigation:** Printers (in sidebar)
+
+The fleet dashboard shows all registered printers at a glance:
+
+```
+Fleet Status Summary
+═══════════════════════════════════════
+Online:      6 / 8 printers
+Printing:    4
+Idle:        2
+Offline:     1
+Maintenance: 1
+═══════════════════════════════════════
+```
+
+### 7.2 Printer Cards
+
+Each printer displays as a card with:
+
+```
+┌─────────────────────────────────────┐
+│ 🟢 Leonardo (X1C)           BAM-001│
+│ Status: Printing (67%)              │
+│ Nozzle: 220°C / 220°C              │
+│ Bed: 60°C / 60°C                   │
+│ Layer: 145 / 217                    │
+│ Time Remaining: 1h 23m             │
+│ Job: Phone Stand v3                 │
+│ Work Center: FDM-POOL              │
+│ Location: Rack A, Shelf 1          │
+└─────────────────────────────────────┘
+```
+
+### 7.3 Active Work View
+
+**Navigation:** Printers → **Active Work**
+
+Shows current and queued production work per printer:
+
+```
+Active Work Assignments
+═══════════════════════════════════════════════════════════
+Printer         Current Job              Queue
+═══════════════════════════════════════════════════════════
+Leonardo (X1C)  PO-2026-042 (OP-10)     2 queued
+                Phone Stand × 10
+                Status: printing (67%)
+
+Donatello (X1C) PO-2026-043 (OP-10)     1 queued
+                Bracket × 25
+                Status: printing (34%)
+
+Michelangelo    (idle)                   0 queued
+Raphael         (maintenance)            0 queued
+═══════════════════════════════════════════════════════════
+```
+
+**Columns:**
+- Printer name and model
+- Current production order and operation
+- Product and quantity
+- Operation status (running/queued)
+- Queue depth (number of waiting jobs)
+
+---
+
+## 8. Print Job Tracking
+
+### 8.1 What is a Print Job?
+
+A **Print Job** represents a single print operation on a specific printer. It links a production order operation to a physical printer.
+
+### 8.2 Print Job Statuses
+
+| Status | Meaning | Triggered By |
+|--------|---------|-------------|
+| **queued** | Waiting to start | Job assigned to printer |
+| **assigned** | Assigned, awaiting start | Operator confirms |
+| **printing** | Currently printing | MQTT status or manual start |
+| **completed** | Print finished successfully | MQTT status or manual complete |
+| **failed** | Print failed | MQTT error or manual report |
+
+### 8.3 Job Details
+
+Each print job tracks:
+
+```
+Print Job: JOB-2026-0042
+═══════════════════════════════════════
+Production Order: PO-2026-0042
+Printer: Leonardo (BAM-001)
+Priority: Normal
+
+File: phone_stand_v3.gcode
+
+Timing:
+  Estimated: 150 minutes
+  Actual: 156 minutes
+  Variance: +4% (6 min over)
+
+Material:
+  Estimated: 450 grams
+  Actual: 462 grams
+  Variance: +2.7% (12 g over)
+
+Timestamps:
+  Queued:    2026-02-07 08:00
+  Started:   2026-02-07 08:15
+  Finished:  2026-02-07 10:51
+
+Status: completed
+Notes: "First layer looked good, no issues"
+═══════════════════════════════════════
+```
+
+### 8.4 Variance Tracking
+
+FilaOps calculates the percentage difference between estimated and actual values:
+
+```
+Time Variance = ((Actual - Estimated) / Estimated) × 100%
+Material Variance = ((Actual - Estimated) / Estimated) × 100%
+```
+
+**Target variances:**
+- Time: < 10% (reasonable)
+- Material: < 5% (good slicer estimates)
+
+**High variances indicate:**
+- Inaccurate slicer estimates (update profiles)
+- Print quality issues (supports, retraction, speed)
+- Material waste (failed starts, purge)
+
+---
+
+## 9. Maintenance Tracking
+
+### 9.1 Maintenance Types
+
+| Type | Description | Frequency |
+|------|-------------|-----------|
+| **routine** | Scheduled preventive maintenance | Weekly/monthly |
+| **repair** | Emergency fix for breakdowns | As needed |
+| **calibration** | Bed leveling, extrusion calibration | Monthly |
+| **cleaning** | Nozzle, bed, enclosure cleaning | Weekly |
+
+### 9.2 Recording Maintenance
+
+**Navigation:** Printers → Select printer → **Maintenance** → **+ Log Maintenance**
+
+```
+Maintenance Type: routine
+Description: "Weekly nozzle cleaning and bed inspection"
+Performed By: "John Smith"
+Performed At: 2026-02-07 09:00
+
+Cost: $5.00 (nozzle replacement parts)
+Downtime: 30 minutes
+
+Parts Used: "0.4mm hardened steel nozzle"
+
+Next Due: 2026-02-14 (in 7 days)
+
+Notes: "Noticed slight wear on bed surface,
+        monitor for next 2 weeks"
+```
+
+### 9.3 Maintenance History
+
+**Navigation:** Printers → Select printer → **Maintenance History**
+
+```
+Maintenance Log: Leonardo (BAM-001)
+═══════════════════════════════════════════════════════════
+Date       Type         Description           Cost  Downtime
+═══════════════════════════════════════════════════════════
+2026-02-07 routine      Weekly nozzle clean    $5     30 min
+2026-01-31 calibration  Bed level + flow cal   $0     45 min
+2026-01-25 repair       PTFE tube replacement  $8     60 min
+2026-01-24 routine      Weekly nozzle clean    $0     30 min
+═══════════════════════════════════════════════════════════
+Total Cost: $13.00
+Total Downtime: 2 hrs 45 min
+```
+
+### 9.4 Scheduling Next Maintenance
+
+When recording maintenance, set the **Next Due** date. The system will show upcoming maintenance in the fleet dashboard.
+
+```
+Upcoming Maintenance (Next 7 Days)
+═══════════════════════════════════════
+Printer         Type        Due Date
+═══════════════════════════════════════
+Leonardo        routine     Feb 14
+Donatello       calibration Feb 12
+Michelangelo    routine     Feb 14
+═══════════════════════════════════════
+```
+
+---
+
+## 10. Work Center Integration
+
+### 10.1 Assigning Printers to Work Centers
+
+Each printer can belong to a **Work Center** for production scheduling:
+
+```
+Work Center: FDM-POOL
+  ├── Leonardo (X1C) - BAM-001
+  ├── Donatello (X1C) - BAM-002
+  ├── Michelangelo (P1S) - BAM-003
+  └── Raphael (P1S) - BAM-004
+```
+
+**To assign:**
+1. Navigate to Printers → Select printer → Edit
+2. Select Work Center: FDM-POOL
+3. Save
+
+**Or from Work Centers:**
+1. Settings → Work Centers → FDM-POOL
+2. Resources tab → + Add Resource
+3. Select printer
+
+### 10.2 How Scheduling Uses Printers
+
+When a production order operation is assigned to a work center:
+
+1. **Operation** → Assigned to **Work Center** (FDM-POOL)
+2. **Work Center** → Contains **Printers** (Leonardo, Donatello, etc.)
+3. **Scheduler** → Assigns operation to specific **Printer** based on:
+   - Availability (idle, not in maintenance)
+   - Capability (enclosure for ABS, bed size for large parts)
+   - Queue depth (balance load)
+   - Priority (rush orders first)
+
+### 10.3 Material Compatibility
+
+Printers with **enclosures** can print all materials. Open-frame printers are limited:
+
+| Printer Type | PLA | PETG | TPU | ABS | ASA | PC |
+|-------------|-----|------|-----|-----|-----|-----|
+| Open frame (A1, A1 Mini) | Yes | Yes | Yes | No | No | No |
+| Enclosed (P1S, X1C) | Yes | Yes | Yes | Yes | Yes | Yes |
+
+**Scheduling enforces these constraints** - ABS orders won't be assigned to open-frame printers.
+
+---
+
+## 11. Bulk Import
+
+### 11.1 CSV Import
+
+For large print farms, import printers from a CSV file.
+
+**Navigation:** Settings → Printers → **Import**
+
+**Step 1: Download Template**
+
+Click **Download Template** to get the CSV format:
+
+```csv
+code,name,model,brand,serial_number,ip_address,location,notes
+BAM-001,Leonardo,X1C,bambulab,01P00A123456,192.168.1.100,Rack A Shelf 1,Primary printer
+BAM-002,Donatello,X1C,bambulab,01P00A789012,192.168.1.101,Rack A Shelf 2,
+BAM-003,Michelangelo,P1S,bambulab,01P00B345678,192.168.1.102,Rack B Shelf 1,
+KLP-001,Voron 2.4,voron,klipper,,192.168.1.110,Rack C,Custom build
+```
+
+**Required Columns:**
+- `code` - Unique printer code
+- `name` - Human-readable name
+- `model` - Printer model
+
+**Optional Columns:**
+- `brand` - Printer brand (defaults to "generic")
+- `serial_number` - Serial number
+- `ip_address` - Network address
+- `location` - Physical location
+- `notes` - Additional information
+
+**Step 2: Upload and Import**
+
+```
+Upload CSV: [Select File]
+Skip Duplicates: ☑ (skip rows where code already exists)
+```
+
+**Step 3: Review Results**
+
+```
+Import Results
+═══════════════════════════════════
+Total Rows: 10
+Imported: 8
+Skipped (duplicates): 1
+Errors: 1
+  Row 7: Missing required field 'name'
+═══════════════════════════════════
+```
+
+### 11.2 Import Tips
+
+- **code** must be unique across all printers
+- **brand** must be one of: bambulab, klipper, octoprint, prusa, creality, generic
+- All imported printers start with status `offline`
+- Connection config (access codes, API keys) must be added manually after import
+- Use **Skip Duplicates** to safely re-run imports
+
+---
+
+## 12. Tier Limits
+
+### 12.1 Community Tier
+
+The **Community (open-source) tier** has a limit on active printers:
+
+| Tier | Active Printer Limit |
+|------|---------------------|
+| Community | 4 printers |
+
+**Active** means `active = true`. You can register more printers but only 4 can be active at once.
+
+### 12.2 Managing Within Limits
+
+If you hit the limit:
+1. Deactivate printers not currently in use
+2. Swap active/inactive as needed
+3. Inactive printers retain all history and configuration
+
+**To deactivate:**
+1. Printers → Select printer → Edit
+2. Set Active: No
+3. Save (printer hidden from scheduling and monitoring)
+
+**To reactivate:**
+1. Printers → Filter: Show Inactive
+2. Select printer → Edit
+3. Set Active: Yes (will fail if at tier limit)
+
+---
+
+## 13. Common Workflows
+
+### Workflow 1: Setting Up a New Printer
+
+```
+1. Unbox and connect printer to WiFi
+2. Note the IP address and serial number
+3. Enable LAN mode (Bambu Lab):
+   - Printer LCD → Settings → Network → LAN Mode
+   - Note the access code
+4. Register in FilaOps:
+   - Printers → + New Printer
+   - Enter: name, brand, model, IP, serial, access code
+   - Assign to work center
+5. Test connection:
+   - Click "Test Connection"
+   - Verify: ✅ Connected
+6. Verify MQTT monitoring:
+   - Wait 30 seconds
+   - Check status updates to "idle"
+   - ✅ Printer online and monitored
+```
+
+**Time estimate:** 10 minutes
+
+### Workflow 2: Fleet Discovery (New Setup)
+
+```
+1. Ensure all printers are on the network
+2. Navigate to Printers → Discover
+3. Select brands to scan
+4. Click "Start Discovery"
+5. Review found printers:
+   - 6 printers found
+   - 0 duplicates
+6. Click "Add" for each printer
+7. Customize names and codes
+8. Assign to work centers
+9. Test all connections
+10. Verify monitoring is active
+```
+
+**Time estimate:** 20 minutes for 6 printers
+
+### Workflow 3: Weekly Maintenance Routine
+
+```
+1. Check fleet dashboard for maintenance due:
+   - Leonardo: routine cleaning due today
+   - Donatello: calibration due tomorrow
+
+2. Mark Leonardo as "maintenance":
+   - Update status to maintenance
+   - Production scheduler stops assigning jobs
+
+3. Perform maintenance:
+   - Clean nozzle
+   - Inspect bed surface
+   - Check belt tension
+   - Run calibration print
+
+4. Log maintenance:
+   - Printers → Leonardo → Maintenance → + Log
+   - Type: routine
+   - Description: "Weekly clean + belt check"
+   - Downtime: 30 min
+   - Next due: +7 days
+
+5. Return to service:
+   - Update status to idle
+   - Scheduler resumes assigning jobs
+
+6. Repeat for Donatello's calibration
+```
+
+**Time estimate:** 30-45 minutes per printer
+
+### Workflow 4: Handling a Print Failure
+
+```
+1. MQTT reports: Leonardo status = error
+2. Fleet dashboard shows red indicator
+3. Investigate:
+   - Check printer display for error code
+   - View camera feed (if available)
+   - Found: Spaghetti failure (poor adhesion)
+4. Clear the failure:
+   - Remove failed print from bed
+   - Clean bed surface
+   - Reset printer
+5. Update in FilaOps:
+   - Print job status → failed
+   - Notes: "First layer adhesion failure"
+   - Scrap reason: adhesion
+6. Restart production:
+   - Printer status resets to idle
+   - Re-queue the print job
+   - Assign to same or different printer
+7. Log if maintenance needed:
+   - If recurring: Schedule bed replacement
+```
+
+### Workflow 5: Scaling the Fleet
+
+```
+1. Purchase new printers (e.g., 4 × P1S)
+2. Network setup:
+   - Connect all to WiFi
+   - Assign static IPs (recommended)
+   - Enable LAN mode
+3. Bulk import:
+   - Create CSV with all 4 printers
+   - Import via Printers → Import
+4. Configure connections:
+   - Add access codes for each
+   - Test connections
+5. Assign to work center:
+   - Add all to FDM-POOL
+   - Update capacity: 8 printers → 12 printers
+6. Update work center rates:
+   - Adjust capacity hours/day
+   - Machine depreciation rate may decrease (per-unit)
+7. Verify monitoring:
+   - All 4 showing "idle" on dashboard
+   - MQTT connections established
+8. Production ready:
+   - MRP and scheduler now see additional capacity
+```
+
+---
+
+## 14. Best Practices
+
+### Fleet Management
+
+- **Do:** Use consistent naming conventions (e.g., Printer-001, Printer-002)
+- **Do:** Assign static IP addresses (printers changing IPs breaks monitoring)
+- **Do:** Keep firmware updated across the fleet
+- **Do:** Label physical printers with their FilaOps code
+- **Do:** Assign all printers to work centers for scheduling
+
+- **Don't:** Mix printer codes between logical groups
+- **Don't:** Forget to update FilaOps when moving printers physically
+- **Don't:** Ignore "offline" status for extended periods
+
+### Monitoring
+
+- **Do:** Check fleet dashboard daily for offline or error printers
+- **Do:** Investigate failed prints promptly (prevent repeat failures)
+- **Do:** Monitor print variance trends (consistent overestimates = update slicer)
+- **Do:** Use camera feeds for remote monitoring when available
+
+- **Don't:** Rely solely on automatic monitoring (check physically too)
+- **Don't:** Ignore recurring error patterns
+
+### Maintenance
+
+- **Do:** Schedule routine maintenance weekly (nozzle, bed, belts)
+- **Do:** Log all maintenance activities (builds history for planning)
+- **Do:** Track costs and downtime (for OEE calculations)
+- **Do:** Set the "Next Due" date for preventive scheduling
+
+- **Don't:** Skip maintenance to save time (causes bigger failures)
+- **Don't:** Forget to change status to "maintenance" before working on a printer
+- **Don't:** Use a printer that needs repair for production
+
+### Network
+
+- **Do:** Use a dedicated VLAN or subnet for printers
+- **Do:** Assign static IPs or DHCP reservations
+- **Do:** Ensure FilaOps server can reach all printer IPs
+- **Do:** Open required ports (8883 MQTT, 7125 Moonraker, 5000 OctoPrint)
+
+- **Don't:** Put printers on guest WiFi
+- **Don't:** Rely on DHCP without reservations (IP changes break connections)
+
+---
+
+## 15. Troubleshooting
+
+### Printer Shows "Offline"
+
+**Symptom:** Printer card shows gray "offline" status
+
+**Causes & Solutions:**
+
+**Network issue:**
+```
+1. Verify printer is powered on
+2. Check printer's WiFi connection
+3. Ping printer IP from FilaOps server
+4. Check firewall rules
+5. Verify printer and server are on same network/VLAN
+```
+
+**MQTT connection lost (Bambu Lab):**
+```
+1. Verify LAN mode is still enabled on printer
+2. Check access code hasn't changed (firmware update can reset)
+3. Re-enter access code in FilaOps printer config
+4. Test connection to verify
+```
+
+**Monitoring service not running:**
+```
+1. Check FilaOps backend logs for MQTT errors
+2. Restart backend service
+3. MQTT service auto-reconnects on startup
+```
+
+### Discovery Finds No Printers
+
+**Symptom:** Network discovery returns 0 results
+
+**Causes & Solutions:**
+
+**SSDP blocked (Bambu Lab):**
+```
+1. SSDP uses UDP multicast on port 1990
+2. Some routers block multicast between subnets
+3. Solution: Use IP probe instead of discovery
+4. Or configure router to allow multicast
+```
+
+**Docker networking:**
+```
+1. Docker containers can't receive SSDP broadcasts
+2. Use host networking mode for discovery
+3. Or use IP probe with known addresses
+```
+
+**Printers not discoverable:**
+```
+1. Not all brands support auto-discovery
+2. Prusa and Creality require manual registration
+3. Use IP probe or manual entry instead
+```
+
+### Test Connection Fails
+
+**Symptom:** "Connection Failed" when testing
+
+**By Brand:**
+
+**Bambu Lab:**
+```
+1. Check IP address is correct
+2. Verify LAN mode enabled
+3. Verify access code is correct
+4. Port 8883 must be open (MQTT over TLS)
+```
+
+**Klipper:**
+```
+1. Check Moonraker is running
+2. Verify port 7125 is accessible
+3. Check API key if authentication is enabled
+4. Try: curl http://{ip}:7125/server/info
+```
+
+**OctoPrint:**
+```
+1. Check OctoPrint is running
+2. Verify API key in OctoPrint Settings → API
+3. Try: curl -H "X-Api-Key: {key}" http://{ip}/api/version
+```
+
+### Print Job Stuck in "Queued"
+
+**Symptom:** Job doesn't start printing
+
+**Causes:**
+```
+1. Printer status not "idle" (check dashboard)
+2. Printer not assigned to correct work center
+3. Previous job not completed/cleared
+4. Printer in maintenance mode
+```
+
+**Solution:**
+```
+1. Check printer status on dashboard
+2. Clear any stuck jobs or error states
+3. Verify work center assignment
+4. Manually start the job if auto-dispatch fails
+```
+
+### High Material Variance
+
+**Symptom:** Actual material usage consistently >10% over estimate
+
+**Causes:**
+```
+1. Slicer estimates don't include purge/waste
+2. Support material not accounted for
+3. Failed starts (partial prints) consuming material
+4. AMS filament changes adding purge waste
+```
+
+**Solution:**
+```
+1. Update slicer profile with more accurate flow rates
+2. Add waste factor to BOM (5-10%)
+3. Track failed starts separately
+4. Account for AMS purge in material estimates
+```
+
+---
+
+## 16. Quick Reference
+
+### Printer Status Values
+
+| Status | Color | Auto-Detected | Description |
+|--------|-------|--------------|-------------|
+| offline | Gray | Yes (timeout) | Not seen in 5+ min |
+| idle | Green | Yes | Ready, no job |
+| printing | Blue | Yes | Active print |
+| paused | Yellow | Yes | Print paused |
+| error | Red | Yes | Error state |
+| maintenance | Orange | Manual | Under maintenance |
+
+### Print Job Status Values
+
+| Status | Meaning |
+|--------|---------|
+| queued | Waiting to start |
+| assigned | Assigned to printer |
+| printing | Currently printing |
+| completed | Finished successfully |
+| failed | Print failed |
+
+### Maintenance Types
+
+| Type | Frequency | Typical Duration |
+|------|-----------|-----------------|
+| routine | Weekly | 30 min |
+| calibration | Monthly | 45 min |
+| cleaning | Weekly | 15 min |
+| repair | As needed | 30-120 min |
+
+### Required Network Ports
+
+| Port | Protocol | Brand | Purpose |
+|------|----------|-------|---------|
+| 8883 | TCP (TLS) | Bambu Lab | MQTT monitoring |
+| 1990 | UDP | Bambu Lab | SSDP discovery |
+| 7125 | TCP | Klipper | Moonraker API |
+| 5000 | TCP | OctoPrint | REST API |
+| 80/443 | TCP | Various | HTTP/HTTPS |
+
+### API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/printers/` | GET | List printers |
+| `/api/v1/printers/` | POST | Create printer |
+| `/api/v1/printers/{id}` | GET | Get printer details |
+| `/api/v1/printers/{id}` | PUT | Update printer |
+| `/api/v1/printers/{id}` | DELETE | Delete printer |
+| `/api/v1/printers/{id}/status` | PATCH | Update status |
+| `/api/v1/printers/generate-code` | GET | Generate unique code |
+| `/api/v1/printers/brands/info` | GET | Supported brands |
+| `/api/v1/printers/discover` | POST | Network discovery |
+| `/api/v1/printers/probe-ip` | POST | Probe single IP |
+| `/api/v1/printers/test-connection` | POST | Test connectivity |
+| `/api/v1/printers/import-csv` | POST | Bulk CSV import |
+| `/api/v1/printers/active-work` | GET | Current/queued work |
+
+---
+
+## Related Guides
+
+- **[Getting Started](getting-started.md)** - Initial setup and first-time configuration
+- **[Manufacturing](manufacturing.md)** - Production orders, work centers, and scheduling
+- **[Settings & Admin](settings-and-admin.md)** - Work center configuration and user management
+- **[Inventory Management](inventory-management.md)** - Material tracking for print operations
+
+---
+
+**Need Help?**
+- Consult the [API Reference](../API-REFERENCE.md) for integration details
+- Report issues on [GitHub](https://github.com/Blb3D/filaops/issues)
+- See [Getting Started](getting-started.md) for initial setup
+
+---
+
+*Last Updated: February 2026 | FilaOps v3.0.0*

--- a/docs/user-guide/purchasing.md
+++ b/docs/user-guide/purchasing.md
@@ -1,0 +1,1071 @@
+# Purchasing Guide
+
+This guide covers FilaOps' purchasing system for managing vendors, purchase orders, and inventory receiving.
+
+## Overview
+
+FilaOps purchasing system handles the complete procurement workflow:
+
+- **Vendors** - Manage supplier information and terms
+- **Purchase Orders** - Create and track orders to vendors
+- **Receiving** - Record incoming inventory and update stock levels
+- **Documents** - Attach invoices, packing slips, receipts
+- **MRP Integration** - Automatic PO generation from material requirements
+- **Cost Tracking** - Update product costs from actual purchases
+
+**Purchasing Flow:**
+```
+Reorder Point Triggered → Create Purchase Order → Send to Vendor →
+Vendor Ships → Receive Inventory → Update Costs → Close PO
+```
+
+---
+
+## Part 1: Vendors
+
+### What is a Vendor?
+
+A **Vendor** (also called **Supplier**) is a company you purchase materials, components, or supplies from.
+
+**Vendor information includes:**
+- Contact details (name, email, phone, website)
+- Address (shipping/billing)
+- Business terms (payment terms, lead time)
+- Performance tracking (rating, lead time)
+- Account information
+
+### Creating Vendors
+
+**Navigation:** Purchasing → Vendors → **+ New Vendor**
+
+**Step 1: Basic Information**
+
+```
+Code: VND-001 (auto-generated or manual)
+Name: 3D Filament Warehouse
+
+Contact Name: John Smith
+Email: orders@3dfilament.com
+Phone: (555) 123-4567
+Website: https://www.3dfilament.com
+```
+
+**Step 2: Address**
+
+```
+Address Line 1: 123 Industrial Pkwy
+Address Line 2: Suite 200
+City: Springfield
+State: IL
+Postal Code: 62701
+Country: USA
+```
+
+**Step 3: Business Terms**
+
+```
+Payment Terms: Net 30 (options: COD, Net 30, Net 60, Upon Receipt)
+Account Number: ACCT-12345 (your account with them)
+Tax ID: 12-3456789 (vendor's tax ID)
+
+Lead Time (days): 7 (average shipping time)
+```
+
+**Step 4: Performance Tracking**
+
+```
+Rating: 4.5 (1.0-5.0 scale)
+  - 5.0 = Excellent (fast, reliable, quality)
+  - 4.0 = Good
+  - 3.0 = Average
+  - 2.0 = Below Average
+  - 1.0 = Poor (slow, unreliable)
+
+Notes:
+"Reliable vendor for PLA and PETG. Ships same-day if ordered before 2 PM EST.
+Occasional backorders on specialty colors. Good customer service."
+```
+
+**Step 5: Save**
+
+Click **Create Vendor** → Vendor is created and ready for purchase orders
+
+**✅ Result:** Vendor code generated (e.g., `VND-001`)
+
+### Vendor List View
+
+**Navigation:** Purchasing → Vendors
+
+**Columns:**
+- Vendor Code (VND-001, VND-002, etc.)
+- Name
+- Contact Email
+- Phone
+- Lead Time
+- Rating
+- Active (✓ / ✗)
+
+**Filter by:**
+- Active/Inactive
+- Search (name, email, code)
+
+**Actions:**
+- Click vendor to view details
+- Edit vendor information
+- Deactivate (don't delete - preserves history)
+- Create PO for vendor
+
+### Vendor Detail View
+
+**Sections:**
+
+1. **Vendor Information**
+   - All contact/address/terms data
+   - Edit button
+
+2. **Purchase Orders**
+   - List of all POs for this vendor
+   - Filter by status (draft, ordered, received, closed)
+   - Total spend
+
+3. **Products Purchased**
+   - List of products ordered from this vendor
+   - Last purchase price
+   - Last order date
+
+4. **Performance Metrics**
+   - Total POs
+   - Total spend ($ amount)
+   - Average lead time
+   - On-time delivery rate
+
+---
+
+## Part 2: Purchase Orders
+
+### What is a Purchase Order?
+
+A **Purchase Order (PO)** is an official order document sent to a vendor to purchase items.
+
+**PO contains:**
+- Vendor information
+- List of items to purchase
+- Quantities and prices
+- Expected delivery date
+- Payment terms
+- Shipping instructions
+
+**PO number format:** `PO-2026-001` (auto-generated)
+
+### Purchase Order Statuses
+
+| Status | Meaning | Next Actions |
+|--------|---------|--------------|
+| **draft** | Being created/edited | Submit to vendor |
+| **ordered** | Sent to vendor, awaiting shipment | Wait for shipment |
+| **shipped** | Vendor has shipped | Receive inventory |
+| **received** | Inventory received, pending close | Review and close |
+| **closed** | Completed and archived | No further action |
+| **cancelled** | Order cancelled | No further action |
+
+### Purchase Order Lifecycle
+
+**Standard Flow:**
+```
+draft → ordered → shipped → received → closed
+```
+
+**Can skip directly:**
+```
+draft → received → closed (for immediate purchases)
+```
+
+---
+
+## Part 3: Creating Purchase Orders
+
+### Manual PO Creation
+
+**Navigation:** Purchasing → Purchase Orders → **+ New Purchase Order**
+
+**Step 1: Vendor Selection**
+
+```
+Vendor: 3D Filament Warehouse (VND-001)
+  - Auto-fills vendor details
+  - Shows payment terms, lead time
+
+Order Date: 2026-02-08 (today)
+Expected Date: 2026-02-15 (order date + vendor lead time)
+```
+
+**Step 2: Add Line Items**
+
+Click **+ Add Line** for each product:
+
+**Line 1 - Filament:**
+```
+Product: MAT-PLA-BASIC-BLK (PLA Basic Black)
+
+Quantity: 5
+Purchase Unit: KG (how vendor sells it)
+  - Shows product's purchase_uom
+  - Can override if needed
+
+Unit Cost: $25.00 ($/KG)
+Line Total: $125.00 (5 KG × $25/KG)
+
+Notes: "Request fresh batch, < 30 days old"
+```
+
+**Line 2 - Hardware:**
+```
+Product: INSERT-M3 (M3 Heat Set Inserts)
+
+Quantity: 1000
+Purchase Unit: EA
+Unit Cost: $0.15
+Line Total: $150.00
+
+Notes: "Brass, M3×5mm"
+```
+
+**Line 3 - Packaging:**
+```
+Product: BAG-POLY-4X6 (4"×6" Poly Bags)
+
+Quantity: 500
+Purchase Unit: EA
+Unit Cost: $0.08
+Line Total: $40.00
+```
+
+**Step 3: Totals and Shipping**
+
+```
+Subtotal: $315.00 (sum of all line totals)
+
+Tax Amount: $0.00 (if applicable)
+Shipping Cost: $12.00
+───────────────────────────
+Total Amount: $327.00
+```
+
+**Step 4: Payment and Shipping**
+
+```
+Payment Method: Credit Card (options: Card, Check, Wire, COD)
+Payment Reference: Last 4: 1234 (optional)
+
+Tracking Number: (leave blank, fill when shipped)
+Carrier: (leave blank, fill when shipped)
+```
+
+**Step 5: Notes and Documents**
+
+```
+Notes: "Rush order - need by Feb 15 for production schedule"
+
+Document URL: (optional Google Drive link to quote/invoice)
+```
+
+**Step 6: Submit**
+
+Click **Create Purchase Order** → PO number generated (e.g., `PO-2026-010`)
+
+**✅ Result:** PO created with status "draft"
+
+### Ordering (Sending to Vendor)
+
+**From "draft" → "ordered":**
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Mark as Ordered**
+
+**Actions:**
+1. Review all line items and totals
+2. Click **Mark as Ordered**
+3. Enter order date (defaults to today)
+4. Status changes to "ordered"
+
+**Next steps:**
+- Email PO to vendor (print or export PDF)
+- Vendor confirms order
+- Wait for shipment notification
+
+**⚠️ Cannot edit after ordering** - must cancel and create new PO
+
+### Vendor Ships Order
+
+**From "ordered" → "shipped":**
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Mark as Shipped**
+
+When vendor notifies you of shipment:
+
+```
+Shipped Date: 2026-02-10
+Tracking Number: 1Z999AA10123456784
+Carrier: UPS (options: UPS, FedEx, USPS, DHL, Other)
+```
+
+Click **Update** → Status changes to "shipped"
+
+**System actions:**
+- Expected date adjusted based on carrier (if tracking integration)
+- Notification sent (if configured)
+
+---
+
+## Part 4: Receiving Inventory
+
+### What is Receiving?
+
+**Receiving** is the process of recording inventory when it arrives from the vendor.
+
+**Receiving actions:**
+1. Physical inspection of shipment
+2. Count quantities received
+3. Record receipt in system
+4. Update inventory quantities
+5. Update product costs
+6. Create material spools (for filament)
+
+### Receiving Process
+
+**From "shipped" → "received":**
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Receive Inventory**
+
+**Step 1: Verify Shipment**
+
+```
+PO Number: PO-2026-010
+Vendor: 3D Filament Warehouse
+Expected Date: 2026-02-15
+Arrived Date: 2026-02-13 (✓ early!)
+
+Carrier: UPS
+Tracking: 1Z999AA10123456784
+
+Shipment Condition:
+☑ Boxes intact
+☑ No damage
+☑ All items present
+```
+
+**Step 2: Count and Record**
+
+**Line 1: PLA Basic Black**
+```
+Ordered: 5 KG
+Received: 5 KG ✓
+
+Unit Cost: $25.00/KG
+Total: $125.00
+
+Create Spools:
+  ☑ SPOOL-PLA-BLK-010 (1 KG)
+  ☑ SPOOL-PLA-BLK-011 (1 KG)
+  ☑ SPOOL-PLA-BLK-012 (1 KG)
+  ☑ SPOOL-PLA-BLK-013 (1 KG)
+  ☑ SPOOL-PLA-BLK-014 (1 KG)
+
+Supplier Lot Number: LOT-2026-0210
+Notes: "Sealed packages, good condition"
+```
+
+**Line 2: M3 Inserts**
+```
+Ordered: 1000 EA
+Received: 1000 EA ✓
+
+Count Verified: Yes (spot check of 100 pieces)
+Quality: Good
+```
+
+**Line 3: Poly Bags**
+```
+Ordered: 500 EA
+Received: 480 EA ⚠️ (short 20)
+
+Reason: Damaged in shipping
+Action: Contact vendor for credit or replacement
+```
+
+**Step 3: Location Assignment**
+
+```
+All items to: Main Warehouse (default location)
+
+Or specify per line:
+  - PLA Black → WH-A-B1-03
+  - Inserts → WH-A-B2-05
+  - Bags → WH-A-C3-01
+```
+
+**Step 4: Cost Update**
+
+```
+Update Product Costs: ✓ Yes (default)
+
+System updates for each line:
+  - Last Cost = Unit Cost from PO
+  - Average Cost = Weighted average calculation
+  - Updates inventory valuation
+```
+
+**Step 5: Submit Receipt**
+
+Click **Receive Inventory** → System processes:
+
+1. **Inventory Transactions Created:**
+   ```
+   +5000 G PLA Basic Black @ $0.025/G = $125.00
+   +1000 EA M3 Inserts @ $0.15/EA = $150.00
+   +480 EA Poly Bags @ $0.08/EA = $38.40
+   ```
+
+2. **Inventory Quantities Updated:**
+   ```
+   PLA Black: 2000 G → 7000 G (+5000 G)
+   M3 Inserts: 500 EA → 1500 EA (+1000 EA)
+   Poly Bags: 100 EA → 580 EA (+480 EA)
+   ```
+
+3. **Material Spools Created** (for filament):
+   ```
+   SPOOL-PLA-BLK-010: 1.000 kg, Active
+   SPOOL-PLA-BLK-011: 1.000 kg, Active
+   ... (5 spools total)
+   ```
+
+4. **Product Costs Updated:**
+   ```
+   PLA Black:
+     Last Cost: $25.00/KG (from this PO)
+     Average Cost: $24.50/KG (weighted average)
+
+   M3 Inserts:
+     Last Cost: $0.15/EA
+     Average Cost: $0.155/EA
+   ```
+
+5. **PO Status Updated:**
+   ```
+   Status: received
+   Received Date: 2026-02-13
+   ```
+
+**✅ Result:** Inventory received and ready for production!
+
+### Partial Receipts
+
+**If items arrive in multiple shipments:**
+
+**First Shipment:**
+```
+Line 1: PLA Black - Receive 3 KG (of 5 ordered)
+Line 2: Inserts - Receive 500 EA (of 1000 ordered)
+Line 3: Bags - Not received yet
+
+Status: partially_received (not shown, but recorded)
+```
+
+**Second Shipment:**
+```
+Line 1: PLA Black - Receive 2 KG (remaining)
+Line 2: Inserts - Receive 500 EA (remaining)
+Line 3: Bags - Receive 480 EA
+
+Status: received (all lines complete)
+```
+
+**Each receipt creates separate inventory transactions** with different dates.
+
+---
+
+## Part 5: Closing Purchase Orders
+
+**From "received" → "closed":**
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Close PO**
+
+**Requirements:**
+- ✅ All lines received (or documented short)
+- ✅ Inventory transactions created
+- ✅ Costs updated
+- ✅ Any discrepancies resolved
+
+**Closing actions:**
+
+```
+Review:
+  - All items received: ✓
+  - Costs updated: ✓
+  - Documents attached: ✓
+
+Final Notes: "20 bags short, vendor issued $1.60 credit"
+
+Close Purchase Order: [Confirm]
+```
+
+**System actions:**
+1. PO locked (no further edits)
+2. Status → "closed"
+3. PO archived and searchable
+4. Accounting finalized
+
+**✅ Result:** Purchase complete!
+
+---
+
+## Part 6: Document Management
+
+### Document Types
+
+**Attach documents to purchase orders:**
+
+| Type | Description | When to Upload |
+|------|-------------|----------------|
+| **invoice** | Vendor invoice | After receiving |
+| **packing_slip** | Packing list | When shipment arrives |
+| **receipt** | Payment receipt | After payment |
+| **quote** | Vendor quote | When creating PO |
+| **shipping_label** | Shipping label | When vendor ships |
+| **other** | Misc documents | As needed |
+
+### Uploading Documents
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Documents** → **+ Upload**
+
+```
+Document Type: invoice
+File: Browse (PDF, JPG, PNG)
+
+Notes: "Invoice #INV-2026-0210"
+
+Upload: [Confirm]
+```
+
+**Result:** Document attached and viewable
+
+**Multiple documents allowed** - upload all related files
+
+### Viewing Documents
+
+**Navigation:** Purchasing → Purchase Orders → Select PO → **Documents**
+
+**Shows:**
+- Document type
+- File name
+- Upload date
+- Uploaded by
+- File size
+- Actions: View, Download, Delete
+
+**Click to view/download** - opens in browser or downloads file
+
+---
+
+## Part 7: Integration with MRP
+
+### Automatic PO Generation
+
+**MRP analyzes requirements** and suggests purchase orders:
+
+1. **MRP Run** calculates material needs
+2. **Planned Orders** created for items below reorder point
+3. **User reviews** planned orders
+4. **Convert to POs** - one click to create purchase order
+
+**Example:**
+
+```
+MRP Output:
+
+Item: PLA Basic Black
+On Hand: 1000 G
+Allocated: 4500 G (production orders)
+Available: -3500 G (shortage!)
+
+Reorder Point: 4500 G
+Safety Stock: 1000 G
+Lead Time: 7 days
+
+Suggestion: Order 10 KG (10,000 G)
+  → Covers shortage + safety stock + 1 week demand
+
+Preferred Vendor: 3D Filament Warehouse (VND-001)
+Unit Cost: $25.00/KG
+Total: $250.00
+
+Action: [Create Purchase Order]
+```
+
+**Click "Create Purchase Order":**
+- Pre-fills vendor, product, quantity, cost
+- User reviews and adjusts
+- Submit to vendor
+
+**See:** [MRP Guide](mrp.md) for full MRP workflow
+
+### Low Stock Alerts
+
+**Automatic notifications when:**
+
+```
+Reorder Point Trigger:
+  Item: PLA Basic Black
+  On Hand: 4400 G
+  Reorder Point: 4500 G
+
+  → Alert: "PLA Basic Black below reorder point"
+  → Suggest: "Create PO for 10 KG from VND-001"
+```
+
+**Configure alerts:** Settings → Notifications → Inventory Alerts
+
+---
+
+## Part 8: Purchasing Reports
+
+### Purchase Order List
+
+**Navigation:** Purchasing → Purchase Orders
+
+**Filter by:**
+- Status (all, draft, ordered, shipped, received, closed, cancelled)
+- Vendor
+- Date range (order date, expected date, received date)
+- Search (PO number, vendor name)
+
+**Columns:**
+- PO Number
+- Vendor
+- Order Date
+- Expected Date
+- Status
+- Total Amount
+- Items (count)
+
+**Export to CSV** for analysis in Excel
+
+### Vendor Performance Report
+
+**Navigation:** Purchasing → Reports → **Vendor Performance**
+
+**Shows:**
+
+```
+Vendor: 3D Filament Warehouse (VND-001)
+Period: Last 6 Months
+
+Total POs: 24
+Total Spend: $6,850.00
+
+On-Time Delivery:
+  On Time: 22 POs (92%)
+  Late: 2 POs (8%)
+  Average Delay: 1.2 days
+
+Lead Time:
+  Average: 6.8 days
+  Min: 5 days
+  Max: 10 days
+
+Quality:
+  Perfect Orders: 21 (88%)
+  Short Shipments: 2 (8%)
+  Damaged: 1 (4%)
+
+Rating: 4.5 / 5.0
+Recommendation: ✓ Preferred Vendor
+```
+
+### Purchasing Costs Report
+
+**Navigation:** Purchasing → Reports → **Purchasing Costs**
+
+**Shows:**
+
+```
+Period: Last 30 Days
+
+Total POs: 8
+Total Spend: $2,450.00
+
+By Category:
+  Filament: $1,800.00 (73%)
+  Hardware: $400.00 (16%)
+  Packaging: $250.00 (11%)
+
+By Vendor:
+  VND-001: 3D Filament Warehouse: $1,800.00 (73%)
+  VND-002: Hardware Supply Co: $400.00 (16%)
+  VND-003: Packaging Inc: $250.00 (11%)
+
+Average PO Value: $306.25
+```
+
+### Cost Variance Report
+
+**Navigation:** Purchasing → Reports → **Cost Variance**
+
+**Shows price changes over time:**
+
+```
+Product: PLA Basic Black (MAT-PLA-BASIC-BLK)
+
+Last 6 Purchases:
+
+Date       PO #         Vendor  Qty    Unit Cost  Change
+────────── ──────────── ─────── ────── ────────── ──────
+2026-02-13 PO-2026-010  VND-001 5 KG   $25.00/KG  +$2.00 (+8.7%)
+2026-01-28 PO-2026-005  VND-001 10 KG  $23.00/KG  -$1.00 (-4.2%)
+2025-12-15 PO-2025-085  VND-001 5 KG   $24.00/KG  +$1.00 (+4.3%)
+2025-11-20 PO-2025-068  VND-001 10 KG  $23.00/KG  $0.00 (0%)
+2025-10-15 PO-2025-042  VND-001 5 KG   $23.00/KG  -$2.00 (-8.0%)
+2025-09-10 PO-2025-018  VND-001 10 KG  $25.00/KG  --
+
+Average Cost: $23.83/KG
+Current Cost: $25.00/KG (+5% above average)
+Trend: ↗ Increasing
+```
+
+---
+
+## Part 9: Best Practices
+
+### Vendor Management
+
+✅ **Do:**
+- Maintain at least 2 vendors per critical item (backup supply)
+- Update lead times based on actual performance
+- Rate vendors after each order (honest feedback)
+- Negotiate volume discounts for bulk purchases
+- Build relationships with vendor reps
+
+❌ **Don't:**
+- Use single-source vendors for critical materials
+- Forget to update contact information
+- Keep inactive vendors cluttering the list
+- Ignore vendor quality issues
+
+### Purchase Order Creation
+
+✅ **Do:**
+- Check inventory before ordering (use MRP)
+- Order in vendor's standard units (KG, BOX, etc.)
+- Include clear notes for special requests
+- Verify product SKUs match vendor's catalog
+- Plan orders to minimize shipping costs
+
+❌ **Don't:**
+- Order without checking reorder points
+- Create rush orders at premium prices unnecessarily
+- Forget to include all needed items in PO
+- Order quantities below minimum order qty
+- Mix incompatible items in one PO
+
+### Receiving Best Practices
+
+✅ **Do:**
+- Count all items upon receipt
+- Inspect for damage immediately
+- Document shortages/damages with photos
+- Update costs from actual purchase prices
+- Create spools for all filament received
+- Record lot numbers for traceability
+
+❌ **Don't:**
+- Receive without counting (trust vendor)
+- Delay receiving (inventory inaccurate)
+- Skip quality inspection
+- Forget to update product costs
+- Lose packing slips/invoices
+
+### Cost Management
+
+✅ **Do:**
+- Update product costs from actual purchases
+- Review cost variance reports monthly
+- Negotiate better prices with high-volume vendors
+- Track price trends to plan purchases
+- Use average costing for most items
+
+❌ **Don't:**
+- Leave product costs at $0.00
+- Ignore price increases
+- Accept price increases without negotiation
+- Order premium rush shipments regularly
+
+---
+
+## Part 10: Common Workflows
+
+### Workflow 1: Simple Purchase (One Vendor)
+
+```
+1. Check inventory: PLA Black at 1000 G
+2. Reorder point: 4500 G → Need to order
+3. Create PO:
+   - Vendor: 3D Filament Warehouse
+   - Product: PLA Basic Black
+   - Quantity: 10 KG @ $25/KG = $250
+   - Expected: 7 days
+4. Mark as Ordered (send to vendor)
+5. Vendor confirms order
+6. Vendor ships (tracking: UPS 1Z999...)
+7. Receive shipment:
+   - Count: 10 KG ✓
+   - Create 10 spools (1 KG each)
+   - Update costs
+8. Close PO
+9. Inventory: 11,000 G → Ready for production
+```
+
+**Time estimate:** 7-10 days (vendor lead time)
+
+### Workflow 2: Emergency Rush Order
+
+```
+1. Production order needs 5 KG PLA immediately
+2. Inventory: 500 G (insufficient!)
+3. Contact vendor for rush shipping:
+   - Call vendor: "Need 5 KG overnight"
+   - Vendor confirms: $150 + $50 rush = $200 total
+4. Create PO:
+   - Priority: Urgent
+   - Shipping: $50 overnight
+   - Notes: "RUSH - Production awaiting"
+5. Order and pay immediately (credit card)
+6. Vendor ships same day
+7. Receive next morning:
+   - Expedite receiving process
+   - Immediately create spools
+   - Release to production
+8. Close PO
+9. Production order continues
+```
+
+**Time estimate:** 1 day (overnight shipping)
+
+### Workflow 3: Bulk Order (Multi-Vendor)
+
+```
+1. MRP run suggests:
+   - 50 KG filament (various colors)
+   - 5000 EA inserts
+   - 2000 EA bags
+2. Create 3 separate POs:
+
+   PO-1: 3D Filament Warehouse
+     - 10 KG PLA Black @ $25 = $250
+     - 10 KG PLA White @ $25 = $250
+     - 10 KG PETG Black @ $28 = $280
+     - 10 KG PETG Clear @ $28 = $280
+     - 10 KG TPU @ $35 = $350
+     Total: $1,410
+
+   PO-2: Hardware Supply Co
+     - 5000 EA M3 Inserts @ $0.14 = $700
+     Total: $700
+
+   PO-3: Packaging Inc
+     - 2000 EA Poly Bags @ $0.07 = $140
+     Total: $140
+
+3. Send all POs to vendors
+4. Track shipments (different arrival dates)
+5. Receive each shipment separately:
+   - PO-1: Day 7 (filament)
+   - PO-2: Day 10 (inserts)
+   - PO-3: Day 5 (bags)
+6. Close all POs
+7. Inventory restocked for production
+```
+
+**Time estimate:** 10-14 days (staggered arrivals)
+
+---
+
+## Part 11: Advanced Features
+
+### Vendor Item Mapping
+
+**Map vendor SKUs to your products:**
+
+**Navigation:** Purchasing → Vendors → Select vendor → **Vendor Items**
+
+```
+Add Vendor Item Mapping:
+
+Vendor SKU: PLA-BLK-1KG
+Vendor Description: "Black PLA Filament 1kg Spool"
+
+Your Product: MAT-PLA-BASIC-BLK
+Default Unit Cost: $25.00/KG
+Default Purchase Unit: KG
+
+Save: [Confirm]
+```
+
+**Use case:**
+- Vendor invoice shows "PLA-BLK-1KG"
+- System auto-maps to MAT-PLA-BASIC-BLK
+- Faster PO creation (select from vendor's catalog)
+- Consistent ordering
+
+### Purchase Order Templates
+
+**Create template POs for recurring orders:**
+
+```
+Template: Monthly Filament Restock
+
+Vendor: 3D Filament Warehouse
+
+Lines:
+  - PLA Black: 10 KG @ $25/KG
+  - PLA White: 10 KG @ $25/KG
+  - PETG Black: 5 KG @ $28/KG
+  - TPU 95A: 5 KG @ $35/KG
+
+Total: $1,090
+
+Use: Create PO from template, adjust quantities as needed
+```
+
+### Multi-Location Receiving
+
+**Receive to different warehouse locations:**
+
+```
+PO-2026-010: Bulk Order
+
+Line 1: PLA Black (10 KG)
+  → Receive to: WH-A (5 KG)
+  → Receive to: WH-B (5 KG)
+
+Line 2: Inserts (5000 EA)
+  → Receive to: WH-A (5000 EA)
+
+Line 3: Bags (2000 EA)
+  → Receive to: WH-C (2000 EA) [Shipping dept]
+```
+
+**System creates separate inventory transactions** per location.
+
+### Partial Payments
+
+**Track payments for large orders:**
+
+```
+PO Total: $5,000
+
+Payment 1: $2,500 (Deposit, 2026-02-01)
+Payment 2: $2,500 (Balance, 2026-02-15)
+
+Payment Status: Fully Paid
+```
+
+---
+
+## Part 12: Troubleshooting
+
+### PO Won't Close
+
+**Problem:** Cannot close PO, error message
+
+**Possible causes:**
+- Some lines not fully received
+- Inventory transactions missing
+- Status not "received"
+
+**Solution:**
+1. Check all line quantities: Ordered vs Received
+2. Verify inventory transactions created
+3. Ensure status is "received" (not "shipped")
+4. If items short, document reason in notes
+5. Retry close
+
+### Cost Not Updating
+
+**Problem:** Product cost shows old value after receiving
+
+**Cause:** "Update Costs" option not checked during receiving
+
+**Solution:**
+1. Navigate to product
+2. Edit product costs manually:
+   - Last Cost: Enter from PO
+   - Average Cost: Calculate weighted average
+3. Or re-receive PO (if possible)
+
+### Duplicate Inventory Receipt
+
+**Problem:** Accidentally received same PO twice
+
+**Cause:** Clicked "Receive" twice or received from multiple locations
+
+**Solution:**
+1. Check inventory transactions for duplicate entries
+2. Create adjustment transaction to correct:
+   - Adjustment: Negative quantity
+   - Amount: Negative cost
+   - Reason: "Duplicate receipt correction"
+3. Document in PO notes
+
+### Vendor Not Showing in Dropdown
+
+**Problem:** Cannot select vendor when creating PO
+
+**Cause:** Vendor is inactive
+
+**Solution:**
+1. Navigate to Purchasing → Vendors
+2. Find vendor
+3. Check "Active" status
+4. Activate vendor
+5. Retry PO creation
+
+---
+
+## Next Steps
+
+Now that you understand purchasing, explore these related guides:
+
+| Guide | Learn About |
+|-------|-------------|
+| **Inventory Management** | Stock levels, transactions, cycle counting |
+| **MRP** | Automatic purchase order generation from material requirements |
+| **Manufacturing** | How production consumes purchased materials |
+| **Accounting** | COGS calculation, vendor payments, AP aging |
+
+## Quick Reference
+
+### Purchase Order Status Flow
+
+```
+draft → ordered → shipped → received → closed
+```
+
+### Document Types
+
+- invoice - Vendor invoice
+- packing_slip - Packing list
+- receipt - Payment receipt
+- quote - Vendor quote
+- shipping_label - Tracking label
+- other - Miscellaneous
+
+### Keyboard Shortcuts
+
+- `n` - New purchase order
+- `r` - Receive inventory
+- `c` - Close PO
+- `/` - Search
+
+---
+
+**🎉 Congratulations!** You now understand the complete FilaOps purchasing system. Create your first purchase order and start managing vendor relationships!

--- a/docs/user-guide/sales-and-quotes.md
+++ b/docs/user-guide/sales-and-quotes.md
@@ -1,0 +1,838 @@
+# Sales & Quotes Guide
+
+This guide covers the complete sales workflow in FilaOps, from quote creation to order fulfillment.
+
+## Overview
+
+FilaOps supports two primary sales workflows:
+
+1. **Quote-Based Sales** - For custom 3D printing jobs
+   - Customer requests quote → Admin reviews → Quote approved → Customer accepts → Convert to sales order
+
+2. **Direct Sales Orders** - For standard products
+   - Create sales order directly without quote (manual entry or marketplace integration)
+
+Both workflows converge at the **Sales Order**, which drives production planning and fulfillment.
+
+## Sales Workflow Diagram
+
+```
+┌─────────────────┐
+│  Quote Request  │ (Optional)
+└────────┬────────┘
+         │
+         ▼
+    ┌────────┐
+    │ Quote  │ → pending → approved → accepted
+    └────┬───┘              ↓          ↓
+         │              rejected   expired
+         │
+         ▼ (Convert)
+┌──────────────────┐
+│  Sales Order     │ → draft → confirmed → in_production
+└────────┬─────────┘                           ↓
+         │                              ready_to_ship
+         │                                     ↓
+         └────────────────────────────────→ shipped
+                                                ↓
+                                           delivered
+                                                ↓
+                                           completed
+```
+
+---
+
+## Part 1: Quotes
+
+### What is a Quote?
+
+A **Quote** is a price estimate for a 3D printing job. It includes:
+
+- Product/part details
+- Material and color selection
+- Quantity
+- Unit price and total price
+- Print time and material usage estimates
+- Expiration date (default: 30 days)
+- Optional: Rush level, shipping, tax
+
+### Quote Statuses
+
+| Status | Meaning | Next Actions |
+|--------|---------|--------------|
+| **pending** | Waiting for admin review | Approve, Reject, Edit |
+| **approved** | Admin approved pricing | Customer can accept or decline |
+| **accepted** | Customer accepted quote | Convert to sales order |
+| **rejected** | Admin declined the request | No further action |
+| **expired** | Past expiration date | Create new quote if still needed |
+| **converted** | Converted to sales order | View sales order |
+| **cancelled** | Cancelled by admin or customer | No further action |
+
+### Creating a Manual Quote
+
+**Navigation:** Sales → Quotes → **+ New Quote**
+
+**Step 1: Customer & Product Information**
+
+Fill in the quote form:
+
+```
+Product Name: "Custom Phone Stand"
+Customer Name: "John Doe"
+Customer Email: john@example.com
+Quantity: 10
+
+Material Type: PLA_BASIC
+Color: BLK (Black)
+Finish: standard (options: standard, smooth, painted)
+
+Customer Notes: "Need logo embossed on base"
+```
+
+**Step 2: Pricing**
+
+Enter pricing details:
+
+```
+Unit Price: $12.50
+Material (grams): 45
+Print Time (hours): 2.5
+
+Apply Tax: ✓ (uses company tax rate from Settings)
+Shipping Cost: $8.00 (optional)
+```
+
+**Calculated Automatically:**
+- Subtotal = Unit Price × Quantity = $125.00
+- Tax Amount = $10.31 (if 8.25% tax enabled)
+- Total Price = $143.31
+
+**Step 3: Quote Settings**
+
+```
+Valid Days: 30 (quote expires in 30 days)
+Rush Level: standard (options: standard, rush, super_rush, urgent)
+Admin Notes: (internal notes, not visible to customer)
+```
+
+**Step 4: Submit**
+
+Click **Create Quote** → Quote number generated (e.g., `Q-2026-000001`)
+
+**✅ Result:** Quote is created with status "pending"
+
+### Reviewing and Approving Quotes
+
+**View Quote:** Click on any quote in the list to open the detail view
+
+**Approve a Quote:**
+
+1. Review all details (product, pricing, material requirements)
+2. Add admin notes if needed
+3. Click **Approve Quote**
+4. Status changes to "approved"
+5. Customer can now accept the quote
+
+**Reject a Quote:**
+
+1. Click **Reject Quote**
+2. Enter rejection reason (e.g., "Material not available", "Design infeasible")
+3. Status changes to "rejected"
+4. Customer is notified (if email integration configured)
+
+### Editing Quotes
+
+You can edit quotes in "pending" or "approved" status:
+
+1. Open quote detail
+2. Click **Edit**
+3. Modify pricing, quantity, or details
+4. Click **Save Changes**
+
+**Note:** Once a quote is "converted" to a sales order, it cannot be edited.
+
+### Converting Quote to Sales Order
+
+When a customer accepts a quote (or admin manually converts):
+
+**Navigation:** Sales → Quotes → Open quote → **Convert to Order**
+
+**Requirements:**
+- ✅ Quote status must be "approved" or "accepted"
+- ✅ Quote must not be expired
+- ✅ Quote cannot already be converted
+
+**Conversion Process:**
+
+1. Click **Convert to Sales Order**
+2. System generates sales order number (e.g., `SO-2026-0001`)
+3. All quote details copied to sales order:
+   - Product name, quantity, material, color
+   - Pricing (locked at conversion time)
+   - Customer information
+   - Shipping address (if provided)
+4. Quote status changes to "converted"
+5. Sales order created with status "draft"
+
+**✅ Result:** You're redirected to the new sales order
+
+---
+
+## Part 2: Sales Orders
+
+### What is a Sales Order?
+
+A **Sales Order** is a confirmed customer order that drives production and fulfillment. It can be created:
+
+1. **From a quote** (conversion)
+2. **Manually** (direct entry via wizard)
+3. **From marketplace integration** (Squarespace, WooCommerce - if configured)
+
+### Sales Order Statuses
+
+| Status | Meaning | Next Actions |
+|--------|---------|--------------|
+| **draft** | Being created/edited | Confirm order |
+| **pending_payment** | Awaiting payment | Record payment |
+| **payment_failed** | Payment declined | Retry payment or cancel |
+| **confirmed** | Payment received, ready for planning | Create production order |
+| **in_production** | Manufacturing in progress | Monitor production |
+| **ready_to_ship** | All items completed & QC passed | Ship order |
+| **partially_shipped** | Some items shipped (multi-line) | Ship remaining items |
+| **shipped** | All items shipped | Update tracking, await delivery |
+| **delivered** | Carrier confirmed delivery | Complete order |
+| **completed** | Order fully closed | Archive |
+| **on_hold** | Paused (payment issue, customer request) | Resolve and resume |
+| **cancelled** | Order terminated | No further action |
+
+### Creating a Sales Order (Manual)
+
+**Navigation:** Sales → Sales Orders → **+ New Sales Order**
+
+**Step 1: Customer Selection**
+
+```
+Select Customer: (dropdown or "+ Create New Customer")
+  - If new customer, enter:
+    Name: "Acme Corporation"
+    Email: orders@acmecorp.com
+    Phone: (555) 123-4567
+
+Order Date: (defaults to today)
+Due Date: (optional - requested delivery date)
+```
+
+**Step 2: Add Line Items**
+
+Sales orders support multiple products (line items):
+
+```
+Click "+ Add Line"
+
+Product: Select from dropdown (e.g., "Example Standard Product")
+  - Or search by SKU or name
+
+Quantity: 5
+Unit Price: $15.00 (auto-filled from product, or enter custom)
+Material: PLA_BASIC (for manufactured items)
+Color: BLK
+Finish: standard
+
+Notes: (optional line-item notes)
+```
+
+**Calculated per line:**
+- Line Total = Unit Price × Quantity
+
+**Add more lines as needed** (repeat Step 2)
+
+**Step 3: Order Details**
+
+```
+Rush Level: standard (affects production scheduling)
+Payment Method: credit_card (options: credit_card, paypal, manual, cash, check)
+
+Shipping Address:
+  Line 1: 123 Main St
+  Line 2: Suite 200
+  City: Springfield
+  State: IL
+  ZIP: 62701
+  Country: USA
+
+Shipping Cost: $12.00
+Apply Tax: ✓ (calculates tax on subtotal)
+```
+
+**Step 4: Review Totals**
+
+```
+Subtotal: $75.00 (sum of all line items)
+Tax (8.25%): $6.19
+Shipping: $12.00
+───────────────────
+Grand Total: $93.19
+```
+
+**Step 5: Submit**
+
+Click **Create Sales Order** → Order number generated (e.g., `SO-2026-0042`)
+
+**✅ Result:** Sales order is created with status "draft"
+
+### Sales Order Lifecycle Management
+
+#### Confirming Orders
+
+**From "draft" → "confirmed":**
+
+1. Open sales order
+2. Review all details
+3. Click **Confirm Order**
+4. Status changes to "confirmed"
+5. Order is now ready for production planning
+
+#### Recording Payment
+
+**From "pending_payment" → "confirmed":**
+
+1. Open sales order
+2. Click **Record Payment**
+3. Enter payment details:
+   - Payment Method: credit_card
+   - Transaction ID: ch_1234567890 (optional)
+   - Paid At: (date/time)
+4. Payment status changes to "paid"
+5. Order status changes to "confirmed"
+
+#### Creating Production Orders
+
+Once a sales order is **confirmed**, you can create production orders:
+
+**Navigation:** Sales → Sales Orders → Open order → **Create Production Order**
+
+**For Quote-Based Orders:**
+- One production order per sales order
+- Automatically uses material/color from quote
+
+**For Line-Item Orders:**
+- Create production order for each line
+- Select which lines to include
+
+See [Manufacturing Guide](manufacturing.md) for production order details.
+
+#### Shipping Orders
+
+**From "ready_to_ship" → "shipped":**
+
+1. Open sales order
+2. Click **Mark as Shipped**
+3. Enter tracking information (optional):
+   - Carrier: USPS / FedEx / UPS / DHL
+   - Tracking Number: 1Z999AA10123456784
+   - Shipped Date: (defaults to today)
+4. Status changes to "shipped"
+
+**Partial Shipments:**
+- For multi-line orders, mark individual lines as shipped
+- Order status becomes "partially_shipped"
+- When all lines shipped, status becomes "shipped"
+
+#### Completing Orders
+
+**From "delivered" → "completed":**
+
+1. Verify delivery confirmation (manual or carrier webhook)
+2. Click **Complete Order**
+3. Order is archived and closed
+
+**Or mark as completed directly:**
+- Click **Complete Order** from any status
+- Use for orders that don't require delivery tracking
+
+### Viewing Sales Orders
+
+**List View:** Sales → Sales Orders
+
+**Filter by:**
+- Status (all, draft, confirmed, in_production, etc.)
+- Date range
+- Customer
+- Search (order number, customer name, product)
+
+**Columns:**
+- Order Number (e.g., SO-2026-0042)
+- Customer Name
+- Order Date
+- Due Date
+- Total Amount
+- Payment Status
+- Status
+
+**Click any order to view details**
+
+### Sales Order Detail View
+
+**Sections:**
+
+1. **Order Header**
+   - Order number, customer, dates
+   - Status badges (order status, payment status, fulfillment status)
+   - Quick actions (Confirm, Ship, Cancel, etc.)
+
+2. **Line Items**
+   - Product, quantity, material, color, finish
+   - Unit price, line total
+   - Production order status (if created)
+
+3. **Pricing Summary**
+   - Subtotal
+   - Tax
+   - Shipping
+   - Grand total
+
+4. **Customer Information**
+   - Name, email, phone
+   - Billing address (if different from shipping)
+
+5. **Shipping Address**
+   - Full address
+   - Tracking info (if shipped)
+
+6. **Timeline / Order Events**
+   - History of status changes
+   - Created, confirmed, shipped, delivered dates
+   - Who performed actions
+
+7. **Notes**
+   - Customer notes (from quote or order)
+   - Internal notes (admin only)
+
+### Editing Sales Orders
+
+**Edit in "draft" status:**
+- Can change all fields (customer, lines, pricing, shipping)
+
+**Edit in "confirmed" status:**
+- Can modify quantities, add lines, change shipping
+- **Cannot** change customer or remove paid items
+
+**Cannot edit:**
+- Orders in "in_production" or later (create adjustment/credit instead)
+
+### Cancelling Sales Orders
+
+**Cancel any order:**
+
+1. Open sales order
+2. Click **Cancel Order**
+3. Confirm cancellation
+4. Enter cancellation reason (optional)
+5. Status changes to "cancelled"
+
+**Effect:**
+- Linked production orders are marked as cancelled
+- Inventory allocations released
+- Customer refund processed (if already paid)
+
+**Note:** You can only cancel before "shipped" status. For shipped orders, create a return/refund instead.
+
+---
+
+## Part 3: Customers
+
+### Creating Customers
+
+**Navigation:** Sales → Customers → **+ New Customer**
+
+**Required Fields:**
+```
+Name: "Acme Corporation"
+Email: orders@acmecorp.com
+```
+
+**Optional Fields:**
+```
+Phone: (555) 123-4567
+Company: Acme Corp
+Tax ID: 12-3456789 (for B2B orders)
+
+Billing Address:
+  Line 1: 123 Main St
+  Line 2: Suite 200
+  City: Springfield
+  State: IL
+  ZIP: 62701
+  Country: USA
+
+Shipping Address: (same as billing or different)
+  ✓ Same as billing address
+
+Notes: "Net 30 payment terms"
+```
+
+**Customer Code:** Auto-generated (e.g., `CUST-00001`)
+
+### Customer Detail View
+
+**View customer:**
+- All quotes (pending, approved, converted)
+- All sales orders
+- Total revenue
+- Order history
+
+### Customer Settings
+
+**Per-customer settings:**
+- Tax Exempt: ☐ (if customer doesn't pay sales tax)
+- Payment Terms: Net 30 (if not immediate payment)
+- Credit Limit: $5,000 (optional)
+- Discount Rate: 10% (optional - applies to all orders)
+
+---
+
+## Part 4: Integration with Manufacturing
+
+### From Sales Order to Production
+
+**Workflow:**
+
+1. Sales order confirmed → **Create Production Order**
+2. Production order created → Manufacturing begins
+3. Production order completed → Sales order status → "ready_to_ship"
+4. Ship order → Status → "shipped"
+
+**Production Order Creation:**
+
+**For Quote-Based Orders:**
+```
+Product: Custom Phone Stand
+Quantity: 10
+Material: PLA_BASIC - BLK
+Routing: Standard 3D Print Routing
+  → Print (2.5 hrs @ 45g/unit)
+  → Finishing (optional)
+  → QC
+  → Pack
+```
+
+**For Standard Products with BOMs:**
+```
+Product: Standard Product SKU
+BOM: BOM-001 (Bill of Materials)
+  → Component 1: Material product (450g)
+  → Component 2: Hardware (10 units)
+  → Component 3: Packaging
+Routing: Routing-001
+  → Operations defined in routing
+```
+
+**See:** [Manufacturing Guide](manufacturing.md) for production details
+
+---
+
+## Part 5: Pricing and Financial Settings
+
+### Company Tax Settings
+
+**Navigation:** Settings → Company Settings → **Tax Settings**
+
+```
+Enable Tax: ✓
+Tax Rate: 8.25% (0.0825)
+Tax Label: "Sales Tax" (or "VAT", "GST")
+```
+
+**Per-Customer Tax Exempt:**
+- Customers can be marked "Tax Exempt"
+- No tax charged on their orders
+
+### Payment Methods
+
+**Supported payment methods:**
+- Credit Card (via payment gateway)
+- PayPal
+- Manual (cash, check, wire transfer)
+- Net Terms (invoice with payment terms)
+
+**Configuration:** Settings → Payment Settings
+
+### Shipping Calculations
+
+**Shipping cost can be:**
+1. **Manual entry** - Enter dollar amount per order
+2. **Flat rate** - Configured per order or customer
+3. **Carrier integration** - EasyPost (if configured) for real-time rates
+
+---
+
+## Part 6: Reporting and Analytics
+
+### Sales Dashboard
+
+**Navigation:** Dashboard (home page)
+
+**Widgets:**
+- **Sales Chart** - Revenue over time (daily, weekly, monthly)
+- **Recent Orders** - Last 10 sales orders
+- **Order Status Breakdown** - Count by status
+- **Revenue This Month** - Total sales
+
+### Quote Statistics
+
+**Navigation:** Sales → Quotes → **Stats**
+
+**Metrics:**
+- Total quotes
+- Pending (awaiting review)
+- Approved (awaiting customer acceptance)
+- Conversion rate (accepted / approved)
+- Average quote value
+- Expired quotes
+
+### Sales Order Reports
+
+**Navigation:** Sales → Sales Orders → **Reports** (coming soon)
+
+**Available Reports:**
+- Sales by Customer
+- Sales by Product
+- Sales by Date Range
+- Outstanding Orders (not completed)
+- Revenue by Payment Method
+
+---
+
+## Part 7: Common Workflows
+
+### Workflow 1: Simple Quote → Order
+
+```
+1. Customer requests quote via portal (or manual entry)
+2. Admin reviews → Approve quote
+3. Customer accepts quote
+4. Admin converts to sales order
+5. Admin confirms order
+6. Create production order
+7. Manufacture product
+8. Ship to customer
+9. Mark as delivered
+10. Complete order
+```
+
+**Time estimate:** Quote to ship: 3-7 days (depending on production time)
+
+### Workflow 2: Direct Sales Order (No Quote)
+
+```
+1. Customer calls/emails with order
+2. Create sales order directly (skip quote)
+3. Confirm payment
+4. Create production order
+5. Manufacture
+6. Ship
+7. Complete
+```
+
+**Time estimate:** 2-5 days
+
+### Workflow 3: Rush Order
+
+```
+1. Customer requests rush quote
+2. Admin creates quote with Rush Level: "super_rush"
+3. Higher unit price charged (rush fee)
+4. Convert to order → Confirm
+5. Create production order with rush flag
+6. Production prioritizes rush orders
+7. Expedited shipping
+8. Complete
+```
+
+**Time estimate:** Same day or next day
+
+---
+
+## Part 8: Troubleshooting
+
+### Quote Conversion Fails
+
+**Problem:** "Quote must be approved or accepted to convert"
+
+**Solution:**
+- Verify quote status is "approved" or "accepted"
+- If "pending", approve it first
+- If "expired", extend expiration date or create new quote
+
+### Cannot Edit Sales Order
+
+**Problem:** "Cannot modify order in production"
+
+**Solution:**
+- Orders in "in_production" or later cannot be edited
+- Cancel the order and create a new one
+- Or create a change order / adjustment (contact support)
+
+### Tax Not Calculating
+
+**Problem:** Tax amount shows $0.00
+
+**Solution:**
+- Check Settings → Company Settings → Tax Settings
+- Ensure "Enable Tax" is checked
+- Verify Tax Rate is set (e.g., 0.0825 for 8.25%)
+- Check if customer is marked "Tax Exempt"
+
+### Production Order Button Disabled
+
+**Problem:** Cannot click "Create Production Order"
+
+**Solution:**
+- Order must be in "confirmed" status
+- If "draft", confirm the order first
+- If already has production order, view existing PO instead
+
+### Shipping Address Missing
+
+**Problem:** No shipping address on order
+
+**Solution:**
+- For quote-based orders, shipping address comes from quote
+- Customer must provide address when accepting quote
+- For manual orders, enter address in order wizard
+- Can update address in order detail view (before shipping)
+
+---
+
+## Part 9: Best Practices
+
+### Quote Management
+
+✅ **Do:**
+- Review quotes daily to maintain fast response times
+- Use admin notes to document pricing decisions
+- Set realistic expiration dates (30 days standard)
+- Include material and print time estimates for transparency
+
+❌ **Don't:**
+- Approve quotes without verifying material availability
+- Let quotes expire without follow-up
+- Modify pricing after customer sees original quote (create new quote instead)
+
+### Sales Order Management
+
+✅ **Do:**
+- Confirm payment before starting production
+- Create production orders as soon as order is confirmed
+- Update shipping tracking for customer visibility
+- Add internal notes for special handling instructions
+
+❌ **Don't:**
+- Start production without confirmed order
+- Ship without marking order as "shipped" (breaks inventory tracking)
+- Cancel orders without customer notification
+
+### Customer Communication
+
+✅ **Do:**
+- Document customer communication in internal notes
+- Set accurate due dates and communicate delays early
+- Provide tracking information when shipping
+- Follow up on delivered orders
+
+❌ **Don't:**
+- Promise delivery dates without checking production capacity
+- Charge shipping without customer agreement
+- Apply rush fees without customer approval
+
+---
+
+## Part 10: Advanced Features
+
+### Multi-Line Orders
+
+**Line-item based orders** support multiple products:
+
+```
+Sales Order SO-2026-0050
+  Line 1: Product A × 10 @ $12.00 = $120.00
+  Line 2: Product B × 5 @ $20.00 = $100.00
+  Line 3: Product C × 2 @ $50.00 = $100.00
+  ──────────────────────────────────────────
+  Subtotal: $320.00
+```
+
+**Each line can have:**
+- Different product
+- Different material/color
+- Different production order
+- Individual ship dates (partial shipments)
+
+### Rush Levels
+
+**Rush levels affect pricing and scheduling:**
+
+| Rush Level | Lead Time | Price Multiplier | Priority |
+|------------|-----------|------------------|----------|
+| **standard** | 5-7 days | 1.0x | Normal |
+| **rush** | 2-3 days | 1.5x | High |
+| **super_rush** | 1 day | 2.0x | Very High |
+| **urgent** | Same day | 3.0x | Critical |
+
+**Set rush level on:**
+- Quote (charges premium)
+- Sales order (manual entry)
+- Production order (prioritizes scheduling)
+
+### Payment Status Tracking
+
+**Payment status separate from order status:**
+
+| Payment Status | Meaning |
+|----------------|---------|
+| **pending** | No payment received |
+| **paid** | Full payment received |
+| **partial** | Partial payment (deposits) |
+| **refunded** | Payment refunded |
+| **cancelled** | Payment cancelled |
+
+**Workflow:**
+- Order created → payment_status: "pending"
+- Payment received → payment_status: "paid", order status: "confirmed"
+- Refund issued → payment_status: "refunded"
+
+---
+
+## Next Steps
+
+Now that you understand quotes and sales orders, explore these related guides:
+
+| Guide | Learn About |
+|-------|-------------|
+| **Manufacturing** | Creating production orders from sales orders, operations, BOMs |
+| **Inventory Management** | Tracking material usage, stock levels, cycle counting |
+| **MRP** | Material requirements planning, automated PO generation |
+| **Accounting** | Revenue recognition, COGS calculation, financial reports |
+
+## Quick Reference
+
+### Quote Statuses
+
+`pending` → `approved` → `accepted` → `converted`
+    ↓            ↓
+`rejected`   `expired`
+
+### Sales Order Statuses
+
+`draft` → `confirmed` → `in_production` → `ready_to_ship` → `shipped` → `delivered` → `completed`
+
+### Keyboard Shortcuts (in quote/order lists)
+
+- `n` - New quote/order
+- `r` - Refresh list
+- `f` - Focus search
+- `/` - Quick search
+
+---
+
+**🎉 Congratulations!** You now understand the complete sales workflow in FilaOps. Create your first quote and convert it to a sales order to see the process in action.

--- a/docs/user-guide/settings-and-admin.md
+++ b/docs/user-guide/settings-and-admin.md
@@ -1,0 +1,1289 @@
+# Settings & Administration
+
+## Overview
+
+The Settings & Administration module is your control center for configuring FilaOps. From company branding and tax settings to user management, work centers, and system updates, this guide covers everything you need to manage your FilaOps installation.
+
+**What This Module Covers:**
+- **Company Settings** - Name, address, logo, tax configuration
+- **User Management** - Creating admin/operator accounts, roles, password resets
+- **Locations** - Warehouses, bins, and stock location hierarchy
+- **Materials & Colors** - Filament types, color definitions, and inventory
+- **Work Centers** - Production areas, costing rates, and capacity
+- **Printers** - Multi-brand printer registration, discovery, and monitoring
+- **AI Configuration** - Anthropic or Ollama integration for AI features
+- **System Administration** - Version info, updates, and dashboard
+
+**Who Uses This Module:**
+- **Administrators** - Full access to all settings
+- **Operators** - Access to operational settings (printers, work centers)
+- **Note:** Customer accounts cannot access admin settings
+
+---
+
+## Table of Contents
+
+1. [Company Settings](#1-company-settings)
+2. [User Management](#2-user-management)
+3. [Roles and Permissions](#3-roles-and-permissions)
+4. [Location Management](#4-location-management)
+5. [Material Types and Colors](#5-material-types-and-colors)
+6. [Work Centers](#6-work-centers)
+7. [Printer Management](#7-printer-management)
+8. [AI Configuration](#8-ai-configuration)
+9. [Accounting Settings](#9-accounting-settings)
+10. [Admin Dashboard](#10-admin-dashboard)
+11. [System Administration](#11-system-administration)
+12. [Data Import and Export](#12-data-import-and-export)
+13. [Troubleshooting](#13-troubleshooting)
+14. [Quick Reference](#14-quick-reference)
+
+---
+
+## 1. Company Settings
+
+### 1.1 Company Information
+
+**Navigation:** Settings → **Company**
+
+Configure your business identity that appears on quotes, invoices, and reports.
+
+**Fields:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Company Name** | Legal business name | "Acme 3D Printing LLC" |
+| **Address Line 1** | Street address | "123 Innovation Blvd" |
+| **Address Line 2** | Suite/Unit (optional) | "Suite 200" |
+| **City** | City | "Austin" |
+| **State** | State/Province | "TX" |
+| **ZIP** | Postal code | "78701" |
+| **Country** | Country code | "US" |
+| **Phone** | Business phone | "(512) 555-0123" |
+| **Email** | Business email | "info@acme3d.com" |
+| **Website** | Company URL | "https://acme3d.com" |
+
+**To Update:**
+1. Navigate to Settings → Company
+2. Edit any fields
+3. Click **Save**
+
+### 1.2 Company Logo
+
+**Navigation:** Settings → Company → **Logo**
+
+Upload your company logo for use on quotes, invoices, and the application header.
+
+**Supported Formats:**
+- PNG (recommended for transparency)
+- JPEG/JPG
+- GIF
+- WebP
+
+**Constraints:**
+- Maximum file size: **2 MB**
+- Recommended dimensions: 200-400px wide
+
+**To Upload:**
+1. Navigate to Settings → Company
+2. Click **Upload Logo**
+3. Select image file
+4. Preview the logo
+5. Click **Save**
+
+**To Remove:**
+1. Navigate to Settings → Company
+2. Click **Delete Logo**
+
+The logo is stored directly in the database (not on the filesystem), so it persists across deployments.
+
+### 1.3 Tax Configuration
+
+**Navigation:** Settings → Company → **Tax**
+
+Configure sales tax for quotes and invoices.
+
+**Fields:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Tax Enabled** | Enable/disable tax calculation | Yes |
+| **Tax Rate** | Decimal rate (not percentage) | 0.0825 (= 8.25%) |
+| **Tax Name** | Display label | "Sales Tax" or "VAT" |
+| **Tax Registration Number** | Tax ID or VAT number | "XX-1234567" |
+
+**Examples:**
+
+| Location | Tax Name | Rate (decimal) | Rate (%) |
+|----------|----------|----------------|----------|
+| Texas, US | Sales Tax | 0.0825 | 8.25% |
+| California, US | Sales Tax | 0.0725 | 7.25% |
+| UK | VAT | 0.20 | 20% |
+| No tax | N/A | 0 | 0% |
+
+**To Configure:**
+1. Set **Tax Enabled** to Yes
+2. Enter tax rate as a decimal (e.g., 0.0825 for 8.25%)
+3. Set the display name
+4. Enter your tax registration number
+5. Click **Save**
+
+---
+
+## 2. User Management
+
+### 2.1 Understanding User Types
+
+FilaOps has three account types:
+
+| Type | Access Level | Purpose |
+|------|-------------|---------|
+| **Admin** | Full access to everything | Business owner, IT administrator |
+| **Operator** | Operational features only | Production staff, warehouse team |
+| **Customer** | Portal access only | External customers (if portal enabled) |
+
+**Note:** The Community tier supports a limited number of admin/operator accounts. See your tier limits in Settings → System.
+
+### 2.2 Creating Users
+
+**Navigation:** Settings → **Users** → **+ New User**
+
+**Required Fields:**
+- **Email** - Must be unique, used for login
+- **Password** - Minimum 8 characters
+- **First Name** - User's first name
+- **Last Name** - User's last name
+- **Role** - Admin or Operator
+
+**Optional Fields:**
+- **Company Name** - If user represents an external org
+- **Phone** - Contact number
+
+**Steps:**
+1. Click **+ New User**
+2. Fill in email, name, and password
+3. Select role (Admin or Operator)
+4. Click **Create User**
+
+The new user can immediately log in with their credentials.
+
+### 2.3 Managing Existing Users
+
+**Navigation:** Settings → **Users**
+
+**User List Shows:**
+- Name and email
+- Role (admin/operator)
+- Status (active/inactive/suspended)
+- Last login date
+- Date created
+
+**Actions Available:**
+
+| Action | Description |
+|--------|-------------|
+| **Edit** | Change name, email, or role |
+| **Reset Password** | Set a new password for the user |
+| **Deactivate** | Disable login (soft delete) |
+| **Reactivate** | Re-enable a deactivated account |
+
+### 2.4 Editing a User
+
+**Navigation:** Settings → Users → (click user) → **Edit**
+
+**Editable Fields:**
+- Email address
+- First name, last name
+- Role (admin ↔ operator)
+- Status (active/inactive)
+
+**Safety Rules:**
+- You **cannot** demote yourself (admin → operator)
+- You **cannot** deactivate yourself
+- You **cannot** remove the last admin (at least one admin must exist)
+
+### 2.5 Password Resets
+
+**Admin-Initiated Reset:**
+1. Navigate to Settings → Users
+2. Click on the user
+3. Click **Reset Password**
+4. Enter new password
+5. Click **Confirm**
+
+**What Happens:**
+- Password is immediately changed
+- All existing refresh tokens for this user are revoked
+- User must log in again with new password
+
+### 2.6 Deactivating and Reactivating Users
+
+**To Deactivate:**
+1. Settings → Users → Select user
+2. Click **Deactivate**
+3. Confirm
+
+**Effect:** User can no longer log in. Their data is preserved (orders, audit trail, etc.).
+
+**To Reactivate:**
+1. Settings → Users → Filter: Inactive
+2. Select deactivated user
+3. Click **Reactivate**
+4. User can log in again
+
+### 2.7 User Dashboard Stats
+
+**Navigation:** Settings → Users → **Stats**
+
+View summary information:
+- Total admin accounts
+- Total operator accounts
+- Inactive accounts
+- Accounts created this month
+
+---
+
+## 3. Roles and Permissions
+
+### 3.1 Role Comparison
+
+| Feature | Admin | Operator | Customer |
+|---------|-------|----------|----------|
+| **Dashboard** | Full | Limited | No |
+| **Company Settings** | Edit | View | No |
+| **User Management** | Full | No | No |
+| **Inventory** | Full | Full | No |
+| **Production Orders** | Full | Full | No |
+| **Sales Orders** | Full | Full | No |
+| **Purchasing** | Full | View | No |
+| **MRP** | Full | View | No |
+| **Accounting** | Full | No | No |
+| **Printers** | Full | Full | No |
+| **AI Settings** | Full | No | No |
+| **System Updates** | Full | No | No |
+| **Own Profile** | Edit | Edit | Edit |
+
+### 3.2 When to Use Each Role
+
+**Use Admin for:**
+- Business owners
+- IT administrators
+- Finance/accounting staff
+- Anyone who needs full system access
+
+**Use Operator for:**
+- Production floor workers
+- Warehouse/shipping staff
+- Quality control inspectors
+- Anyone who needs operational access but not configuration
+
+---
+
+## 4. Location Management
+
+### 4.1 Understanding Locations
+
+Locations represent physical places where inventory is stored. FilaOps supports a hierarchical location structure.
+
+**Location Hierarchy Example:**
+```
+Main Warehouse (warehouse)
+├── Filament Storage (rack)
+│   ├── Shelf A - PLA (bin)
+│   ├── Shelf B - PETG (bin)
+│   └── Shelf C - Specialty (bin)
+├── Hardware Zone (rack)
+│   ├── Bin 1 - Fasteners (bin)
+│   └── Bin 2 - Electronics (bin)
+├── Finished Goods (rack)
+└── Shipping Area (station)
+```
+
+### 4.2 Location Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Warehouse** | Top-level facility | "Main Warehouse" |
+| **Rack** | Section within warehouse | "Filament Storage" |
+| **Bin** | Individual storage slot | "Shelf A - PLA" |
+| **Station** | Work or staging area | "Shipping Area" |
+
+### 4.3 Creating Locations
+
+**Navigation:** Settings → **Locations** → **+ New Location**
+
+**Fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Code** | Yes | Unique location code (e.g., "WH-01", "BIN-A1") |
+| **Name** | Yes | Human-readable name |
+| **Type** | Yes | warehouse, rack, bin, station |
+| **Parent** | No | Parent location (for hierarchy) |
+
+**Steps:**
+1. Click **+ New Location**
+2. Enter code and name
+3. Select type
+4. Optionally select parent location
+5. Click **Create**
+
+### 4.4 Managing Locations
+
+**Edit:** Change name, type, or parent relationship
+**Deactivate:** Soft-delete (hides from selection but preserves history)
+
+**Best Practices:**
+- Create a default location before adding inventory
+- Use consistent code patterns (WH-01, RACK-A, BIN-A1)
+- Keep hierarchy shallow (2-3 levels)
+- Deactivate rather than delete (preserves transaction history)
+
+---
+
+## 5. Material Types and Colors
+
+### 5.1 Understanding Material Management
+
+FilaOps has a three-level material system designed for 3D printing:
+
+```
+Material Type (e.g., PLA)
+├── Color (e.g., Black)
+│   └── Material-Color Combo (PLA Black)
+│       └── Material Inventory (stock tracking)
+├── Color (e.g., White)
+│   └── Material-Color Combo (PLA White)
+└── Color (e.g., Red)
+    └── Material-Color Combo (PLA Red)
+```
+
+### 5.2 Material Types
+
+**Navigation:** Settings → **Materials** → **Types**
+
+**Material Type Fields:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Code** | Unique material code | "PLA" |
+| **Name** | Display name | "PLA (Polylactic Acid)" |
+| **Base Material** | Material class | PLA, PETG, ABS, ASA, TPU |
+| **Process Type** | Manufacturing process | FDM, RESIN, SLS |
+| **Density** | Material density (g/cm3) | 1.24 |
+| **Requires Enclosure** | Needs enclosed printer | No (PLA), Yes (ABS) |
+
+**Print Settings (per material):**
+- Nozzle Temperature: min/max (e.g., 190-220 C for PLA)
+- Bed Temperature: min/max (e.g., 50-60 C)
+- Volumetric Flow Limit (mm3/s)
+
+**Pricing:**
+- Base price per KG
+- Price multiplier (for premium variants)
+
+**Visibility:**
+- Active / Inactive
+- Customer Visible (for portal display)
+- Display Order (sort priority)
+
+**Common Material Types (seeded):**
+
+| Code | Base Material | Process | Enclosure | Typical Temp |
+|------|--------------|---------|-----------|-------------|
+| PLA | PLA | FDM | No | 190-220 C |
+| PLA+ | PLA | FDM | No | 200-230 C |
+| PETG | PETG | FDM | No | 220-250 C |
+| ABS | ABS | FDM | Yes | 230-260 C |
+| ASA | ASA | FDM | Yes | 240-260 C |
+| TPU | TPU | FDM | No | 210-230 C |
+
+### 5.3 Colors
+
+**Navigation:** Settings → **Materials** → **Colors**
+
+**Color Fields:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Code** | Unique color code | "BLK" |
+| **Name** | Display name | "Black" |
+| **Hex Code** | Primary color (for UI) | "#000000" |
+| **Hex Code Secondary** | Secondary (dual-color) | "#333333" |
+| **Active** | Available for use | Yes |
+| **Customer Visible** | Shown in portal | Yes |
+| **Display Order** | Sort priority | 1 |
+
+### 5.4 Material-Color Combinations
+
+Link colors to material types to define which combinations are available.
+
+**Example:** PLA comes in 12 colors, but specialty TPU only comes in 3 colors.
+
+**To Add a Color to a Material:**
+1. Navigate to Settings → Materials → Types
+2. Select material type (e.g., PLA)
+3. Go to **Colors** tab
+4. Click **+ Add Color**
+5. Select color (e.g., Red)
+6. Set display order and visibility
+7. Save
+
+### 5.5 Bulk Import Materials
+
+**Navigation:** Settings → Materials → **Import**
+
+**Steps:**
+1. Click **Download Template** to get CSV format
+2. Fill in material data in CSV
+3. Upload CSV file
+4. Options:
+   - **Update Existing** - Override matching records
+   - **Import Categories** - Which categories to import
+5. Click **Import**
+6. Review results (created, updated, skipped, errors)
+
+---
+
+## 6. Work Centers
+
+### 6.1 Understanding Work Centers
+
+Work centers represent **logical production areas** in your facility. They define where work happens and how much it costs.
+
+**Typical 3D Print Farm Work Centers:**
+
+| Code | Name | Type | Purpose |
+|------|------|------|---------|
+| FDM-POOL | FDM Printer Pool | machine | 3D printing operations |
+| ASSEMBLY | Assembly Station | station | Part assembly and finishing |
+| QC | Quality Control | station | Inspection and testing |
+| SHIPPING | Shipping Station | station | Packing and label creation |
+| FINISHING | Finishing Station | station | Sanding, painting, etc. |
+
+### 6.2 Creating Work Centers
+
+**Navigation:** Settings → **Work Centers** → **+ New Work Center**
+
+**Fields:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Code** | Unique identifier | "FDM-POOL" |
+| **Name** | Display name | "FDM Printer Pool" |
+| **Description** | Details | "All FDM printers for production" |
+| **Type** | Category | machine, station, production |
+| **Active** | Available for use | Yes |
+
+### 6.3 Work Center Costing
+
+**Navigation:** Settings → Work Centers → (select) → **Costing**
+
+Work centers have three cost rates that combine to calculate total hourly cost:
+
+| Rate | Description | Example |
+|------|-------------|---------|
+| **Machine Rate ($/hr)** | Equipment depreciation, power, maintenance | $1.50/hr |
+| **Labor Rate ($/hr)** | Operator wages allocated to this center | $25.00/hr |
+| **Overhead Rate ($/hr)** | Facility costs, supervision, utilities | $5.00/hr |
+
+**Total Hourly Rate** = Machine + Labor + Overhead = $31.50/hr
+
+**How This Is Used:**
+- Production orders calculate manufacturing cost using routing operations
+- Each routing operation references a work center
+- Operation cost = (setup_time + run_time) x work center hourly rate
+
+### 6.4 Work Center Capacity
+
+**Navigation:** Settings → Work Centers → (select) → **Capacity**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Hours Per Day** | Operating hours | 16 hrs (two shifts) |
+| **Units Per Hour** | Throughput rate | 2 parts/hr |
+| **Is Bottleneck** | Constrains production | Yes (for printing) |
+| **Scheduling Priority** | 1-10 (higher = sooner) | 8 |
+
+**Capacity Planning:**
+- MRP and scheduling use capacity to plan realistic timelines
+- Bottleneck work centers get priority in scheduling
+- Over-capacity warnings highlight when you need more printers/staff
+
+### 6.5 Resources (Machines in Work Centers)
+
+Each work center can contain multiple **resources** (individual machines).
+
+**Example:**
+```
+FDM-POOL (Work Center)
+├── P1X-001 (Bambu Lab P1S)
+├── P1X-002 (Bambu Lab P1S)
+├── A1M-001 (Bambu Lab A1 Mini)
+└── A1M-002 (Bambu Lab A1 Mini)
+```
+
+**To Add a Resource:**
+1. Navigate to Settings → Work Centers → (select work center)
+2. Go to **Resources** tab
+3. Click **+ Add Resource**
+4. Enter code, name, machine type
+5. Optionally link Bambu device ID and IP address
+6. Set capacity hours per day
+7. Save
+
+---
+
+## 7. Printer Management
+
+### 7.1 Supported Printer Brands
+
+FilaOps supports multiple 3D printer brands:
+
+| Brand | Connection | Features |
+|-------|-----------|----------|
+| **Bambu Lab** | MQTT / LAN | Full monitoring, AMS support, camera |
+| **Klipper** | HTTP API | Print status, temperatures |
+| **OctoPrint** | REST API | Print status, webcam |
+| **Prusa** | PrusaLink | Basic monitoring |
+| **Creality** | Network | Basic monitoring |
+| **Generic** | Manual | Manual status updates only |
+
+### 7.2 Adding Printers
+
+**Navigation:** Settings → **Printers** → **+ New Printer**
+
+**Required Fields:**
+- **Code** - Unique printer ID (auto-generated if blank)
+- **Name** - Human-readable name (e.g., "Printer 1 - P1S")
+- **Brand** - Manufacturer (bambulab, klipper, etc.)
+- **Model** - Printer model (e.g., "P1S", "X1C")
+
+**Optional Fields:**
+- **Serial Number** - For tracking and warranty
+- **IP Address** - Network address for monitoring
+- **MQTT Topic** - For Bambu Lab MQTT integration
+- **Work Center** - Which production area this printer belongs to
+- **Location** - Physical location description
+- **Notes** - Additional information
+
+### 7.3 Printer Capabilities
+
+When adding a printer, configure its capabilities:
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| **Bed Size** | Print volume | "256x256x256" |
+| **Heated Bed** | Has heated bed | Yes |
+| **Enclosure** | Enclosed chamber | Yes (for ABS/ASA) |
+| **AMS Slots** | Auto Material System slots | 4 |
+| **Camera** | Has built-in camera | Yes |
+| **Max Temp** | Maximum nozzle temperature | 300 C |
+
+These capabilities are stored as flexible JSON, so custom properties can be added.
+
+### 7.4 Printer Discovery
+
+**Navigation:** Settings → Printers → **Discover**
+
+FilaOps can automatically find printers on your network:
+
+**Bambu Lab Discovery:**
+1. Click **Discover**
+2. Select "Bambu Lab"
+3. FilaOps scans the local network
+4. Found printers appear in list
+5. Click **Add** to register each printer
+
+**Klipper/OctoPrint Discovery:**
+1. Click **Discover**
+2. Enter IP range to scan
+3. Found instances appear
+4. Click **Add** to register
+
+### 7.5 Bulk Import Printers
+
+**Navigation:** Settings → Printers → **Import**
+
+Import multiple printers from a CSV file:
+1. Download CSV template
+2. Fill in printer details
+3. Upload CSV
+4. Review and confirm import
+
+### 7.6 Printer Status
+
+Printers have the following status values:
+
+| Status | Meaning | Color |
+|--------|---------|-------|
+| **Idle** | Ready, no current job | Green |
+| **Printing** | Actively printing | Blue |
+| **Paused** | Print paused | Yellow |
+| **Error** | Error state | Red |
+| **Maintenance** | Under maintenance | Orange |
+| **Offline** | Not responding | Gray |
+
+**Online Detection:** A printer is considered online if it was last seen within 5 minutes.
+
+### 7.7 Testing Printer Connection
+
+**Navigation:** Settings → Printers → (select) → **Test Connection**
+
+Tests network connectivity and API access to the printer. Useful for:
+- Verifying IP address is correct
+- Checking firewall/network settings
+- Confirming API keys/credentials work
+
+---
+
+## 8. AI Configuration
+
+### 8.1 AI Provider Options
+
+FilaOps supports two AI providers:
+
+| Provider | Type | Best For |
+|----------|------|----------|
+| **Anthropic** (Claude) | Cloud API | Highest quality, requires internet |
+| **Ollama** | Local/Self-hosted | Privacy, offline use, no API costs |
+
+### 8.2 Configuring Anthropic
+
+**Navigation:** Settings → **AI** → Provider: Anthropic
+
+**Fields:**
+- **API Key** - Your Anthropic API key (starts with `sk-ant-`)
+- **Model** - Which Claude model to use (default: claude-sonnet-4-20250514)
+
+**Steps:**
+1. Get an API key from [console.anthropic.com](https://console.anthropic.com)
+2. Navigate to Settings → AI
+3. Select Provider: **Anthropic**
+4. Enter your API key
+5. Select model
+6. Click **Test Connection** to verify
+7. Click **Save**
+
+**Security:** API keys are masked in the UI (displayed as `sk-...XYZ`). The full key is stored in the database.
+
+### 8.3 Configuring Ollama
+
+**Navigation:** Settings → **AI** → Provider: Ollama
+
+**Fields:**
+- **Ollama URL** - Server address (default: http://localhost:11434)
+- **Model** - Which model to use (default: llama3.2)
+
+**Steps:**
+1. Install Ollama on your server
+2. Pull a model: `ollama pull llama3.2`
+3. Navigate to Settings → AI
+4. Select Provider: **Ollama**
+5. Enter Ollama URL
+6. Select model
+7. Click **Test Connection** to verify
+8. Click **Save**
+
+**Start Ollama:** If Ollama is installed but not running, use the **Start Ollama** button to attempt to start the service.
+
+### 8.4 Blocking External AI
+
+**Navigation:** Settings → AI → **External AI Blocked**
+
+If enabled, forces all AI features to use local-only (Ollama) processing. No data is sent to external APIs.
+
+**Use When:**
+- Handling sensitive business data
+- Operating in air-gapped environments
+- Company policy prohibits external AI services
+
+---
+
+## 9. Accounting Settings
+
+### 9.1 Fiscal Year
+
+**Navigation:** Settings → Company → **Accounting**
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| **Fiscal Year Start** | Month fiscal year begins | 1 (January) |
+| **Accounting Method** | Cash or Accrual | Accrual |
+| **Currency Code** | Base currency | USD |
+
+**Common Fiscal Year Starts:**
+- January (1) - Calendar year (most common)
+- April (4) - UK tax year
+- July (7) - Australian financial year
+- October (10) - US federal government
+
+### 9.2 Business Hours
+
+**Navigation:** Settings → Company → **Schedule**
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| **Timezone** | IANA timezone | America/New_York |
+| **Business Hours Start** | Opening hour (0-23) | 8 (8:00 AM) |
+| **Business Hours End** | Closing hour (0-23) | 16 (4:00 PM) |
+| **Business Days Per Week** | Work days | 5 |
+| **Work Days** | Specific days | "0,1,2,3,4" (Mon-Fri) |
+
+**How This Is Used:**
+- Lead time calculations use business days
+- Scheduling respects working hours
+- Shipping estimates account for non-business days
+
+### 9.3 Quote and Invoice Settings
+
+**Navigation:** Settings → Company → **Documents**
+
+**Quote Settings:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Default Validity Days** | Days quote stays valid | 30 |
+| **Quote Terms** | Terms & conditions text | "Payment due within 30 days..." |
+| **Quote Footer** | Footer on quote documents | "Thank you for your business!" |
+
+**Invoice Settings:**
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Invoice Prefix** | Prefix for invoice numbers | "INV" |
+| **Invoice Terms** | Payment terms text | "Net 30" |
+
+---
+
+## 10. Admin Dashboard
+
+### 10.1 Dashboard Overview
+
+**Navigation:** Home or Dashboard icon
+
+The admin dashboard provides a real-time operational overview.
+
+**Key Metric Cards:**
+
+| Metric | What It Shows |
+|--------|--------------|
+| **Pending Quotes** | Quotes awaiting response |
+| **Orders in Production** | Active production orders |
+| **Ready to Ship** | Orders waiting for shipping |
+| **Overdue Orders** | Orders past due date |
+| **Low Stock Items** | Items below reorder point |
+| **MRP Shortages** | Materials with shortages |
+| **Revenue (30-day)** | Sales in last 30 days |
+| **Revenue (YTD)** | Year-to-date sales |
+
+### 10.2 Trend Charts
+
+**Available Trends:**
+
+| Chart | Description | Periods |
+|-------|-------------|---------|
+| **Sales Trend** | Daily sales and payments | WTD, MTD, QTD, YTD, ALL |
+| **Shipping Trend** | Daily shipped orders | Same |
+| **Production Trend** | Daily completed production | Same |
+| **Purchasing Trend** | Daily PO receipts and spend | Same |
+
+**How to Use:**
+1. Select trend chart
+2. Choose period (Week-to-Date, Month-to-Date, etc.)
+3. View daily breakdown with totals
+
+### 10.3 Profit Summary
+
+**Navigation:** Dashboard → **Profit Summary**
+
+| Metric | Formula |
+|--------|---------|
+| **Revenue** | Sum of completed sales |
+| **COGS** | Cost of Goods Sold (materials + manufacturing) |
+| **Gross Profit** | Revenue - COGS |
+| **Gross Margin** | (Gross Profit / Revenue) x 100% |
+
+### 10.4 Quick Actions
+
+The dashboard provides quick-action buttons for common tasks:
+- Create Sales Order
+- Create Production Order
+- Run MRP
+- View Low Stock Items
+- View Pending BOMs
+
+---
+
+## 11. System Administration
+
+### 11.1 System Version
+
+**Navigation:** Settings → **System**
+
+View your current FilaOps version information:
+- Version number (from git tag)
+- Environment (development/production)
+- Database connection status
+- Tier (Community)
+
+### 11.2 System Updates (Docker)
+
+**Navigation:** Settings → System → **Update**
+
+For Docker-based deployments, FilaOps supports one-click updates:
+
+**Update Process:**
+1. Navigate to Settings → System → Update
+2. Click **Check for Updates**
+3. If update available, review changes
+4. Click **Start Update**
+
+**What Happens:**
+1. Pulls latest code from git repository
+2. Rebuilds Docker containers
+3. Runs database migrations (Alembic)
+4. Restarts services
+5. Reports success or failure
+
+**Update Status Values:**
+- **Idle** - No update in progress
+- **Checking** - Looking for updates
+- **Updating** - Update in progress
+- **Success** - Update completed
+- **Error** - Update failed (check logs)
+
+**To Update to a Specific Version:**
+- Enter a specific version tag (e.g., "v3.1.0")
+- Click **Start Update**
+
+### 11.3 Environment Configuration
+
+Key environment variables in `backend/.env`:
+
+**Essential Settings:**
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `DATABASE_URL` | Database connection | `postgresql+psycopg://...` |
+| `SECRET_KEY` | JWT signing key | Random 64-char hex string |
+| `ENVIRONMENT` | Dev or production | `development` |
+| `ALLOWED_ORIGINS` | CORS origins | `http://localhost:5173` |
+
+**MRP Settings:**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `INCLUDE_SALES_ORDERS_IN_MRP` | false | Include SOs as MRP demand |
+| `AUTO_MRP_ON_ORDER_CREATE` | false | Auto-run MRP on new orders |
+| `MRP_ENABLE_SUB_ASSEMBLY_CASCADING` | false | Lead time cascading |
+
+**Manufacturing Settings:**
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MACHINE_HOURLY_RATE` | 1.50 | Default machine rate ($/hr) |
+| `PRINTING_HOURS_PER_DAY` | 8 | Daily printing capacity |
+| `PROCESSING_BUFFER_DAYS` | 2 | Buffer days for production |
+
+**See the [Getting Started](getting-started.md) guide for complete `.env` setup.**
+
+---
+
+## 12. Data Import and Export
+
+### 12.1 Available Imports
+
+FilaOps supports bulk data import for:
+
+| Data Type | Format | Navigation |
+|-----------|--------|------------|
+| **Materials** | CSV | Settings → Materials → Import |
+| **Printers** | CSV | Settings → Printers → Import |
+| **Customers** | CSV | Sales → Customers → Import |
+| **Products** | CSV | Items → Import |
+
+**Import Process:**
+1. Download the CSV template (ensures correct columns)
+2. Fill in data using a spreadsheet editor
+3. Upload the CSV file
+4. Choose import options:
+   - **Update Existing** - Overwrite matching records
+   - **Skip Existing** - Only add new records
+5. Preview results
+6. Confirm import
+
+### 12.2 Export
+
+**Navigation:** Admin → **Export**
+
+Export data from FilaOps for:
+- Backup purposes
+- Reporting in external tools
+- Migration to other systems
+
+### 12.3 Seed Example Data
+
+**Navigation:** Settings → **Seed Data** (or via API)
+
+For new installations, seed example data to explore FilaOps:
+
+**What Gets Created:**
+- Example items (finished goods, packaging, hardware)
+- Material types (PLA, PETG, ABS, TPU, etc.)
+- Basic colors (Black, White, Gray, Red, Blue, etc.)
+- Material-color combinations for common filaments
+
+**To Seed:**
+```
+POST /api/v1/setup/seed-example-data
+Authorization: Bearer YOUR_TOKEN
+```
+
+**See [Getting Started](getting-started.md) for details.**
+
+---
+
+## 13. Troubleshooting
+
+### Issue 1: Can't Create New Users
+
+**Symptoms:**
+- "User limit reached" error
+- Create button disabled
+
+**Cause:** Community tier user limit reached
+
+**Solution:**
+1. Check Settings → Users for inactive accounts
+2. Deactivate unused accounts
+3. Or upgrade tier for more user slots
+
+---
+
+### Issue 2: Logo Upload Fails
+
+**Symptoms:**
+- "File too large" or "Invalid format" error
+
+**Causes & Solutions:**
+
+**File too large:**
+```
+Solution:
+Maximum size is 2 MB.
+1. Resize image to 400px wide
+2. Compress PNG/JPEG
+3. Try WebP format (smaller files)
+```
+
+**Wrong format:**
+```
+Solution:
+Supported: PNG, JPEG, GIF, WebP
+Not supported: SVG, BMP, TIFF
+Convert to PNG if needed.
+```
+
+---
+
+### Issue 3: Printer Not Connecting
+
+**Symptoms:**
+- Status stays "Offline"
+- Test Connection fails
+
+**Causes & Solutions:**
+
+**Network issue:**
+```
+Solution:
+1. Verify printer IP address is correct
+2. Ensure FilaOps server can reach printer
+3. Check firewall rules (ports 1883/MQTT, 80/HTTP)
+4. Try pinging printer from server
+```
+
+**Wrong credentials:**
+```
+Solution:
+1. Verify MQTT topic (Bambu Lab)
+2. Check API key (OctoPrint)
+3. Verify access code (Bambu Lab LAN mode)
+```
+
+**Printer not on network:**
+```
+Solution:
+1. Check printer WiFi connection
+2. Verify printer is on same subnet
+3. Try printer discovery to find actual IP
+```
+
+---
+
+### Issue 4: Tax Not Appearing on Quotes
+
+**Symptoms:**
+- Quotes show $0 tax
+- Tax line missing
+
+**Causes & Solutions:**
+
+**Tax not enabled:**
+```
+Solution:
+1. Settings → Company → Tax
+2. Set Tax Enabled = Yes
+3. Enter tax rate (e.g., 0.0825)
+4. Save
+```
+
+**Tax rate set incorrectly:**
+```
+Solution:
+Rate is DECIMAL, not percentage.
+Wrong: 8.25 (this means 825% tax!)
+Right: 0.0825 (this means 8.25% tax)
+```
+
+---
+
+### Issue 5: AI Features Not Working
+
+**Symptoms:**
+- "AI not configured" error
+- AI features grayed out
+
+**Causes & Solutions:**
+
+**No provider configured:**
+```
+Solution:
+1. Settings → AI
+2. Select provider (Anthropic or Ollama)
+3. Enter credentials
+4. Test connection
+5. Save
+```
+
+**Anthropic API key invalid:**
+```
+Solution:
+1. Verify key starts with "sk-ant-"
+2. Check key hasn't expired
+3. Verify billing is active on Anthropic account
+4. Click "Test Connection"
+```
+
+**Ollama not running:**
+```
+Solution:
+1. Check if Ollama is installed
+2. Click "Start Ollama" button
+3. Or manually: `ollama serve`
+4. Verify URL is correct (default: http://localhost:11434)
+```
+
+---
+
+### Issue 6: Company Settings Not Saving
+
+**Symptoms:**
+- Changes revert after refresh
+- "Error saving settings" message
+
+**Causes & Solutions:**
+
+**Permission denied:**
+```
+Solution:
+Only Admin users can change company settings.
+1. Check your role (Settings → Users → Your account)
+2. Contact admin if you need changes made
+```
+
+**Validation error:**
+```
+Solution:
+Check for required fields:
+1. Company name cannot be blank
+2. Tax rate must be 0-1 range (decimal)
+3. Fiscal year start must be 1-12
+```
+
+---
+
+## 14. Quick Reference
+
+### Navigation Map
+
+```
+Settings
+├── Company
+│   ├── Company Information (name, address, contact)
+│   ├── Logo (upload/delete)
+│   ├── Tax (enable, rate, registration)
+│   ├── Accounting (fiscal year, method, currency)
+│   ├── Schedule (timezone, business hours)
+│   └── Documents (quote terms, invoice prefix)
+├── Users
+│   ├── User List (search, filter)
+│   ├── Create User (admin/operator)
+│   ├── Edit User (role, status, info)
+│   └── Password Reset
+├── Locations
+│   ├── Location List (hierarchical)
+│   └── Create/Edit Location
+├── Materials
+│   ├── Material Types (PLA, PETG, etc.)
+│   ├── Colors (with hex codes)
+│   ├── Material-Color Combos
+│   └── Import (CSV)
+├── Work Centers
+│   ├── Work Center List
+│   ├── Create/Edit (costing, capacity)
+│   └── Resources (machines per center)
+├── Printers
+│   ├── Printer List (status, brand)
+│   ├── Add Printer (manual or discover)
+│   ├── Capabilities Configuration
+│   └── Import (CSV)
+├── AI
+│   ├── Provider Selection
+│   ├── Anthropic Config (API key, model)
+│   └── Ollama Config (URL, model)
+└── System
+    ├── Version Info
+    └── System Update (Docker)
+```
+
+### User Roles
+
+| Role | Code | Settings | Users | Operations | Accounting |
+|------|------|----------|-------|------------|------------|
+| **Admin** | `admin` | Full | Full | Full | Full |
+| **Operator** | `operator` | View | None | Full | None |
+| **Customer** | `customer` | None | Own profile | None | None |
+
+### Account Status
+
+| Status | Login | Data | Reversible |
+|--------|-------|------|------------|
+| **Active** | Yes | Accessible | N/A |
+| **Inactive** | No | Preserved | Yes (Reactivate) |
+| **Suspended** | No | Preserved | Yes (Admin action) |
+
+### API Endpoints
+
+**Company Settings:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/settings/company` | GET | Get company settings |
+| `/api/v1/settings/company` | PATCH | Update company settings |
+| `/api/v1/settings/company/logo` | POST | Upload logo |
+| `/api/v1/settings/company/logo` | GET | Download logo |
+| `/api/v1/settings/company/logo` | DELETE | Delete logo |
+
+**User Management:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/admin/users` | GET | List users |
+| `/api/v1/admin/users` | POST | Create user |
+| `/api/v1/admin/users/{id}` | GET | Get user |
+| `/api/v1/admin/users/{id}` | PATCH | Update user |
+| `/api/v1/admin/users/{id}` | DELETE | Deactivate user |
+| `/api/v1/admin/users/{id}/reactivate` | POST | Reactivate user |
+| `/api/v1/admin/users/{id}/reset-password` | POST | Reset password |
+| `/api/v1/admin/users/stats/summary` | GET | User stats |
+
+**Locations:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/locations` | GET | List locations |
+| `/api/v1/locations` | POST | Create location |
+| `/api/v1/locations/{id}` | GET | Get location |
+| `/api/v1/locations/{id}` | PUT | Update location |
+| `/api/v1/locations/{id}` | DELETE | Deactivate location |
+
+**AI Settings:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/settings/ai` | GET | Get AI config |
+| `/api/v1/settings/ai` | PATCH | Update AI config |
+| `/api/v1/settings/ai/test` | POST | Test AI connection |
+| `/api/v1/settings/ai/start-ollama` | POST | Start Ollama service |
+
+**Work Centers:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/work-centers` | GET | List work centers |
+| `/api/v1/work-centers` | POST | Create work center |
+| `/api/v1/work-centers/{id}` | GET | Get work center |
+| `/api/v1/work-centers/{id}` | PUT | Update work center |
+| `/api/v1/work-centers/{id}/resources` | GET | List resources |
+| `/api/v1/work-centers/{id}/resources` | POST | Add resource |
+
+**Printers:**
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/printers` | GET | List printers |
+| `/api/v1/printers` | POST | Create printer |
+| `/api/v1/printers/{id}` | GET | Get printer |
+| `/api/v1/printers/{id}` | PUT | Update printer |
+| `/api/v1/printers/{id}/test-connection` | POST | Test connection |
+| `/api/v1/printers/discover` | POST | Network discovery |
+| `/api/v1/printers/brands/info` | GET | Supported brands |
+
+### Key Environment Variables
+
+```ini
+# Core
+DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/filaops
+SECRET_KEY=your-64-char-hex-secret
+ENVIRONMENT=development
+
+# CORS
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+
+# MRP
+INCLUDE_SALES_ORDERS_IN_MRP=false
+AUTO_MRP_ON_ORDER_CREATE=false
+MRP_ENABLE_SUB_ASSEMBLY_CASCADING=false
+
+# Manufacturing
+MACHINE_HOURLY_RATE=1.50
+PRINTING_HOURS_PER_DAY=8
+
+# Logging
+LOG_LEVEL=INFO
+LOG_FORMAT=json
+```
+
+---
+
+## Related Guides
+
+- **[Getting Started](getting-started.md)** - Initial setup, environment configuration, first-time wizard
+- **[Inventory Management](inventory-management.md)** - Using locations for stock management
+- **[Manufacturing](manufacturing.md)** - Work centers and routing operations
+- **[MRP](mrp.md)** - MRP configuration settings
+- **[Sales & Quotes](sales-and-quotes.md)** - Quote terms and tax on quotes
+- **[Purchasing](purchasing.md)** - Vendor management and purchase orders
+
+---
+
+**Need Help?**
+- Consult the [API Reference](../API-REFERENCE.md) for integration details
+- Report issues on [GitHub](https://github.com/Blb3D/filaops/issues)
+- See [Getting Started](getting-started.md) for initial setup
+
+---
+
+*Last Updated: February 2026 | FilaOps v3.0.0*


### PR DESCRIPTION
## Summary
- Expanded `accounting-module.md` from a 148-line stub to a full ~1,200-line guide covering Chart of Accounts, journal entries, trial balance, fiscal periods, COGS, tax reporting, Schedule C, and more
- Created new standalone `printers-and-fleet.md` guide (~850 lines) covering multi-brand printer management, MQTT monitoring, network discovery, maintenance tracking, and work center integration
- Added `index.md` navigation page with workflow diagrams and module connection map
- Included all existing guides (getting-started, sales-and-quotes, inventory, manufacturing, purchasing, mrp, settings-and-admin) as tracked files

## Files changed
- `docs/user-guide/index.md` — **new** navigation hub
- `docs/user-guide/accounting-module.md` — **expanded** (148 → ~1,200 lines)
- `docs/user-guide/printers-and-fleet.md` — **new** standalone guide
- 7 existing guides now tracked in repo

## Test plan
- [ ] Verify all internal markdown links resolve correctly
- [ ] Confirm API endpoint references match current backend routes
- [ ] Review accounting workflows against actual GL behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * New Getting Started guide with installation and first-time setup instructions
  * Comprehensive module guides added for Sales & Quotes, Inventory Management, Manufacturing, MRP, Purchasing, Accounting, Printers & Fleet, and Settings & Admin
  * Updated user guide index with module navigation and typical workflow overview
  * Expanded accounting module documentation with detailed procedures and governance guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->