### PR TITLE
security: migrate auth to httpOnly cookies + harden endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Auth tokens migrated from localStorage to httpOnly cookies** — prevents XSS token theft
+  - All browser-based auth now uses httpOnly cookies with `SameSite=Lax`
+  - `AUTH_MODE` env var (`cookie`/`header`) for rollback safety
+  - `COOKIE_SECURE` env var — set `true` in production (requires HTTPS)
+  - Programmatic API access via `Authorization: Bearer` header still supported
+  - Tokens are **no longer returned** in login/register response bodies (cookie mode)
+- Password reset approve/deny changed from GET to POST — prevents CSRF and browser prefetch side effects
+- Rate limiting added to token refresh endpoint (`10/minute`)
+- Rate limiting added to password reset approve/deny endpoints (`10/minute`)
+- Server-side refresh token revocation on logout
+
 ### Changed
 - Removed deprecated `Machine` model alias; use `Resource` from `manufacturing.py` directly
 - Expanded `.env.example` to cover all settings groups
+- Frontend: all 70+ components migrated from manual `Authorization` header to `credentials: "include"`
 
 ## [3.0.1] - 2026-02-06
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,11 @@ SECRET_KEY=change-this-to-a-random-secret-key-in-production
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 # API_KEY=optional-api-key-for-integrations
 
+# Cookie security: false for local dev (no TLS), true for production (requires HTTPS)
+COOKIE_SECURE=false
+# Auth token delivery: 'cookie' (httpOnly, recommended) or 'header' (legacy bearer-in-body)
+AUTH_MODE=cookie
+
 # ===========================================
 # ENVIRONMENT
 # ===========================================

--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -6,7 +6,7 @@ that can be safely imported without triggering rate limiter initialization issue
 """
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 
@@ -15,26 +15,32 @@ from app.models.user import User
 from app.core.security import get_user_from_token
 from app.schemas.common import PaginationParams
 
-# OAuth2 scheme for token authentication
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+# OAuth2 scheme — auto_error=False so we can fall back to cookies
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
-    db: Session = Depends(get_db)
+    request: Request,
+    token: Annotated[str | None, Depends(oauth2_scheme)] = None,
+    db: Session = Depends(get_db),
 ) -> User:
     """
-    Dependency to get the current authenticated user from access token
+    Dependency to get the current authenticated user.
+
+    Checks for auth token in this order:
+    1. httpOnly cookie ``access_token`` (browser sessions)
+    2. Authorization: Bearer header (programmatic / API access)
 
     Args:
-        token: JWT access token from Authorization header
+        request: FastAPI Request (for cookie access)
+        token: JWT access token from Authorization header (may be None)
         db: Database session
 
     Returns:
         User object if token is valid
 
     Raises:
-        HTTPException 401 if token is invalid or user not found
+        HTTPException 401 if no valid token found
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -42,8 +48,13 @@ async def get_current_user(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
+    # Try cookie first, then Authorization header
+    access_token = request.cookies.get("access_token") or token
+    if not access_token:
+        raise credentials_exception
+
     # Decode token and extract user ID
-    user_id = get_user_from_token(token, expected_type="access")
+    user_id = get_user_from_token(access_token, expected_type="access")
     if user_id is None:
         raise credentials_exception
 

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -1,13 +1,17 @@
 """
 Authentication endpoints for FilaOps Core
 
-Handles user registration, login, token refresh, and profile retrieval
+Handles user registration, login, token refresh, and profile retrieval.
+
+Auth delivery is controlled by ``settings.AUTH_MODE``:
+- ``cookie`` (default): tokens are set as httpOnly cookies — never exposed to JS.
+- ``header``: tokens are returned in the JSON body (legacy / programmatic use).
 """
 from datetime import datetime, timezone, timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi import APIRouter, Depends, HTTPException, Response, status, Request
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from app.core.limiter import limiter
 
@@ -21,6 +25,7 @@ from app.schemas.auth import (
     RefreshTokenRequest,
     PasswordResetRequestCreate,
     PasswordResetRequestResponse,
+    PasswordResetApprovalRequest,
     PasswordResetApprovalResponse,
     PasswordResetComplete,
     PasswordResetStatus,
@@ -35,9 +40,12 @@ from app.core.security import (
     create_refresh_token,
     get_user_from_token,
     hash_refresh_token,
+    set_auth_cookies,
+    clear_auth_cookies,
     REFRESH_TOKEN_EXPIRE_DAYS,
 )
 from app.logging_config import get_logger
+from app.api.v1.deps import get_current_user  # noqa: F401
 # Re-exports for backwards compatibility (prefer importing from app.api.v1.deps directly)
 from app.api.v1.deps import get_current_admin_user as get_current_admin_user  # noqa: F401, E402
 from app.api.v1.deps import get_current_staff_user as get_current_staff_user  # noqa: F401, E402
@@ -46,83 +54,27 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
-# OAuth2 scheme for token authentication
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
-
-
-# ============================================================================
-# DEPENDENCY: Get Current User
-# ============================================================================
-
-async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
-    db: Session = Depends(get_db)
-) -> User:
-    """
-    Dependency to get the current authenticated user from access token
-
-    Args:
-        token: JWT access token from Authorization header
-        db: Database session
-
-    Returns:
-        User object if token is valid
-
-    Raises:
-        HTTPException 401 if token is invalid or user not found
-    """
-    credentials_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
-
-    # Decode token and extract user ID
-    user_id = get_user_from_token(token, expected_type="access")
-    if user_id is None:
-        raise credentials_exception
-
-    # Get user from database
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
-        raise credentials_exception
-
-    # Check if user is active
-    if not user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="User account is inactive"
-        )
-
-    return user
+_USE_COOKIES = settings.AUTH_MODE.lower() == "cookie"
 
 
 # ============================================================================
 # ENDPOINT: User Registration
 # ============================================================================
 
-@router.post("/register", response_model=UserWithTokens, status_code=status.HTTP_201_CREATED)
+@router.post("/register", status_code=status.HTTP_201_CREATED)
 @limiter.limit("3/minute")  # type: ignore
 async def register_user(
     request: Request,
+    response: Response,
     user_data: UserRegister,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     """
     Register a new user
 
     Creates a new user account with the provided email and password.
-    Returns the user profile along with access and refresh tokens for immediate login.
-
-    Args:
-        user_data: User registration data (email, password, name, etc.)
-        db: Database session
-
-    Returns:
-        User profile with access and refresh tokens
-
-    Raises:
-        HTTPException 400 if email is already registered
+    In cookie mode, tokens are set as httpOnly cookies.
+    In header mode, tokens are returned in the response body.
     """
     # Check if email already exists
     existing_user = db.query(User).filter(User.email == user_data.email).first()
@@ -167,13 +119,18 @@ async def register_user(
     db.add(refresh_token_record)
     db.commit()
 
-    # Return user profile with tokens
     user_dict = UserResponse.model_validate(new_user).model_dump()
+
+    if _USE_COOKIES:
+        set_auth_cookies(response, access_token, refresh_token)
+        return {**user_dict, "token_type": "cookie"}
+
+    # Header mode — return tokens in body
     return {
         **user_dict,
         "access_token": access_token,
         "refresh_token": refresh_token,
-        "token_type": "bearer"
+        "token_type": "bearer",
     }
 
 
@@ -181,28 +138,19 @@ async def register_user(
 # ENDPOINT: User Login
 # ============================================================================
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login")
 @limiter.limit("5/minute")  # type: ignore
 async def login_user(
     request: Request,
+    response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     """
-    Login with email and password
+    Login with email and password.
 
-    Authenticates user credentials and returns access and refresh tokens.
-    Uses OAuth2 password flow (username field contains email).
-
-    Args:
-        form_data: OAuth2 form with username (email) and password
-        db: Database session
-
-    Returns:
-        Access and refresh tokens
-
-    Raises:
-        HTTPException 401 if credentials are incorrect
+    In cookie mode, tokens are set as httpOnly cookies and user info is returned.
+    In header mode, tokens are returned in the response body (legacy).
     """
     try:
         # Get user by email (username field in OAuth2 form)
@@ -215,7 +163,7 @@ async def login_user(
                 detail="Incorrect email or password",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        
+
         # Verify password
         try:
             password_valid = verify_password(form_data.password, user.password_hash)  # type: ignore[arg-type]
@@ -226,7 +174,7 @@ async def login_user(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Authentication error. Please contact support."
             )
-        
+
         if not password_valid:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -253,12 +201,12 @@ async def login_user(
         # Store refresh token in database
         token_hash = hash_refresh_token(refresh_token)
         expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-        
+
         # Check if token hash already exists (shouldn't happen, but handle it)
         existing_token = db.query(RefreshToken).filter(
             RefreshToken.token_hash == token_hash
         ).first()
-        
+
         if existing_token:
             # Revoke old token
             existing_token.revoked = True  # type: ignore[assignment]
@@ -268,7 +216,7 @@ async def login_user(
             refresh_token = create_refresh_token(user.id)  # type: ignore[arg-type]
             token_hash = hash_refresh_token(refresh_token)
             expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-        
+
         refresh_token_record = RefreshToken(
             user_id=user.id,
             token_hash=token_hash,
@@ -278,10 +226,16 @@ async def login_user(
         db.add(refresh_token_record)
         db.commit()
 
+        if _USE_COOKIES:
+            set_auth_cookies(response, access_token, refresh_token)
+            user_dict = UserResponse.model_validate(user).model_dump()
+            return {"message": "Login successful", "user": user_dict, "token_type": "cookie"}
+
+        # Header mode — return tokens in body
         return {
             "access_token": access_token,
             "refresh_token": refresh_token,
-            "token_type": "bearer"
+            "token_type": "bearer",
         }
     except HTTPException:
         raise
@@ -298,26 +252,20 @@ async def login_user(
 # ENDPOINT: Refresh Token
 # ============================================================================
 
-@router.post("/refresh", response_model=TokenResponse)
+@router.post("/refresh")
+@limiter.limit("10/minute")  # type: ignore
 async def refresh_access_token(
-    refresh_data: RefreshTokenRequest,
-    db: Session = Depends(get_db)
+    request: Request,
+    response: Response,
+    refresh_data: RefreshTokenRequest | None = None,
+    db: Session = Depends(get_db),
 ):
     """
-    Refresh access token using refresh token
+    Refresh access token using refresh token.
 
-    Validates the refresh token and issues a new access token and refresh token.
-    The old refresh token is revoked after successful refresh.
-
-    Args:
-        refresh_data: Refresh token request with token string
-        db: Database session
-
-    Returns:
-        New access and refresh tokens
-
-    Raises:
-        HTTPException 401 if refresh token is invalid or expired
+    In cookie mode, reads the refresh token from the httpOnly cookie.
+    In header mode, reads from the JSON body.
+    The old refresh token is always revoked (token rotation).
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -325,13 +273,20 @@ async def refresh_access_token(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
+    # Resolve the raw refresh token: cookie first, then body
+    raw_refresh_token: str | None = request.cookies.get("refresh_token")
+    if not raw_refresh_token and refresh_data:
+        raw_refresh_token = refresh_data.refresh_token
+    if not raw_refresh_token:
+        raise credentials_exception
+
     # Decode refresh token and extract user ID
-    user_id = get_user_from_token(refresh_data.refresh_token, expected_type="refresh")
+    user_id = get_user_from_token(raw_refresh_token, expected_type="refresh")
     if user_id is None:
         raise credentials_exception
 
     # Verify refresh token exists in database and is not revoked
-    token_hash = hash_refresh_token(refresh_data.refresh_token)
+    token_hash = hash_refresh_token(raw_refresh_token)
     stored_token = db.query(RefreshToken).filter(
         RefreshToken.token_hash == token_hash,
         RefreshToken.user_id == user_id,
@@ -365,10 +320,14 @@ async def refresh_access_token(
     db.add(new_refresh_token_record)
     db.commit()
 
+    if _USE_COOKIES:
+        set_auth_cookies(response, new_access_token, new_refresh_token)
+        return {"message": "Token refreshed", "token_type": "cookie"}
+
     return {
         "access_token": new_access_token,
         "refresh_token": new_refresh_token,
-        "token_type": "bearer"
+        "token_type": "bearer",
     }
 
 
@@ -393,6 +352,41 @@ async def get_current_user_profile(
         User profile data
     """
     return current_user
+
+
+# ============================================================================
+# ENDPOINT: Logout
+# ============================================================================
+
+@router.post("/logout")
+async def logout(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """
+    Logout the current user.
+
+    Clears httpOnly cookies and revokes the refresh token server-side.
+    """
+    # Attempt to revoke refresh token if present in cookie
+    raw_refresh = request.cookies.get("refresh_token")
+    if raw_refresh:
+        user_id = get_user_from_token(raw_refresh, expected_type="refresh")
+        if user_id is not None:
+            token_hash = hash_refresh_token(raw_refresh)
+            stored = db.query(RefreshToken).filter(
+                RefreshToken.token_hash == token_hash,
+                RefreshToken.user_id == user_id,
+                RefreshToken.revoked.is_(False),
+            ).first()
+            if stored:
+                stored.revoked = True  # type: ignore[assignment]
+                stored.revoked_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+                db.commit()
+
+    clear_auth_cookies(response)
+    return {"message": "Logged out"}
 
 
 # ============================================================================
@@ -514,19 +508,22 @@ async def request_password_reset(
         )
 
 
-@router.get("/password-reset/approve/{approval_token}", response_model=PasswordResetApprovalResponse)
+@router.post("/password-reset/approve", response_model=PasswordResetApprovalResponse)
+@limiter.limit("10/minute")  # type: ignore
 async def approve_password_reset(
-    approval_token: str,
-    db: Session = Depends(get_db)
+    request: Request,
+    body: PasswordResetApprovalRequest,
+    db: Session = Depends(get_db),
 ):
     """
-    Approve a password reset request (admin action via email link).
+    Approve a password reset request (admin action).
 
+    Moved from GET to POST to prevent CSRF and browser-prefetch side effects.
     After approval, the user will receive an email with the reset link.
     """
     # Find the reset request
     reset_request = db.query(PasswordResetRequest).filter(
-        PasswordResetRequest.approval_token == approval_token
+        PasswordResetRequest.approval_token == body.approval_token
     ).first()
 
     if not reset_request:
@@ -588,20 +585,22 @@ async def approve_password_reset(
     )
 
 
-@router.get("/password-reset/deny/{approval_token}", response_model=PasswordResetApprovalResponse)
+@router.post("/password-reset/deny", response_model=PasswordResetApprovalResponse)
+@limiter.limit("10/minute")  # type: ignore
 async def deny_password_reset(
-    approval_token: str,
-    reason: str | None = None,
-    db: Session = Depends(get_db)
+    request: Request,
+    body: PasswordResetApprovalRequest,
+    db: Session = Depends(get_db),
 ):
     """
-    Deny a password reset request (admin action via email link).
+    Deny a password reset request (admin action).
 
+    Moved from GET to POST to prevent CSRF and browser-prefetch side effects.
     The user will be notified that their request was denied.
     """
     # Find the reset request
     reset_request = db.query(PasswordResetRequest).filter(
-        PasswordResetRequest.approval_token == approval_token
+        PasswordResetRequest.approval_token == body.approval_token
     ).first()
 
     if not reset_request:
@@ -626,14 +625,14 @@ async def deny_password_reset(
 
     # Deny the request
     reset_request.status = 'denied'  # type: ignore[assignment]
-    reset_request.admin_notes = reason  # type: ignore[assignment]
+    reset_request.admin_notes = body.reason  # type: ignore[assignment]
     db.commit()
 
     # Notify user
     email_service.send_password_reset_denied(
         user_email=user.email,  # type: ignore[arg-type]
         user_name=user.full_name,
-        reason=reason
+        reason=body.reason
     )
 
     logger.info(
@@ -642,7 +641,7 @@ async def deny_password_reset(
             "user_id": user.id,
             "email": user.email,
             "request_id": reset_request.id,
-            "reason": reason
+            "reason": body.reason
         }
     )
 

--- a/backend/app/api/v1/endpoints/setup.py
+++ b/backend/app/api/v1/endpoints/setup.py
@@ -4,14 +4,15 @@ First-run setup endpoint for FilaOps
 Allows creating the initial admin account when no users exist.
 This endpoint is disabled once any user has been created.
 """
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Response
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 import sys
 
 from app.db.session import get_db
 from app.models.user import User
-from app.core.security import hash_password, create_access_token, validate_password_strength
+from app.core.security import hash_password, create_access_token, validate_password_strength, set_auth_cookies
+from app.core.config import settings
 from app.api.v1.deps import get_current_admin_user
 from app.logging_config import get_logger
 
@@ -64,18 +65,20 @@ def get_setup_status(db: Session = Depends(get_db)):
     )
 
 
-@router.post("/initial-admin", response_model=SetupCompleteResponse)
+@router.post("/initial-admin")
 def create_initial_admin(
     admin_data: InitialAdminCreate,
-    db: Session = Depends(get_db)
+    response: Response,
+    db: Session = Depends(get_db),
 ):
     """
     Create the initial admin user during first-run setup.
-    
+
     This endpoint ONLY works when no users exist in the database.
     Once any user is created, this endpoint returns 403 Forbidden.
-    
-    Security: This prevents unauthorized admin creation after initial setup.
+
+    In cookie mode, the access token is set as an httpOnly cookie.
+    In header mode, the token is returned in the response body.
     """
     # Check if any users already exist
     user_count = db.query(User).count()
@@ -84,7 +87,7 @@ def create_initial_admin(
             status_code=403,
             detail="Setup already complete. Admin creation is disabled."
         )
-    
+
     # Check if email already exists (shouldn't happen, but be safe)
     existing = db.query(User).filter(User.email == admin_data.email).first()
     if existing:
@@ -92,7 +95,7 @@ def create_initial_admin(
             status_code=400,
             detail="Email already registered"
         )
-    
+
     # Validate password strength
     is_valid, error_msg = validate_password_strength(admin_data.password)
     if not is_valid:
@@ -100,13 +103,13 @@ def create_initial_admin(
             status_code=400,
             detail=error_msg
         )
-    
+
     # Create the admin user
     # Parse full_name into first/last
     name_parts = admin_data.full_name.strip().split(' ', 1)
     first_name = name_parts[0]
     last_name = name_parts[1] if len(name_parts) > 1 else ''
-    
+
     admin = User(
         email=admin_data.email,
         password_hash=hash_password(admin_data.password),
@@ -117,18 +120,26 @@ def create_initial_admin(
         status="active",
         email_verified=True
     )
-    
+
     db.add(admin)
     db.commit()
     db.refresh(admin)
-    
+
     # Generate access token so they're logged in immediately
     access_token = create_access_token(user_id=admin.id)
-    
+
+    if settings.AUTH_MODE.lower() == "cookie":
+        set_auth_cookies(response, access_token)
+        return {
+            "message": "Admin account created successfully! Welcome to FilaOps.",
+            "email": admin.email,
+            "token_type": "cookie",
+        }
+
     return SetupCompleteResponse(
         message="Admin account created successfully! Welcome to FilaOps.",
         email=admin.email,
-        access_token=access_token
+        access_token=access_token,
     )
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -245,3 +245,47 @@ def hash_refresh_token(token: str) -> str:
         SHA256 hash of token (hex string, 64 characters)
     """
     return hashlib.sha256(token.encode()).hexdigest()
+
+
+# ============================================================================
+# AUTH COOKIE HELPERS
+# ============================================================================
+
+def set_auth_cookies(
+    response,
+    access_token: str,
+    refresh_token: Optional[str] = None,
+) -> None:
+    """
+    Set httpOnly auth cookies on a FastAPI Response.
+
+    Args:
+        response: FastAPI/Starlette Response object
+        access_token: JWT access token
+        refresh_token: JWT refresh token (optional, e.g. setup only returns access)
+    """
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=settings.COOKIE_SECURE,
+        samesite="lax",
+        path="/api",
+        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+    if refresh_token:
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            secure=settings.COOKIE_SECURE,
+            samesite="lax",
+            path="/api/v1/auth",
+            max_age=REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        )
+
+
+def clear_auth_cookies(response) -> None:
+    """Clear auth cookies from a FastAPI Response."""
+    response.delete_cookie("access_token", path="/api")
+    response.delete_cookie("refresh_token", path="/api/v1/auth")

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -80,6 +80,14 @@ class Settings(BaseSettings):
         default=30, description="JWT token expiration in minutes"
     )
     API_KEY: Optional[str] = Field(default=None, description="API key for integrations")
+    COOKIE_SECURE: bool = Field(
+        default=False,
+        description="Set Secure flag on auth cookies (requires HTTPS). Must be true in production.",
+    )
+    AUTH_MODE: str = Field(
+        default="cookie",
+        description="Auth token delivery: 'cookie' (httpOnly) or 'header' (bearer in body). Use 'header' to rollback.",
+    )
 
     @field_validator("SECRET_KEY")
     @classmethod

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -161,6 +161,12 @@ class MultiCustomerLoginResponse(BaseModel):
 # PASSWORD RESET SCHEMAS
 # ============================================================================
 
+class PasswordResetApprovalRequest(BaseModel):
+    """Schema for admin approval/denial of password reset via POST"""
+    approval_token: str
+    reason: Optional[str] = None
+
+
 class PasswordResetRequestCreate(BaseModel):
     """Schema for requesting a password reset"""
     email: EmailStr

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -7,10 +7,11 @@ Covers:
 - POST /api/v1/auth/register
 - POST /api/v1/auth/login
 - POST /api/v1/auth/refresh
+- POST /api/v1/auth/logout
 - GET  /api/v1/auth/me
 - POST /api/v1/auth/password-reset/request
-- GET  /api/v1/auth/password-reset/approve/{approval_token}
-- GET  /api/v1/auth/password-reset/deny/{approval_token}
+- POST /api/v1/auth/password-reset/approve
+- POST /api/v1/auth/password-reset/deny
 - GET  /api/v1/auth/password-reset/status/{token}
 - POST /api/v1/auth/password-reset/complete
 """
@@ -28,6 +29,16 @@ def _disable_rate_limits():
     limiter.enabled = False
     yield
     limiter.enabled = original_enabled
+
+
+@pytest.fixture(autouse=True)
+def _force_header_mode(monkeypatch):
+    """Force header (bearer-in-body) mode for existing tests.
+
+    Cookie-mode tests are in a dedicated class that overrides this.
+    """
+    import app.api.v1.endpoints.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "_USE_COOKIES", False)
 
 
 # =============================================================================
@@ -383,7 +394,9 @@ class TestPasswordResetFullFlow:
             },
         )
         assert resp.status_code == 200
-        assert "access_token" in resp.json()
+        # In header mode: token in body; in cookie mode: token in cookie
+        data = resp.json()
+        assert "access_token" in data or data.get("token_type") == "cookie"
 
     def test_reset_with_weak_password_fails(self, unauthed_client, registered_user):
         # Request reset
@@ -409,13 +422,121 @@ class TestPasswordResetFullFlow:
 class TestPasswordResetApproval:
 
     def test_approve_invalid_token(self, unauthed_client):
-        resp = unauthed_client.get(
-            f"{BASE_URL}/password-reset/approve/nonexistent-approval-token",
+        resp = unauthed_client.post(
+            f"{BASE_URL}/password-reset/approve",
+            json={"approval_token": "nonexistent-approval-token"},
         )
         assert resp.status_code == 404
 
     def test_deny_invalid_token(self, unauthed_client):
-        resp = unauthed_client.get(
-            f"{BASE_URL}/password-reset/deny/nonexistent-approval-token",
+        resp = unauthed_client.post(
+            f"{BASE_URL}/password-reset/deny",
+            json={"approval_token": "nonexistent-approval-token"},
         )
         assert resp.status_code == 404
+
+    def test_approve_old_get_endpoint_returns_405(self, unauthed_client):
+        """Old GET-style approve endpoint should no longer exist."""
+        resp = unauthed_client.get(
+            f"{BASE_URL}/password-reset/approve/some-token",
+        )
+        assert resp.status_code in (404, 405)
+
+    def test_deny_old_get_endpoint_returns_405(self, unauthed_client):
+        """Old GET-style deny endpoint should no longer exist."""
+        resp = unauthed_client.get(
+            f"{BASE_URL}/password-reset/deny/some-token",
+        )
+        assert resp.status_code in (404, 405)
+
+
+# =============================================================================
+# Cookie-Mode Tests
+# =============================================================================
+
+class TestCookieMode:
+    """Test httpOnly cookie auth delivery."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_cookie_mode(self, monkeypatch):
+        """Override the module-level header-mode fixture for this class."""
+        import app.api.v1.endpoints.auth as auth_mod
+        monkeypatch.setattr(auth_mod, "_USE_COOKIES", True)
+
+    def test_login_sets_httponly_cookies(self, unauthed_client, registered_user):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/login",
+            data={"username": registered_user.email, "password": "TestPass123!"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Body should NOT contain tokens
+        assert "access_token" not in data
+        assert "refresh_token" not in data
+        assert data["token_type"] == "cookie"
+        assert "user" in data
+
+        # Cookies should be set
+        assert "access_token" in resp.cookies
+        assert "refresh_token" in resp.cookies
+
+    def test_cookie_auth_works(self, unauthed_client, registered_user):
+        """Request with cookie, no Authorization header → 200."""
+        # Login to get cookies
+        login_resp = unauthed_client.post(
+            f"{BASE_URL}/login",
+            data={"username": registered_user.email, "password": "TestPass123!"},
+        )
+        assert login_resp.status_code == 200
+
+        # /me should work using cookie from login (TestClient carries cookies)
+        me_resp = unauthed_client.get(f"{BASE_URL}/me")
+        assert me_resp.status_code == 200
+        assert me_resp.json()["email"] == registered_user.email
+
+    def test_header_auth_fallback(self, unauthed_client, registered_user):
+        """Request with Authorization header, no cookie → 200."""
+        from app.core.security import create_access_token
+        token = create_access_token(registered_user.id)
+        resp = unauthed_client.get(
+            f"{BASE_URL}/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_no_auth_returns_401(self, unauthed_client):
+        """No cookie, no header → 401."""
+        resp = unauthed_client.get(f"{BASE_URL}/me")
+        assert resp.status_code == 401
+
+    def test_logout_clears_cookies(self, unauthed_client, registered_user):
+        # Login first
+        unauthed_client.post(
+            f"{BASE_URL}/login",
+            data={"username": registered_user.email, "password": "TestPass123!"},
+        )
+
+        # Logout
+        resp = unauthed_client.post(f"{BASE_URL}/logout")
+        assert resp.status_code == 200
+
+        # Cookies should be cleared — next /me should fail
+        me_resp = unauthed_client.get(f"{BASE_URL}/me")
+        assert me_resp.status_code == 401
+
+    def test_refresh_via_cookie(self, unauthed_client, registered_user):
+        """Refresh endpoint should read refresh_token from cookie."""
+        # Login to set cookies
+        login_resp = unauthed_client.post(
+            f"{BASE_URL}/login",
+            data={"username": registered_user.email, "password": "TestPass123!"},
+        )
+        assert login_resp.status_code == 200
+
+        # Refresh — no body needed, cookie is sent automatically by TestClient
+        resp = unauthed_client.post(f"{BASE_URL}/refresh")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["token_type"] == "cookie"
+        assert "access_token" not in data

--- a/backend/tests/endpoints/test_settings_auth_printers.py
+++ b/backend/tests/endpoints/test_settings_auth_printers.py
@@ -48,6 +48,13 @@ def _disable_rate_limits():
     limiter.enabled = original_enabled
 
 
+@pytest.fixture(autouse=True)
+def _force_header_mode(monkeypatch):
+    """Force header (bearer-in-body) mode so existing tests see tokens in body."""
+    import app.api.v1.endpoints.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "_USE_COOKIES", False)
+
+
 @pytest.fixture
 def non_admin_user(db):
     """Create a non-admin user (account_type=customer) for 403 tests."""
@@ -536,8 +543,9 @@ class TestPasswordResetApprovalFlow:
     ):
         """Approving a pending request should succeed."""
         mock_email.send_password_reset_approved.return_value = True
-        resp = unauthed_client.get(
-            f"{AUTH_URL}/password-reset/approve/{reset_request_pending.approval_token}"
+        resp = unauthed_client.post(
+            f"{AUTH_URL}/password-reset/approve",
+            json={"approval_token": reset_request_pending.approval_token},
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -550,8 +558,9 @@ class TestPasswordResetApprovalFlow:
     ):
         """Denying a pending request should succeed."""
         mock_email.send_password_reset_denied.return_value = True
-        resp = unauthed_client.get(
-            f"{AUTH_URL}/password-reset/deny/{reset_request_pending.approval_token}"
+        resp = unauthed_client.post(
+            f"{AUTH_URL}/password-reset/deny",
+            json={"approval_token": reset_request_pending.approval_token},
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -561,8 +570,9 @@ class TestPasswordResetApprovalFlow:
         self, unauthed_client, reset_request_approved
     ):
         """Approving an already-approved request should fail."""
-        resp = unauthed_client.get(
-            f"{AUTH_URL}/password-reset/approve/{reset_request_approved.approval_token}"
+        resp = unauthed_client.post(
+            f"{AUTH_URL}/password-reset/approve",
+            json={"approval_token": reset_request_approved.approval_token},
         )
         assert resp.status_code == 400
         assert "already been" in resp.json()["detail"].lower()
@@ -571,8 +581,9 @@ class TestPasswordResetApprovalFlow:
         self, unauthed_client, reset_request_denied
     ):
         """Denying an already-denied request should fail."""
-        resp = unauthed_client.get(
-            f"{AUTH_URL}/password-reset/deny/{reset_request_denied.approval_token}"
+        resp = unauthed_client.post(
+            f"{AUTH_URL}/password-reset/deny",
+            json={"approval_token": reset_request_denied.approval_token},
         )
         assert resp.status_code == 400
 
@@ -595,9 +606,9 @@ class TestPasswordResetApprovalFlow:
 
         with patch("app.api.v1.endpoints.auth.email_service") as mock_email:
             mock_email.send_password_reset_denied.return_value = True
-            resp = unauthed_client.get(
-                f"{AUTH_URL}/password-reset/deny/{approval_token}",
-                params={"reason": "Suspicious request"},
+            resp = unauthed_client.post(
+                f"{AUTH_URL}/password-reset/deny",
+                json={"approval_token": approval_token, "reason": "Suspicious request"},
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "denied"
@@ -626,8 +637,9 @@ class TestPasswordResetApprovalExpired:
         db.add(req)
         db.flush()
 
-        resp = unauthed_client.get(
-            f"{AUTH_URL}/password-reset/approve/{approval_token}"
+        resp = unauthed_client.post(
+            f"{AUTH_URL}/password-reset/approve",
+            json={"approval_token": approval_token},
         )
         assert resp.status_code == 400
         assert "expired" in resp.json()["detail"].lower()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -53,15 +53,13 @@ export default function App() {
     () =>
       createApiClient({
         baseUrl: API_URL,
-        getToken: () => localStorage.getItem("adminToken"),
         onUnauthorized: async () => {
-          localStorage.removeItem("adminToken");
+          localStorage.removeItem("adminUser");
           // eslint-disable-next-line react-hooks/immutability -- Redirect in callback, not during render
           window.location.href = "/admin/login";
         },
         onError: (err) => {
           // why: centralized logging hook (also toasts via ApiErrorToaster)
-           
           console.warn("API error:", err.status, err.message);
         },
       }),

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -1,16 +1,12 @@
 /**
  * Axios-like API wrapper using fetch
- * 
+ *
  * Provides a consistent API interface similar to axios for making HTTP requests.
  * Used by components that need progress tracking and cleaner response handling.
+ *
+ * Auth: Uses httpOnly cookies (set by backend on login). No manual token handling.
  */
 import { API_URL } from '../config/api';
-
-// Get auth token
-const getAuthHeaders = () => {
-  const token = localStorage.getItem('adminToken');
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
 
 // Build full URL
 const buildUrl = (path) => {
@@ -22,18 +18,18 @@ const buildUrl = (path) => {
 // Parse response
 const parseResponse = async (response) => {
   const contentType = response.headers.get('content-type');
-  
+
   if (contentType?.includes('application/json')) {
     return response.json();
   }
-  
+
   // For blob/file downloads
-  if (contentType?.includes('application/octet-stream') || 
+  if (contentType?.includes('application/octet-stream') ||
       contentType?.includes('application/pdf') ||
       contentType?.includes('text/csv')) {
     return response.blob();
   }
-  
+
   return response.text();
 };
 
@@ -42,12 +38,12 @@ const handleResponse = async (response) => {
   if (!response.ok) {
     const error = new Error(`HTTP ${response.status}`);
     try {
-      error.response = { 
+      error.response = {
         data: await response.json(),
         status: response.status,
       };
     } catch {
-      error.response = { 
+      error.response = {
         data: { detail: response.statusText },
         status: response.status,
       };
@@ -63,12 +59,12 @@ const handleResponse = async (response) => {
 const get = async (path, config = {}) => {
   const response = await fetch(buildUrl(path), {
     method: 'GET',
+    credentials: 'include',
     headers: {
-      ...getAuthHeaders(),
       ...config.headers,
     },
   });
-  
+
   await handleResponse(response);
   const data = await parseResponse(response);
   return { data, status: response.status };
@@ -78,19 +74,19 @@ const get = async (path, config = {}) => {
  * POST request with FormData support and upload progress
  */
 const post = async (path, body, config = {}) => {
-  const headers = { ...getAuthHeaders() };
-  
+  const headers = {};
+
   // Don't set Content-Type for FormData - browser sets it with boundary
   if (!(body instanceof FormData)) {
     headers['Content-Type'] = 'application/json';
     body = JSON.stringify(body);
   }
-  
+
   // If we have onUploadProgress, use XMLHttpRequest for progress tracking
   if (config.onUploadProgress && body instanceof FormData) {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
-      
+
       xhr.upload.addEventListener('progress', (event) => {
         if (event.lengthComputable) {
           config.onUploadProgress({
@@ -99,7 +95,7 @@ const post = async (path, body, config = {}) => {
           });
         }
       });
-      
+
       xhr.addEventListener('load', () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
@@ -111,12 +107,12 @@ const post = async (path, body, config = {}) => {
         } else {
           const error = new Error(`HTTP ${xhr.status}`);
           try {
-            error.response = { 
+            error.response = {
               data: JSON.parse(xhr.responseText),
               status: xhr.status,
             };
           } catch {
-            error.response = { 
+            error.response = {
               data: { detail: xhr.statusText },
               status: xhr.status,
             };
@@ -124,30 +120,29 @@ const post = async (path, body, config = {}) => {
           reject(error);
         }
       });
-      
+
       xhr.addEventListener('error', () => {
         reject(new Error('Network error'));
       });
-      
+
       xhr.open('POST', buildUrl(path));
-      
-      // Set auth header
-      const token = localStorage.getItem('adminToken');
-      if (token) {
-        xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-      }
-      
+      xhr.withCredentials = true;
+
       xhr.send(body);
     });
   }
-  
+
   // Standard fetch for non-progress requests
   const response = await fetch(buildUrl(path), {
     method: 'POST',
-    headers,
+    credentials: 'include',
+    headers: {
+      ...headers,
+      ...config.headers,
+    },
     body,
   });
-  
+
   await handleResponse(response);
   const data = await parseResponse(response);
   return { data, status: response.status };
@@ -159,16 +154,16 @@ const post = async (path, body, config = {}) => {
 const put = async (path, body, config = {}) => {
   const headers = {
     'Content-Type': 'application/json',
-    ...getAuthHeaders(),
     ...config.headers,
   };
-  
+
   const response = await fetch(buildUrl(path), {
     method: 'PUT',
+    credentials: 'include',
     headers,
     body: JSON.stringify(body),
   });
-  
+
   await handleResponse(response);
   const data = await parseResponse(response);
   return { data, status: response.status };
@@ -180,19 +175,19 @@ const put = async (path, body, config = {}) => {
 const del = async (path, config = {}) => {
   const response = await fetch(buildUrl(path), {
     method: 'DELETE',
+    credentials: 'include',
     headers: {
-      ...getAuthHeaders(),
       ...config.headers,
     },
   });
-  
+
   await handleResponse(response);
-  
+
   // DELETE might return empty body
   if (response.status === 204) {
     return { data: null, status: 204 };
   }
-  
+
   const data = await parseResponse(response);
   return { data, status: response.status };
 };
@@ -203,16 +198,16 @@ const del = async (path, config = {}) => {
 const patch = async (path, body, config = {}) => {
   const headers = {
     'Content-Type': 'application/json',
-    ...getAuthHeaders(),
     ...config.headers,
   };
-  
+
   const response = await fetch(buildUrl(path), {
     method: 'PATCH',
+    credentials: 'include',
     headers,
     body: JSON.stringify(body),
   });
-  
+
   await handleResponse(response);
   const data = await parseResponse(response);
   return { data, status: response.status };

--- a/frontend/src/components/ActivityTimeline.jsx
+++ b/frontend/src/components/ActivityTimeline.jsx
@@ -166,10 +166,8 @@ export default function ActivityTimeline({ orderId, className = "" }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
-    if (!orderId || !token) return;
+    if (!orderId) return;
 
     const fetchEvents = async () => {
       setLoading(true);
@@ -179,7 +177,7 @@ export default function ActivityTimeline({ orderId, className = "" }) {
         const res = await fetch(
           `${API_URL}/api/v1/sales-orders/${orderId}/events`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 
@@ -197,7 +195,7 @@ export default function ActivityTimeline({ orderId, className = "" }) {
     };
 
     fetchEvents();
-  }, [orderId, token]);
+  }, [orderId]);
 
   if (loading) {
     return (

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -534,12 +534,11 @@ export default function AdminLayout() {
 
   useEffect(() => {
     const fetchAiSettings = async () => {
-      const token = localStorage.getItem("adminToken");
-      if (!token) return;
+      if (!localStorage.getItem("adminUser")) return;
 
       try {
         const response = await fetch(`${API_URL}/api/v1/settings/ai`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (response.ok) {
           const data = await response.json();
@@ -577,8 +576,7 @@ export default function AdminLayout() {
     .filter((group) => group.items.length > 0);
 
   useEffect(() => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) {
+    if (!localStorage.getItem("adminUser")) {
       navigate("/admin/login");
     }
   }, [navigate]);
@@ -596,8 +594,10 @@ export default function AdminLayout() {
   }, []);
 
   const handleLogout = () => {
-    localStorage.removeItem("adminToken");
-    localStorage.removeItem("adminRefreshToken");
+    fetch(`${API_URL}/api/v1/auth/logout`, {
+      method: "POST",
+      credentials: "include",
+    });
     localStorage.removeItem("adminUser");
     navigate("/admin/login");
   };

--- a/frontend/src/components/BOMEditor.jsx
+++ b/frontend/src/components/BOMEditor.jsx
@@ -16,7 +16,6 @@ export default function BOMEditor({
   bomId = null, // If editing existing BOM
   onSuccess,
 }) {
-  const token = localStorage.getItem("adminToken");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [bom, setBom] = useState(null);
@@ -40,7 +39,7 @@ export default function BOMEditor({
   const fetchBOM = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -50,14 +49,14 @@ export default function BOMEditor({
     } catch {
       // BOM fetch failure - will show empty editor
     }
-  }, [bomId, token]);
+  }, [bomId]);
 
   const fetchBOMByProduct = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/bom/product/${productId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -72,14 +71,14 @@ export default function BOMEditor({
     } catch {
       // BOM fetch failure - will show empty editor
     }
-  }, [productId, token]);
+  }, [productId]);
 
   const fetchComponents = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/items?limit=500&active_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -89,12 +88,12 @@ export default function BOMEditor({
     } catch {
       // Components fetch failure is non-critical
     }
-  }, [token]);
+  }, []);
 
   const fetchMaterials = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/materials/for-bom`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -103,12 +102,12 @@ export default function BOMEditor({
     } catch {
       // Materials fetch failure is non-critical
     }
-  }, [token]);
+  }, []);
 
   const fetchUomClasses = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/uom/classes`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -117,7 +116,7 @@ export default function BOMEditor({
     } catch {
       setUomClasses([]);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
@@ -156,9 +155,9 @@ export default function BOMEditor({
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/bom/`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           product_id: productId,
@@ -205,9 +204,9 @@ export default function BOMEditor({
             `${API_URL}/api/v1/admin/bom/${bom.id}/lines/${line.id}`,
             {
               method: "PATCH",
+              credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify({
                 quantity: line.quantity,
@@ -226,9 +225,9 @@ export default function BOMEditor({
             `${API_URL}/api/v1/admin/bom/${bom.id}/lines`,
             {
               method: "POST",
+              credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify({
                 component_id: line.component_id,
@@ -248,7 +247,7 @@ export default function BOMEditor({
       // Recalculate BOM cost
       await fetch(`${API_URL}/api/v1/admin/bom/${bom.id}/recalculate`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       onSuccess?.();

--- a/frontend/src/components/CompleteOrderModal.jsx
+++ b/frontend/src/components/CompleteOrderModal.jsx
@@ -22,8 +22,6 @@ export default function CompleteOrderModal({
   const [acknowledgeShort, setAcknowledgeShort] = useState(false);
   const [createRemakeForShortfall, setCreateRemakeForShortfall] = useState(true); // Default to creating remake
 
-  const token = localStorage.getItem("adminToken");
-
   const quantityOrdered = productionOrder.quantity_ordered || 1;
   const quantityScrapped = productionOrder.quantity_scrapped || 0;
   const isOverrun = quantityCompleted > quantityOrdered;
@@ -39,14 +37,14 @@ export default function CompleteOrderModal({
   }, [productionOrder.id]);
 
   const fetchBomMaterials = async () => {
-    if (!token || !productionOrder.product_id) return;
+    if (!productionOrder.product_id) return;
     
     setLoadingMaterials(true);
     try {
       // Get BOM for the product
       const bomRes = await fetch(
         `${API_URL}/api/v1/admin/bom/product/${productionOrder.product_id}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       
       if (bomRes.ok) {
@@ -71,7 +69,7 @@ export default function CompleteOrderModal({
             try {
               const spoolsRes = await fetch(
                 `${API_URL}/api/v1/spools/product/${material.component_id}/available`,
-                { headers: { Authorization: `Bearer ${token}` } }
+                { credentials: "include" }
               );
               if (spoolsRes.ok) {
                 const spoolsData = await spoolsRes.json();
@@ -134,8 +132,8 @@ export default function CompleteOrderModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/complete?${params}`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(requestBody),
@@ -150,8 +148,8 @@ export default function CompleteOrderModal({
           try {
             const remakeRes = await fetch(`${API_URL}/api/v1/production-orders/`, {
               method: "POST",
+              credentials: "include",
               headers: {
-                Authorization: `Bearer ${token}`,
                 "Content-Type": "application/json",
               },
               body: JSON.stringify({

--- a/frontend/src/components/ExportImport.jsx
+++ b/frontend/src/components/ExportImport.jsx
@@ -10,11 +10,8 @@ const ExportImport = ({ type }) => {
 
   const handleExport = async () => {
     try {
-      const token = localStorage.getItem("access_token");
       const response = await fetch(`${API_URL}/api/v1/admin/export/${type}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -45,15 +42,12 @@ const ExportImport = ({ type }) => {
     setFile(selectedFile);
 
     try {
-      const token = localStorage.getItem("access_token");
       const formData = new FormData();
       formData.append("file", selectedFile);
 
       const response = await fetch(`${API_URL}/api/v1/admin/import/${type}`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
         body: formData,
       });
 

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -41,7 +41,6 @@ export default function ItemForm({
   onSuccess,
   editingItem = null,
 }) {
-  const token = localStorage.getItem("adminToken");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [errors, setErrors] = useState({});
@@ -68,7 +67,7 @@ export default function ItemForm({
   const fetchCategories = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/items/categories`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -83,12 +82,12 @@ export default function ItemForm({
         });
       }
     }
-  }, [token]);
+  }, []);
 
   const fetchUomClasses = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/uom/classes`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -104,7 +103,7 @@ export default function ItemForm({
       }
       setUomClasses([]);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
@@ -231,9 +230,9 @@ export default function ItemForm({
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
       });
@@ -443,9 +442,7 @@ export default function ItemForm({
                             `${API_URL}/api/v1/admin/uploads/product-image`,
                             {
                               method: "POST",
-                              headers: {
-                                Authorization: `Bearer ${token}`,
-                              },
+                              credentials: "include",
                               body: uploadData,
                             }
                           );

--- a/frontend/src/components/ItemWizard.jsx
+++ b/frontend/src/components/ItemWizard.jsx
@@ -17,8 +17,6 @@ import PricingStep from "./items/PricingStep";
  * - showPricing: boolean - Whether to show pricing step (default: true)
  */
 export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = null, categories: propCategories = null, showPricing = true }) {
-  const token = localStorage.getItem("adminToken");
-
   // Wizard step tracking
   const [currentStep, setCurrentStep] = useState(1);
   const [loading, setLoading] = useState(false);
@@ -148,7 +146,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
   const fetchCategories = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/items/categories`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -162,10 +160,10 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
   const fetchComponents = async () => {
     try {
       const itemsRes = await fetch(`${API_URL}/api/v1/items?limit=500&active_only=true`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       const materialsRes = await fetch(`${API_URL}/api/v1/materials/for-bom`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       let allComponents = [];
@@ -195,7 +193,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
   const fetchWorkCenters = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/work-centers/`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -209,7 +207,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
   const fetchRoutingTemplates = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/?templates_only=true`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -223,7 +221,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
   const fetchMaterialTypesAndColors = async () => {
     try {
       const typesRes = await fetch(`${API_URL}/api/v1/materials/types?customer_visible_only=false`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (typesRes.ok) {
         const data = await typesRes.json();
@@ -243,7 +241,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
     try {
       const res = await fetch(
         `${API_URL}/api/v1/materials/types/${materialTypeCode}/colors?in_stock_only=false&customer_visible_only=false`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -307,8 +305,8 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
       const sku = subComponent.sku || `CP-${Date.now().toString(36).toUpperCase()}`;
       const res = await fetch(`${API_URL}/api/v1/items`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -345,8 +343,8 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
     try {
       const res = await fetch(`${API_URL}/api/v1/materials/inventory`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(newMaterial),
@@ -432,8 +430,8 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
         : `${API_URL}/api/v1/items`;
       const itemRes = await fetch(itemUrl, {
         method: editingItem ? "PATCH" : "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(itemPayload),
@@ -459,8 +457,8 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
 
         const bomRes = await fetch(`${API_URL}/api/v1/admin/bom/`, {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(bomPayload),
@@ -491,8 +489,8 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
 
         const routingRes = await fetch(`${API_URL}/api/v1/routings/`, {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(routingPayload),

--- a/frontend/src/components/ManufacturingBOMEditor.jsx
+++ b/frontend/src/components/ManufacturingBOMEditor.jsx
@@ -25,7 +25,6 @@ export default function ManufacturingBOMEditor({
   onSuccess,
 }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -59,7 +58,7 @@ export default function ManufacturingBOMEditor({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/routings/manufacturing-bom/${productId}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       
       if (res.status === 404) {
@@ -84,14 +83,14 @@ export default function ManufacturingBOMEditor({
     } finally {
       setLoading(false);
     }
-  }, [productId, token]);
+  }, [productId]);
 
   // Fetch components (for material selection)
   const fetchComponents = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/products?item_type=component,supply&limit=500`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -100,7 +99,7 @@ export default function ManufacturingBOMEditor({
     } catch {
       // Non-critical - component selector will be empty
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     if (isOpen && productId) {
@@ -178,9 +177,9 @@ export default function ManufacturingBOMEditor({
           `${API_URL}/api/v1/routings/materials/${editingMaterial.id}`,
           {
             method: "PUT",
+            credentials: "include",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify(payload),
           }
@@ -191,9 +190,9 @@ export default function ManufacturingBOMEditor({
           `${API_URL}/api/v1/routings/operations/${selectedOperationId}/materials`,
           {
             method: "POST",
+            credentials: "include",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify(payload),
           }
@@ -225,7 +224,7 @@ export default function ManufacturingBOMEditor({
         `${API_URL}/api/v1/routings/materials/${materialId}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/MaterialForm.jsx
+++ b/frontend/src/components/MaterialForm.jsx
@@ -10,7 +10,6 @@ import { API_URL } from "../config/api";
 import Modal from "./Modal";
 
 export default function MaterialForm({ isOpen, onClose, onSuccess }) {
-  const token = localStorage.getItem("adminToken");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -37,7 +36,7 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
       const res = await fetch(
         `${API_URL}/api/v1/materials/types?customer_visible_only=false`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -47,7 +46,7 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
     } catch {
       // Material types fetch failure is non-critical
     }
-  }, [token]);
+  }, []);
 
   const fetchColors = useCallback(
     async (materialTypeCode) => {
@@ -55,7 +54,7 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
         const res = await fetch(
           `${API_URL}/api/v1/materials/types/${materialTypeCode}/colors?in_stock_only=false&customer_visible_only=false`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
         if (res.ok) {
@@ -66,7 +65,7 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
         setColors([]);
       }
     },
-    [token]
+    []
   );
 
   useEffect(() => {
@@ -109,9 +108,9 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
         `${API_URL}/api/v1/materials/types/${selectedMaterialType}/colors`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
             name: newColorName.trim(),
@@ -160,9 +159,9 @@ export default function MaterialForm({ isOpen, onClose, onSuccess }) {
 
       const res = await fetch(`${API_URL}/api/v1/items/material`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
       });

--- a/frontend/src/components/OperationMaterialModal.jsx
+++ b/frontend/src/components/OperationMaterialModal.jsx
@@ -14,7 +14,6 @@ export default function OperationMaterialModal({
   material = null, // If provided, editing existing material
   onSave,
 }) {
-  const token = localStorage.getItem('adminToken');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [products, setProducts] = useState([]);
@@ -78,7 +77,7 @@ export default function OperationMaterialModal({
         }
 
         const res = await fetch(`${API_URL}/api/v1/products?${params}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -91,7 +90,7 @@ export default function OperationMaterialModal({
 
     const timer = setTimeout(fetchProducts, 300);
     return () => clearTimeout(timer);
-  }, [isOpen, searchTerm, token]);
+  }, [isOpen, searchTerm]);
 
   const handleSubmit = async () => {
     if (!formData.component_id) {
@@ -124,9 +123,9 @@ export default function OperationMaterialModal({
         // Update existing material
         res = await fetch(`${API_URL}/api/v1/routings/materials/${material.id}`, {
           method: 'PUT',
+          credentials: "include",
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify(payload),
         });
@@ -134,9 +133,9 @@ export default function OperationMaterialModal({
         // Add new material
         res = await fetch(`${API_URL}/api/v1/routings/operations/${operationId}/materials`, {
           method: 'POST',
+          credentials: "include",
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify(payload),
         });
@@ -170,7 +169,7 @@ export default function OperationMaterialModal({
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/materials/${material.id}`, {
         method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {

--- a/frontend/src/components/POActivityTimeline.jsx
+++ b/frontend/src/components/POActivityTimeline.jsx
@@ -145,10 +145,8 @@ export default function POActivityTimeline({ poId, className = "" }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
-    if (!poId || !token) return;
+    if (!poId) return;
 
     const fetchEvents = async () => {
       setLoading(true);
@@ -158,7 +156,7 @@ export default function POActivityTimeline({ poId, className = "" }) {
         const res = await fetch(
           `${API_URL}/api/v1/purchase-orders/${poId}/events`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 
@@ -176,7 +174,7 @@ export default function POActivityTimeline({ poId, className = "" }) {
     };
 
     fetchEvents();
-  }, [poId, token]);
+  }, [poId]);
 
   if (loading) {
     return (

--- a/frontend/src/components/QCInspectionModal.jsx
+++ b/frontend/src/components/QCInspectionModal.jsx
@@ -13,8 +13,6 @@ export default function QCInspectionModal({
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   const handleSubmit = async () => {
     setSubmitting(true);
     try {
@@ -22,8 +20,8 @@ export default function QCInspectionModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/qc`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/frontend/src/components/RemediationModal.jsx
+++ b/frontend/src/components/RemediationModal.jsx
@@ -54,9 +54,9 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
   const fetchRemediationGuide = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/${check.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -77,10 +77,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
   const handleAutoFix = async () => {
     setAutoFixing(true);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/update-secret-key`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -106,10 +106,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
     setFixingDependencies(true);
     setDependencyFixResult(null);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/fix-dependencies`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -136,10 +136,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
     setFixingRateLimiting(true);
     setRateLimitingFixResult(null);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/fix-rate-limiting`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -170,11 +170,11 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
     setHttpsFixing(true);
     setHttpsFixResult(null);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/setup-https`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json"
         },
         body: JSON.stringify({ domain: httpsDomain.trim() })
@@ -203,10 +203,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
     setFixingDotfiles(true);
     setDotfileFixResult(null);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/fix-dotfile-blocking`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -231,10 +231,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
   const handleOpenInNotepad = async () => {
     setOpeningFile(true);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/open-env-file`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -254,10 +254,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
   const handleOpenTerminal = async () => {
     setOpeningTerminal(true);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/open-restart-terminal`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -277,10 +277,10 @@ const RemediationModal = ({ isOpen, onClose, check, onComplete }) => {
   const handleGenerateKey = async () => {
     setGeneratingKey(true);
     try {
-      const token = localStorage.getItem("adminToken");
+
       const response = await fetch(`${API_URL}/api/v1/security/remediate/generate-secret-key`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {

--- a/frontend/src/components/RoutingEditor.jsx
+++ b/frontend/src/components/RoutingEditor.jsx
@@ -18,7 +18,6 @@ export default function RoutingEditor({
   onSuccess,
   products = [], // Optional - for product selection when productId not provided
 }) {
-  const token = localStorage.getItem("adminToken");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [routing, setRouting] = useState(null);
@@ -54,7 +53,7 @@ export default function RoutingEditor({
   const fetchRouting = useCallback(async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/${routingId}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -64,7 +63,7 @@ export default function RoutingEditor({
     } catch {
       // Routing fetch failure - will show empty editor
     }
-  }, [routingId, token]);
+  }, [routingId]);
 
   const fetchRoutingByProduct = useCallback(async () => {
     const finalProductId = selectedProductId || productId;
@@ -73,7 +72,7 @@ export default function RoutingEditor({
       const res = await fetch(
         `${API_URL}/api/v1/routings/product/${finalProductId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -88,14 +87,14 @@ export default function RoutingEditor({
     } catch {
       // Routing fetch failure - will show empty editor
     }
-  }, [selectedProductId, productId, token]);
+  }, [selectedProductId, productId]);
 
   const fetchWorkCenters = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/work-centers?active_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -105,14 +104,14 @@ export default function RoutingEditor({
     } catch {
       // Work centers fetch failure is non-critical - work center selector will be empty
     }
-  }, [token]);
+  }, []);
 
   const fetchTemplates = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/routings?templates_only=true&active_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -122,7 +121,7 @@ export default function RoutingEditor({
     } catch {
       // Templates fetch failure is non-critical - templates list will be empty
     }
-  }, [token]);
+  }, []);
 
   // Fetch materials for a specific operation
   const fetchOperationMaterials = useCallback(async (operationId) => {
@@ -130,7 +129,7 @@ export default function RoutingEditor({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/routings/operations/${operationId}/materials`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -142,7 +141,7 @@ export default function RoutingEditor({
     } catch {
       // Material fetch failure - materials will show as empty
     }
-  }, [token]);
+  }, []);
 
   // Fetch materials for all operations when routing loads
   useEffect(() => {
@@ -186,9 +185,9 @@ export default function RoutingEditor({
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/from-template`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           template_routing_id: parseInt(selectedTemplate),
@@ -225,9 +224,9 @@ export default function RoutingEditor({
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           product_id: finalProductId,
@@ -281,9 +280,9 @@ export default function RoutingEditor({
             `${API_URL}/api/v1/routings/operations/${op.id}`,
             {
               method: "PUT",
+              credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify({
                 work_center_id: op.work_center_id,
@@ -307,9 +306,9 @@ export default function RoutingEditor({
             `${API_URL}/api/v1/routings/${routing.id}/operations`,
             {
               method: "POST",
+              credentials: "include",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify({
                 work_center_id: op.work_center_id,
@@ -405,7 +404,7 @@ export default function RoutingEditor({
           `${API_URL}/api/v1/routings/operations/${operation.id}`,
           {
             method: "DELETE",
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 

--- a/frontend/src/components/SalesOrderWizard.jsx
+++ b/frontend/src/components/SalesOrderWizard.jsx
@@ -71,8 +71,6 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
   const [currentStep, setCurrentStep] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const token = localStorage.getItem("adminToken");
-
   // Data loaded from API
   const [customers, setCustomers] = useState([]);
   const [products, setProducts] = useState([]);
@@ -268,7 +266,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
   const fetchCustomers = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/customers?limit=200`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -291,7 +289,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       const res = await fetch(
         `${API_URL}/api/v1/products?limit=500&active_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -306,7 +304,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
   const fetchCategories = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/items/categories`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -323,13 +321,13 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       const itemsRes = await fetch(
         `${API_URL}/api/v1/items?limit=500&active_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
       // Fetch materials with real product IDs (creates products if needed)
       const materialsRes = await fetch(`${API_URL}/api/v1/materials/for-bom`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       let allComponents = [];
@@ -365,7 +363,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
   const fetchWorkCenters = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/work-centers/`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -381,7 +379,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       const res = await fetch(
         `${API_URL}/api/v1/routings/?templates_only=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -398,7 +396,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       const typesRes = await fetch(
         `${API_URL}/api/v1/materials/types?customer_visible_only=false`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (typesRes.ok) {
@@ -413,7 +411,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
   const fetchTaxSettings = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/settings/company`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -437,7 +435,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/materials/types/${materialTypeCode}/colors?in_stock_only=false&customer_visible_only=false`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -459,8 +457,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/materials/inventory`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(newMaterial),
@@ -598,8 +596,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/items`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(subComponent),
@@ -793,8 +791,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
 
       const itemRes = await fetch(`${API_URL}/api/v1/items`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(itemPayload),
@@ -821,8 +819,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
 
         const bomRes = await fetch(`${API_URL}/api/v1/admin/bom/`, {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(bomPayload),
@@ -853,8 +851,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
 
         const routingRes = await fetch(`${API_URL}/api/v1/routings/`, {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(routingPayload),
@@ -963,8 +961,8 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
 
       const res = await fetch(`${API_URL}/api/v1/sales-orders/`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(payload),

--- a/frontend/src/components/ScrapOrderModal.jsx
+++ b/frontend/src/components/ScrapOrderModal.jsx
@@ -15,8 +15,6 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
   const [scrapReasons, setScrapReasons] = useState([]);  // Array of { code, name, description }
   const [loading, setLoading] = useState(true);
 
-  const token = localStorage.getItem("adminToken");
-
   // Calculate remaining quantity that can be scrapped
   const remainingQty = productionOrder.quantity_ordered - (productionOrder.quantity_completed || 0) - (productionOrder.quantity_scrapped || 0);
   const isPartialScrap = quantityScrapped < remainingQty;
@@ -27,7 +25,7 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
       try {
         console.log("Fetching scrap reasons from:", `${API_URL}/api/v1/production-orders/scrap-reasons`);
         const res = await fetch(`${API_URL}/api/v1/production-orders/scrap-reasons`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         console.log("Scrap reasons response:", res.status, res.statusText);
         if (res.ok) {
@@ -53,7 +51,7 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
       }
     };
     fetchReasons();
-  }, [token]);
+  }, []);
 
   const handleSubmit = async () => {
     if (!scrapReason) {
@@ -86,8 +84,8 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/scrap?${params}`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }

--- a/frontend/src/components/ShippingTimeline.jsx
+++ b/frontend/src/components/ShippingTimeline.jsx
@@ -136,10 +136,8 @@ export default function ShippingTimeline({ orderId, className = "" }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
-    if (!orderId || !token) return;
+    if (!orderId) return;
 
     const fetchEvents = async () => {
       setLoading(true);
@@ -149,7 +147,7 @@ export default function ShippingTimeline({ orderId, className = "" }) {
         const res = await fetch(
           `${API_URL}/api/v1/sales-orders/${orderId}/shipping-events`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 
@@ -167,7 +165,7 @@ export default function ShippingTimeline({ orderId, className = "" }) {
     };
 
     fetchEvents();
-  }, [orderId, token]);
+  }, [orderId]);
 
   if (loading) {
     return (

--- a/frontend/src/components/SplitOrderModal.jsx
+++ b/frontend/src/components/SplitOrderModal.jsx
@@ -46,13 +46,12 @@ export default function SplitOrderModal({ productionOrder, onClose, onSplit }) {
 
     setSubmitting(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/split`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/frontend/src/components/UpdateNotification.jsx
+++ b/frontend/src/components/UpdateNotification.jsx
@@ -32,8 +32,6 @@ const UpdateNotification = () => {
 
     try {
       setLoading(true);
-      const token = localStorage.getItem("adminToken");
-      
       // Show immediate feedback
       alert("Upgrade started!\n\nContainers are rebuilding. This page will automatically reload in 60 seconds.\n\nDo not close this window.");
       
@@ -44,7 +42,8 @@ const UpdateNotification = () => {
       // Fire upgrade request (may not get response as server restarts)
       fetch(`${API_URL}/api/v1/system/updates/upgrade`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
       }).catch(() => console.log("Connection lost during upgrade (expected)"));
       
       // Wait for upgrade to start

--- a/frontend/src/components/accounting/COGSTab.jsx
+++ b/frontend/src/components/accounting/COGSTab.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
-export default function COGSTab({ token }) {
+export default function COGSTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -22,7 +22,7 @@ export default function COGSTab({ token }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/cogs-summary?days=${days}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {

--- a/frontend/src/components/accounting/DashboardTab.jsx
+++ b/frontend/src/components/accounting/DashboardTab.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
-export default function DashboardTab({ token }) {
+export default function DashboardTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -18,7 +18,7 @@ export default function DashboardTab({ token }) {
     setError(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/accounting/dashboard`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         setData(await res.json());

--- a/frontend/src/components/accounting/GLReportsTab.jsx
+++ b/frontend/src/components/accounting/GLReportsTab.jsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 import { ErrorAlert, TableSkeleton, CardSkeleton, HelpIcon } from "./AccountingShared";
 
-export default function GLReportsTab({ token }) {
+export default function GLReportsTab() {
   const [activeReport, setActiveReport] = useState("trial-balance");
   const [trialBalance, setTrialBalance] = useState(null);
   const [inventoryVal, setInventoryVal] = useState(null);
@@ -21,7 +21,7 @@ export default function GLReportsTab({ token }) {
     setError(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/trial-balance`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         setTrialBalance(await res.json());
@@ -41,7 +41,7 @@ export default function GLReportsTab({ token }) {
     setError(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/inventory-valuation`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         setInventoryVal(await res.json());
@@ -62,7 +62,7 @@ export default function GLReportsTab({ token }) {
     setError(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/ledger/${accountCode}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         setLedger(await res.json());

--- a/frontend/src/components/accounting/PaymentsTab.jsx
+++ b/frontend/src/components/accounting/PaymentsTab.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
-export default function PaymentsTab({ token }) {
+export default function PaymentsTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState(null);
@@ -30,7 +30,7 @@ export default function PaymentsTab({ token }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/payments-journal?${params}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -58,11 +58,10 @@ export default function PaymentsTab({ token }) {
         end_date: new Date(endDate).toISOString(),
       });
 
-      // Use fetch with Authorization header to keep credentials secure
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/payments-journal/export?${params}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/accounting/PeriodsTab.jsx
+++ b/frontend/src/components/accounting/PeriodsTab.jsx
@@ -7,7 +7,7 @@ import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 import { ErrorAlert, Skeleton, TableSkeleton, HelpIcon } from "./AccountingShared";
 
-export default function PeriodsTab({ token }) {
+export default function PeriodsTab() {
   const [periods, setPeriods] = useState([]);
   const [currentPeriod, setCurrentPeriod] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -27,7 +27,7 @@ export default function PeriodsTab({ token }) {
     setError(null);
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/periods`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -56,10 +56,8 @@ export default function PeriodsTab({ token }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/periods/${periodId}/close`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ confirm: true }),
       });
       if (res.ok) {
@@ -83,7 +81,7 @@ export default function PeriodsTab({ token }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/accounting/periods/${periodId}/reopen`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const result = await res.json();

--- a/frontend/src/components/accounting/SalesJournalTab.jsx
+++ b/frontend/src/components/accounting/SalesJournalTab.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
-export default function SalesJournalTab({ token }) {
+export default function SalesJournalTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -34,7 +34,7 @@ export default function SalesJournalTab({ token }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/sales-journal?${params}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -58,12 +58,10 @@ export default function SalesJournalTab({ token }) {
         end_date: new Date(endDate).toISOString(),
       });
 
-      // Use fetch with Authorization header to keep credentials secure
-      // (avoids exposing tokens in URL query strings, browser history, and server logs)
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/sales-journal/export?${params}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/accounting/TaxCenterTab.jsx
+++ b/frontend/src/components/accounting/TaxCenterTab.jsx
@@ -5,7 +5,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
-export default function TaxCenterTab({ token }) {
+export default function TaxCenterTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -23,7 +23,7 @@ export default function TaxCenterTab({ token }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/tax-summary?period=${period}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -42,11 +42,10 @@ export default function TaxCenterTab({ token }) {
   const handleExport = async () => {
     setExportError(null); // Clear previous errors
     try {
-      // Use fetch with Authorization header to keep credentials secure
       const res = await fetch(
         `${API_URL}/api/v1/admin/accounting/tax-summary/export?period=${period}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/bom/BOMRoutingSection.jsx
+++ b/frontend/src/components/bom/BOMRoutingSection.jsx
@@ -23,7 +23,6 @@ export default function BOMRoutingSection({
   savingRouting,
   addingOperation,
   setShowAddMaterialModal,
-  token,
   handleAddPendingOperation,
   handleRemovePendingOperation,
   handleSaveRouting,
@@ -346,10 +345,8 @@ export default function BOMRoutingSection({
                                       `${API_URL}/api/v1/routings/operations/${op.id}`,
                                       {
                                         method: "PUT",
-                                        headers: {
-                                          Authorization: `Bearer ${token}`,
-                                          "Content-Type": "application/json",
-                                        },
+                                        headers: { "Content-Type": "application/json" },
+                                        credentials: "include",
                                         body: JSON.stringify({
                                           sequence: newSequence,
                                         }),

--- a/frontend/src/components/bom/CreateBOMForm.jsx
+++ b/frontend/src/components/bom/CreateBOMForm.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { API_URL } from "../../config/api";
 import SearchableSelect from "../SearchableSelect";
 
-export default function CreateBOMForm({ onClose, onCreate, token, existingBoms = [] }) {
+export default function CreateBOMForm({ onClose, onCreate, existingBoms = [] }) {
   const [formData, setFormData] = useState({
     product_id: "",
     name: "",
@@ -20,7 +20,7 @@ export default function CreateBOMForm({ onClose, onCreate, token, existingBoms =
       const res = await fetch(
         `${API_URL}/api/v1/products?limit=500&is_raw_material=false`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) {
@@ -32,7 +32,7 @@ export default function CreateBOMForm({ onClose, onCreate, token, existingBoms =
     } catch (err) {
       setError(err.message || "Failed to load products. Please refresh the page.");
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchProducts();
@@ -102,10 +102,8 @@ export default function CreateBOMForm({ onClose, onCreate, token, existingBoms =
 
       const res = await fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           product_id: parseInt(formData.product_id),
           name: formData.name || null,

--- a/frontend/src/components/bom/CreateProductionOrderModal.jsx
+++ b/frontend/src/components/bom/CreateProductionOrderModal.jsx
@@ -6,7 +6,6 @@ export default function CreateProductionOrderModal({
   bom,
   quoteContext,
   onClose,
-  token,
   onSuccess,
 }) {
   // Calculate max producible based on inventory
@@ -75,10 +74,8 @@ export default function CreateProductionOrderModal({
         `${API_URL}/api/v1/production-orders?auto_start_print=false`,
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({
             product_id: bom.product_id,
             quantity_ordered: produceQty,

--- a/frontend/src/components/bom/PurchaseRequestModal.jsx
+++ b/frontend/src/components/bom/PurchaseRequestModal.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 
 // Purchase Request Modal content - Creates actual PO from BOM shortage
-export default function PurchaseRequestModal({ line, onClose, token, onSuccess }) {
+export default function PurchaseRequestModal({ line, onClose, onSuccess }) {
   const [quantity, setQuantity] = useState(line?.shortage || 1);
   const [vendorId, setVendorId] = useState("");
   const [unitCost, setUnitCost] = useState(line?.component_cost || 0);
@@ -18,7 +18,7 @@ export default function PurchaseRequestModal({ line, onClose, token, onSuccess }
     const fetchVendors = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/vendors/?active_only=true`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -31,7 +31,7 @@ export default function PurchaseRequestModal({ line, onClose, token, onSuccess }
       }
     };
     fetchVendors();
-  }, [token]);
+  }, []);
 
   const handleSubmit = async () => {
     if (!vendorId) {
@@ -53,10 +53,8 @@ export default function PurchaseRequestModal({ line, onClose, token, onSuccess }
     try {
       const res = await fetch(`${API_URL}/api/v1/purchase-orders/`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           vendor_id: parseInt(vendorId),
           notes: notes || `PO for ${line.component_name}`,

--- a/frontend/src/components/bom/WorkOrderRequestModal.jsx
+++ b/frontend/src/components/bom/WorkOrderRequestModal.jsx
@@ -5,7 +5,7 @@ import { API_URL } from "../../config/api";
  * Work Order Request Modal content - Creates a production/work order for make items.
  * Used when a component has its own BOM (sub-assembly).
  */
-export default function WorkOrderRequestModal({ line, onClose, token, onSuccess }) {
+export default function WorkOrderRequestModal({ line, onClose, onSuccess }) {
   const [quantity, setQuantity] = useState(line?.shortage || 1);
   const [priority, setPriority] = useState(3);
   const [dueDate, setDueDate] = useState("");
@@ -26,10 +26,8 @@ export default function WorkOrderRequestModal({ line, onClose, token, onSuccess 
     try {
       const res = await fetch(`${API_URL}/api/v1/production-orders/`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           product_id: line.component_id,
           quantity_ordered: quantity,

--- a/frontend/src/components/bom/useBOMLines.js
+++ b/frontend/src/components/bom/useBOMLines.js
@@ -5,7 +5,7 @@ import { API_URL } from "../../config/api.js";
  * Custom hook that manages BOM line CRUD operations,
  * product/UOM reference data, and the exploded BOM view.
  */
-export default function useBOMLines({ bom, token, toast, onUpdate }) {
+export default function useBOMLines({ bom, toast, onUpdate }) {
   const [lines, setLines] = useState(bom.lines || []);
   const [loading, setLoading] = useState(false);
   const [editingLine, setEditingLine] = useState(null);
@@ -33,7 +33,7 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
       try {
         const res = await fetch(
           `${API_URL}/api/v1/products?limit=500&is_raw_material=true`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         );
         if (res.ok) {
           const data = await res.json();
@@ -47,7 +47,7 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
     const fetchUOMs = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/admin/uom`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -62,7 +62,7 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
       try {
         const res = await fetch(
           `${API_URL}/api/v1/admin/bom/${bom.id}/cost-rollup`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         );
         if (res.ok) {
           const data = await res.json();
@@ -85,7 +85,7 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/bom/${bom.id}/explode`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -112,10 +112,8 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/bom/${bom.id}/lines`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           component_id: parseInt(newLine.component_id),
           quantity: parseFloat(newLine.quantity),
@@ -161,10 +159,8 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
         `${API_URL}/api/v1/admin/bom/${bom.id}/lines/${lineId}`,
         {
           method: "PATCH",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify(updates),
         }
       );
@@ -198,7 +194,7 @@ export default function useBOMLines({ bom, token, toast, onUpdate }) {
         `${API_URL}/api/v1/admin/bom/${bom.id}/lines/${lineId}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/bom/useRoutingManager.js
+++ b/frontend/src/components/bom/useRoutingManager.js
@@ -6,7 +6,7 @@ import { API_URL } from "../../config/api.js";
  * for a BOM detail view: product routing, templates, operations,
  * operation materials, and time overrides.
  */
-export default function useRoutingManager({ bom, token, toast }) {
+export default function useRoutingManager({ bom, toast }) {
   // Process Path / Routing state
   const [routingTemplates, setRoutingTemplates] = useState([]);
   const [productRouting, setProductRouting] = useState(null);
@@ -43,11 +43,11 @@ export default function useRoutingManager({ bom, token, toast }) {
   // ─── Data fetching ───────────────────────────────────────────
 
   const fetchProductRouting = useCallback(async () => {
-    if (!bom.product_id || !token) return;
+    if (!bom.product_id) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/routings?product_id=${bom.product_id}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -56,7 +56,7 @@ export default function useRoutingManager({ bom, token, toast }) {
         if (activeRouting) {
           const detailRes = await fetch(
             `${API_URL}/api/v1/routings/${activeRouting.id}`,
-            { headers: { Authorization: `Bearer ${token}` } }
+            { credentials: "include" }
           );
           if (detailRes.ok) {
             const routingDetail = await detailRes.json();
@@ -77,14 +77,14 @@ export default function useRoutingManager({ bom, token, toast }) {
     } catch {
       // Product routing fetch failure is non-critical
     }
-  }, [token, bom.product_id]);
+  }, [bom.product_id]);
 
   const fetchManufacturingBOM = useCallback(async () => {
-    if (!bom?.product_id || !token) return;
+    if (!bom?.product_id) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/routings/manufacturing-bom/${bom.product_id}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -97,7 +97,7 @@ export default function useRoutingManager({ bom, token, toast }) {
     } catch {
       // Non-critical failure
     }
-  }, [bom?.product_id, token]);
+  }, [bom?.product_id]);
 
   // Fetch manufacturing BOM when productRouting is loaded
   useEffect(() => {
@@ -127,10 +127,8 @@ export default function useRoutingManager({ bom, token, toast }) {
         `${API_URL}/api/v1/routings/operations/${operationId}/materials`,
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({
             component_id: parseInt(newMaterial.component_id),
             quantity: parseFloat(newMaterial.quantity),
@@ -162,7 +160,7 @@ export default function useRoutingManager({ bom, token, toast }) {
         `${API_URL}/api/v1/routings/materials/${materialId}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -205,10 +203,8 @@ export default function useRoutingManager({ bom, token, toast }) {
 
       const res = await fetch(`${API_URL}/api/v1/routings/apply-template`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           product_id: bom.product_id,
           template_id: parseInt(selectedTemplateId),
@@ -261,10 +257,8 @@ export default function useRoutingManager({ bom, token, toast }) {
         `${API_URL}/api/v1/routings/operations/${operationId}`,
         {
           method: "PUT",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({
             [field]: parseFloat(value) || 0,
           }),
@@ -302,7 +296,7 @@ export default function useRoutingManager({ bom, token, toast }) {
         `${API_URL}/api/v1/routings/operations/${operationId}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -360,10 +354,8 @@ export default function useRoutingManager({ bom, token, toast }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           product_id: bom.product_id,
           operations: pendingOperations.map((op) => ({
@@ -408,10 +400,8 @@ export default function useRoutingManager({ bom, token, toast }) {
         `${API_URL}/api/v1/routings/${productRouting.id}/operations`,
         {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify({
             work_center_id: parseInt(newOperation.work_center_id),
             sequence: nextSequence,
@@ -467,7 +457,7 @@ export default function useRoutingManager({ bom, token, toast }) {
       try {
         const res = await fetch(
           `${API_URL}/api/v1/routings?templates_only=true`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         );
         if (res.ok) {
           const data = await res.json();
@@ -482,7 +472,7 @@ export default function useRoutingManager({ bom, token, toast }) {
       try {
         const res = await fetch(
           `${API_URL}/api/v1/work-centers/?active_only=true`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         );
         if (res.ok) {
           const data = await res.json();

--- a/frontend/src/components/customers/CustomerDetailsModal.jsx
+++ b/frontend/src/components/customers/CustomerDetailsModal.jsx
@@ -88,7 +88,6 @@ function PortalSettingsTab({ customerId: _customerId, portalDetails, loading, on
 }
 
 export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
-  const token = localStorage.getItem("adminToken");
   const { isPro } = useFeatureFlags();
   const [activeTab, setActiveTab] = useState("overview");
   const [orders, setOrders] = useState([]);
@@ -111,7 +110,7 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/customers/${customer.id}/orders?limit=10`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -131,7 +130,7 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
       const res = await fetch(
         `${API_URL}/api/v1/admin/customers/${customer.id}/portal-details`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {

--- a/frontend/src/components/customers/ImportCSVModal.jsx
+++ b/frontend/src/components/customers/ImportCSVModal.jsx
@@ -8,7 +8,6 @@ import { API_URL } from "../../config/api";
 import Modal from "../Modal";
 
 export default function ImportCSVModal({ onClose, onImportComplete }) {
-  const token = localStorage.getItem("adminToken");
   const [step, setStep] = useState("upload"); // upload, preview, importing, complete
   const [file, setFile] = useState(null);
   const [preview, setPreview] = useState(null);
@@ -51,7 +50,7 @@ export default function ImportCSVModal({ onClose, onImportComplete }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/customers/import/preview`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         body: formData,
       });
 
@@ -79,7 +78,7 @@ export default function ImportCSVModal({ onClose, onImportComplete }) {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/customers/import`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         body: formData,
       });
 

--- a/frontend/src/components/manufacturing/ResourceModal.jsx
+++ b/frontend/src/components/manufacturing/ResourceModal.jsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 import { RESOURCE_STATUSES } from "./constants";
 
-export default function ResourceModal({ resource, workCenter, onClose, onSave, token }) {
+export default function ResourceModal({ resource, workCenter, onClose, onSave }) {
   const [form, setForm] = useState({
     code: resource?.code || "",
     name: resource?.name || "",
@@ -32,15 +32,11 @@ export default function ResourceModal({ resource, workCenter, onClose, onSave, t
       Promise.all([
         fetch(
           `${API_URL}/api/v1/work-centers/${workCenter.id}/printers?active_only=true`,
-          {
-            headers: { Authorization: `Bearer ${token}` },
-          }
+          { credentials: "include" }
         ).then((res) => (res.ok ? res.json() : [])),
         fetch(
           `${API_URL}/api/v1/work-centers/${workCenter.id}/resources?active_only=false`,
-          {
-            headers: { Authorization: `Bearer ${token}` },
-          }
+          { credentials: "include" }
         ).then((res) => (res.ok ? res.json() : [])),
       ])
         .then(([printersData, resourcesData]) => {
@@ -53,7 +49,7 @@ export default function ResourceModal({ resource, workCenter, onClose, onSave, t
         })
         .finally(() => setLoadingPrinters(false));
     }
-  }, [workCenter, resource, token]);
+  }, [workCenter, resource]);
 
   // Filter out printers that are already added as resources
   const availablePrinters = printers.filter(

--- a/frontend/src/components/manufacturing/WorkCenterCard.jsx
+++ b/frontend/src/components/manufacturing/WorkCenterCard.jsx
@@ -28,15 +28,13 @@ export default function WorkCenterCard({
   const resourcesLoaded = useRef(false);
   const printersLoaded = useRef(false);
 
-  const token = localStorage.getItem("adminToken");
-
   const fetchResources = useCallback(async () => {
     if (resourcesLoaded.current) return;
     setLoadingResources(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/work-centers/${workCenter.id}/resources?active_only=false`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -48,14 +46,14 @@ export default function WorkCenterCard({
     } finally {
       setLoadingResources(false);
     }
-  }, [workCenter.id, token]);
+  }, [workCenter.id]);
 
   const fetchPrinters = useCallback(async () => {
     if (printersLoaded.current) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/work-centers/${workCenter.id}/printers?active_only=false`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -65,7 +63,7 @@ export default function WorkCenterCard({
     } catch {
       // Printers fetch failure is non-critical
     }
-  }, [workCenter.id, token]);
+  }, [workCenter.id]);
 
   useEffect(() => {
     if (expanded) {
@@ -116,9 +114,9 @@ export default function WorkCenterCard({
           `${API_URL}/api/v1/work-centers/${workCenter.id}/resources`,
           {
             method: "POST",
+            credentials: "include",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify(resourceData),
           }

--- a/frontend/src/components/orders/ShippingAddressSection.jsx
+++ b/frontend/src/components/orders/ShippingAddressSection.jsx
@@ -9,7 +9,6 @@ import { useToast } from "../Toast";
 
 export default function ShippingAddressSection({ order, onOrderUpdated }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   const [editingAddress, setEditingAddress] = useState(false);
   const [savingAddress, setSavingAddress] = useState(false);
   const [addressForm, setAddressForm] = useState({});
@@ -33,10 +32,8 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
         `${API_URL}/api/v1/sales-orders/${order.id}/address`,
         {
           method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
           body: JSON.stringify(addressForm),
         }
       );

--- a/frontend/src/components/payments/RecordPaymentModal.jsx
+++ b/frontend/src/components/payments/RecordPaymentModal.jsx
@@ -32,8 +32,6 @@ export default function RecordPaymentModal({
   onSuccess,
 }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
-
   const [loading, setLoading] = useState(false);
   const [orders, setOrders] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -54,7 +52,7 @@ export default function RecordPaymentModal({
     try {
       // Fetch orders that might need payment (not cancelled, not fully paid for payments)
       const res = await fetch(`${API_URL}/api/v1/sales-orders?page_size=100`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -63,13 +61,13 @@ export default function RecordPaymentModal({
     } catch {
       // Non-critical: Order list fetch failure doesn't block user - they can still search
     }
-  }, [token]);
+  }, []);
 
   const fetchOrderDetails = useCallback(
     async (id) => {
       try {
         const res = await fetch(`${API_URL}/api/v1/sales-orders/${id}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const order = await res.json();
@@ -80,7 +78,7 @@ export default function RecordPaymentModal({
         // Non-critical: Pre-selected order fetch failure - user can select manually
       }
     },
-    [token]
+    []
   );
 
   const fetchPaymentSummary = useCallback(
@@ -89,7 +87,7 @@ export default function RecordPaymentModal({
         const res = await fetch(
           `${API_URL}/api/v1/payments/order/${orderId}/summary`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
         if (res.ok) {
@@ -99,7 +97,7 @@ export default function RecordPaymentModal({
         // Non-critical: Payment summary fetch failure - form still works without it
       }
     },
-    [token]
+    []
   );
 
   // Fetch orders for selection
@@ -148,13 +146,6 @@ export default function RecordPaymentModal({
         ? `${API_URL}/api/v1/payments/refund`
         : `${API_URL}/api/v1/payments`;
 
-      // Debug: Check if token exists
-      if (!token) {
-        toast.error("Not authenticated. Please log in again.");
-        setLoading(false);
-        return;
-      }
-
       // Parse date as local time (noon to avoid timezone date shifts)
       let paymentDate = null;
       if (form.payment_date) {
@@ -174,21 +165,11 @@ export default function RecordPaymentModal({
         notes: form.notes || null,
       };
 
-      // Debug logging
-      console.log("Payment request:", {
-        endpoint,
-        body,
-        API_URL,
-        tokenPresent: !!token,
-        tokenLength: token?.length,
-      });
-
       const res = await fetch(endpoint, {
         method: "POST",
-        mode: "cors",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(body),
       });

--- a/frontend/src/components/printers/IPProbeSection.jsx
+++ b/frontend/src/components/printers/IPProbeSection.jsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 
-export default function IPProbeSection({ token, onPrinterFound }) {
+export default function IPProbeSection({ onPrinterFound }) {
   const toast = useToast();
   const [ipAddress, setIpAddress] = useState("");
   const [probing, setProbing] = useState(false);
@@ -34,7 +34,7 @@ export default function IPProbeSection({ token, onPrinterFound }) {
         `${API_URL}/api/v1/printers/probe-ip?ip_address=${encodeURIComponent(ipAddress.trim())}`,
         {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/components/printers/MaintenanceModal.jsx
+++ b/frontend/src/components/printers/MaintenanceModal.jsx
@@ -31,8 +31,6 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
     notes: "",
   });
 
-  const token = localStorage.getItem("adminToken");
-
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -58,8 +56,8 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
 
       const res = await fetch(`${API_URL}/api/v1/maintenance/printers/${form.printer_id}/maintenance`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(payload),

--- a/frontend/src/components/printers/PrinterModal.jsx
+++ b/frontend/src/components/printers/PrinterModal.jsx
@@ -27,7 +27,6 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
     active: printer?.active !== false,
   });
 
-  const token = localStorage.getItem("adminToken");
   const isEdit = !!printer;
 
   // Fetch machine-type work centers on mount
@@ -35,7 +34,7 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
     const fetchWorkCenters = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/work-centers/?center_type=machine`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -46,7 +45,7 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
       }
     };
     fetchWorkCenters();
-  }, [token]);
+  }, []);
 
   // Get models for selected brand
   const selectedBrand = brandInfo.find((b) => b.code === form.brand);
@@ -70,8 +69,8 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
 
       const res = await fetch(url, {
         method: isEdit ? "PUT" : "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(payload),
@@ -95,7 +94,7 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
     try {
       const prefix = form.brand === "generic" ? "PRT" : form.brand.toUpperCase().slice(0, 3);
       const res = await fetch(`${API_URL}/api/v1/printers/generate-code?prefix=${prefix}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();

--- a/frontend/src/components/production/OperationActions.jsx
+++ b/frontend/src/components/production/OperationActions.jsx
@@ -12,7 +12,6 @@ import { API_URL } from '../../config/api';
  */
 function StartButton({ operation, productionOrderId, onSuccess, onError }) {
   const [loading, setLoading] = useState(false);
-  const token = localStorage.getItem('adminToken');
 
   const handleStart = async () => {
     setLoading(true);
@@ -20,7 +19,7 @@ function StartButton({ operation, productionOrderId, onSuccess, onError }) {
       // First check if operation can start (blocking issues)
       const checkRes = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/can-start`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
 
       if (checkRes.ok) {
@@ -40,8 +39,8 @@ function StartButton({ operation, productionOrderId, onSuccess, onError }) {
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/start`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({

--- a/frontend/src/components/production/OperationCompletionModal.jsx
+++ b/frontend/src/components/production/OperationCompletionModal.jsx
@@ -119,8 +119,6 @@ export default function OperationCompletionModal({
   const [notes, setNotes] = useState('');
   const [createReplacement, setCreateReplacement] = useState(true);
 
-  const token = localStorage.getItem('adminToken');
-
   // Validation
   const total = qtyGood + qtyBad;
   const hasScrap = qtyBad > 0;
@@ -134,7 +132,7 @@ export default function OperationCompletionModal({
     const fetchReasons = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/production-orders/scrap-reasons`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -146,7 +144,7 @@ export default function OperationCompletionModal({
     };
 
     fetchReasons();
-  }, [isOpen, token]);
+  }, [isOpen]);
 
   // Fetch cascade preview when scrapping
   const fetchCascade = useCallback(async () => {
@@ -159,7 +157,7 @@ export default function OperationCompletionModal({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/scrap-cascade?quantity=${qtyBad}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
 
       if (res.ok) {
@@ -174,7 +172,7 @@ export default function OperationCompletionModal({
     } finally {
       setLoading(false);
     }
-  }, [isOpen, productionOrderId, operation?.id, qtyBad, token]);
+  }, [isOpen, productionOrderId, operation?.id, qtyBad]);
 
   // Debounced cascade fetch
   useEffect(() => {
@@ -233,8 +231,8 @@ export default function OperationCompletionModal({
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/complete`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -63,8 +63,6 @@ export default function OperationSchedulerModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem('adminToken');
-
   // Get available resources for the operation's work center
   const { resources, loading: loadingResources } = useResources(operation?.work_center_id);
 
@@ -129,8 +127,8 @@ export default function OperationSchedulerModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${operation.id}/schedule`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({

--- a/frontend/src/components/production/OperationsPanel.jsx
+++ b/frontend/src/components/production/OperationsPanel.jsx
@@ -150,8 +150,6 @@ export default function OperationsPanel({ productionOrderId, productionOrder, or
   const [completionModalOpen, setCompletionModalOpen] = useState(false);
   const [operationToComplete, setOperationToComplete] = useState(null);
 
-  const token = localStorage.getItem('adminToken');
-
   useEffect(() => {
     fetchOperations();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -168,12 +166,12 @@ export default function OperationsPanel({ productionOrderId, productionOrder, or
   }, [operations]);
 
   const fetchOperations = async () => {
-    if (!token || !productionOrderId) return;
+    if (!productionOrderId) return;
 
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
 
       if (!res.ok) throw new Error('Failed to fetch operations');

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -79,8 +79,6 @@ export default function ProductionOrderModal({
   const [scheduledStart, setScheduledStart] = useState('');
   const [suggestedSlot, setSuggestedSlot] = useState(null); // { start, end } when conflict occurs
 
-  const token = localStorage.getItem('adminToken');
-
   // Fetch operations on mount
   useEffect(() => {
     if (productionOrder?.id) {
@@ -108,7 +106,7 @@ export default function ProductionOrderModal({
       setLoading(true);
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -132,7 +130,7 @@ export default function ProductionOrderModal({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/work-centers/?center_type=machine&active_only=true`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         setWorkCenters(await res.json());
@@ -147,11 +145,11 @@ export default function ProductionOrderModal({
       const [resourcesRes, printersRes] = await Promise.all([
         fetch(
           `${API_URL}/api/v1/work-centers/${workCenterId}/resources?active_only=true`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         ),
         fetch(
           `${API_URL}/api/v1/work-centers/${workCenterId}/printers?active_only=true`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         ),
       ]);
 
@@ -233,8 +231,8 @@ export default function ProductionOrderModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${operationToSchedule.id}/schedule`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
@@ -256,8 +254,8 @@ export default function ProductionOrderModal({
               `${API_URL}/api/v1/production-orders/resources/next-available`,
               {
                 method: 'POST',
+                credentials: 'include',
                 headers: {
-                  Authorization: `Bearer ${token}`,
                   'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
@@ -318,8 +316,8 @@ export default function ProductionOrderModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${operation.id}/start`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({}),
@@ -359,8 +357,8 @@ export default function ProductionOrderModal({
         `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${operationId}/complete`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
@@ -417,8 +415,8 @@ export default function ProductionOrderModal({
     try {
       await fetch(`${API_URL}/api/v1/production-orders/${productionOrder.id}`, {
         method: 'PUT',
+        credentials: 'include',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ notes }),

--- a/frontend/src/components/production/ProductionQueueList.jsx
+++ b/frontend/src/components/production/ProductionQueueList.jsx
@@ -198,14 +198,12 @@ export default function ProductionQueueList({
   const [loadingOps, setLoadingOps] = useState(false);
   const [workCenters, setWorkCenters] = useState([]);
 
-  const token = localStorage.getItem('adminToken');
-
   // Fetch work centers on mount
   useEffect(() => {
     const fetchWorkCenters = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/work-centers`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -216,7 +214,7 @@ export default function ProductionQueueList({
       }
     };
     fetchWorkCenters();
-  }, [token]);
+  }, []);
 
   // Fetch operations for all orders
   useEffect(() => {
@@ -236,7 +234,7 @@ export default function ProductionQueueList({
             try {
               const res = await fetch(
                 `${API_URL}/api/v1/production-orders/${order.id}/operations`,
-                { headers: { Authorization: `Bearer ${token}` } }
+                { credentials: "include" }
               );
               if (res.ok) {
                 const data = await res.json();
@@ -254,7 +252,7 @@ export default function ProductionQueueList({
     };
 
     fetchAllOperations();
-  }, [orders, token]);
+  }, [orders]);
 
   // Filter orders
   const filteredOrders = orders?.filter((order) => {

--- a/frontend/src/components/production/ScrapEntryModal.jsx
+++ b/frontend/src/components/production/ScrapEntryModal.jsx
@@ -122,8 +122,6 @@ export default function ScrapEntryModal({
   const [notes, setNotes] = useState('');
   const [createReplacement, setCreateReplacement] = useState(true);
 
-  const token = localStorage.getItem('adminToken');
-
   // Calculate max scrap quantity (from operation input or PO remaining)
   const maxQuantity = operation?.quantity_input
     ? Number(operation.quantity_input) - Number(operation.quantity_completed || 0)
@@ -138,7 +136,7 @@ export default function ScrapEntryModal({
     const fetchReasons = async () => {
       try {
         const res = await fetch(`${API_URL}/api/v1/production-orders/scrap-reasons`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
         if (res.ok) {
           const data = await res.json();
@@ -150,7 +148,7 @@ export default function ScrapEntryModal({
     };
 
     fetchReasons();
-  }, [isOpen, token]);
+  }, [isOpen]);
 
   // Fetch cascade preview when quantity changes
   const fetchCascade = useCallback(async () => {
@@ -163,7 +161,7 @@ export default function ScrapEntryModal({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/scrap-cascade?quantity=${quantity}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
 
       if (res.ok) {
@@ -180,7 +178,7 @@ export default function ScrapEntryModal({
     } finally {
       setLoading(false);
     }
-  }, [isOpen, productionOrderId, operation?.id, quantity, token]);
+  }, [isOpen, productionOrderId, operation?.id, quantity]);
 
   // Debounced cascade fetch
   useEffect(() => {
@@ -216,8 +214,8 @@ export default function ScrapEntryModal({
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/scrap`,
         {
           method: 'POST',
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({

--- a/frontend/src/components/production/ShortageModal.jsx
+++ b/frontend/src/components/production/ShortageModal.jsx
@@ -22,8 +22,6 @@ export default function ShortageModal({
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem('adminToken');
-
   const handleCreateReplacement = async () => {
     setCreating(true);
     setError(null);
@@ -32,8 +30,8 @@ export default function ShortageModal({
       // Create a new PO for the shortage quantity
       const res = await fetch(`${API_URL}/api/v1/production-orders`, {
         method: 'POST',
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({

--- a/frontend/src/components/production/SkipOperationModal.jsx
+++ b/frontend/src/components/production/SkipOperationModal.jsx
@@ -18,8 +18,6 @@ export default function SkipOperationModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem('adminToken');
-
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -36,8 +34,8 @@ export default function SkipOperationModal({
         `${API_URL}/api/v1/production-orders/${productionOrderId}/operations/${operation.id}/skip`,
         {
           method: 'POST',
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({ reason: reason.trim() })

--- a/frontend/src/components/purchasing/QuickCreateItemModal.jsx
+++ b/frontend/src/components/purchasing/QuickCreateItemModal.jsx
@@ -38,12 +38,11 @@ export default function QuickCreateItemModal({ onClose, onCreated, initialName =
 
     setLoading(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const res = await fetch(`${API_URL}/api/v1/items`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           sku: form.sku.trim(),

--- a/frontend/src/components/quotes/QuoteDetailModal.jsx
+++ b/frontend/src/components/quotes/QuoteDetailModal.jsx
@@ -22,7 +22,6 @@ export default function QuoteDetailModal({
   onRefresh,
 }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   const [uploadingImage, setUploadingImage] = useState(false);
   const [imageUrl, setImageUrl] = useState(null);
   const imageUrlRef = useRef(null);
@@ -35,7 +34,7 @@ export default function QuoteDetailModal({
   useEffect(() => {
     if (quote.has_image) {
       fetch(`${API_URL}/api/v1/quotes/${quote.id}/image`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       })
         .then((res) => {
           if (res.ok) return res.blob();
@@ -58,7 +57,7 @@ export default function QuoteDetailModal({
         imageUrlRef.current = null;
       }
     };
-  }, [quote.id, quote.has_image, token]);
+  }, [quote.id, quote.has_image]);
 
   const handleImageUpload = async (e) => {
     const file = e.target.files?.[0];
@@ -83,7 +82,7 @@ export default function QuoteDetailModal({
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/image`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         body: formData,
       });
 
@@ -95,7 +94,7 @@ export default function QuoteDetailModal({
       toast.success("Image uploaded successfully");
       // Refresh image by fetching with auth
       const imgRes = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/image`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (imgRes.ok) {
         const blob = await imgRes.blob();
@@ -120,7 +119,7 @@ export default function QuoteDetailModal({
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/image`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {

--- a/frontend/src/components/quotes/QuoteFormModal.jsx
+++ b/frontend/src/components/quotes/QuoteFormModal.jsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 
-export default function QuoteFormModal({ quote, onSave, onClose, token }) {
+export default function QuoteFormModal({ quote, onSave, onClose }) {
   const navigate = useNavigate();
   const toast = useToast();
   const [step, setStep] = useState(quote ? 2 : 1); // 1=product, 2=customer+details
@@ -48,7 +48,7 @@ export default function QuoteFormModal({ quote, onSave, onClose, token }) {
   const fetchProducts = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/products?limit=500&active_only=true`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -64,7 +64,7 @@ export default function QuoteFormModal({ quote, onSave, onClose, token }) {
   const fetchCustomers = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/customers?limit=200`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -78,7 +78,7 @@ export default function QuoteFormModal({ quote, onSave, onClose, token }) {
   const fetchCompanySettings = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/settings/company`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -142,8 +142,8 @@ export default function QuoteFormModal({ quote, onSave, onClose, token }) {
 
         const customerRes = await fetch(`${API_URL}/api/v1/admin/customers`, {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/frontend/src/components/settings/AiSettingsSection.jsx
+++ b/frontend/src/components/settings/AiSettingsSection.jsx
@@ -40,14 +40,8 @@ export default function AiSettingsSection() {
 
   const fetchAiSettings = async () => {
     try {
-      const token = localStorage.getItem("adminToken");
-      if (!token) {
-        setAnthropicStatus((prev) => ({ ...prev, loading: false }));
-        return;
-      }
-
       const response = await fetch(`${API_URL}/api/v1/settings/ai`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -81,9 +75,8 @@ export default function AiSettingsSection() {
 
   const checkAnthropicStatus = async () => {
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/ai/anthropic-status`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (response.ok) {
         const data = await response.json();
@@ -100,10 +93,9 @@ export default function AiSettingsSection() {
   const handleInstallAnthropic = async () => {
     setInstallingAnthropic(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/ai/install-anthropic`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -129,8 +121,6 @@ export default function AiSettingsSection() {
   const handleSaveAiSettings = async () => {
     setSavingAi(true);
     try {
-      const token = localStorage.getItem("adminToken");
-
       const payload = {
         ai_provider: aiForm.ai_provider || null,
         ai_ollama_url: aiForm.ai_ollama_url || null,
@@ -143,8 +133,8 @@ export default function AiSettingsSection() {
 
       const response = await fetch(`${API_URL}/api/v1/settings/ai`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(payload),
@@ -176,10 +166,9 @@ export default function AiSettingsSection() {
   const handleTestAiConnection = async () => {
     setTestingAi(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/ai/test`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -200,11 +189,10 @@ export default function AiSettingsSection() {
 
     setSavingAi(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/ai`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -230,10 +218,9 @@ export default function AiSettingsSection() {
   const handleStartOllama = async () => {
     setStartingOllama(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/ai/start-ollama`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       const data = await response.json();
@@ -281,11 +268,10 @@ export default function AiSettingsSection() {
               const newValue = !aiForm.external_ai_blocked;
               setSavingAi(true);
               try {
-                const token = localStorage.getItem("adminToken");
                 const response = await fetch(`${API_URL}/api/v1/settings/ai`, {
                   method: "PATCH",
+                  credentials: "include",
                   headers: {
-                    Authorization: `Bearer ${token}`,
                     "Content-Type": "application/json",
                   },
                   body: JSON.stringify({ external_ai_blocked: newValue }),

--- a/frontend/src/hooks/useActivityTokenRefresh.js
+++ b/frontend/src/hooks/useActivityTokenRefresh.js
@@ -2,48 +2,22 @@
  * Activity-Based Token Refresh Hook
  *
  * Prevents users from losing work due to session expiration while actively working.
- * Tracks user activity and automatically refreshes the access token before it expires.
+ * Tracks user activity and calls POST /auth/refresh periodically.
+ *
+ * With httpOnly cookies the JS layer cannot read token expiry, so we refresh
+ * on a fixed interval while the user is active.
  */
 import { useEffect, useRef, useCallback } from "react";
 import { API_URL } from "../config/api";
 
-// How often to check if token needs refresh (in ms)
-const CHECK_INTERVAL = 60 * 1000; // 1 minute
-
-// Refresh token when it will expire within this many minutes
-const REFRESH_THRESHOLD_MINUTES = 5;
+// How often to attempt a refresh (in ms)
+const REFRESH_INTERVAL = 10 * 60 * 1000; // 10 minutes
 
 // Consider user inactive after this many minutes of no activity
 const INACTIVITY_TIMEOUT_MINUTES = 25;
 
 /**
- * Decode JWT token to get expiration time
- * @param {string} token - JWT token
- * @returns {number|null} - Expiration timestamp in ms, or null if invalid
- */
-function getTokenExpiration(token) {
-  if (!token) return null;
-
-  try {
-    // JWT format: header.payload.signature
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-
-    // Decode payload (base64url)
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-
-    // exp is in seconds, convert to ms
-    if (payload.exp) {
-      return payload.exp * 1000;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Hook to automatically refresh auth tokens based on user activity
+ * Hook to automatically refresh auth tokens based on user activity.
  *
  * Usage:
  *   useActivityTokenRefresh(); // Call once in your app root or layout
@@ -57,38 +31,23 @@ export default function useActivityTokenRefresh() {
     lastActivityRef.current = Date.now();
   }, []);
 
-  // Refresh the access token using the refresh token
+  // Refresh the access token by calling POST /auth/refresh (cookie-based)
   const refreshToken = useCallback(async () => {
     if (isRefreshingRef.current) return false;
-
-    const refreshTokenValue = localStorage.getItem("adminRefreshToken");
-    if (!refreshTokenValue) {
-      return false;
-    }
-
     isRefreshingRef.current = true;
 
     try {
       const response = await fetch(`${API_URL}/api/v1/auth/refresh`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ refresh_token: refreshTokenValue }),
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
       });
 
       if (!response.ok) {
-        // Refresh token is invalid/expired - user needs to log in again
-        console.warn("Token refresh failed - session may have expired");
+        // Refresh failed — session expired, user needs to log in again
+        console.warn("Token refresh failed — session may have expired");
         return false;
-      }
-
-      const data = await response.json();
-
-      // Update stored tokens
-      localStorage.setItem("adminToken", data.access_token);
-      if (data.refresh_token) {
-        localStorage.setItem("adminRefreshToken", data.refresh_token);
       }
 
       console.debug("Token refreshed successfully");
@@ -101,26 +60,18 @@ export default function useActivityTokenRefresh() {
     }
   }, []);
 
-  // Check if token needs refresh
+  // Check if user is active, then refresh
   const checkAndRefresh = useCallback(() => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
-    const expiration = getTokenExpiration(token);
-    if (!expiration) return;
+    // Only refresh if we appear to be logged in (adminUser in localStorage)
+    if (!localStorage.getItem("adminUser")) return;
 
     const now = Date.now();
-    const timeUntilExpiry = expiration - now;
-    const thresholdMs = REFRESH_THRESHOLD_MINUTES * 60 * 1000;
     const inactivityMs = INACTIVITY_TIMEOUT_MINUTES * 60 * 1000;
-
-    // Check if user has been active recently
     const timeSinceActivity = now - lastActivityRef.current;
     const isUserActive = timeSinceActivity < inactivityMs;
 
-    // If token expires soon and user is active, refresh it
-    if (timeUntilExpiry < thresholdMs && timeUntilExpiry > 0 && isUserActive) {
-      console.debug(`Token expires in ${Math.round(timeUntilExpiry / 1000 / 60)} min, user active - refreshing`);
+    if (isUserActive) {
+      console.debug("User active — refreshing token");
       refreshToken();
     }
   }, [refreshToken]);
@@ -145,11 +96,8 @@ export default function useActivityTokenRefresh() {
       window.addEventListener(event, throttledActivity, { passive: true });
     });
 
-    // Set up periodic token check
-    const intervalId = setInterval(checkAndRefresh, CHECK_INTERVAL);
-
-    // Initial check
-    checkAndRefresh();
+    // Set up periodic token refresh
+    const intervalId = setInterval(checkAndRefresh, REFRESH_INTERVAL);
 
     // Cleanup
     return () => {

--- a/frontend/src/hooks/useBlockingIssues.js
+++ b/frontend/src/hooks/useBlockingIssues.js
@@ -35,16 +35,15 @@ export function useBlockingIssues(orderType, orderId) {
     setError(null);
 
     try {
-      const token = localStorage.getItem('adminToken');
       const endpoint = orderType === 'sales'
         ? `${API_URL}/api/v1/sales-orders/${orderId}/blocking-issues`
         : `${API_URL}/api/v1/production-orders/${orderId}/blocking-issues`;
 
       const response = await fetch(endpoint, {
         headers: {
-          'Authorization': token ? `Bearer ${token}` : '',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
 
       if (!response.ok) {

--- a/frontend/src/hooks/useCommandCenter.js
+++ b/frontend/src/hooks/useCommandCenter.js
@@ -17,10 +17,8 @@ export function useActionItems(autoRefresh = false, refreshInterval = 60000) {
   const [error, setError] = useState(null);
   const intervalRef = useRef(null);
 
-  const token = localStorage.getItem('adminToken');
-
   const fetchData = useCallback(async () => {
-    if (!token) {
+    if (!localStorage.getItem('adminUser')) {
       setError('Not authenticated');
       setLoading(false);
       return;
@@ -28,9 +26,7 @@ export function useActionItems(autoRefresh = false, refreshInterval = 60000) {
 
     try {
       const res = await fetch(`${API_URL}/api/v1/command-center/action-items`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
+        credentials: 'include',
       });
 
       if (!res.ok) {
@@ -46,7 +42,7 @@ export function useActionItems(autoRefresh = false, refreshInterval = 60000) {
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchData();
@@ -74,10 +70,8 @@ export function useSummary(autoRefresh = false, refreshInterval = 60000) {
   const [error, setError] = useState(null);
   const intervalRef = useRef(null);
 
-  const token = localStorage.getItem('adminToken');
-
   const fetchData = useCallback(async () => {
-    if (!token) {
+    if (!localStorage.getItem('adminUser')) {
       setError('Not authenticated');
       setLoading(false);
       return;
@@ -85,9 +79,7 @@ export function useSummary(autoRefresh = false, refreshInterval = 60000) {
 
     try {
       const res = await fetch(`${API_URL}/api/v1/command-center/summary`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
+        credentials: 'include',
       });
 
       if (!res.ok) {
@@ -102,7 +94,7 @@ export function useSummary(autoRefresh = false, refreshInterval = 60000) {
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchData();
@@ -131,10 +123,8 @@ export function useResourceStatuses(autoRefresh = false, refreshInterval = 30000
   const [error, setError] = useState(null);
   const intervalRef = useRef(null);
 
-  const token = localStorage.getItem('adminToken');
-
   const fetchData = useCallback(async () => {
-    if (!token) {
+    if (!localStorage.getItem('adminUser')) {
       setError('Not authenticated');
       setLoading(false);
       return;
@@ -142,9 +132,7 @@ export function useResourceStatuses(autoRefresh = false, refreshInterval = 30000
 
     try {
       const res = await fetch(`${API_URL}/api/v1/command-center/resources`, {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
+        credentials: 'include',
       });
 
       if (!res.ok) {
@@ -160,7 +148,7 @@ export function useResourceStatuses(autoRefresh = false, refreshInterval = 30000
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchData();

--- a/frontend/src/hooks/useFulfillmentStatus.js
+++ b/frontend/src/hooks/useFulfillmentStatus.js
@@ -30,14 +30,13 @@ export function useFulfillmentStatus(orderId) {
     setError(null);
 
     try {
-      const token = localStorage.getItem('adminToken');
       const response = await fetch(
         `${API_URL}/api/v1/sales-orders/${orderId}/fulfillment-status`,
         {
           headers: {
-            'Authorization': token ? `Bearer ${token}` : '',
             'Content-Type': 'application/json',
           },
+          credentials: 'include',
         }
       );
 

--- a/frontend/src/hooks/useItemDemand.js
+++ b/frontend/src/hooks/useItemDemand.js
@@ -29,12 +29,11 @@ export function useItemDemand(itemId) {
     setError(null);
 
     try {
-      const token = localStorage.getItem('adminToken');
       const response = await fetch(`${API_URL}/api/v1/items/${itemId}/demand-summary`, {
         headers: {
-          'Authorization': token ? `Bearer ${token}` : '',
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
 
       if (!response.ok) {
@@ -116,15 +115,14 @@ export function useMultipleItemDemands(itemIds) {
       setError(null);
 
       try {
-        const token = localStorage.getItem('adminToken');
         const results = await Promise.all(
           itemIds.map(async (id) => {
             try {
               const response = await fetch(`${API_URL}/api/v1/items/${id}/demand-summary`, {
                 headers: {
-                  'Authorization': token ? `Bearer ${token}` : '',
                   'Content-Type': 'application/json',
                 },
+                credentials: 'include',
               });
               if (!response.ok) return null;
               return response.json();

--- a/frontend/src/hooks/useResources.js
+++ b/frontend/src/hooks/useResources.js
@@ -15,11 +15,9 @@ export function useResources(workCenterId = null) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const token = localStorage.getItem('adminToken');
-
   useEffect(() => {
     const fetchResources = async () => {
-      if (!token) {
+      if (!localStorage.getItem('adminUser')) {
         setError('Not authenticated');
         setLoading(false);
         return;
@@ -33,11 +31,11 @@ export function useResources(workCenterId = null) {
           const [resourcesRes, printersRes] = await Promise.all([
             fetch(
               `${API_URL}/api/v1/work-centers/${workCenterId}/resources`,
-              { headers: { Authorization: `Bearer ${token}` } }
+              { credentials: 'include' }
             ),
             fetch(
               `${API_URL}/api/v1/work-centers/${workCenterId}/printers`,
-              { headers: { Authorization: `Bearer ${token}` } }
+              { credentials: 'include' }
             )
           ]);
 
@@ -64,7 +62,7 @@ export function useResources(workCenterId = null) {
           // Fetch all work centers and extract resources + printers
           const res = await fetch(
             `${API_URL}/api/v1/work-centers/`,
-            { headers: { Authorization: `Bearer ${token}` } }
+            { credentials: 'include' }
           );
 
           if (!res.ok) throw new Error('Failed to fetch work centers');
@@ -77,11 +75,11 @@ export function useResources(workCenterId = null) {
               const [wcResources, wcPrinters] = await Promise.all([
                 fetch(
                   `${API_URL}/api/v1/work-centers/${wc.id}/resources`,
-                  { headers: { Authorization: `Bearer ${token}` } }
+                  { credentials: 'include' }
                 ).then(r => r.ok ? r.json() : []),
                 fetch(
                   `${API_URL}/api/v1/work-centers/${wc.id}/printers`,
-                  { headers: { Authorization: `Bearer ${token}` } }
+                  { credentials: 'include' }
                 ).then(r => r.ok ? r.json() : [])
               ]);
 
@@ -120,7 +118,7 @@ export function useResources(workCenterId = null) {
     };
 
     fetchResources();
-  }, [token, workCenterId]);
+  }, [workCenterId]);
 
   return { resources, loading, error };
 }
@@ -136,8 +134,6 @@ export function useResourceConflicts(resourceId, startTime, endTime) {
   const [conflicts, setConflicts] = useState([]);
   const [checking, setChecking] = useState(false);
   const [error, setError] = useState(null);
-
-  const token = localStorage.getItem('adminToken');
 
   useEffect(() => {
     const checkConflicts = async () => {
@@ -158,7 +154,7 @@ export function useResourceConflicts(resourceId, startTime, endTime) {
 
         const res = await fetch(
           `${API_URL}/api/v1/scheduling/resource-conflicts?${params}`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: 'include' }
         );
 
         if (res.ok) {
@@ -183,7 +179,7 @@ export function useResourceConflicts(resourceId, startTime, endTime) {
     // Debounce the conflict check
     const timer = setTimeout(checkConflicts, 300);
     return () => clearTimeout(timer);
-  }, [token, resourceId, startTime, endTime]);
+  }, [resourceId, startTime, endTime]);
 
   return { conflicts, checking, error, hasConflicts: conflicts.length > 0 };
 }

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,6 +1,8 @@
 /**
  * Fetch wrapper with auth, JSON parsing, retries, and typed errors.
- * Usage: const api = createApiClient({ baseUrl: API_URL, getToken: () => localStorage.getItem('adminToken') });
+ *
+ * Auth: Uses httpOnly cookies (credentials: 'include'). No manual token handling.
+ * Usage: const api = createApiClient({ baseUrl: API_URL });
  */
 import { emit } from "./events";
 
@@ -19,17 +21,12 @@ export class ApiError extends Error {
 /**
  * @typedef {Object} ApiConfig
  * @property {string} baseUrl
- * @property {() => string|null} [getToken]
  * @property {() => (void|Promise<void>)} [onUnauthorized]
  * @property {(err:ApiError)=>void} [onError]
  * @property {Record<string,string>} [defaultHeaders]
  */
 export function createApiClient(/** @type {ApiConfig} */ cfg) {
   const base = cfg.baseUrl.replace(/\/+$/, "");
-  const getAuth = () => {
-    const t = cfg.getToken?.();
-    return t ? { Authorization: `Bearer ${t}` } : {};
-  };
 
   /** @param {RequestInit & {json?: any, retry?: number}} init */
   async function doFetch(
@@ -43,7 +40,6 @@ export function createApiClient(/** @type {ApiConfig} */ cfg) {
       Accept: "application/json",
       ...(init.json !== undefined ? { "Content-Type": "application/json" } : {}),
       ...(cfg.defaultHeaders || {}),
-      ...getAuth(),
       ...(init.headers || {}),
     };
     const retry = Math.max(0, init.retry ?? 2);
@@ -52,6 +48,7 @@ export function createApiClient(/** @type {ApiConfig} */ cfg) {
     while (true) {
       const res = await fetch(url, {
         ...init,
+        credentials: "include",
         headers,
         body: init.json !== undefined ? JSON.stringify(init.json) : init.body,
       }).catch((e) => ({
@@ -60,11 +57,9 @@ export function createApiClient(/** @type {ApiConfig} */ cfg) {
         text: async () => String(e?.message || "Network error"),
       }));
 
-      // 401: optional handler (token refresh hook point)
+      // 401: clear auth state and redirect to login
       if (res.status === 401 && cfg.onUnauthorized) {
         await cfg.onUnauthorized();
-        // update auth header and retry once
-        Object.assign(headers, getAuth());
       }
 
       if (res.ok) {

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -156,16 +156,13 @@ export default function Onboarding() {
         throw new Error(data.detail || "Setup failed");
       }
 
-      // Store the token - user is now logged in
-      localStorage.setItem("access_token", data.access_token);
-      localStorage.setItem("adminToken", data.access_token); // Also store as adminToken for consistency
-
       // Fetch and store user data so AdminLayout knows the user is an admin
       try {
         const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
-          headers: {
-            Authorization: `Bearer ${data.access_token}`,
-          },
+          credentials: "include",
+          headers: data.access_token
+            ? { Authorization: `Bearer ${data.access_token}` }
+            : {},
         });
         if (meRes.ok) {
           const userData = await meRes.json();
@@ -195,13 +192,10 @@ export default function Onboarding() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("access_token");
       const res = await fetch(`${API_URL}/api/v1/setup/seed-example-data`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
       });
 
       const data = await res.json();
@@ -230,15 +224,12 @@ export default function Onboarding() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("access_token");
       const formData = new FormData();
       formData.append("file", productsFile);
 
       const res = await fetch(`${API_URL}/api/v1/items/import`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
         body: formData,
       });
 
@@ -268,15 +259,12 @@ export default function Onboarding() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("access_token");
       const formData = new FormData();
       formData.append("file", customersFile);
 
       const res = await fetch(`${API_URL}/api/v1/admin/customers/import`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
         body: formData,
       });
 
@@ -306,7 +294,6 @@ export default function Onboarding() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("access_token");
       const formData = new FormData();
       formData.append("file", ordersFile);
 
@@ -315,12 +302,10 @@ export default function Onboarding() {
       params.set("source", ordersSource);
 
       const url = `${API_URL}/api/v1/admin/orders/import?${params}`;
-      
+
       const res = await fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
         body: formData,
       });
 
@@ -356,15 +341,12 @@ export default function Onboarding() {
     setError(null);
 
     try {
-      const token = localStorage.getItem("access_token");
       const formData = new FormData();
       formData.append("file", inventoryFile);
 
       const res = await fetch(`${API_URL}/api/v1/admin/import/inventory`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
         body: formData,
       });
 

--- a/frontend/src/pages/Setup.jsx
+++ b/frontend/src/pages/Setup.jsx
@@ -88,6 +88,7 @@ export default function Setup() {
     try {
       const res = await fetch(`${API_URL}/api/v1/setup/initial-admin`, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: formData.email,
@@ -103,15 +104,14 @@ export default function Setup() {
         throw new Error(data.detail || "Setup failed");
       }
 
-      // Store the token - user is now logged in
-      localStorage.setItem("adminToken", data.access_token);
-
+      // Token is now in an httpOnly cookie (or in body for header mode)
       // Fetch and store user data so AdminLayout knows the user is an admin
       try {
         const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
-          headers: {
-            Authorization: `Bearer ${data.access_token}`,
-          },
+          credentials: "include",
+          headers: data.access_token
+            ? { Authorization: `Bearer ${data.access_token}` }
+            : {},
         });
         if (meRes.ok) {
           const userData = await meRes.json();

--- a/frontend/src/pages/admin/AdminAccounting.jsx
+++ b/frontend/src/pages/admin/AdminAccounting.jsx
@@ -10,7 +10,6 @@ import PeriodsTab from "../../components/accounting/PeriodsTab";
 
 export default function AdminAccounting() {
   const [activeTab, setActiveTab] = useState("dashboard");
-  const token = localStorage.getItem("adminToken");
   const { isPro, isEnterprise } = useFeatureFlags();
 
   const tabs = [
@@ -191,13 +190,13 @@ export default function AdminAccounting() {
       </div>
 
       {/* Tab Content */}
-      {activeTab === "dashboard" && <DashboardTab token={token} />}
-      {activeTab === "sales" && <SalesJournalTab token={token} />}
-      {activeTab === "payments" && <PaymentsTab token={token} />}
-      {activeTab === "cogs" && <COGSTab token={token} />}
-      {activeTab === "tax" && <TaxCenterTab token={token} />}
-      {activeTab === "glreports" && <GLReportsTab token={token} />}
-      {activeTab === "periods" && <PeriodsTab token={token} />}
+      {activeTab === "dashboard" && <DashboardTab />}
+      {activeTab === "sales" && <SalesJournalTab />}
+      {activeTab === "payments" && <PaymentsTab />}
+      {activeTab === "cogs" && <COGSTab />}
+      {activeTab === "tax" && <TaxCenterTab />}
+      {activeTab === "glreports" && <GLReportsTab />}
+      {activeTab === "periods" && <PeriodsTab />}
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminAnalytics.jsx
+++ b/frontend/src/pages/admin/AdminAnalytics.jsx
@@ -15,18 +15,10 @@ const AdminAnalytics = () => {
     setLoading(true);
     setError(null);
     try {
-      const token = localStorage.getItem("access_token");
-      if (!token) {
-        setLoading(false);
-        return;
-      }
-
       const response = await fetch(
         `${API_URL}/api/v1/admin/analytics/dashboard?days=${days}`,
         {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/pages/admin/AdminBOM.jsx
+++ b/frontend/src/pages/admin/AdminBOM.jsx
@@ -24,7 +24,6 @@ export default function AdminBOM() {
     active: searchParams.get("active") || "all",
   });
 
-  const token = localStorage.getItem("adminToken");
   const productId = searchParams.get("product");
   const quotedQuantity = searchParams.get("quantity");
   const quoteId = searchParams.get("quote_id");
@@ -33,8 +32,6 @@ export default function AdminBOM() {
   const [quoteContext, setQuoteContext] = useState(null);
 
   const fetchBOMs = useCallback(async () => {
-    if (!token) return;
-
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -43,7 +40,7 @@ export default function AdminBOM() {
         params.set("active", filters.active === "active");
 
       const res = await fetch(`${API_URL}/api/v1/admin/bom?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to fetch BOMs");
@@ -55,7 +52,7 @@ export default function AdminBOM() {
     } finally {
       setLoading(false);
     }
-  }, [token, filters]);
+  }, [filters]);
 
   useEffect(() => {
     fetchBOMs();
@@ -66,7 +63,7 @@ export default function AdminBOM() {
     async (bomId) => {
       try {
         const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         });
 
         if (!res.ok) throw new Error("Failed to fetch BOM details");
@@ -81,7 +78,7 @@ export default function AdminBOM() {
         setError(`Failed to load BOM: ${err.message || "Unknown error"}`);
       }
     },
-    [token]
+    []
   );
 
   // Track whether URL-driven auto-open has been performed
@@ -128,7 +125,7 @@ export default function AdminBOM() {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {
@@ -149,7 +146,7 @@ export default function AdminBOM() {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}/copy`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {
@@ -356,7 +353,6 @@ export default function AdminBOM() {
                 fetchBOMs();
                 handleViewBOM(selectedBOM.id);
               }}
-              token={token}
               onCreateProductionOrder={handleCreateProductionOrder}
             />
           )}
@@ -394,7 +390,6 @@ export default function AdminBOM() {
                 setProductionBOM(null);
                 setQuoteContext(null);
               }}
-              token={token}
               onSuccess={handleProductionOrderCreated}
             />
           )}
@@ -424,7 +419,6 @@ export default function AdminBOM() {
               fetchBOMs();
               handleViewBOM(newBom.id);
             }}
-            token={token}
             existingBoms={boms}
           />
         </div>

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -26,8 +26,6 @@ export default function AdminCustomers() {
   const [viewingCustomer, setViewingCustomer] = useState(null);
   const [showImportModal, setShowImportModal] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   // Check for action=new parameter and open modal
   useEffect(() => {
     const action = searchParams.get("action");
@@ -51,7 +49,6 @@ export default function AdminCustomers() {
   }, [filters.status]);
 
   const fetchCustomers = async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -59,7 +56,7 @@ export default function AdminCustomers() {
       if (filters.status !== "all") params.set("status", filters.status);
 
       const res = await fetch(`${API_URL}/api/v1/admin/customers?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch customers");
       const data = await res.json();
@@ -104,8 +101,8 @@ export default function AdminCustomers() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(customerData),
@@ -152,7 +149,7 @@ export default function AdminCustomers() {
       const res = await fetch(
         `${API_URL}/api/v1/admin/customers/${customerId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) throw new Error("Failed to fetch customer details");
@@ -170,7 +167,7 @@ export default function AdminCustomers() {
       const res = await fetch(
         `${API_URL}/api/v1/admin/customers/${customerId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) throw new Error("Failed to fetch customer details");

--- a/frontend/src/pages/admin/AdminCycleCount.jsx
+++ b/frontend/src/pages/admin/AdminCycleCount.jsx
@@ -43,9 +43,6 @@ export default function AdminCycleCount() {
   }, [filters.location_id, filters.category_id, filters.show_zero]);
 
   const fetchInventorySummary = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     try {
       setLoading(true);
       const params = new URLSearchParams();
@@ -60,7 +57,7 @@ export default function AdminCycleCount() {
       const res = await fetch(
         `${API_URL}/api/v1/admin/inventory/transactions/inventory-summary?${params.toString()}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -75,14 +72,11 @@ export default function AdminCycleCount() {
   };
 
   const fetchLocations = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/inventory/transactions/locations`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -144,9 +138,6 @@ export default function AdminCycleCount() {
   };
 
   const handleSubmit = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     // Build items array from entries that have changes
     const items = [];
     for (const [productId, value] of Object.entries(countEntries)) {
@@ -183,8 +174,8 @@ export default function AdminCycleCount() {
         `${API_URL}/api/v1/admin/inventory/transactions/batch`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -26,14 +26,11 @@ export default function AdminDashboard() {
   }, [salesPeriod]);
 
   const fetchSalesData = async (period) => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     setSalesLoading(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/dashboard/sales-trend?period=${period}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -55,13 +52,6 @@ export default function AdminDashboard() {
   };
 
   const fetchDashboardData = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) {
-      setError("Authentication required");
-      setLoading(false);
-      return;
-    }
-
     try {
       setLoading(true);
 
@@ -69,7 +59,7 @@ export default function AdminDashboard() {
       const summaryRes = await fetch(
         `${API_URL}/api/v1/admin/dashboard/summary`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -81,7 +71,7 @@ export default function AdminDashboard() {
       const ordersRes = await fetch(
         `${API_URL}/api/v1/admin/dashboard/recent-orders?limit=5`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -94,7 +84,7 @@ export default function AdminDashboard() {
       const posRes = await fetch(
         `${API_URL}/api/v1/purchase-orders?status=draft,ordered&limit=5`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -35,9 +35,6 @@ export default function AdminInventoryTransactions() {
   }, [filters]);
 
   const fetchTransactions = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     try {
       setLoading(true);
       const params = new URLSearchParams();
@@ -50,7 +47,7 @@ export default function AdminInventoryTransactions() {
       const res = await fetch(
         `${API_URL}/api/v1/admin/inventory/transactions?${params.toString()}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -80,14 +77,11 @@ export default function AdminInventoryTransactions() {
   };
 
   const fetchLocations = async () => {
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
-
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/inventory/transactions/locations`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -102,8 +96,6 @@ export default function AdminInventoryTransactions() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const token = localStorage.getItem("adminToken");
-    if (!token) return;
 
     try {
       const payload = {
@@ -129,8 +121,8 @@ export default function AdminInventoryTransactions() {
         `${API_URL}/api/v1/admin/inventory/transactions`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(payload),

--- a/frontend/src/pages/admin/AdminItems.jsx
+++ b/frontend/src/pages/admin/AdminItems.jsx
@@ -84,16 +84,13 @@ export default function AdminItems() {
   const [categoryToDelete, setCategoryToDelete] = useState(null);
   const [showRecostConfirm, setShowRecostConfirm] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   const fetchCategories = useCallback(async () => {
-    if (!token) return;
     try {
       // Fetch flat list
       const res = await fetch(
         `${API_URL}/api/v1/items/categories?include_inactive=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) throw new Error("Failed to fetch categories");
@@ -102,7 +99,7 @@ export default function AdminItems() {
 
       // Fetch tree structure
       const treeRes = await fetch(`${API_URL}/api/v1/items/categories/tree`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (treeRes.ok) {
         const treeData = await treeRes.json();
@@ -111,14 +108,13 @@ export default function AdminItems() {
     } catch {
       // Category fetch failure is non-critical - category tree will just be empty
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchCategories();
   }, [fetchCategories]);
 
   const fetchItems = useCallback(async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -134,7 +130,7 @@ export default function AdminItems() {
       if (filters.search) params.set("search", filters.search);
 
       const res = await fetch(`${API_URL}/api/v1/items?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch items");
       const data = await res.json();
@@ -146,7 +142,6 @@ export default function AdminItems() {
       setLoading(false);
     }
   }, [
-    token,
     pagination.pageSize,
     pagination.page,
     filters.activeOnly,
@@ -309,7 +304,7 @@ export default function AdminItems() {
         `${API_URL}/api/v1/items/categories/${categoryToDelete.id}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) {
@@ -338,8 +333,8 @@ export default function AdminItems() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(catData),
@@ -420,8 +415,8 @@ export default function AdminItems() {
         `${API_URL}/api/v1/inventory/adjust-quantity?${params}`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -478,8 +473,8 @@ export default function AdminItems() {
     try {
       const res = await fetch(`${API_URL}/api/v1/items/bulk-update`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -520,7 +515,7 @@ export default function AdminItems() {
 
       const res = await fetch(`${API_URL}/api/v1/items/recost-all?${params}`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {

--- a/frontend/src/pages/admin/AdminLocations.jsx
+++ b/frontend/src/pages/admin/AdminLocations.jsx
@@ -20,21 +20,18 @@ export default function AdminLocations() {
   const [editingLocation, setEditingLocation] = useState(null);
   const [includeInactive, setIncludeInactive] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchLocations();
   }, [includeInactive]);
 
   const fetchLocations = async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
       if (includeInactive) params.set("include_inactive", "true");
 
       const res = await fetch(`${API_URL}/api/v1/admin/locations?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch locations");
       const data = await res.json();
@@ -67,8 +64,8 @@ export default function AdminLocations() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(locationData),
@@ -100,7 +97,7 @@ export default function AdminLocations() {
         `${API_URL}/api/v1/admin/locations/${location.id}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -122,8 +119,8 @@ export default function AdminLocations() {
         `${API_URL}/api/v1/admin/locations/${location.id}`,
         {
           method: "PUT",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ active: true }),

--- a/frontend/src/pages/admin/AdminLogin.jsx
+++ b/frontend/src/pages/admin/AdminLogin.jsx
@@ -59,6 +59,7 @@ export default function AdminLogin() {
 
       const res = await fetch(`${API_URL}/api/v1/auth/login`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
@@ -72,18 +73,26 @@ export default function AdminLogin() {
 
       const data = await res.json();
 
-      // Verify this is an admin user
-      const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
-        headers: {
-          Authorization: `Bearer ${data.access_token}`,
-        },
-      });
+      // In cookie mode, tokens are in httpOnly cookies — verify user via /me
+      // In header mode (legacy), tokens are in the body
+      let userData;
+      if (data.user) {
+        // Cookie mode: user info returned directly in login response
+        userData = data.user;
+      } else {
+        // Header mode fallback: use access_token to call /me
+        const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
+          credentials: "include",
+          headers: data.access_token
+            ? { Authorization: `Bearer ${data.access_token}` }
+            : {},
+        });
 
-      if (!meRes.ok) {
-        throw new Error("Failed to verify user");
+        if (!meRes.ok) {
+          throw new Error("Failed to verify user");
+        }
+        userData = await meRes.json();
       }
-
-      const userData = await meRes.json();
 
       if (!["admin", "operator"].includes(userData.account_type)) {
         throw new Error(
@@ -91,11 +100,7 @@ export default function AdminLogin() {
         );
       }
 
-      // Store tokens and user data
-      localStorage.setItem("adminToken", data.access_token);
-      if (data.refresh_token) {
-        localStorage.setItem("adminRefreshToken", data.refresh_token);
-      }
+      // Store non-sensitive user info for display (name, role, etc.)
       localStorage.setItem("adminUser", JSON.stringify(userData));
 
       // Redirect to admin dashboard

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -27,8 +27,6 @@ export default function AdminManufacturing() {
   const [routingProductId, setRoutingProductId] = useState(null);
   const [selectedWorkCenter, setSelectedWorkCenter] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   // Fetch both on initial mount so tab badges show correct counts
   useEffect(() => {
     fetchWorkCenters();
@@ -42,7 +40,7 @@ export default function AdminManufacturing() {
       const res = await fetch(
         `${API_URL}/api/v1/work-centers/?active_only=false`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) throw new Error("Failed to fetch work centers");
@@ -59,7 +57,7 @@ export default function AdminManufacturing() {
     setLoading(true);
     try {
       const res = await fetch(`${API_URL}/api/v1/routings/`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch routings");
       const data = await res.json();
@@ -74,7 +72,7 @@ export default function AdminManufacturing() {
   const fetchProducts = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/products?limit=500`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -95,9 +93,9 @@ export default function AdminManufacturing() {
 
       const res = await fetch(url, {
         method: editingWorkCenter ? "PUT" : "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(data),
       });
@@ -124,7 +122,7 @@ export default function AdminManufacturing() {
     try {
       const res = await fetch(`${API_URL}/api/v1/work-centers/${wc.id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to delete");
@@ -144,7 +142,7 @@ export default function AdminManufacturing() {
         `${API_URL}/api/v1/work-centers/resources/${resource.id}`,
         {
           method: "DELETE",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -164,9 +162,9 @@ export default function AdminManufacturing() {
 
       const res = await fetch(url, {
         method: editingResource ? "PUT" : "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(data),
       });
@@ -433,7 +431,6 @@ export default function AdminManufacturing() {
         <ResourceModal
           resource={editingResource}
           workCenter={selectedWorkCenter}
-          token={token}
           onClose={() => {
             setShowResourceModal(false);
             setEditingResource(null);

--- a/frontend/src/pages/admin/AdminMaterialImport.jsx
+++ b/frontend/src/pages/admin/AdminMaterialImport.jsx
@@ -11,8 +11,6 @@ export default function AdminMaterialImport() {
   const [updateExisting, setUpdateExisting] = useState(false);
   const [importCategories, setImportCategories] = useState(true);
 
-  const token = localStorage.getItem("adminToken") || localStorage.getItem("access_token");
-
   const handleDrag = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -51,7 +49,7 @@ export default function AdminMaterialImport() {
   const downloadTemplate = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/materials/import/template`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -96,7 +94,7 @@ export default function AdminMaterialImport() {
       
       const res = await fetch(url, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         body: formData,
       });
 

--- a/frontend/src/pages/admin/AdminOrderImport.jsx
+++ b/frontend/src/pages/admin/AdminOrderImport.jsx
@@ -11,8 +11,6 @@ export default function AdminOrderImport() {
   const [createCustomers, setCreateCustomers] = useState(true);
   const [source, setSource] = useState("manual");
 
-  const token = localStorage.getItem("adminToken") || localStorage.getItem("access_token");
-
   const handleDrag = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -51,7 +49,7 @@ export default function AdminOrderImport() {
   const downloadTemplate = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/orders/import/template`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -94,7 +92,7 @@ export default function AdminOrderImport() {
         `${API_URL}/api/v1/admin/orders/import?${params}`,
         {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
           body: formData,
         }
       );

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -35,8 +35,6 @@ export default function AdminOrders() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deletingOrder, setDeletingOrder] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   // Check if returning from customer/item creation
   useEffect(() => {
     const pendingData = sessionStorage.getItem("pendingOrderData");
@@ -53,8 +51,6 @@ export default function AdminOrders() {
   }, [fulfillmentFilter, sortValue, location.key]);
 
   const fetchOrders = async () => {
-    if (!token) return;
-
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -73,7 +69,7 @@ export default function AdminOrders() {
       if (sortOrder) params.set("sort_order", sortOrder);
 
       const res = await fetch(`${API_URL}/api/v1/sales-orders/?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to fetch orders");
@@ -93,8 +89,8 @@ export default function AdminOrders() {
         `${API_URL}/api/v1/sales-orders/${orderId}/status`,
         {
           method: "PATCH",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ status: newStatus }),
@@ -132,8 +128,8 @@ export default function AdminOrders() {
         `${API_URL}/api/v1/sales-orders/${orderId}/generate-production-orders`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         }
@@ -235,8 +231,8 @@ export default function AdminOrders() {
         `${API_URL}/api/v1/sales-orders/${cancellingOrder.id}/cancel`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ cancellation_reason: cancellationReason }),
@@ -268,9 +264,7 @@ export default function AdminOrders() {
         `${API_URL}/api/v1/sales-orders/${deletingOrder.id}`,
         {
           method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/pages/admin/AdminPasswordResetApproval.jsx
+++ b/frontend/src/pages/admin/AdminPasswordResetApproval.jsx
@@ -1,24 +1,30 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { API_URL } from "../../config/api";
 
 export default function AdminPasswordResetApproval() {
   const { action, token } = useParams();
   const [result, setResult] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [confirmed, setConfirmed] = useState(false);
 
-  useEffect(() => {
-    processApproval();
-  }, [action, token]);
+  const isApprove = action === "approve";
 
   const processApproval = async () => {
+    setLoading(true);
+    setError(null);
     try {
-      const endpoint = action === "approve"
-        ? `${API_URL}/api/v1/auth/password-reset/approve/${token}`
-        : `${API_URL}/api/v1/auth/password-reset/deny/${token}`;
+      const endpoint = isApprove
+        ? `${API_URL}/api/v1/auth/password-reset/approve`
+        : `${API_URL}/api/v1/auth/password-reset/deny`;
 
-      const res = await fetch(endpoint);
+      const res = await fetch(endpoint, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approval_token: token }),
+      });
 
       if (!res.ok) {
         const errData = await res.json();
@@ -27,23 +33,13 @@ export default function AdminPasswordResetApproval() {
 
       const data = await res.json();
       setResult(data);
+      setConfirmed(true);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
   };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-950">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-          <p className="text-gray-400">Processing request...</p>
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -69,53 +65,103 @@ export default function AdminPasswordResetApproval() {
     );
   }
 
-  const isApproved = action === "approve";
+  // Show confirmation result
+  if (confirmed && result) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-950 px-4">
+        <div className="w-full max-w-md text-center">
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-8">
+            <div className={`w-16 h-16 ${isApprove ? 'bg-green-500/20' : 'bg-red-500/20'} rounded-full flex items-center justify-center mx-auto mb-6`}>
+              {isApprove ? (
+                <svg className="w-8 h-8 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              ) : (
+                <svg className="w-8 h-8 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              )}
+            </div>
 
+            <h1 className="text-2xl font-bold text-white mb-4">
+              Password Reset {isApprove ? "Approved" : "Denied"}
+            </h1>
+
+            <div className="bg-gray-800 rounded-lg p-4 mb-6 text-left">
+              <div className="text-sm">
+                <p className="text-gray-400">User Email:</p>
+                <p className="text-white font-medium">{result?.user_email}</p>
+              </div>
+              <div className="text-sm mt-3">
+                <p className="text-gray-400">Status:</p>
+                <p className={`font-medium ${isApprove ? 'text-green-400' : 'text-red-400'}`}>
+                  {result?.status?.toUpperCase()}
+                </p>
+              </div>
+            </div>
+
+            <p className="text-gray-400 mb-6">
+              {isApprove
+                ? "The user has been notified and can now reset their password."
+                : "The user has been notified that their request was denied."}
+            </p>
+
+            <Link
+              to="/admin"
+              className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              Go to Admin Dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Confirmation prompt — ask admin to confirm before making the POST
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-950 px-4">
       <div className="w-full max-w-md text-center">
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-8">
-          <div className={`w-16 h-16 ${isApproved ? 'bg-green-500/20' : 'bg-red-500/20'} rounded-full flex items-center justify-center mx-auto mb-6`}>
-            {isApproved ? (
-              <svg className="w-8 h-8 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-            ) : (
-              <svg className="w-8 h-8 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            )}
+          <div className={`w-16 h-16 ${isApprove ? 'bg-blue-500/20' : 'bg-orange-500/20'} rounded-full flex items-center justify-center mx-auto mb-6`}>
+            <svg className={`w-8 h-8 ${isApprove ? 'text-blue-400' : 'text-orange-400'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
           </div>
 
           <h1 className="text-2xl font-bold text-white mb-4">
-            Password Reset {isApproved ? "Approved" : "Denied"}
+            {isApprove ? "Approve" : "Deny"} Password Reset?
           </h1>
 
-          <div className="bg-gray-800 rounded-lg p-4 mb-6 text-left">
-            <div className="text-sm">
-              <p className="text-gray-400">User Email:</p>
-              <p className="text-white font-medium">{result?.user_email}</p>
-            </div>
-            <div className="text-sm mt-3">
-              <p className="text-gray-400">Status:</p>
-              <p className={`font-medium ${isApproved ? 'text-green-400' : 'text-red-400'}`}>
-                {result?.status?.toUpperCase()}
-              </p>
-            </div>
-          </div>
-
-          <p className="text-gray-400 mb-6">
-            {isApproved
-              ? "The user has been notified and can now reset their password."
-              : "The user has been notified that their request was denied."}
+          <p className="text-gray-400 mb-8">
+            {isApprove
+              ? "This will allow the user to reset their password. They will receive a reset link via email."
+              : "This will deny the password reset request. The user will be notified."}
           </p>
 
-          <Link
-            to="/admin"
-            className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-          >
-            Go to Admin Dashboard
-          </Link>
+          <div className="flex gap-3 justify-center">
+            <Link
+              to="/admin"
+              className="px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            >
+              Cancel
+            </Link>
+            <button
+              onClick={processApproval}
+              disabled={loading}
+              className={`px-6 py-3 text-white rounded-lg font-medium disabled:opacity-50 ${
+                isApprove
+                  ? "bg-green-600 hover:bg-green-700"
+                  : "bg-red-600 hover:bg-red-700"
+              }`}
+            >
+              {loading
+                ? "Processing..."
+                : isApprove
+                  ? "Approve Reset"
+                  : "Deny Reset"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/admin/AdminPayments.jsx
+++ b/frontend/src/pages/admin/AdminPayments.jsx
@@ -36,8 +36,6 @@ const statusColors = {
 
 export default function AdminPayments() {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
-
   // State
   const [loading, setLoading] = useState(true);
   const [dashboard, setDashboard] = useState(null);
@@ -77,7 +75,7 @@ export default function AdminPayments() {
   const fetchDashboard = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/payments/dashboard`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         setDashboard(await res.json());
@@ -104,7 +102,7 @@ export default function AdminPayments() {
       if (filters.toDate) params.append("to_date", filters.toDate);
 
       const res = await fetch(`${API_URL}/api/v1/payments?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {
@@ -130,7 +128,7 @@ export default function AdminPayments() {
     try {
       const res = await fetch(`${API_URL}/api/v1/payments/${paymentId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -50,8 +50,6 @@ export default function AdminPrinters() {
   // Active work tracking
   const [activeWork, setActiveWork] = useState({}); // printer_id -> work info
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchPrinters();
     fetchBrandInfo();
@@ -87,7 +85,7 @@ export default function AdminPrinters() {
       params.set("page_size", "100");
 
       const res = await fetch(`${API_URL}/api/v1/printers?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch printers");
       const data = await res.json();
@@ -102,7 +100,7 @@ export default function AdminPrinters() {
   const fetchBrandInfo = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/brands/info`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -116,7 +114,7 @@ export default function AdminPrinters() {
   const fetchActiveWork = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/active-work`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -131,7 +129,7 @@ export default function AdminPrinters() {
     setMaintenanceLoading(true);
     try {
       const res = await fetch(`${API_URL}/api/v1/maintenance/?page_size=50`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -147,7 +145,7 @@ export default function AdminPrinters() {
   const fetchMaintenanceDue = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/maintenance/due?days_ahead=14`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -170,8 +168,8 @@ export default function AdminPrinters() {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/discover`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ timeout_seconds: 10 }),
@@ -199,8 +197,8 @@ export default function AdminPrinters() {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -246,8 +244,8 @@ export default function AdminPrinters() {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/test-connection`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -266,8 +264,8 @@ export default function AdminPrinters() {
         // Update printer status to idle
         await fetch(`${API_URL}/api/v1/printers/${printer.id}/status`, {
           method: "PATCH",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ status: "idle" }),
@@ -291,7 +289,7 @@ export default function AdminPrinters() {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/${printer.id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to delete printer");
@@ -315,8 +313,8 @@ export default function AdminPrinters() {
     try {
       const res = await fetch(`${API_URL}/api/v1/printers/import-csv`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ csv_data: csvData, skip_duplicates: true }),
@@ -611,7 +609,6 @@ export default function AdminPrinters() {
         <div className="space-y-6">
           {/* IP Probe - works from Docker */}
           <IPProbeSection
-            token={token}
             onPrinterFound={(printer) => {
               setDiscoveredPrinters((prev) => {
                 // Don't add duplicates

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -282,15 +282,12 @@ export default function AdminProduction() {
   const [trendPeriod, setTrendPeriod] = useState("MTD");
   const [trendLoading, setTrendLoading] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   const fetchProductionTrend = useCallback(async (period) => {
-    if (!token) return;
     setTrendLoading(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/dashboard/production-trend?period=${period}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -301,11 +298,9 @@ export default function AdminProduction() {
     } finally {
       setTrendLoading(false);
     }
-  }, [token]);
+  }, []);
 
   const fetchProductionOrders = useCallback(async () => {
-    if (!token) return;
-
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -318,7 +313,7 @@ export default function AdminProduction() {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/?${params}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -331,14 +326,14 @@ export default function AdminProduction() {
     } finally {
       setLoading(false);
     }
-  }, [token, filters.status]);
+  }, [filters.status]);
 
   const fetchProducts = useCallback(async () => {
     try {
       const res = await fetch(
         `${API_URL}/api/v1/products?limit=500&active=true`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -348,7 +343,7 @@ export default function AdminProduction() {
     } catch {
       // Products fetch failure is non-critical - product selector will just be empty
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchProductionOrders();
@@ -384,8 +379,8 @@ export default function AdminProduction() {
     try {
       const res = await fetch(`${API_URL}/api/v1/production-orders/`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({

--- a/frontend/src/pages/admin/AdminPurchasing.jsx
+++ b/frontend/src/pages/admin/AdminPurchasing.jsx
@@ -61,8 +61,6 @@ export default function AdminPurchasing() {
   const [trendPeriod, setTrendPeriod] = useState("MTD");
   const [trendLoading, setTrendLoading] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   // Handle create_po URL param - auto-open PO modal with pre-filled item
   useEffect(() => {
     const createPO = searchParams.get("create_po");
@@ -209,12 +207,11 @@ export default function AdminPurchasing() {
   };
 
   const fetchPurchasingTrend = async (period) => {
-    if (!token) return;
     setTrendLoading(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/dashboard/purchasing-trend?period=${period}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -273,7 +270,7 @@ export default function AdminPurchasing() {
       params.set("limit", "100");
 
       const res = await fetch(`${API_URL}/api/v1/purchase-orders?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch orders");
       const data = await res.json();
@@ -291,7 +288,7 @@ export default function AdminPurchasing() {
     if (showLoading) setLoading(true);
     try {
       const res = await fetch(`${API_URL}/api/v1/vendors?active_only=false`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch vendors");
       const data = await res.json();
@@ -308,7 +305,7 @@ export default function AdminPurchasing() {
   const fetchProducts = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/items?limit=2000`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -327,7 +324,7 @@ export default function AdminPurchasing() {
     setLowStockLoading(true);
     try {
       const res = await fetch(`${API_URL}/api/v1/items/low-stock`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -344,7 +341,7 @@ export default function AdminPurchasing() {
   const fetchCompanySettings = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/settings/company`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -359,7 +356,7 @@ export default function AdminPurchasing() {
   const fetchPODetails = async (poId) => {
     try {
       const res = await fetch(`${API_URL}/api/v1/purchase-orders/${poId}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -387,8 +384,8 @@ export default function AdminPurchasing() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(vendorData),
@@ -413,7 +410,7 @@ export default function AdminPurchasing() {
     try {
       const res = await fetch(`${API_URL}/api/v1/vendors/${vendorId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to delete vendor");
       toast.success("Vendor deleted");
@@ -436,8 +433,8 @@ export default function AdminPurchasing() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(poData),
@@ -463,8 +460,8 @@ export default function AdminPurchasing() {
         `${API_URL}/api/v1/purchase-orders/${poId}/status`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ status: newStatus, ...extraData }),
@@ -492,8 +489,8 @@ export default function AdminPurchasing() {
         `${API_URL}/api/v1/purchase-orders/${selectedPO.id}/receive`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(receiveData),
@@ -528,7 +525,7 @@ export default function AdminPurchasing() {
     try {
       const res = await fetch(`${API_URL}/api/v1/purchase-orders/${poId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -555,8 +552,8 @@ export default function AdminPurchasing() {
         `${API_URL}/api/v1/purchase-orders/${poId}/status`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ status: "cancelled" }),

--- a/frontend/src/pages/admin/AdminQuotes.jsx
+++ b/frontend/src/pages/admin/AdminQuotes.jsx
@@ -28,15 +28,12 @@ export default function AdminQuotes() {
   const [editingQuote, setEditingQuote] = useState(null);
   const [viewingQuote, setViewingQuote] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchQuotes();
     fetchStats();
   }, [filters.status]);
 
   const fetchQuotes = async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -44,7 +41,7 @@ export default function AdminQuotes() {
       if (filters.status !== "all") params.set("status", filters.status);
 
       const res = await fetch(`${API_URL}/api/v1/quotes?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch quotes");
       const data = await res.json();
@@ -57,10 +54,9 @@ export default function AdminQuotes() {
   };
 
   const fetchStats = async () => {
-    if (!token) return;
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/stats`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -91,8 +87,8 @@ export default function AdminQuotes() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(quoteData),
@@ -117,8 +113,8 @@ export default function AdminQuotes() {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}/status`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -148,9 +144,7 @@ export default function AdminQuotes() {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}/convert`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -174,7 +168,7 @@ export default function AdminQuotes() {
   const handleDownloadPDF = async (quote) => {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/pdf`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to generate PDF");
@@ -198,7 +192,7 @@ export default function AdminQuotes() {
   const handlePrintPDF = async (quote) => {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/pdf`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to generate PDF");
@@ -243,8 +237,8 @@ export default function AdminQuotes() {
 
       const res = await fetch(`${API_URL}/api/v1/quotes`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(newQuoteData),
@@ -283,7 +277,7 @@ export default function AdminQuotes() {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -605,7 +599,6 @@ export default function AdminQuotes() {
             setShowQuoteModal(false);
             setEditingQuote(null);
           }}
-          token={token}
         />
       )}
 
@@ -630,7 +623,7 @@ export default function AdminQuotes() {
           onRefresh={async () => {
             // Refresh the viewing quote to get updated has_image flag
             const res = await fetch(`${API_URL}/api/v1/quotes/${viewingQuote.id}`, {
-              headers: { Authorization: `Bearer ${token}` },
+              credentials: "include",
             });
             if (res.ok) {
               const updated = await res.json();

--- a/frontend/src/pages/admin/AdminScrapReasons.jsx
+++ b/frontend/src/pages/admin/AdminScrapReasons.jsx
@@ -10,16 +10,13 @@ export default function AdminScrapReasons() {
   const [showModal, setShowModal] = useState(false);
   const [editingReason, setEditingReason] = useState(null);
 
-  const token = localStorage.getItem("adminToken");
-
   const fetchReasons = useCallback(async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders/scrap-reasons/all`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (!res.ok) throw new Error("Failed to fetch scrap reasons");
@@ -30,7 +27,7 @@ export default function AdminScrapReasons() {
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     fetchReasons();
@@ -54,8 +51,8 @@ export default function AdminScrapReasons() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
@@ -88,7 +85,7 @@ export default function AdminScrapReasons() {
         `${API_URL}/api/v1/production-orders/scrap-reasons/${reason.id}?${params}`,
         {
           method: "PUT",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/pages/admin/AdminSecurity.jsx
+++ b/frontend/src/pages/admin/AdminSecurity.jsx
@@ -116,14 +116,8 @@ const AdminSecurity = () => {
     setError(null);
 
     try {
-      const token = localStorage.getItem("adminToken");
-      if (!token) {
-        setError("Not logged in. Please log in again.");
-        return;
-      }
-
       const response = await fetch(`${API_URL}/api/v1/security/audit`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -149,9 +143,8 @@ const AdminSecurity = () => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/security/audit/export?format=json`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -66,14 +66,8 @@ const AdminSettings = () => {
 
   const fetchSettings = async () => {
     try {
-      const token = localStorage.getItem("adminToken");
-      if (!token) {
-        toast.error("Not logged in. Please log in again.");
-        setLoading(false);
-        return;
-      }
       const response = await fetch(`${API_URL}/api/v1/settings/company`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {
@@ -134,11 +128,10 @@ const AdminSettings = () => {
     setSaving(true);
 
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/company`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -177,10 +170,9 @@ const AdminSettings = () => {
     formData.append("file", file);
 
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/company/logo`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         body: formData,
       });
 
@@ -202,10 +194,9 @@ const AdminSettings = () => {
     if (!confirm("Are you sure you want to delete the company logo?")) return;
 
     try {
-      const token = localStorage.getItem("adminToken");
       const response = await fetch(`${API_URL}/api/v1/settings/company/logo`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (response.ok) {

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -320,8 +320,6 @@ export default function AdminShipping() {
   const [shippingPeriod, setShippingPeriod] = useState("MTD");
   const [trendLoading, setTrendLoading] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchOrders();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -333,12 +331,11 @@ export default function AdminShipping() {
   }, [shippingPeriod]);
 
   const fetchShippingTrend = async (period) => {
-    if (!token) return;
     setTrendLoading(true);
     try {
       const res = await fetch(
         `${API_URL}/api/v1/admin/dashboard/shipping-trend?period=${period}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -371,14 +368,12 @@ export default function AdminShipping() {
   }, [orderIdParam, orders, productionStatus]);
 
   const fetchOrders = async () => {
-    if (!token) return;
-
     setLoading(true);
     try {
       // Fetch orders ready to ship
       const res = await fetch(
         `${API_URL}/api/v1/sales-orders/?status=confirmed&status=in_production&status=ready_to_ship&status=qc_passed&limit=100`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
 
       if (!res.ok) throw new Error("Failed to fetch orders");
@@ -404,7 +399,7 @@ export default function AdminShipping() {
       const today = new Date().toISOString().split("T")[0];
       const res = await fetch(
         `${API_URL}/api/v1/sales-orders/?status=shipped&shipped_after=${today}&limit=100`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -432,11 +427,11 @@ export default function AdminShipping() {
 
   // Batch fetch: one API call for all production orders, group by sales_order_id
   const fetchAllProductionStatuses = async (orderList) => {
-    if (!token || orderList.length === 0) return;
+    if (orderList.length === 0) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders?limit=500`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -463,11 +458,10 @@ export default function AdminShipping() {
 
   // Single order fetch (used for individual refresh)
   const fetchProductionStatus = async (orderId) => {
-    if (!token) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders?sales_order_id=${orderId}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (res.ok) {
         const data = await res.json();
@@ -492,8 +486,8 @@ export default function AdminShipping() {
     try {
       const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}/ship`, {
         method: "POST",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -524,8 +518,8 @@ export default function AdminShipping() {
     try {
       const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}/status`, {
         method: "PATCH",
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ status: "shipped" }),

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -20,8 +20,6 @@ export default function AdminSpools() {
   const [products, setProducts] = useState([]);
   const [locations, setLocations] = useState([]);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchSpools();
     fetchProducts();
@@ -40,7 +38,7 @@ export default function AdminSpools() {
       if (filters.search) params.set("search", filters.search);
 
       const res = await fetch(`${API_URL}/api/v1/spools?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) throw new Error("Failed to fetch spools");
@@ -57,7 +55,7 @@ export default function AdminSpools() {
   const fetchProducts = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/products?type=material&limit=200`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -71,7 +69,7 @@ export default function AdminSpools() {
   const fetchLocations = async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/inventory/locations`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (res.ok) {
         const data = await res.json();
@@ -88,7 +86,7 @@ export default function AdminSpools() {
     try {
       const res = await fetch(`${API_URL}/api/v1/spools/${spoolId}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {
@@ -286,7 +284,6 @@ export default function AdminSpools() {
 
 function SpoolModal({ spool, products, locations, onClose, onSave }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   const [form, setForm] = useState({
     spool_number: spool?.spool_number || "",
     product_id: spool?.product_id || "",
@@ -327,7 +324,7 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
 
       const res = await fetch(`${url}?${params}`, {
         method,
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -45,14 +45,11 @@ export default function AdminUsers() {
   const [savingUser, setSavingUser] = useState(false);
   const [resettingPassword, setResettingPassword] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   useEffect(() => {
     fetchUsers();
   }, [filters.role, filters.includeInactive]);
 
   const fetchUsers = async () => {
-    if (!token) return;
     setLoading(true);
     try {
       const params = new URLSearchParams();
@@ -61,7 +58,7 @@ export default function AdminUsers() {
       if (filters.includeInactive) params.set("include_inactive", "true");
 
       const res = await fetch(`${API_URL}/api/v1/admin/users?${params}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
       if (!res.ok) throw new Error("Failed to fetch users");
       const data = await res.json();
@@ -124,8 +121,8 @@ export default function AdminUsers() {
 
       const res = await fetch(url, {
         method,
+        credentials: "include",
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(userData),
@@ -159,7 +156,7 @@ export default function AdminUsers() {
     try {
       const res = await fetch(`${API_URL}/api/v1/admin/users/${user.id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -181,7 +178,7 @@ export default function AdminUsers() {
         `${API_URL}/api/v1/admin/users/${user.id}/reactivate`,
         {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -207,8 +204,8 @@ export default function AdminUsers() {
         `${API_URL}/api/v1/admin/users/${resetPasswordUser.id}/reset-password`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ new_password: newPassword }),

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -28,7 +28,6 @@ export default function OrderDetail() {
   const { orderId } = useParams();
   const navigate = useNavigate();
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
 
   const [order, setOrder] = useState(null);
   const [materialRequirements, setMaterialRequirements] = useState([]);
@@ -91,12 +90,6 @@ export default function OrderDetail() {
   }, [orderId]);
 
   const fetchOrder = async () => {
-    if (!token) {
-      setError("Not authenticated. Please log in.");
-      setLoading(false);
-      return;
-    }
-
     setLoading(true);
     setError(null);
 
@@ -104,7 +97,7 @@ export default function OrderDetail() {
 
     try {
       const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
         cache: "no-cache",
       });
 
@@ -134,7 +127,7 @@ export default function OrderDetail() {
           const quoteRes = await fetch(
             `${API_URL}/api/v1/quotes/${data.quote_id}`,
             {
-              headers: { Authorization: `Bearer ${token}` },
+              credentials: "include",
             }
           );
           if (quoteRes.ok) {
@@ -163,12 +156,12 @@ export default function OrderDetail() {
   };
 
   const fetchProductionOrders = async () => {
-    if (!token || !orderId) return;
+    if (!orderId) return;
     try {
       const res = await fetch(
         `${API_URL}/api/v1/production-orders?sales_order_id=${orderId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
       if (res.ok) {
@@ -181,11 +174,11 @@ export default function OrderDetail() {
   };
 
   const fetchPaymentData = async () => {
-    if (!token || !orderId) return;
+    if (!orderId) return;
     try {
       const summaryRes = await fetch(
         `${API_URL}/api/v1/payments/order/${orderId}/summary`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (summaryRes.ok) {
         setPaymentSummary(await summaryRes.json());
@@ -193,7 +186,7 @@ export default function OrderDetail() {
 
       const paymentsRes = await fetch(
         `${API_URL}/api/v1/payments?order_id=${orderId}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: "include" }
       );
       if (paymentsRes.ok) {
         const data = await paymentsRes.json();
@@ -235,7 +228,7 @@ export default function OrderDetail() {
       const matReqRes = await fetch(
         `${API_URL}/api/v1/sales-orders/${orderId}/material-requirements`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -264,7 +257,7 @@ export default function OrderDetail() {
         const res = await fetch(
           `${API_URL}/api/v1/mrp/requirements?product_id=${productId}`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 
@@ -304,7 +297,7 @@ export default function OrderDetail() {
           const bomRes = await fetch(
             `${API_URL}/api/v1/mrp/explode-bom/${productId}?quantity=${quantity}`,
             {
-              headers: { Authorization: `Bearer ${token}` },
+              credentials: "include",
             }
           );
 
@@ -334,7 +327,7 @@ export default function OrderDetail() {
         const routingRes = await fetch(
           `${API_URL}/api/v1/routings/product/${productId}`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           }
         );
 
@@ -382,9 +375,9 @@ export default function OrderDetail() {
         `${API_URL}/api/v1/sales-orders/${orderId}/generate-production-orders`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
           },
         }
       );
@@ -412,9 +405,9 @@ export default function OrderDetail() {
     try {
       const res = await fetch(`${API_URL}/api/v1/production-orders`, {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           product_id: materialReq.product_id,
@@ -447,8 +440,8 @@ export default function OrderDetail() {
         `${API_URL}/api/v1/sales-orders/${orderId}/cancel`,
         {
           method: "POST",
+          credentials: "include",
           headers: {
-            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ cancellation_reason: cancellationReason }),
@@ -472,9 +465,7 @@ export default function OrderDetail() {
     try {
       const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
 
       if (res.ok || res.status === 204) {
@@ -529,7 +520,7 @@ export default function OrderDetail() {
             const res = await fetch(
               `${API_URL}/api/v1/production-orders/${po.id}/material-availability`,
               {
-                headers: { Authorization: `Bearer ${token}` },
+                credentials: "include",
               }
             );
             if (res.ok) {

--- a/frontend/src/pages/admin/ProductionOrderDetail.jsx
+++ b/frontend/src/pages/admin/ProductionOrderDetail.jsx
@@ -23,15 +23,14 @@ import {
  */
 function OperationsTimelineWrapper({ productionOrderId }) {
   const [operations, setOperations] = useState([]);
-  const token = localStorage.getItem('adminToken');
 
   useEffect(() => {
     const fetchOps = async () => {
-      if (!token || !productionOrderId) return;
+      if (!productionOrderId) return;
       try {
         const res = await fetch(
           `${API_URL}/api/v1/production-orders/${productionOrderId}/operations`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { credentials: "include" }
         );
         if (res.ok) {
           const data = await res.json();
@@ -42,7 +41,7 @@ function OperationsTimelineWrapper({ productionOrderId }) {
       }
     };
     fetchOps();
-  }, [productionOrderId, token]);
+  }, [productionOrderId]);
 
   if (operations.length === 0) return null;
 
@@ -53,7 +52,6 @@ export default function ProductionOrderDetail() {
   const { orderId } = useParams();
   const navigate = useNavigate();
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
 
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -70,18 +68,12 @@ export default function ProductionOrderDetail() {
   }, [orderId]);
 
   const fetchOrder = async () => {
-    if (!token) {
-      setError("Not authenticated. Please log in.");
-      setLoading(false);
-      return;
-    }
-
     setLoading(true);
     setError(null);
 
     try {
       const res = await fetch(`${API_URL}/api/v1/production-orders/${orderId}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (!res.ok) {
@@ -104,7 +96,7 @@ export default function ProductionOrderDetail() {
         `${API_URL}/api/v1/production-orders/${orderId}/${action}`,
         {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 

--- a/frontend/src/pages/admin/quality/MaterialTraceability.jsx
+++ b/frontend/src/pages/admin/quality/MaterialTraceability.jsx
@@ -15,8 +15,6 @@ export default function MaterialTraceability() {
   const [spools, setSpools] = useState([]);
   const [loadingSpools, setLoadingSpools] = useState(false);
 
-  const token = localStorage.getItem("adminToken");
-
   // Fetch spools for forward trace
   useEffect(() => {
     if (activeTab === "forward" && spools.length === 0) {
@@ -24,7 +22,7 @@ export default function MaterialTraceability() {
         setLoadingSpools(true);
         try {
           const res = await fetch(`${API_URL}/api/v1/spools?limit=200`, {
-            headers: { Authorization: `Bearer ${token}` },
+            credentials: "include",
           });
           const data = await res.json();
           // Handle error responses and ensure we always set an array
@@ -43,7 +41,7 @@ export default function MaterialTraceability() {
       };
       fetchSpools();
     }
-  }, [activeTab, token, spools.length]);
+  }, [activeTab, spools.length]);
 
   return (
     <div className="space-y-6 p-6">
@@ -90,7 +88,6 @@ export default function MaterialTraceability() {
  */
 function ForwardTrace({ spools, loadingSpools }) {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   const [spoolId, setSpoolId] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState(null);
@@ -109,7 +106,7 @@ function ForwardTrace({ spools, loadingSpools }) {
       const res = await fetch(
         `${API_URL}/api/v1/traceability/forward/spool/${spoolId}`,
         {
-          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
         }
       );
 
@@ -298,7 +295,6 @@ function ForwardTrace({ spools, loadingSpools }) {
  */
 function BackwardTrace() {
   const toast = useToast();
-  const token = localStorage.getItem("adminToken");
   const [traceType, setTraceType] = useState("serial");
   const [searchValue, setSearchValue] = useState("");
   const [loading, setLoading] = useState(false);
@@ -321,7 +317,7 @@ function BackwardTrace() {
           : `/api/v1/traceability/backward/sales-order/${searchValue}`;
 
       const res = await fetch(`${API_URL}${endpoint}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: "include",
       });
 
       if (res.ok) {


### PR DESCRIPTION
## Summary

- **httpOnly cookie auth** — Auth tokens stored in httpOnly cookies (`SameSite=Lax`, `Secure` configurable) instead of localStorage, preventing XSS token theft
- **`AUTH_MODE` env var** — `cookie` (default) or `header` (legacy Bearer-in-body) for rollback safety
- **Password reset endpoints changed from GET to POST** — prevents CSRF and browser prefetch side effects
- **Rate limiting** added to `/auth/refresh` and password reset approve/deny endpoints (10/min)
- **Server-side refresh token revocation** on logout
- **All 70+ frontend components** migrated from manual `Authorization: Bearer` header to `credentials: "include"`

Closes #188, closes #167

## Breaking Changes

- Auth tokens are **no longer returned** in login/register response body (cookie mode). Set `AUTH_MODE=header` to restore old behavior.
- `GET /api/v1/auth/password-reset/approve/{token}` → `POST /api/v1/auth/password-reset/approve` (token in JSON body)
- `GET /api/v1/auth/password-reset/deny/{token}` → `POST /api/v1/auth/password-reset/deny` (token in JSON body)
- Outstanding password reset emails with old GET-style URLs will stop working

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `COOKIE_SECURE` | `false` | Set `true` in production (requires HTTPS) |
| `AUTH_MODE` | `cookie` | `cookie` = httpOnly cookies, `header` = legacy Bearer tokens in body |

## Rollback Procedure

1. Set `AUTH_MODE=header` in `.env`
2. Restart backend
3. Users may need to re-login

## Test Plan

- [x] 4503 backend tests pass (7 new cookie-mode tests)
- [x] Frontend builds successfully (Vite)
- [x] Zero remaining `adminToken`/`adminRefreshToken` localStorage references
- [ ] Manual: verify `document.cookie` doesn't expose auth tokens in browser console
- [ ] Manual: verify login sets httpOnly cookie (DevTools → Application → Cookies)
- [ ] Manual: verify 429 on rapid refresh endpoint calls
- [ ] Manual: verify `GET /password-reset/approve` returns 405

## Files Changed

**Backend (9 files):** deps.py, auth.py, setup.py, security.py, settings.py, schemas/auth.py, .env.example, test_auth.py, test_settings_auth_printers.py

**Frontend (96 files):** All components, pages, hooks, and API clients migrated from `Authorization: Bearer ${token}` to `credentials: "include"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/logout` endpoint to clear authentication sessions server-side
  * Implemented rate limiting (10/minute) on token refresh and password reset endpoints

* **Security**
  * Auth tokens now stored in secure httpOnly cookies with SameSite=Lax protection instead of localStorage
  * Added server-side refresh token revocation on logout
  * Bearer token authentication still supported for programmatic API access

* **Changed**
  * Password reset approval/denial endpoints changed from GET to POST requests with JSON body
  * Auth tokens no longer returned in login/register response bodies when using cookie mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->