### PR TITLE
infra: runtime API URL, CI audits, rate limiting

### DIFF
--- a/.github/workflows/filaops-ci.yml
+++ b/.github/workflows/filaops-ci.yml
@@ -46,6 +46,13 @@ jobs:
           python -m pip install -U pip
           pip install -r requirements.txt
 
+      - name: Security audit (pip-audit)
+        working-directory: backend
+        run: |
+          pip install pip-audit
+          pip-audit --strict --ignore-vuln PYSEC-2024-XXX || true
+        continue-on-error: true
+
       - name: Wait for Postgres
         run: |
           for i in {1..30}; do
@@ -100,6 +107,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install
         run: npm ci
+      - name: Security audit (npm)
+        run: npm audit --audit-level=high || true
+        continue-on-error: true
       - name: Build (development mode)
         run: npm run build
         env:

--- a/backend/app/api/v1/endpoints/admin/data_import.py
+++ b/backend/app/api/v1/endpoints/admin/data_import.py
@@ -3,11 +3,12 @@ Import functionality for products, inventory
 
 Business logic lives in ``app.services.data_import_service``.
 """
-from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.api.v1.deps import get_current_staff_user
+from app.core.limiter import limiter
 from app.models.user import User
 from app.services import data_import_service as svc
 
@@ -41,7 +42,9 @@ async def _read_csv_upload(file: UploadFile) -> str:
 
 
 @router.post("/products")
+@limiter.limit("30/minute")  # type: ignore
 async def import_products(
+    request: Request,
     file: UploadFile = File(...),
     current_user: User = Depends(get_current_staff_user),
     db: Session = Depends(get_db),
@@ -52,7 +55,9 @@ async def import_products(
 
 
 @router.post("/inventory")
+@limiter.limit("30/minute")  # type: ignore
 async def import_inventory(
+    request: Request,
     file: UploadFile = File(...),
     current_user: User = Depends(get_current_staff_user),
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/admin/export.py
+++ b/backend/app/api/v1/endpoints/admin/export.py
@@ -7,12 +7,13 @@ import csv
 import io
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.api.v1.deps import get_current_staff_user
+from app.core.limiter import limiter
 from app.models.user import User
 from app.services import export_service as svc
 from app.services.export_service import sanitize_csv_field as _san
@@ -21,7 +22,9 @@ router = APIRouter(prefix="/export", tags=["export"])
 
 
 @router.get("/products")
+@limiter.limit("30/minute")  # type: ignore
 async def export_products(
+    request: Request,
     current_user: User = Depends(get_current_staff_user),
     db: Session = Depends(get_db),
 ):
@@ -54,7 +57,9 @@ async def export_products(
 
 
 @router.get("/orders")
+@limiter.limit("30/minute")  # type: ignore
 async def export_orders(
+    request: Request,
     start_date: str = None,
     end_date: str = None,
     current_user: User = Depends(get_current_staff_user),

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,13 +17,16 @@ FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 # Run as non-root nginx user
-RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d \
+RUN chmod +x /docker-entrypoint.sh \
+    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d \
     && touch /var/run/nginx.pid \
     && chown nginx:nginx /var/run/nginx.pid
 
 USER nginx
 
 EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Write runtime config for the frontend.
+# This runs at container startup so the API URL can be set via environment
+# variables without rebuilding the image.
+cat > /usr/share/nginx/html/config.js << EOF
+window.__FILAOPS_CONFIG__ = {
+  API_URL: "${VITE_API_URL:-}"
+};
+EOF
+exec "$@"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -7,7 +7,13 @@
  * so requests go through the proxy. Otherwise use localhost for dev.
  */
 const getApiUrl = () => {
-  // If explicitly set via env var, use that
+  // Runtime config injected by docker-entrypoint.sh at container startup
+  const runtimeUrl = window.__FILAOPS_CONFIG__?.API_URL;
+  if (runtimeUrl) {
+    return runtimeUrl;
+  }
+
+  // Build-time Vite env var
   if (import.meta.env.VITE_API_URL) {
     return import.meta.env.VITE_API_URL;
   }


### PR DESCRIPTION
## Summary
- **Runtime API URL** (#189): Added `docker-entrypoint.sh` that injects `window.__FILAOPS_CONFIG__` at container startup, enabling runtime API URL configuration without rebuilding
- **CI Security Audits** (#222): Added `pip-audit` for backend and `npm audit` for frontend in CI pipeline (non-blocking, continue-on-error)
- **Rate Limiting** (#221): Added `@limiter.limit("30/minute")` to bulk import and export endpoints

Closes #189, closes #222, closes #221

## Test plan
- [x] Frontend builds clean (`npm run build`)
- [x] All 4503 backend tests pass
- [x] Docker entrypoint script creates config.js with runtime values
- [x] Rate limiting decorators applied to import/export endpoints
- [x] CI workflow includes audit steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security audits to CI/CD pipeline for backend and frontend dependencies
  * Implemented rate limiting on admin data import and export endpoints (30 requests/minute)
  * Enabled runtime API endpoint configuration via environment variables

* **Chores**
  * Optimized frontend container initialization with custom startup script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->