### PR TITLE
refactor: replace raw fetch() with useApi/useCRUD hooks (#129)

### DIFF
--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { createApiClient } from "../lib/apiClient";
+import { API_URL } from "../config/api";
+
+/**
+ * React hook wrapping apiClient with memoized singleton.
+ *
+ * Returns { get, post, put, patch, del } — all return parsed JSON.
+ * Auth handled via httpOnly cookies (credentials: 'include').
+ * Retries, error events, and JSON parsing are built in.
+ */
+let _sharedClient = null;
+
+function getClient() {
+  if (!_sharedClient) {
+    _sharedClient = createApiClient({
+      baseUrl: API_URL,
+      onUnauthorized: () => {
+        // Redirect to login on 401
+        if (!window.location.pathname.includes("/login")) {
+          window.location.href = "/login";
+        }
+      },
+    });
+  }
+  return _sharedClient;
+}
+
+export function useApi() {
+  return useMemo(() => {
+    const client = getClient();
+    return {
+      get: client.get,
+      post: client.post,
+      put: client.put,
+      patch: client.patch,
+      del: client.delete,
+    };
+  }, []);
+}

--- a/frontend/src/hooks/useCRUD.js
+++ b/frontend/src/hooks/useCRUD.js
@@ -1,0 +1,84 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useApi } from "./useApi";
+
+/**
+ * Generic CRUD hook for admin pages.
+ *
+ * @param {string} endpoint - API path, e.g. '/api/v1/admin/customers'
+ * @param {object} [options]
+ * @param {boolean} [options.immediate=true] - Fetch on mount
+ * @param {string|null} [options.extractKey='items'] - Key to extract array from response.
+ *   Use 'items' for paginated responses ({items: [...]}),
+ *   null for raw array responses, or any other key.
+ * @param {object} [options.defaultParams] - Default query params for fetchAll
+ *
+ * @returns {{ items, loading, error, fetchAll, create, update, remove, refresh }}
+ */
+export function useCRUD(endpoint, options = {}) {
+  const { immediate = true, extractKey = "items", defaultParams } = options;
+  const api = useApi();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(immediate);
+  const [error, setError] = useState(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  const fetchAll = useCallback(async (params) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const merged = { ...defaultParams, ...params };
+      const qs = Object.keys(merged).length
+        ? "?" + new URLSearchParams(merged).toString()
+        : "";
+      const data = await api.get(`${endpoint}${qs}`);
+      if (!mountedRef.current) return data;
+
+      let result;
+      if (Array.isArray(data)) {
+        result = data;
+      } else if (extractKey && data?.[extractKey]) {
+        result = data[extractKey];
+      } else {
+        result = Array.isArray(data) ? data : [];
+      }
+      setItems(result);
+      return data; // return full response for pagination meta etc.
+    } catch (err) {
+      if (mountedRef.current) setError(err.message || "Failed to fetch");
+      throw err;
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, [api, endpoint, defaultParams, extractKey]);
+
+  const create = useCallback(async (body) => {
+    const data = await api.post(endpoint, body);
+    return data;
+  }, [api, endpoint]);
+
+  const update = useCallback(async (id, body, method = "put") => {
+    const fn = method === "patch" ? api.patch : api.put;
+    const data = await fn(`${endpoint}/${id}`, body);
+    return data;
+  }, [api, endpoint]);
+
+  const remove = useCallback(async (id) => {
+    const data = await api.del(`${endpoint}/${id}`);
+    return data;
+  }, [api, endpoint]);
+
+  // Convenience: refetch with last params
+  const refresh = useCallback(() => fetchAll(), [fetchAll]);
+
+  useEffect(() => {
+    if (immediate) {
+      fetchAll().catch(() => {});
+    }
+  }, [immediate, fetchAll]);
+
+  return { items, setItems, loading, error, fetchAll, create, update, remove, refresh };
+}

--- a/frontend/src/pages/admin/AdminAnalytics.jsx
+++ b/frontend/src/pages/admin/AdminAnalytics.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 
 const AdminAnalytics = () => {
+  const api = useApi();
   const [analytics, setAnalytics] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -15,28 +16,16 @@ const AdminAnalytics = () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch(
-        `${API_URL}/api/v1/admin/analytics/dashboard?days=${days}`,
-        {
-          credentials: "include",
-        }
+      const data = await api.get(
+        `/api/v1/admin/analytics/dashboard?days=${days}`
       );
-
-      if (response.status === 402) {
+      setAnalytics(data);
+    } catch (err) {
+      if (err.status === 402) {
         // Tier required - user will see the Pro announcement
         setLoading(false);
         return;
       }
-
-      if (response.ok) {
-        const data = await response.json();
-        setAnalytics(data);
-      } else {
-        const errorText = await response.text();
-        console.error("Analytics fetch failed:", response.status, errorText);
-        setError(`Failed to load analytics (${response.status})`);
-      }
-    } catch (err) {
       console.error("Analytics fetch error:", err);
       setError(err.message || "Failed to connect to analytics service");
     } finally {

--- a/frontend/src/pages/admin/AdminBOM.jsx
+++ b/frontend/src/pages/admin/AdminBOM.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import CreateBOMForm from "../../components/bom/CreateBOMForm";
 import CreateProductionOrderModal from "../../components/bom/CreateProductionOrderModal";
@@ -11,6 +11,7 @@ import Modal from "../../components/Modal";
 export default function AdminBOM() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const api = useApi();
   const toast = useToast();
   const [boms, setBoms] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -39,20 +40,14 @@ export default function AdminBOM() {
       if (filters.active !== "all")
         params.set("active", filters.active === "active");
 
-      const res = await fetch(`${API_URL}/api/v1/admin/bom?${params}`, {
-        credentials: "include",
-      });
-
-      if (!res.ok) throw new Error("Failed to fetch BOMs");
-
-      const data = await res.json();
+      const data = await api.get(`/api/v1/admin/bom?${params}`);
       setBoms(data);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  }, [filters]);
+  }, [filters, api]);
 
   useEffect(() => {
     fetchBOMs();
@@ -62,19 +57,13 @@ export default function AdminBOM() {
   const handleViewBOM = useCallback(
     async (bomId) => {
       try {
-        const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}`, {
-          credentials: "include",
-        });
-
-        if (!res.ok) throw new Error("Failed to fetch BOM details");
-
-        const data = await res.json();
+        const data = await api.get(`/api/v1/admin/bom/${bomId}`);
         setSelectedBOM(data);
       } catch (err) {
         setError(`Failed to load BOM: ${err.message || "Unknown error"}`);
       }
     },
-    []
+    [api]
   );
 
   // Track whether URL-driven auto-open has been performed
@@ -119,20 +108,9 @@ export default function AdminBOM() {
     if (!confirm("Are you sure you want to delete this BOM?")) return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        toast.success("BOM deleted");
-        fetchBOMs();
-      } else {
-        const errorData = await res.json();
-        toast.error(
-          `Failed to delete BOM: ${errorData.detail || "Unknown error"}`
-        );
-      }
+      await api.del(`/api/v1/admin/bom/${bomId}`);
+      toast.success("BOM deleted");
+      fetchBOMs();
     } catch (err) {
       toast.error(`Failed to delete BOM: ${err.message || "Network error"}`);
     }
@@ -140,20 +118,9 @@ export default function AdminBOM() {
 
   const handleCopyBOM = async (bomId) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/admin/bom/${bomId}/copy`, {
-        method: "POST",
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        toast.success("BOM copied");
-        fetchBOMs();
-      } else {
-        const errorData = await res.json();
-        toast.error(
-          `Failed to copy BOM: ${errorData.detail || "Unknown error"}`
-        );
-      }
+      await api.post(`/api/v1/admin/bom/${bomId}/copy`);
+      toast.success("BOM copied");
+      fetchBOMs();
     } catch (err) {
       toast.error(`Failed to copy BOM: ${err.message || "Network error"}`);
     }

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
+import { useCRUD } from "../../hooks/useCRUD";
 import { useToast } from "../../components/Toast";
 import StatCard from "../../components/StatCard";
 import { STATUS_OPTIONS, getStatusStyle } from "../../components/customers/constants";
@@ -12,9 +13,14 @@ export default function AdminCustomers() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const toast = useToast();
-  const [customers, setCustomers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const api = useApi();
+  const {
+    items: customers,
+    loading,
+    error,
+    fetchAll: fetchCustomers,
+    refresh,
+  } = useCRUD("/api/v1/admin/customers", { extractKey: null, immediate: false });
   const [filters, setFilters] = useState({
     search: "",
     status: "all",
@@ -45,29 +51,10 @@ export default function AdminCustomers() {
   }, [searchParams, setSearchParams]);
 
   useEffect(() => {
-    fetchCustomers();
-  }, [filters.status]);
-
-  const fetchCustomers = async () => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      params.set("limit", "200");
-      if (filters.status !== "all") params.set("status", filters.status);
-
-      const res = await fetch(`${API_URL}/api/v1/admin/customers?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch customers");
-      const data = await res.json();
-      // API returns array directly, not { customers: [...] }
-      setCustomers(Array.isArray(data) ? data : []);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+    const params = { limit: "200" };
+    if (filters.status !== "all") params.status = filters.status;
+    fetchCustomers(params).catch(() => {});
+  }, [filters.status, fetchCustomers]);
 
   const filteredCustomers = customers.filter((customer) => {
     if (!filters.search) return true;
@@ -94,26 +81,9 @@ export default function AdminCustomers() {
   // Save customer
   const handleSaveCustomer = async (customerData) => {
     try {
-      const url = editingCustomer
-        ? `${API_URL}/api/v1/admin/customers/${editingCustomer.id}`
-        : `${API_URL}/api/v1/admin/customers`;
-      const method = editingCustomer ? "PATCH" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(customerData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save customer");
-      }
-
-      const savedCustomer = await res.json();
+      const savedCustomer = editingCustomer
+        ? await api.patch(`/api/v1/admin/customers/${editingCustomer.id}`, customerData)
+        : await api.post("/api/v1/admin/customers", customerData);
 
       // Check if we need to return to order creation
       const returnTo = searchParams.get("returnTo");
@@ -137,7 +107,7 @@ export default function AdminCustomers() {
       toast.success(editingCustomer ? "Customer updated" : "Customer created");
       setShowCustomerModal(false);
       setEditingCustomer(null);
-      fetchCustomers();
+      refresh();
     } catch (err) {
       toast.error(err.message);
     }
@@ -146,14 +116,7 @@ export default function AdminCustomers() {
   // Edit customer (fetch full details first so address fields are populated)
   const handleEditCustomer = async (customerId) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/customers/${customerId}`,
-        {
-          credentials: "include",
-        }
-      );
-      if (!res.ok) throw new Error("Failed to fetch customer details");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/admin/customers/${customerId}`);
       setEditingCustomer(data);
       setShowCustomerModal(true);
     } catch (err) {
@@ -164,14 +127,7 @@ export default function AdminCustomers() {
   // View customer details
   const handleViewCustomer = async (customerId) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/customers/${customerId}`,
-        {
-          credentials: "include",
-        }
-      );
-      if (!res.ok) throw new Error("Failed to fetch customer details");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/admin/customers/${customerId}`);
       setViewingCustomer(data);
     } catch (err) {
       toast.error(err.message);
@@ -391,7 +347,7 @@ export default function AdminCustomers() {
           onClose={() => setShowImportModal(false)}
           onImportComplete={() => {
             setShowImportModal(false);
-            fetchCustomers();
+            refresh();
           }}
         />
       )}

--- a/frontend/src/pages/admin/AdminCycleCount.jsx
+++ b/frontend/src/pages/admin/AdminCycleCount.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 
 export default function AdminCycleCount() {
+  const api = useApi();
   const [inventoryItems, setInventoryItems] = useState([]);
   const [countEntries, setCountEntries] = useState({});
   const [reasonEntries, setReasonEntries] = useState({}); // Per-item reason overrides
@@ -54,15 +55,9 @@ export default function AdminCycleCount() {
       params.append("show_zero", filters.show_zero.toString());
       params.append("limit", "500");
 
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions/inventory-summary?${params.toString()}`,
-        {
-          credentials: "include",
-        }
+      const data = await api.get(
+        `/api/v1/admin/inventory/transactions/inventory-summary?${params.toString()}`
       );
-
-      if (!res.ok) throw new Error("Failed to fetch inventory");
-      const data = await res.json();
       setInventoryItems(data.items || []);
     } catch (err) {
       toast.error(err.message);
@@ -73,16 +68,10 @@ export default function AdminCycleCount() {
 
   const fetchLocations = async () => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions/locations`,
-        {
-          credentials: "include",
-        }
+      const data = await api.get(
+        "/api/v1/admin/inventory/transactions/locations"
       );
-      if (res.ok) {
-        const data = await res.json();
-        setLocations(data);
-      }
+      setLocations(data);
     } catch {
       // Non-critical
     }
@@ -90,11 +79,8 @@ export default function AdminCycleCount() {
 
   const fetchCategories = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/items/categories`);
-      if (res.ok) {
-        const data = await res.json();
-        setCategories(data);
-      }
+      const data = await api.get("/api/v1/items/categories");
+      setCategories(data);
     } catch {
       // Non-critical
     }
@@ -170,30 +156,17 @@ export default function AdminCycleCount() {
 
     try {
       setSubmitting(true);
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions/batch`,
+      const data = await api.post(
+        "/api/v1/admin/inventory/transactions/batch",
         {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            items,
-            location_id: filters.location_id
-              ? parseInt(filters.location_id)
-              : null,
-            count_reference: countReference,
-          }),
+          items,
+          location_id: filters.location_id
+            ? parseInt(filters.location_id)
+            : null,
+          count_reference: countReference,
         }
       );
 
-      if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.detail || "Failed to submit count");
-      }
-
-      const data = await res.json();
       setResults(data);
       const message = `Cycle count complete: ${data.successful} items updated, ${data.failed} failed`;
       if (data.failed > 0) {

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import StatCard from "../../components/StatCard";
 import RecentOrderRow from "../../components/dashboard/RecentOrderRow";
 import SalesChart from "../../components/dashboard/SalesChart";
 import ProductionPipeline from "../../components/dashboard/ProductionPipeline";
 
 export default function AdminDashboard() {
+  const api = useApi();
   const [stats, setStats] = useState(null);
   const [recentOrders, setRecentOrders] = useState([]);
   const [pendingPOs, setPendingPOs] = useState([]);
@@ -28,14 +29,8 @@ export default function AdminDashboard() {
   const fetchSalesData = async (period) => {
     setSalesLoading(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/sales-trend?period=${period}`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setSalesData(data);
-      }
+      const data = await api.get(`/api/v1/admin/dashboard/sales-trend?period=${period}`);
+      setSalesData(data);
     } catch (err) {
       console.error("Failed to fetch sales data:", err);
     } finally {
@@ -55,42 +50,21 @@ export default function AdminDashboard() {
     try {
       setLoading(true);
 
-      // Fetch summary stats
-      const summaryRes = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/summary`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (!summaryRes.ok) throw new Error("Failed to fetch dashboard summary");
-      const summaryData = await summaryRes.json();
+      const summaryData = await api.get(`/api/v1/admin/dashboard/summary`);
       setStats(summaryData);
 
-      // Fetch recent orders
-      const ordersRes = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/recent-orders?limit=5`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (ordersRes.ok) {
-        const ordersData = await ordersRes.json();
+      try {
+        const ordersData = await api.get(`/api/v1/admin/dashboard/recent-orders?limit=5`);
         setRecentOrders(ordersData);
+      } catch {
+        // Non-critical: recent orders fetch failure
       }
 
-      // Fetch pending purchase orders
-      const posRes = await fetch(
-        `${API_URL}/api/v1/purchase-orders?status=draft,ordered&limit=5`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (posRes.ok) {
-        const posData = await posRes.json();
+      try {
+        const posData = await api.get(`/api/v1/purchase-orders?status=draft,ordered&limit=5`);
         setPendingPOs(posData.items || posData || []);
+      } catch {
+        // Non-critical: pending POs fetch failure
       }
     } catch (err) {
       setError(err.message);

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 
 export default function AdminInventoryTransactions() {
+  const api = useApi();
   const [transactions, setTransactions] = useState([]);
   const [products, setProducts] = useState([]);
   const [locations, setLocations] = useState([]);
@@ -44,15 +45,7 @@ export default function AdminInventoryTransactions() {
       if (filters.location_id)
         params.append("location_id", filters.location_id);
 
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions?${params.toString()}`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) throw new Error("Failed to fetch transactions");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/admin/inventory/transactions?${params.toString()}`);
       setTransactions(data);
     } catch (err) {
       setError(err.message);
@@ -63,14 +56,8 @@ export default function AdminInventoryTransactions() {
 
   const fetchProducts = async () => {
     try {
-      // Items endpoint is public (no auth required), max limit is 2000
-      const res = await fetch(`${API_URL}/api/v1/items?limit=2000`);
-
-      if (res.ok) {
-        const data = await res.json();
-        setProducts(data.items || []);
-      }
-      // Non-critical: Products fetch failure - dropdown will be empty but page still works
+      const data = await api.get(`/api/v1/items?limit=2000`);
+      setProducts(data.items || []);
     } catch {
       // Non-critical: Products fetch failure - dropdown will be empty but page still works
     }
@@ -78,17 +65,8 @@ export default function AdminInventoryTransactions() {
 
   const fetchLocations = async () => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions/locations`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (res.ok) {
-        const data = await res.json();
-        setLocations(data);
-      }
+      const data = await api.get(`/api/v1/admin/inventory/transactions/locations`);
+      setLocations(data);
     } catch {
       // Locations fetch failure is non-critical - location selector will be empty
     }
@@ -117,22 +95,7 @@ export default function AdminInventoryTransactions() {
             : null,
       };
 
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/inventory/transactions`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-        }
-      );
-
-      if (!res.ok) {
-        const error = await res.json();
-        throw new Error(error.detail || "Failed to create transaction");
-      }
+      await api.post(`/api/v1/admin/inventory/transactions`, payload);
 
       // Reset form and refresh
       setFormData({

--- a/frontend/src/pages/admin/AdminItems.jsx
+++ b/frontend/src/pages/admin/AdminItems.jsx
@@ -4,7 +4,7 @@ import MaterialForm from "../../components/MaterialForm";
 import RoutingEditor from "../../components/RoutingEditor";
 import { ItemCard } from "../../components/inventory/ItemCard";
 import ConfirmDialog from "../../components/ConfirmDialog";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import CategorySidebar from "../../components/items/CategorySidebar";
 import CategoryModal from "../../components/items/CategoryModal";
@@ -15,6 +15,7 @@ import ItemsFilterBar from "../../components/items/ItemsFilterBar";
 import AdjustmentReasonModal from "../../components/items/AdjustmentReasonModal";
 
 export default function AdminItems() {
+  const api = useApi();
   const toast = useToast();
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -86,29 +87,19 @@ export default function AdminItems() {
 
   const fetchCategories = useCallback(async () => {
     try {
-      // Fetch flat list
-      const res = await fetch(
-        `${API_URL}/api/v1/items/categories?include_inactive=true`,
-        {
-          credentials: "include",
-        }
-      );
-      if (!res.ok) throw new Error("Failed to fetch categories");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/items/categories?include_inactive=true`);
       setCategories(data);
 
-      // Fetch tree structure
-      const treeRes = await fetch(`${API_URL}/api/v1/items/categories/tree`, {
-        credentials: "include",
-      });
-      if (treeRes.ok) {
-        const treeData = await treeRes.json();
+      try {
+        const treeData = await api.get(`/api/v1/items/categories/tree`);
         setCategoryTree(treeData);
+      } catch {
+        // Tree fetch failure is non-critical
       }
     } catch {
       // Category fetch failure is non-critical - category tree will just be empty
     }
-  }, []);
+  }, [api]);
 
   useEffect(() => {
     fetchCategories();
@@ -129,11 +120,7 @@ export default function AdminItems() {
       if (filters.itemType !== "all") params.set("item_type", filters.itemType);
       if (filters.search) params.set("search", filters.search);
 
-      const res = await fetch(`${API_URL}/api/v1/items?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch items");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/items?${params}`);
       setItems(data.items || []);
       setPagination((prev) => ({ ...prev, total: data.total || 0 }));
     } catch (err) {
@@ -142,6 +129,7 @@ export default function AdminItems() {
       setLoading(false);
     }
   }, [
+    api,
     pagination.pageSize,
     pagination.page,
     filters.activeOnly,
@@ -300,17 +288,7 @@ export default function AdminItems() {
   const confirmDeleteCategory = async () => {
     if (!categoryToDelete) return;
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/items/categories/${categoryToDelete.id}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to delete category");
-      }
+      await api.del(`/api/v1/items/categories/${categoryToDelete.id}`);
       toast.success("Category deleted");
       fetchCategories();
     } catch (err) {
@@ -326,23 +304,10 @@ export default function AdminItems() {
   // Save category
   const handleSaveCategory = async (catData) => {
     try {
-      const url = editingCategory
-        ? `${API_URL}/api/v1/items/categories/${editingCategory.id}`
-        : `${API_URL}/api/v1/items/categories`;
-      const method = editingCategory ? "PATCH" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(catData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save category");
+      if (editingCategory) {
+        await api.patch(`/api/v1/items/categories/${editingCategory.id}`, catData);
+      } else {
+        await api.post(`/api/v1/items/categories`, catData);
       }
 
       toast.success(editingCategory ? "Category updated" : "Category created");
@@ -411,23 +376,7 @@ export default function AdminItems() {
         params.set("notes", adjustmentNotes.trim());
       }
 
-      const res = await fetch(
-        `${API_URL}/api/v1/inventory/adjust-quantity?${params}`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to adjust inventory");
-      }
-
-      const result = await res.json();
+      const result = await api.post(`/api/v1/inventory/adjust-quantity?${params}`);
       const displayQty = item.material_type_id ? result.new_quantity.toFixed(0) : result.new_quantity.toFixed(0);
       const displayUnit = item.material_type_id ? "g" : (item.unit || "EA");
       const prevQty = item.material_type_id ? result.previous_quantity.toFixed(0) : result.previous_quantity.toFixed(0);
@@ -471,24 +420,10 @@ export default function AdminItems() {
     }
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/items/bulk-update`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          item_ids: Array.from(selectedItems),
-          ...updateData,
-        }),
+      const data = await api.post(`/api/v1/items/bulk-update`, {
+        item_ids: Array.from(selectedItems),
+        ...updateData,
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to update items");
-      }
-
-      const data = await res.json();
       toast.success(`Successfully updated ${data.message}`);
       setSelectedItems(new Set());
       setShowBulkUpdateModal(false);
@@ -513,17 +448,7 @@ export default function AdminItems() {
         params.set("category_id", selectedCategory.toString());
       if (filters.itemType !== "all") params.set("item_type", filters.itemType);
 
-      const res = await fetch(`${API_URL}/api/v1/items/recost-all?${params}`, {
-        method: "POST",
-        credentials: "include",
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to recost items");
-      }
-
-      const data = await res.json();
+      const data = await api.post(`/api/v1/items/recost-all?${params}`);
       setRecostResult(data);
       toast.success(`Recosted ${data.updated || 0} items`);
       fetchItems();

--- a/frontend/src/pages/admin/AdminLocations.jsx
+++ b/frontend/src/pages/admin/AdminLocations.jsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useState } from "react";
 import { useToast } from "../../components/Toast";
+import { useCRUD } from "../../hooks/useCRUD";
 
 // Location type options
 const TYPE_OPTIONS = [
@@ -13,35 +13,22 @@ const TYPE_OPTIONS = [
 
 export default function AdminLocations() {
   const toast = useToast();
-  const [locations, setLocations] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [editingLocation, setEditingLocation] = useState(null);
   const [includeInactive, setIncludeInactive] = useState(false);
 
-  useEffect(() => {
-    fetchLocations();
-  }, [includeInactive]);
+  const { items: locations, loading, error, fetchAll, create, update, remove } = useCRUD(
+    "/api/v1/admin/locations",
+    { extractKey: null }
+  );
 
-  const fetchLocations = async () => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      if (includeInactive) params.set("include_inactive", "true");
-
-      const res = await fetch(`${API_URL}/api/v1/admin/locations?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch locations");
-      const data = await res.json();
-      setLocations(Array.isArray(data) ? data : []);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
+  const refetch = () => {
+    const params = includeInactive ? { include_inactive: "true" } : {};
+    fetchAll(params).catch(() => {});
   };
+
+  // Refetch when includeInactive changes
+  useState(() => { refetch(); });
 
   const getTypeStyle = (type) => {
     const found = TYPE_OPTIONS.find((t) => t.value === type);
@@ -57,29 +44,16 @@ export default function AdminLocations() {
 
   const handleSave = async (locationData) => {
     try {
-      const url = editingLocation
-        ? `${API_URL}/api/v1/admin/locations/${editingLocation.id}`
-        : `${API_URL}/api/v1/admin/locations`;
-      const method = editingLocation ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(locationData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save location");
+      if (editingLocation) {
+        await update(editingLocation.id, locationData);
+        toast.success("Location updated");
+      } else {
+        await create(locationData);
+        toast.success("Location created");
       }
-
-      toast.success(editingLocation ? "Location updated" : "Location created");
       setShowModal(false);
       setEditingLocation(null);
-      fetchLocations();
+      refetch();
     } catch (err) {
       toast.error(err.message);
     }
@@ -93,21 +67,9 @@ export default function AdminLocations() {
     if (!confirm(`Deactivate location "${location.name}"?`)) return;
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/locations/${location.id}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to deactivate location");
-      }
-
+      await remove(location.id);
       toast.success("Location deactivated");
-      fetchLocations();
+      refetch();
     } catch (err) {
       toast.error(err.message);
     }
@@ -115,22 +77,9 @@ export default function AdminLocations() {
 
   const handleReactivate = async (location) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/locations/${location.id}`,
-        {
-          method: "PUT",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ active: true }),
-        }
-      );
-
-      if (!res.ok) throw new Error("Failed to reactivate location");
-
+      await update(location.id, { active: true });
       toast.success("Location reactivated");
-      fetchLocations();
+      refetch();
     } catch (err) {
       toast.error(err.message);
     }
@@ -192,7 +141,11 @@ export default function AdminLocations() {
           <input
             type="checkbox"
             checked={includeInactive}
-            onChange={(e) => setIncludeInactive(e.target.checked)}
+            onChange={(e) => {
+              setIncludeInactive(e.target.checked);
+              const params = e.target.checked ? { include_inactive: "true" } : {};
+              fetchAll(params).catch(() => {});
+            }}
             className="rounded bg-gray-800 border-gray-700 text-blue-500 focus:ring-blue-500"
           />
           Show inactive locations

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import RoutingEditor from "../../components/RoutingEditor";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import WorkCenterCard from "../../components/manufacturing/WorkCenterCard";
 import WorkCenterModal from "../../components/manufacturing/WorkCenterModal";
@@ -8,6 +8,7 @@ import ResourceModal from "../../components/manufacturing/ResourceModal";
 import PrinterSetupModal from "../../components/manufacturing/PrinterSetupModal";
 
 export default function AdminManufacturing() {
+  const api = useApi();
   const toast = useToast();
   const [activeTab, setActiveTab] = useState("work-centers");
   const [workCenters, setWorkCenters] = useState([]);
@@ -37,14 +38,7 @@ export default function AdminManufacturing() {
   const fetchWorkCenters = async () => {
     setLoading(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/work-centers/?active_only=false`,
-        {
-          credentials: "include",
-        }
-      );
-      if (!res.ok) throw new Error("Failed to fetch work centers");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/work-centers/?active_only=false`);
       setWorkCenters(data);
     } catch (err) {
       setError(err.message);
@@ -56,11 +50,7 @@ export default function AdminManufacturing() {
   const fetchRoutings = async () => {
     setLoading(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/routings/`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch routings");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/routings/`);
       setRoutings(data);
     } catch (err) {
       setError(err.message);
@@ -71,38 +61,21 @@ export default function AdminManufacturing() {
 
   const fetchProducts = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/products?limit=500`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        // Handle both array and {items: [...]} responses
-        setProducts(Array.isArray(data) ? data : (data.items || data.products || []));
-      }
+      const data = await api.get(`/api/v1/products?limit=500`);
+      // Handle both array and {items: [...]} responses
+      setProducts(Array.isArray(data) ? data : (data.items || data.products || []));
     } catch {
       // Products fetch failure is non-critical - product selector will just be empty
       setProducts([]);
     }
   };
 
-  const handleSaveWorkCenter = async (data) => {
+  const handleSaveWorkCenter = async (formData) => {
     try {
-      const url = editingWorkCenter
-        ? `${API_URL}/api/v1/work-centers/${editingWorkCenter.id}`
-        : `${API_URL}/api/v1/work-centers/`;
-
-      const res = await fetch(url, {
-        method: editingWorkCenter ? "PUT" : "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save work center");
+      if (editingWorkCenter) {
+        await api.put(`/api/v1/work-centers/${editingWorkCenter.id}`, formData);
+      } else {
+        await api.post(`/api/v1/work-centers/`, formData);
       }
 
       toast.success(
@@ -120,12 +93,7 @@ export default function AdminManufacturing() {
     if (!confirm(`Deactivate work center "${wc.name}"?`)) return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/work-centers/${wc.id}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!res.ok) throw new Error("Failed to delete");
+      await api.del(`/api/v1/work-centers/${wc.id}`);
       toast.success("Work center deactivated");
       fetchWorkCenters();
     } catch (err) {
@@ -138,15 +106,7 @@ export default function AdminManufacturing() {
       return;
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/work-centers/resources/${resource.id}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) throw new Error("Failed to delete resource");
+      await api.del(`/api/v1/work-centers/resources/${resource.id}`);
       toast.success("Resource deleted");
       fetchWorkCenters(); // Refresh to update resource counts
     } catch (err) {
@@ -154,24 +114,12 @@ export default function AdminManufacturing() {
     }
   };
 
-  const handleSaveResource = async (data) => {
+  const handleSaveResource = async (formData) => {
     try {
-      const url = editingResource
-        ? `${API_URL}/api/v1/work-centers/resources/${editingResource.id}`
-        : `${API_URL}/api/v1/work-centers/${selectedWorkCenter.id}/resources`;
-
-      const res = await fetch(url, {
-        method: editingResource ? "PUT" : "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save resource");
+      if (editingResource) {
+        await api.put(`/api/v1/work-centers/resources/${editingResource.id}`, formData);
+      } else {
+        await api.post(`/api/v1/work-centers/${selectedWorkCenter.id}/resources`, formData);
       }
 
       toast.success(editingResource ? "Resource updated" : "Resource created");

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import SalesOrderWizard from "../../components/SalesOrderWizard";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { validateLength } from "../../utils/validation";
 import { SalesOrderCard } from "../../components/orders";
@@ -10,6 +10,7 @@ import OrderFilters from "../../components/orders/OrderFilters";
 export default function AdminOrders() {
   const navigate = useNavigate();
   const location = useLocation();
+  const api = useApi();
   const toast = useToast();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -68,13 +69,7 @@ export default function AdminOrders() {
       if (sortBy) params.set("sort_by", sortBy);
       if (sortOrder) params.set("sort_order", sortOrder);
 
-      const res = await fetch(`${API_URL}/api/v1/sales-orders/?${params}`, {
-        credentials: "include",
-      });
-
-      if (!res.ok) throw new Error("Failed to fetch orders");
-
-      const data = await res.json();
+      const data = await api.get(`/api/v1/sales-orders/?${params}`);
       setOrders(data.items || data);
     } catch (err) {
       setError(err.message);
@@ -85,32 +80,15 @@ export default function AdminOrders() {
 
   const handleStatusUpdate = async (orderId, newStatus) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${orderId}/status`,
-        {
-          method: "PATCH",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ status: newStatus }),
-        }
+      const updated = await api.patch(
+        `/api/v1/sales-orders/${orderId}/status`,
+        { status: newStatus }
       );
 
-      if (res.ok) {
-        toast.success("Order status updated");
-        fetchOrders();
-        if (selectedOrder?.id === orderId) {
-          const updated = await res.json();
-          setSelectedOrder(updated);
-        }
-      } else {
-        const errorData = await res.json();
-        toast.error(
-          `Failed to update order status: ${
-            errorData.detail || "Unknown error"
-          }`
-        );
+      toast.success("Order status updated");
+      fetchOrders();
+      if (selectedOrder?.id === orderId) {
+        setSelectedOrder(updated);
       }
     } catch (err) {
       toast.error(
@@ -124,36 +102,23 @@ export default function AdminOrders() {
     setError(null);
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${orderId}/generate-production-orders`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
+      const data = await api.post(
+        `/api/v1/sales-orders/${orderId}/generate-production-orders`
       );
 
-      const data = await res.json();
-
-      if (res.ok) {
-        if (data.created_orders?.length > 0) {
-          toast.success(
-            `Production Order(s) created: ${data.created_orders.join(", ")}`
-          );
-        } else if (data.existing_orders?.length > 0) {
-          toast.info(
-            `Production Order(s) already exist: ${data.existing_orders.join(
-              ", "
-            )}`
-          );
-        }
-        fetchOrders();
-        setSelectedOrder(null);
-      } else {
-        setError(data.detail || "Failed to generate production order");
+      if (data.created_orders?.length > 0) {
+        toast.success(
+          `Production Order(s) created: ${data.created_orders.join(", ")}`
+        );
+      } else if (data.existing_orders?.length > 0) {
+        toast.info(
+          `Production Order(s) already exist: ${data.existing_orders.join(
+            ", "
+          )}`
+        );
       }
+      fetchOrders();
+      setSelectedOrder(null);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -227,29 +192,17 @@ export default function AdminOrders() {
     }
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${cancellingOrder.id}/cancel`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ cancellation_reason: cancellationReason }),
-        }
+      await api.post(
+        `/api/v1/sales-orders/${cancellingOrder.id}/cancel`,
+        { cancellation_reason: cancellationReason }
       );
 
-      if (res.ok) {
-        toast.success(`Order ${cancellingOrder.order_number} cancelled`);
-        setShowCancelModal(false);
-        setCancellingOrder(null);
-        setCancellationReason("");
-        setCancellationError("");
-        fetchOrders();
-      } else {
-        const errorData = await res.json();
-        toast.error(errorData.detail || "Failed to cancel order");
-      }
+      toast.success(`Order ${cancellingOrder.order_number} cancelled`);
+      setShowCancelModal(false);
+      setCancellingOrder(null);
+      setCancellationReason("");
+      setCancellationError("");
+      fetchOrders();
     } catch (err) {
       toast.error(err.message || "Failed to cancel order");
     }
@@ -260,33 +213,11 @@ export default function AdminOrders() {
     if (!deletingOrder) return;
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${deletingOrder.id}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-
-      if (res.ok || res.status === 204) {
-        toast.success(`Order ${deletingOrder.order_number} deleted`);
-        setShowDeleteConfirm(false);
-        setDeletingOrder(null);
-        fetchOrders();
-      } else {
-        let errorMsg = "Failed to delete order";
-        const contentType = res.headers.get("content-type") || "";
-        const text = await res.text();
-        if (text && contentType.includes("application/json")) {
-          try {
-            const errorData = JSON.parse(text);
-            errorMsg = errorData.detail || errorMsg;
-          } catch {
-            // Ignore JSON parse error, fallback to generic message
-          }
-        }
-        toast.error(errorMsg);
-      }
+      await api.del(`/api/v1/sales-orders/${deletingOrder.id}`);
+      toast.success(`Order ${deletingOrder.order_number} deleted`);
+      setShowDeleteConfirm(false);
+      setDeletingOrder(null);
+      fetchOrders();
     } catch (err) {
       toast.error(err.message || "Failed to delete order");
     }

--- a/frontend/src/pages/admin/AdminPayments.jsx
+++ b/frontend/src/pages/admin/AdminPayments.jsx
@@ -9,7 +9,7 @@
  * - Outstanding balance tracking
  */
 import { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import RecordPaymentModal from "../../components/payments/RecordPaymentModal";
 import { PAYMENT_COLORS as statusColors } from "../../lib/statusColors.js";
@@ -28,6 +28,7 @@ const paymentMethodLabels = {
 };
 
 export default function AdminPayments() {
+  const api = useApi();
   const toast = useToast();
   // State
   const [loading, setLoading] = useState(true);
@@ -67,12 +68,8 @@ export default function AdminPayments() {
 
   const fetchDashboard = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/payments/dashboard`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        setDashboard(await res.json());
-      }
+      const data = await api.get("/api/v1/payments/dashboard");
+      setDashboard(data);
     } catch {
       // Non-critical: Dashboard stats fetch failure - payment list still works
     }
@@ -94,19 +91,13 @@ export default function AdminPayments() {
       if (filters.fromDate) params.append("from_date", filters.fromDate);
       if (filters.toDate) params.append("to_date", filters.toDate);
 
-      const res = await fetch(`${API_URL}/api/v1/payments?${params}`, {
-        credentials: "include",
+      const data = await api.get(`/api/v1/payments?${params}`);
+      setPayments(data.items);
+      setPagination({
+        page: data.page,
+        total: data.total,
+        totalPages: data.total_pages,
       });
-
-      if (res.ok) {
-        const data = await res.json();
-        setPayments(data.items);
-        setPagination({
-          page: data.page,
-          total: data.total,
-          totalPages: data.total_pages,
-        });
-      }
     } catch {
       toast.error("Failed to load payments");
     } finally {
@@ -119,21 +110,12 @@ export default function AdminPayments() {
       return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/payments/${paymentId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        toast.success("Payment voided");
-        fetchPayments();
-        fetchDashboard();
-      } else {
-        const err = await res.json();
-        toast.error(err.detail || "Failed to void payment");
-      }
-    } catch {
-      toast.error("Failed to void payment");
+      await api.del(`/api/v1/payments/${paymentId}`);
+      toast.success("Payment voided");
+      fetchPayments();
+      fetchDashboard();
+    } catch (err) {
+      toast.error(err.message || "Failed to void payment");
     }
   };
 

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -5,7 +5,7 @@
  *   PrinterModal, IPProbeSection, MaintenanceModal, constants
  */
 import { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { statusColors, brandLabels, MAINTENANCE_TYPE_CLASS } from "../../components/printers/constants";
 import PrinterModal from "../../components/printers/PrinterModal";
@@ -13,6 +13,7 @@ import IPProbeSection from "../../components/printers/IPProbeSection";
 import MaintenanceModal from "../../components/printers/MaintenanceModal";
 
 export default function AdminPrinters() {
+  const api = useApi();
   const toast = useToast();
   const [activeTab, setActiveTab] = useState("list"); // list | discovery | import
   const [printers, setPrinters] = useState([]);
@@ -84,11 +85,7 @@ export default function AdminPrinters() {
       params.set("page", "1");
       params.set("page_size", "100");
 
-      const res = await fetch(`${API_URL}/api/v1/printers?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch printers");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/printers?${params}`);
       setPrinters(data.items || []);
     } catch (err) {
       setError(err.message);
@@ -99,13 +96,8 @@ export default function AdminPrinters() {
 
   const fetchBrandInfo = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/brands/info`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setBrandInfo(data);
-      }
+      const data = await api.get(`/api/v1/printers/brands/info`);
+      setBrandInfo(data);
     } catch {
       // Non-critical
     }
@@ -113,13 +105,8 @@ export default function AdminPrinters() {
 
   const fetchActiveWork = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/active-work`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setActiveWork(data.printers || {});
-      }
+      const data = await api.get(`/api/v1/printers/active-work`);
+      setActiveWork(data.printers || {});
     } catch {
       // Non-critical - polling will retry
     }
@@ -128,13 +115,8 @@ export default function AdminPrinters() {
   const fetchMaintenanceLogs = async () => {
     setMaintenanceLoading(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/maintenance/?page_size=50`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setMaintenanceLogs(data.items || []);
-      }
+      const data = await api.get(`/api/v1/maintenance/?page_size=50`);
+      setMaintenanceLogs(data.items || []);
     } catch (err) {
       console.error("Error fetching maintenance logs:", err);
     } finally {
@@ -144,13 +126,8 @@ export default function AdminPrinters() {
 
   const fetchMaintenanceDue = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/maintenance/due?days_ahead=14`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setMaintenanceDue(data);
-      }
+      const data = await api.get(`/api/v1/maintenance/due?days_ahead=14`);
+      setMaintenanceDue(data);
     } catch {
       // Non-critical
     }
@@ -166,18 +143,7 @@ export default function AdminPrinters() {
     setDiscoveredPrinters([]);
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/discover`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ timeout_seconds: 10 }),
-      });
-
-      if (!res.ok) throw new Error("Discovery failed");
-
-      const data = await res.json();
+      const data = await api.post(`/api/v1/printers/discover`, { timeout_seconds: 10 });
       setDiscoveredPrinters(data.printers || []);
 
       if (data.printers?.length === 0) {
@@ -195,27 +161,15 @@ export default function AdminPrinters() {
 
   const handleAddDiscovered = async (discovered) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          code: discovered.suggested_code,
-          name: discovered.name,
-          model: discovered.model,
-          brand: discovered.brand,
-          ip_address: discovered.ip_address,
-          serial_number: discovered.serial_number,
-          capabilities: discovered.capabilities,
-        }),
+      await api.post(`/api/v1/printers`, {
+        code: discovered.suggested_code,
+        name: discovered.name,
+        model: discovered.model,
+        brand: discovered.brand,
+        ip_address: discovered.ip_address,
+        serial_number: discovered.serial_number,
+        capabilities: discovered.capabilities,
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to add printer");
-      }
 
       toast.success(`Printer "${discovered.name}" added successfully`);
       fetchPrinters();
@@ -242,34 +196,16 @@ export default function AdminPrinters() {
     setTestingConnection(printer.id);
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/test-connection`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          brand: printer.brand,
-          ip_address: printer.ip_address,
-          connection_config: printer.connection_config || {},
-        }),
+      const result = await api.post(`/api/v1/printers/test-connection`, {
+        brand: printer.brand,
+        ip_address: printer.ip_address,
+        connection_config: printer.connection_config || {},
       });
-
-      if (!res.ok) throw new Error("Connection test failed");
-
-      const result = await res.json();
 
       if (result.success) {
         toast.success(`${printer.name}: Connected! (${Math.round(result.response_time_ms)}ms)`);
         // Update printer status to idle
-        await fetch(`${API_URL}/api/v1/printers/${printer.id}/status`, {
-          method: "PATCH",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ status: "idle" }),
-        });
+        await api.patch(`/api/v1/printers/${printer.id}/status`, { status: "idle" });
         fetchPrinters();
       } else {
         toast.error(`${printer.name}: ${result.message || "Connection failed"}`);
@@ -287,13 +223,7 @@ export default function AdminPrinters() {
     }
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/${printer.id}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!res.ok) throw new Error("Failed to delete printer");
-
+      await api.del(`/api/v1/printers/${printer.id}`);
       toast.success(`Printer "${printer.name}" deleted`);
       fetchPrinters();
     } catch (err) {
@@ -311,21 +241,11 @@ export default function AdminPrinters() {
     setImportResult(null);
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/printers/import-csv`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ csv_data: csvData, skip_duplicates: true }),
+      const result = await api.post(`/api/v1/printers/import-csv`, {
+        csv_data: csvData,
+        skip_duplicates: true,
       });
 
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Import failed");
-      }
-
-      const result = await res.json();
       setImportResult(result);
 
       if (result.imported > 0) {
@@ -958,4 +878,3 @@ export default function AdminPrinters() {
     </div>
   );
 }
-

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -7,7 +7,7 @@ import ScrapOrderModal from "../../components/ScrapOrderModal";
 import CompleteOrderModal from "../../components/CompleteOrderModal";
 import QCInspectionModal from "../../components/QCInspectionModal";
 import Modal from "../../components/Modal";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 
 // Production Trend Chart Component
 function ProductionChart({ data, period, onPeriodChange, loading }) {
@@ -234,6 +234,7 @@ const SoLinkBadge = ({ order }) => {
 };
 
 export default function AdminProduction() {
+  const api = useApi();
   const [searchParams] = useSearchParams();
   const [productionOrders, setProductionOrders] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -285,20 +286,14 @@ export default function AdminProduction() {
   const fetchProductionTrend = useCallback(async (period) => {
     setTrendLoading(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/production-trend?period=${period}`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setProductionTrend(data);
-      }
+      const data = await api.get(`/api/v1/admin/dashboard/production-trend?period=${period}`);
+      setProductionTrend(data);
     } catch (err) {
       console.error("Failed to fetch production trend:", err);
     } finally {
       setTrendLoading(false);
     }
-  }, []);
+  }, [api]);
 
   const fetchProductionOrders = useCallback(async () => {
     setLoading(true);
@@ -310,40 +305,23 @@ export default function AdminProduction() {
       }
       params.set("limit", "100");
 
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders/?${params}`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) throw new Error("Failed to fetch production orders");
-
-      const data = await res.json();
+      const data = await api.get(`/api/v1/production-orders/?${params}`);
       setProductionOrders(data.items || data || []);
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  }, [filters.status]);
+  }, [api, filters.status]);
 
   const fetchProducts = useCallback(async () => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/products?limit=500&active=true`,
-        {
-          credentials: "include",
-        }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setProducts(data.items || data || []);
-      }
+      const data = await api.get(`/api/v1/products?limit=500&active=true`);
+      setProducts(data.items || data || []);
     } catch {
       // Products fetch failure is non-critical - product selector will just be empty
     }
-  }, []);
+  }, [api]);
 
   useEffect(() => {
     fetchProductionOrders();
@@ -377,35 +355,23 @@ export default function AdminProduction() {
 
     setCreating(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/production-orders/`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          product_id: parseInt(createForm.product_id),
-          quantity_ordered: parseInt(createForm.quantity_ordered) || 1,
-          priority: parseInt(createForm.priority) || 3,
-          due_date: createForm.due_date || null,
-          notes: createForm.notes || null,
-        }),
+      await api.post(`/api/v1/production-orders/`, {
+        product_id: parseInt(createForm.product_id),
+        quantity_ordered: parseInt(createForm.quantity_ordered) || 1,
+        priority: parseInt(createForm.priority) || 3,
+        due_date: createForm.due_date || null,
+        notes: createForm.notes || null,
       });
 
-      if (res.ok) {
-        setShowCreateModal(false);
-        setCreateForm({
-          product_id: "",
-          quantity_ordered: 1,
-          priority: 3,
-          due_date: "",
-          notes: "",
-        });
-        fetchProductionOrders();
-      } else {
-        const err = await res.json();
-        setError(err.detail || "Failed to create production order");
-      }
+      setShowCreateModal(false);
+      setCreateForm({
+        product_id: "",
+        quantity_ordered: 1,
+        priority: 3,
+        due_date: "",
+        notes: "",
+      });
+      fetchProductionOrders();
     } catch (err) {
       setError(err.message);
     } finally {

--- a/frontend/src/pages/admin/AdminPurchasing.jsx
+++ b/frontend/src/pages/admin/AdminPurchasing.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import PurchasingChart from "../../components/purchasing/PurchasingChart";
 import VendorModal from "../../components/purchasing/VendorModal";
@@ -13,6 +13,7 @@ import VendorsTab from "../../components/purchasing/VendorsTab";
 import LowStockTab from "../../components/purchasing/LowStockTab";
 
 export default function AdminPurchasing() {
+  const api = useApi();
   const toast = useToast();
   const [searchParams, setSearchParams] = useSearchParams();
   const initialTab = searchParams.get("tab") || "orders";
@@ -205,16 +206,8 @@ export default function AdminPurchasing() {
   const fetchPurchasingTrend = async (period) => {
     setTrendLoading(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/purchasing-trend?period=${period}`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setPurchasingTrend(data);
-      } else {
-        console.error("Purchasing trend API error:", res.status);
-      }
+      const data = await api.get(`/api/v1/admin/dashboard/purchasing-trend?period=${period}`);
+      setPurchasingTrend(data);
     } catch (err) {
       console.error("Failed to fetch purchasing trend:", err);
     } finally {
@@ -265,11 +258,7 @@ export default function AdminPurchasing() {
       if (filters.status !== "all") params.set("status", filters.status);
       params.set("limit", "100");
 
-      const res = await fetch(`${API_URL}/api/v1/purchase-orders?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch orders");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/purchase-orders?${params}`);
       // Handle both array and {items: [...]} responses, and error objects
       setOrders(Array.isArray(data) ? data : (data.items || []));
     } catch (err) {
@@ -283,11 +272,7 @@ export default function AdminPurchasing() {
   const fetchVendors = async (showLoading = true) => {
     if (showLoading) setLoading(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/vendors?active_only=false`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch vendors");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/vendors?active_only=false`);
       // Handle both array and {items: [...]} responses, and error objects
       setVendors(Array.isArray(data) ? data : (data.items || []));
     } catch (err) {
@@ -300,15 +285,8 @@ export default function AdminPurchasing() {
 
   const fetchProducts = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/items?limit=2000`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setProducts(data.items || []);
-      } else {
-        console.warn(`[AdminPurchasing] Failed to fetch products: ${res.status}`);
-      }
+      const data = await api.get(`/api/v1/items?limit=2000`);
+      setProducts(data.items || []);
     } catch (err) {
       // Products fetch failure is non-critical - product selector will just be empty
       console.error("[AdminPurchasing] Error fetching products:", err);
@@ -318,14 +296,9 @@ export default function AdminPurchasing() {
   const fetchLowStock = async () => {
     setLowStockLoading(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/items/low-stock`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setLowStockItems(data.items || []);
-        setLowStockSummary(data.summary || null);
-      }
+      const data = await api.get(`/api/v1/items/low-stock`);
+      setLowStockItems(data.items || []);
+      setLowStockSummary(data.summary || null);
     } catch {
       setError("Failed to load low stock items. Please refresh the page.");
     } finally {
@@ -335,13 +308,8 @@ export default function AdminPurchasing() {
 
   const fetchCompanySettings = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/settings/company`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setCompanySettings(data);
-      }
+      const data = await api.get(`/api/v1/settings/company`);
+      setCompanySettings(data);
     } catch (err) {
       // Non-critical - auto-calc tax just won't work
       console.error("Failed to fetch company settings:", err);
@@ -350,16 +318,9 @@ export default function AdminPurchasing() {
 
   const fetchPODetails = async (poId) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/purchase-orders/${poId}`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setSelectedPO(data);
-        return data;
-      } else {
-        setError("Failed to load purchase order details.");
-      }
+      const data = await api.get(`/api/v1/purchase-orders/${poId}`);
+      setSelectedPO(data);
+      return data;
     } catch (err) {
       setError(`Failed to load purchase order: ${err.message || "Network error"}`);
     }
@@ -372,23 +333,10 @@ export default function AdminPurchasing() {
 
   const handleSaveVendor = async (vendorData) => {
     try {
-      const url = selectedVendor
-        ? `${API_URL}/api/v1/vendors/${selectedVendor.id}`
-        : `${API_URL}/api/v1/vendors`;
-      const method = selectedVendor ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(vendorData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save vendor");
+      if (selectedVendor) {
+        await api.put(`/api/v1/vendors/${selectedVendor.id}`, vendorData);
+      } else {
+        await api.post(`/api/v1/vendors`, vendorData);
       }
 
       toast.success(selectedVendor ? "Vendor updated" : "Vendor created");
@@ -403,11 +351,7 @@ export default function AdminPurchasing() {
   const handleDeleteVendor = async (vendorId) => {
     if (!confirm("Are you sure you want to delete this vendor?")) return;
     try {
-      const res = await fetch(`${API_URL}/api/v1/vendors/${vendorId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to delete vendor");
+      await api.del(`/api/v1/vendors/${vendorId}`);
       toast.success("Vendor deleted");
       fetchVendors();
     } catch (err) {
@@ -421,23 +365,10 @@ export default function AdminPurchasing() {
 
   const handleSavePO = async (poData) => {
     try {
-      const url = selectedPO
-        ? `${API_URL}/api/v1/purchase-orders/${selectedPO.id}`
-        : `${API_URL}/api/v1/purchase-orders`;
-      const method = selectedPO ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(poData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save PO");
+      if (selectedPO) {
+        await api.put(`/api/v1/purchase-orders/${selectedPO.id}`, poData);
+      } else {
+        await api.post(`/api/v1/purchase-orders`, poData);
       }
 
       toast.success(selectedPO ? "Purchase order updated" : "Purchase order created");
@@ -451,22 +382,10 @@ export default function AdminPurchasing() {
 
   const handleStatusChange = async (poId, newStatus, extraData = {}) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/purchase-orders/${poId}/status`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ status: newStatus, ...extraData }),
-        }
+      await api.post(
+        `/api/v1/purchase-orders/${poId}/status`,
+        { status: newStatus, ...extraData }
       );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to update status");
-      }
 
       toast.success(`Status updated to ${newStatus}`);
       fetchOrders();
@@ -480,24 +399,11 @@ export default function AdminPurchasing() {
 
   const handleReceive = async (receiveData) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/purchase-orders/${selectedPO.id}/receive`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(receiveData),
-        }
+      const result = await api.post(
+        `/api/v1/purchase-orders/${selectedPO.id}/receive`,
+        receiveData
       );
 
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to receive items");
-      }
-
-      const result = await res.json();
       toast.success(
         `Received ${result.total_quantity} items. ${result.transactions_created.length} inventory transactions created.`
       );
@@ -518,15 +424,7 @@ export default function AdminPurchasing() {
     if (!confirm(`Delete PO ${poNumber}? This cannot be undone.`)) return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/purchase-orders/${poId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to delete PO");
-      }
+      await api.del(`/api/v1/purchase-orders/${poId}`);
 
       toast.success("Purchase order deleted");
       fetchOrders();
@@ -543,28 +441,15 @@ export default function AdminPurchasing() {
       return;
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/purchase-orders/${poId}/status`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ status: "cancelled" }),
-        }
+      await api.post(
+        `/api/v1/purchase-orders/${poId}/status`,
+        { status: "cancelled" }
       );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to cancel PO");
-      }
 
       toast.success("Purchase order cancelled");
       fetchOrders();
       if (selectedPO?.id === poId) {
-        const updated = await res.json();
-        setSelectedPO(updated);
+        fetchPODetails(poId);
       }
     } catch (err) {
       toast.error(err.message);

--- a/frontend/src/pages/admin/AdminQuotes.jsx
+++ b/frontend/src/pages/admin/AdminQuotes.jsx
@@ -7,6 +7,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { STATUS_OPTIONS, getStatusStyle } from "../../components/quotes/constants";
 import QuoteFormModal from "../../components/quotes/QuoteFormModal";
@@ -14,6 +15,7 @@ import QuoteDetailModal from "../../components/quotes/QuoteDetailModal";
 
 export default function AdminQuotes() {
   const navigate = useNavigate();
+  const api = useApi();
   const toast = useToast();
   const [quotes, setQuotes] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -40,11 +42,7 @@ export default function AdminQuotes() {
       params.set("limit", "200");
       if (filters.status !== "all") params.set("status", filters.status);
 
-      const res = await fetch(`${API_URL}/api/v1/quotes?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch quotes");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/quotes?${params}`);
       setQuotes(Array.isArray(data) ? data : []);
     } catch (err) {
       toast.error(err.message);
@@ -55,13 +53,8 @@ export default function AdminQuotes() {
 
   const fetchStats = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/quotes/stats`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setStats(data);
-      }
+      const data = await api.get("/api/v1/quotes/stats");
+      setStats(data);
     } catch {
       // Stats fetch failure is non-critical
     }
@@ -80,23 +73,10 @@ export default function AdminQuotes() {
 
   const handleSaveQuote = async (quoteData) => {
     try {
-      const url = editingQuote
-        ? `${API_URL}/api/v1/quotes/${editingQuote.id}`
-        : `${API_URL}/api/v1/quotes`;
-      const method = editingQuote ? "PATCH" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(quoteData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save quote");
+      if (editingQuote) {
+        await api.patch(`/api/v1/quotes/${editingQuote.id}`, quoteData);
+      } else {
+        await api.post("/api/v1/quotes", quoteData);
       }
 
       toast.success(editingQuote ? "Quote updated" : "Quote created");
@@ -111,24 +91,11 @@ export default function AdminQuotes() {
 
   const handleUpdateStatus = async (quoteId, newStatus, rejectionReason = null) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}/status`, {
-        method: "PATCH",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          status: newStatus,
-          rejection_reason: rejectionReason,
-        }),
+      const updated = await api.patch(`/api/v1/quotes/${quoteId}/status`, {
+        status: newStatus,
+        rejection_reason: rejectionReason,
       });
 
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to update status");
-      }
-
-      const updated = await res.json();
       toast.success(`Quote ${newStatus}`);
       fetchQuotes();
       fetchStats();
@@ -142,17 +109,8 @@ export default function AdminQuotes() {
 
   const handleConvertToOrder = async (quoteId) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}/convert`, {
-        method: "POST",
-        credentials: "include",
-      });
+      const data = await api.post(`/api/v1/quotes/${quoteId}/convert`);
 
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to convert quote");
-      }
-
-      const data = await res.json();
       toast.success(`Converted to ${data.order_number}`);
       setViewingQuote(null);
       fetchQuotes();
@@ -165,6 +123,7 @@ export default function AdminQuotes() {
     }
   };
 
+  // PDF download/print use raw fetch because apiClient does not support blob responses
   const handleDownloadPDF = async (quote) => {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/pdf`, {
@@ -218,7 +177,6 @@ export default function AdminQuotes() {
 
   const handleDuplicateQuote = async (quote) => {
     try {
-      // Create a new quote based on the existing one
       const newQuoteData = {
         product_id: quote.product_id || null,
         product_name: quote.product_name,
@@ -235,21 +193,7 @@ export default function AdminQuotes() {
         valid_days: 30,
       };
 
-      const res = await fetch(`${API_URL}/api/v1/quotes`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(newQuoteData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to duplicate quote");
-      }
-
-      const newQuote = await res.json();
+      const newQuote = await api.post("/api/v1/quotes", newQuoteData);
       toast.success(`Quote duplicated as ${newQuote.quote_number}`);
       fetchQuotes();
       fetchStats();
@@ -275,16 +219,7 @@ export default function AdminQuotes() {
     if (!confirm("Are you sure you want to delete this quote?")) return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/quotes/${quoteId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to delete quote");
-      }
-
+      await api.del(`/api/v1/quotes/${quoteId}`);
       toast.success("Quote deleted");
       setViewingQuote(null);
       fetchQuotes();
@@ -622,12 +557,11 @@ export default function AdminQuotes() {
           getStatusStyle={getStatusStyle}
           onRefresh={async () => {
             // Refresh the viewing quote to get updated has_image flag
-            const res = await fetch(`${API_URL}/api/v1/quotes/${viewingQuote.id}`, {
-              credentials: "include",
-            });
-            if (res.ok) {
-              const updated = await res.json();
+            try {
+              const updated = await api.get(`/api/v1/quotes/${viewingQuote.id}`);
               setViewingQuote(updated);
+            } catch {
+              // Non-critical: viewing quote refresh failure
             }
             fetchQuotes();
           }}

--- a/frontend/src/pages/admin/AdminScrapReasons.jsx
+++ b/frontend/src/pages/admin/AdminScrapReasons.jsx
@@ -1,37 +1,19 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import { API_URL } from "../../config/api";
+import { useState, useEffect, useRef } from "react";
+import { useApi } from "../../hooks/useApi";
+import { useCRUD } from "../../hooks/useCRUD";
 import { useToast } from "../../components/Toast";
 
 export default function AdminScrapReasons() {
   const toast = useToast();
-  const [reasons, setReasons] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const api = useApi();
+  const {
+    items: reasons,
+    loading,
+    error,
+    refresh,
+  } = useCRUD("/api/v1/production-orders/scrap-reasons/all", { extractKey: null });
   const [showModal, setShowModal] = useState(false);
   const [editingReason, setEditingReason] = useState(null);
-
-  const fetchReasons = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders/scrap-reasons/all`,
-        {
-          credentials: "include",
-        }
-      );
-      if (!res.ok) throw new Error("Failed to fetch scrap reasons");
-      const data = await res.json();
-      setReasons(Array.isArray(data) ? data : []);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchReasons();
-  }, [fetchReasons]);
 
   const handleSave = async (reasonData) => {
     try {
@@ -44,23 +26,10 @@ export default function AdminScrapReasons() {
         requestBody.description = reasonData.description;
       }
 
-      const url = editingReason
-        ? `${API_URL}/api/v1/production-orders/scrap-reasons/${editingReason.id}`
-        : `${API_URL}/api/v1/production-orders/scrap-reasons`;
-      const method = editingReason ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save scrap reason");
+      if (editingReason) {
+        await api.put(`/api/v1/production-orders/scrap-reasons/${editingReason.id}`, requestBody);
+      } else {
+        await api.post("/api/v1/production-orders/scrap-reasons", requestBody);
       }
 
       toast.success(
@@ -68,7 +37,7 @@ export default function AdminScrapReasons() {
       );
       setShowModal(false);
       setEditingReason(null);
-      await fetchReasons();
+      await refresh();
     } catch (err) {
       toast.error(err.message);
       throw err; // Re-throw so modal knows save failed
@@ -81,23 +50,14 @@ export default function AdminScrapReasons() {
         active: (!reason.active).toString(),
       });
 
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders/scrap-reasons/${reason.id}?${params}`,
-        {
-          method: "PUT",
-          credentials: "include",
-        }
+      await api.put(
+        `/api/v1/production-orders/scrap-reasons/${reason.id}?${params}`
       );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to update scrap reason");
-      }
 
       toast.success(
         reason.active ? "Scrap reason deactivated" : "Scrap reason activated"
       );
-      await fetchReasons();
+      await refresh();
     } catch (err) {
       toast.error(err.message);
     }

--- a/frontend/src/pages/admin/AdminSecurity.jsx
+++ b/frontend/src/pages/admin/AdminSecurity.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import RemediationModal from "../../components/RemediationModal";
 
@@ -83,6 +83,7 @@ const getStatusBadge = (status) => {
 };
 
 const AdminSecurity = () => {
+  const api = useApi();
   const toast = useToast();
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -116,24 +117,15 @@ const AdminSecurity = () => {
     setError(null);
 
     try {
-      const response = await fetch(`${API_URL}/api/v1/security/audit`, {
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        setAuditData(data);
-        if (isRefresh) {
-          toast.success("Security audit refreshed");
-        }
-      } else {
-        const errData = await response.json().catch(() => ({}));
-        setError(errData.detail || `Error ${response.status}: Failed to load security audit`);
-        toast.error(errData.detail || "Failed to load security audit");
+      const data = await api.get("/api/v1/security/audit");
+      setAuditData(data);
+      if (isRefresh) {
+        toast.success("Security audit refreshed");
       }
     } catch (err) {
-      setError("Failed to load security audit: " + err.message);
-      toast.error("Failed to load security audit: " + err.message);
+      const msg = err.message || "Failed to load security audit";
+      setError(msg);
+      toast.error(msg);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -143,25 +135,17 @@ const AdminSecurity = () => {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const response = await fetch(`${API_URL}/api/v1/security/audit/export?format=json`, {
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `filaops_security_audit_${new Date().toISOString().split("T")[0]}.json`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-        toast.success("Security report exported");
-      } else {
-        toast.error("Failed to export report");
-      }
+      const data = await api.get("/api/v1/security/audit/export?format=json");
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `filaops_security_audit_${new Date().toISOString().split("T")[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.success("Security report exported");
     } catch (err) {
       toast.error("Failed to export: " + err.message);
     } finally {

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { useApi } from "../../hooks/useApi";
 import { API_URL } from "../../config/api";
 import { useToast } from "../../components/Toast";
 import { useVersionCheck } from "../../hooks/useVersionCheck";
@@ -7,6 +8,7 @@ import { formatPhoneNumber, timezoneOptions } from "../../components/settings/co
 import AiSettingsSection from "../../components/settings/AiSettingsSection";
 
 const AdminSettings = () => {
+  const api = useApi();
   const toast = useToast();
   const [settings, setSettings] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -66,43 +68,32 @@ const AdminSettings = () => {
 
   const fetchSettings = async () => {
     try {
-      const response = await fetch(`${API_URL}/api/v1/settings/company`, {
-        credentials: "include",
+      const data = await api.get(`/api/v1/settings/company`);
+      setSettings(data);
+      setForm({
+        company_name: data.company_name || "",
+        company_address_line1: data.company_address_line1 || "",
+        company_address_line2: data.company_address_line2 || "",
+        company_city: data.company_city || "",
+        company_state: data.company_state || "",
+        company_zip: data.company_zip || "",
+        company_country: data.company_country || "USA",
+        timezone: data.timezone || "America/New_York",
+        company_phone: data.company_phone || "",
+        company_email: data.company_email || "",
+        company_website: data.company_website || "",
+        tax_enabled: data.tax_enabled || false,
+        tax_rate_percent: data.tax_rate_percent || "",
+        tax_name: data.tax_name || "Sales Tax",
+        tax_registration_number: data.tax_registration_number || "",
+        default_quote_validity_days: data.default_quote_validity_days || 30,
+        quote_terms: data.quote_terms || "",
+        quote_footer: data.quote_footer || "",
+        business_hours_start: data.business_hours_start ?? 8,
+        business_hours_end: data.business_hours_end ?? 16,
+        business_days_per_week: data.business_days_per_week ?? 5,
+        business_work_days: data.business_work_days || "0,1,2,3,4",
       });
-
-      if (response.ok) {
-        const data = await response.json();
-        setSettings(data);
-        setForm({
-          company_name: data.company_name || "",
-          company_address_line1: data.company_address_line1 || "",
-          company_address_line2: data.company_address_line2 || "",
-          company_city: data.company_city || "",
-          company_state: data.company_state || "",
-          company_zip: data.company_zip || "",
-          company_country: data.company_country || "USA",
-          timezone: data.timezone || "America/New_York",
-          company_phone: data.company_phone || "",
-          company_email: data.company_email || "",
-          company_website: data.company_website || "",
-          tax_enabled: data.tax_enabled || false,
-          tax_rate_percent: data.tax_rate_percent || "",
-          tax_name: data.tax_name || "Sales Tax",
-          tax_registration_number: data.tax_registration_number || "",
-          default_quote_validity_days: data.default_quote_validity_days || 30,
-          quote_terms: data.quote_terms || "",
-          quote_footer: data.quote_footer || "",
-          business_hours_start: data.business_hours_start ?? 8,
-          business_hours_end: data.business_hours_end ?? 16,
-          business_days_per_week: data.business_days_per_week ?? 5,
-          business_work_days: data.business_work_days || "0,1,2,3,4",
-        });
-      } else {
-        const errData = await response.json().catch(() => ({}));
-        toast.error(
-          errData.detail || `Error ${response.status}: Failed to load settings`
-        );
-      }
     } catch (error) {
       toast.error("Failed to load settings: " + error.message);
     } finally {
@@ -128,31 +119,17 @@ const AdminSettings = () => {
     setSaving(true);
 
     try {
-      const response = await fetch(`${API_URL}/api/v1/settings/company`, {
-        method: "PATCH",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ...form,
-          tax_rate_percent: form.tax_rate_percent
-            ? parseFloat(form.tax_rate_percent)
-            : null,
-          default_quote_validity_days: parseInt(
-            form.default_quote_validity_days
-          ),
-        }),
+      const data = await api.patch(`/api/v1/settings/company`, {
+        ...form,
+        tax_rate_percent: form.tax_rate_percent
+          ? parseFloat(form.tax_rate_percent)
+          : null,
+        default_quote_validity_days: parseInt(
+          form.default_quote_validity_days
+        ),
       });
-
-      if (response.ok) {
-        const data = await response.json();
-        setSettings(data);
-        toast.success("Settings saved successfully!");
-      } else {
-        const errData = await response.json();
-        toast.error(errData.detail || "Failed to save settings");
-      }
+      setSettings(data);
+      toast.success("Settings saved successfully!");
     } catch (error) {
       toast.error("Failed to save settings: " + error.message);
     } finally {
@@ -194,15 +171,9 @@ const AdminSettings = () => {
     if (!confirm("Are you sure you want to delete the company logo?")) return;
 
     try {
-      const response = await fetch(`${API_URL}/api/v1/settings/company/logo`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        toast.success("Logo deleted successfully!");
-        fetchSettings();
-      }
+      await api.del(`/api/v1/settings/company/logo`);
+      toast.success("Logo deleted successfully!");
+      fetchSettings();
     } catch (error) {
       toast.error("Failed to delete logo: " + error.message);
     }

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 
 // Shipping Trend Chart Component
@@ -302,6 +302,7 @@ const sortByDueDate = (orders) => {
 };
 
 export default function AdminShipping() {
+  const api = useApi();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const toast = useToast();
@@ -333,14 +334,8 @@ export default function AdminShipping() {
   const fetchShippingTrend = async (period) => {
     setTrendLoading(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/dashboard/shipping-trend?period=${period}`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setShippingTrend(data);
-      }
+      const data = await api.get(`/api/v1/admin/dashboard/shipping-trend?period=${period}`);
+      setShippingTrend(data);
     } catch (err) {
       console.error("Failed to fetch shipping trend:", err);
     } finally {
@@ -364,21 +359,17 @@ export default function AdminShipping() {
         }
       }
     }
-     
+
   }, [orderIdParam, orders, productionStatus]);
 
   const fetchOrders = async () => {
     setLoading(true);
     try {
       // Fetch orders ready to ship
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/?status=confirmed&status=in_production&status=ready_to_ship&status=qc_passed&limit=100`,
-        { credentials: "include" }
+      const data = await api.get(
+        `/api/v1/sales-orders/?status=confirmed&status=in_production&status=ready_to_ship&status=qc_passed&limit=100`
       );
 
-      if (!res.ok) throw new Error("Failed to fetch orders");
-
-      const data = await res.json();
       const orderList = data.items || data || [];
       setOrders(orderList);
 
@@ -397,14 +388,10 @@ export default function AdminShipping() {
   const fetchShippedToday = async () => {
     try {
       const today = new Date().toISOString().split("T")[0];
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/?status=shipped&shipped_after=${today}&limit=100`,
-        { credentials: "include" }
+      const data = await api.get(
+        `/api/v1/sales-orders/?status=shipped&shipped_after=${today}&limit=100`
       );
-      if (res.ok) {
-        const data = await res.json();
-        setShippedToday(data.items || data || []);
-      }
+      setShippedToday(data.items || data || []);
     } catch {
       // Non-critical
     }
@@ -429,28 +416,22 @@ export default function AdminShipping() {
   const fetchAllProductionStatuses = async (orderList) => {
     if (orderList.length === 0) return;
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders?limit=500`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        const allPOs = data.items || data || [];
-        const orderIds = new Set(orderList.map((o) => o.id));
-        // Group production orders by sales_order_id
-        const grouped = {};
-        for (const po of allPOs) {
-          if (po.sales_order_id && orderIds.has(po.sales_order_id)) {
-            if (!grouped[po.sales_order_id]) grouped[po.sales_order_id] = [];
-            grouped[po.sales_order_id].push(po);
-          }
+      const data = await api.get(`/api/v1/production-orders?limit=500`);
+      const allPOs = data.items || data || [];
+      const orderIds = new Set(orderList.map((o) => o.id));
+      // Group production orders by sales_order_id
+      const grouped = {};
+      for (const po of allPOs) {
+        if (po.sales_order_id && orderIds.has(po.sales_order_id)) {
+          if (!grouped[po.sales_order_id]) grouped[po.sales_order_id] = [];
+          grouped[po.sales_order_id].push(po);
         }
-        const statusMap = {};
-        for (const order of orderList) {
-          statusMap[order.id] = computeProductionStatus(grouped[order.id] || []);
-        }
-        setProductionStatus(statusMap);
       }
+      const statusMap = {};
+      for (const order of orderList) {
+        statusMap[order.id] = computeProductionStatus(grouped[order.id] || []);
+      }
+      setProductionStatus(statusMap);
     } catch {
       // Non-critical - production status just won't show
     }
@@ -459,18 +440,12 @@ export default function AdminShipping() {
   // Single order fetch (used for individual refresh)
   const fetchProductionStatus = async (orderId) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders?sales_order_id=${orderId}`,
-        { credentials: "include" }
-      );
-      if (res.ok) {
-        const data = await res.json();
-        const pos = data.items || data || [];
-        setProductionStatus((prev) => ({
-          ...prev,
-          [orderId]: computeProductionStatus(pos),
-        }));
-      }
+      const data = await api.get(`/api/v1/production-orders?sales_order_id=${orderId}`);
+      const pos = data.items || data || [];
+      setProductionStatus((prev) => ({
+        ...prev,
+        [orderId]: computeProductionStatus(pos),
+      }));
     } catch {
       // Non-critical
     }
@@ -484,22 +459,10 @@ export default function AdminShipping() {
 
     setSaving(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}/ship`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          carrier: trackingForm.carrier,
-          tracking_number: trackingForm.tracking_number.trim(),
-        }),
+      await api.post(`/api/v1/sales-orders/${orderId}/ship`, {
+        carrier: trackingForm.carrier,
+        tracking_number: trackingForm.tracking_number.trim(),
       });
-
-      if (!res.ok) {
-        const errData = await res.json();
-        throw new Error(errData.detail || "Failed to save tracking");
-      }
 
       toast.success("Tracking saved! Order marked as shipped.");
       setTrackingForm({ carrier: "USPS", tracking_number: "" });
@@ -516,23 +479,10 @@ export default function AdminShipping() {
   const handleMarkShipped = async (orderId) => {
     setSaving(true);
     try {
-      const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}/status`, {
-        method: "PATCH",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ status: "shipped" }),
-      });
-
-      if (res.ok) {
-        toast.success("Order marked as shipped");
-        fetchOrders();
-        setExpandedOrder(null);
-      } else {
-        const errorData = await res.json();
-        toast.error(`Failed: ${errorData.detail || "Unknown error"}`);
-      }
+      await api.patch(`/api/v1/sales-orders/${orderId}/status`, { status: "shipped" });
+      toast.success("Order marked as shipped");
+      fetchOrders();
+      setExpandedOrder(null);
     } catch (err) {
       toast.error(`Failed: ${err.message}`);
     } finally {

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { SPOOL_COLORS as statusColors } from "../../lib/statusColors.js";
 
 export default function AdminSpools() {
   const toast = useToast();
+  const api = useApi();
   const [spools, setSpools] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -31,12 +32,7 @@ export default function AdminSpools() {
       if (filters.status !== "all") params.set("status", filters.status);
       if (filters.search) params.set("search", filters.search);
 
-      const res = await fetch(`${API_URL}/api/v1/spools?${params}`, {
-        credentials: "include",
-      });
-
-      if (!res.ok) throw new Error("Failed to fetch spools");
-      const data = await res.json();
+      const data = await api.get(`/api/v1/spools?${params}`);
       setSpools(data.items || data || []);
     } catch (err) {
       setError(err.message);
@@ -48,13 +44,8 @@ export default function AdminSpools() {
 
   const fetchProducts = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/products?type=material&limit=200`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setProducts(data.items || data || []);
-      }
+      const data = await api.get("/api/v1/products?type=material&limit=200");
+      setProducts(data.items || data || []);
     } catch (err) {
       console.error("Failed to fetch products:", err);
     }
@@ -62,13 +53,8 @@ export default function AdminSpools() {
 
   const fetchLocations = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/inventory/locations`, {
-        credentials: "include",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setLocations(data.items || data || []);
-      }
+      const data = await api.get("/api/v1/inventory/locations");
+      setLocations(data.items || data || []);
     } catch (err) {
       console.error("Failed to fetch locations:", err);
     }
@@ -78,20 +64,11 @@ export default function AdminSpools() {
     if (!confirm("Are you sure you want to delete this spool?")) return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/spools/${spoolId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        toast.success("Spool deleted");
-        fetchSpools();
-      } else {
-        const error = await res.json();
-        toast.error(error.detail || "Failed to delete spool");
-      }
+      await api.del(`/api/v1/spools/${spoolId}`);
+      toast.success("Spool deleted");
+      fetchSpools();
     } catch (err) {
-      toast.error(`Error: ${err.message}`);
+      toast.error(err.message);
     }
   };
 
@@ -278,6 +255,7 @@ export default function AdminSpools() {
 
 function SpoolModal({ spool, products, locations, onClose, onSave }) {
   const toast = useToast();
+  const api = useApi();
   const [form, setForm] = useState({
     spool_number: spool?.spool_number || "",
     product_id: spool?.product_id || "",
@@ -296,10 +274,9 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
     setSaving(true);
 
     try {
-      const url = spool
-        ? `${API_URL}/api/v1/spools/${spool.id}`
-        : `${API_URL}/api/v1/spools`;
-      const method = spool ? "PATCH" : "POST";
+      const endpoint = spool
+        ? `/api/v1/spools/${spool.id}`
+        : "/api/v1/spools";
 
       const params = new URLSearchParams();
       if (!spool) {
@@ -316,20 +293,16 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
       if (form.expiry_date) params.set("expiry_date", form.expiry_date);
       if (form.notes) params.set("notes", form.notes);
 
-      const res = await fetch(`${url}?${params}`, {
-        method,
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        toast.success(spool ? "Spool updated" : "Spool created");
-        onSave();
+      if (spool) {
+        await api.patch(`${endpoint}?${params}`);
       } else {
-        const error = await res.json();
-        toast.error(error.detail || "Failed to save spool");
+        await api.post(`${endpoint}?${params}`);
       }
+
+      toast.success(spool ? "Spool updated" : "Spool created");
+      onSave();
     } catch (err) {
-      toast.error(`Error: ${err.message}`);
+      toast.error(err.message);
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
+import { useCRUD } from "../../hooks/useCRUD";
 import { useToast } from "../../components/Toast";
 import Modal from "../../components/Modal";
 
@@ -28,9 +29,14 @@ const STATUS_OPTIONS = [
 
 export default function AdminUsers() {
   const toast = useToast();
-  const [users, setUsers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const api = useApi();
+  const {
+    items: users,
+    loading,
+    error,
+    fetchAll: fetchUsers,
+    refresh,
+  } = useCRUD("/api/v1/admin/users", { extractKey: null, immediate: false });
   const [filters, setFilters] = useState({
     search: "",
     role: "all",
@@ -46,29 +52,11 @@ export default function AdminUsers() {
   const [resettingPassword, setResettingPassword] = useState(false);
 
   useEffect(() => {
-    fetchUsers();
-  }, [filters.role, filters.includeInactive]);
-
-  const fetchUsers = async () => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      params.set("limit", "200");
-      if (filters.role !== "all") params.set("account_type", filters.role);
-      if (filters.includeInactive) params.set("include_inactive", "true");
-
-      const res = await fetch(`${API_URL}/api/v1/admin/users?${params}`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to fetch users");
-      const data = await res.json();
-      setUsers(Array.isArray(data) ? data : []);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+    const params = { limit: "200" };
+    if (filters.role !== "all") params.account_type = filters.role;
+    if (filters.includeInactive) params.include_inactive = "true";
+    fetchUsers(params).catch(() => {});
+  }, [filters.role, filters.includeInactive, fetchUsers]);
 
   const filteredUsers = users.filter((user) => {
     if (!filters.search) return true;
@@ -114,29 +102,16 @@ export default function AdminUsers() {
   const handleSaveUser = async (userData) => {
     setSavingUser(true);
     try {
-      const url = editingUser
-        ? `${API_URL}/api/v1/admin/users/${editingUser.id}`
-        : `${API_URL}/api/v1/admin/users`;
-      const method = editingUser ? "PATCH" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(userData),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to save user");
+      if (editingUser) {
+        await api.patch(`/api/v1/admin/users/${editingUser.id}`, userData);
+      } else {
+        await api.post("/api/v1/admin/users", userData);
       }
 
       toast.success(editingUser ? "User updated" : "User created");
       setShowUserModal(false);
       setEditingUser(null);
-      fetchUsers();
+      refresh();
     } catch (err) {
       toast.error(err.message);
     } finally {
@@ -154,18 +129,9 @@ export default function AdminUsers() {
       return;
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/admin/users/${user.id}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to deactivate user");
-      }
-
+      await api.del(`/api/v1/admin/users/${user.id}`);
       toast.success("User deactivated");
-      fetchUsers();
+      refresh();
     } catch (err) {
       toast.error(err.message);
     }
@@ -174,21 +140,9 @@ export default function AdminUsers() {
   // Reactivate user
   const handleReactivate = async (user) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/users/${user.id}/reactivate`,
-        {
-          method: "POST",
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to reactivate user");
-      }
-
+      await api.post(`/api/v1/admin/users/${user.id}/reactivate`);
       toast.success("User reactivated");
-      fetchUsers();
+      refresh();
     } catch (err) {
       toast.error(err.message);
     }
@@ -200,22 +154,10 @@ export default function AdminUsers() {
 
     setResettingPassword(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/admin/users/${resetPasswordUser.id}/reset-password`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ new_password: newPassword }),
-        }
+      await api.post(
+        `/api/v1/admin/users/${resetPasswordUser.id}/reset-password`,
+        { new_password: newPassword }
       );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to reset password");
-      }
 
       setShowResetPasswordModal(false);
       setResetPasswordUser(null);

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -9,7 +9,7 @@
  */
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import RecordPaymentModal from "../../components/payments/RecordPaymentModal";
 import ActivityTimeline from "../../components/ActivityTimeline";
@@ -28,6 +28,7 @@ export default function OrderDetail() {
   const { orderId } = useParams();
   const navigate = useNavigate();
   const toast = useToast();
+  const api = useApi();
 
   const [order, setOrder] = useState(null);
   const [materialRequirements, setMaterialRequirements] = useState([]);
@@ -93,21 +94,8 @@ export default function OrderDetail() {
     setLoading(true);
     setError(null);
 
-    const url = `${API_URL}/api/v1/sales-orders/${orderId}`;
-
     try {
-      const res = await fetch(url, {
-        credentials: "include",
-        cache: "no-cache",
-      });
-
-      if (!res.ok) {
-        throw new Error(
-          `Failed to fetch order: ${res.status} ${res.statusText}`
-        );
-      }
-
-      const data = await res.json();
+      const data = await api.get(`/api/v1/sales-orders/${orderId}`);
       setOrder(data);
 
       // Explode BOM for material requirements
@@ -124,31 +112,16 @@ export default function OrderDetail() {
         await explodeBOM(data.product_id, data.quantity);
       } else if (data.quote_id) {
         try {
-          const quoteRes = await fetch(
-            `${API_URL}/api/v1/quotes/${data.quote_id}`,
-            {
-              credentials: "include",
-            }
-          );
-          if (quoteRes.ok) {
-            const quoteData = await quoteRes.json();
-            if (quoteData.product_id) {
-              await explodeBOM(quoteData.product_id, data.quantity);
-            }
+          const quoteData = await api.get(`/api/v1/quotes/${data.quote_id}`);
+          if (quoteData.product_id) {
+            await explodeBOM(quoteData.product_id, data.quantity);
           }
         } catch {
           // Quote fetch failure is non-critical
         }
       }
     } catch (err) {
-      if (err.message.includes("Failed to fetch")) {
-        setError(
-          `Network error: Cannot connect to backend at ${API_URL}. ` +
-            `Please check if the backend server is running.`
-        );
-      } else {
-        setError(err.message || "Failed to fetch order");
-      }
+      setError(err.message || "Failed to fetch order");
       throw err;
     } finally {
       setLoading(false);
@@ -158,16 +131,10 @@ export default function OrderDetail() {
   const fetchProductionOrders = async () => {
     if (!orderId) return;
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders?sales_order_id=${orderId}`,
-        {
-          credentials: "include",
-        }
+      const data = await api.get(
+        `/api/v1/production-orders?sales_order_id=${orderId}`
       );
-      if (res.ok) {
-        const data = await res.json();
-        setProductionOrders(data.items || data || []);
-      }
+      setProductionOrders(data.items || data || []);
     } catch {
       // Production orders fetch failure is non-critical
     }
@@ -176,24 +143,18 @@ export default function OrderDetail() {
   const fetchPaymentData = async () => {
     if (!orderId) return;
     try {
-      const summaryRes = await fetch(
-        `${API_URL}/api/v1/payments/order/${orderId}/summary`,
-        { credentials: "include" }
+      const summary = await api.get(
+        `/api/v1/payments/order/${orderId}/summary`
       );
-      if (summaryRes.ok) {
-        setPaymentSummary(await summaryRes.json());
-      }
-
-      const paymentsRes = await fetch(
-        `${API_URL}/api/v1/payments?order_id=${orderId}`,
-        { credentials: "include" }
-      );
-      if (paymentsRes.ok) {
-        const data = await paymentsRes.json();
-        setPayments(data.items || []);
-      }
+      setPaymentSummary(summary);
     } catch {
-      // Payment fetch failure is non-critical
+      // Payment summary fetch failure is non-critical
+    }
+    try {
+      const data = await api.get(`/api/v1/payments?order_id=${orderId}`);
+      setPayments(data.items || []);
+    } catch {
+      // Payment list fetch failure is non-critical
     }
   };
 
@@ -225,15 +186,10 @@ export default function OrderDetail() {
     setExploding(true);
     try {
       // PRIMARY: Use the new material-requirements endpoint (routing-first approach)
-      const matReqRes = await fetch(
-        `${API_URL}/api/v1/sales-orders/${orderId}/material-requirements`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (matReqRes.ok) {
-        const matReqData = await matReqRes.json();
+      try {
+        const matReqData = await api.get(
+          `/api/v1/sales-orders/${orderId}/material-requirements`
+        );
 
         const requirements = (matReqData.requirements || []).map((req) => ({
           product_id: req.product_id,
@@ -252,17 +208,12 @@ export default function OrderDetail() {
         }));
         setMaterialRequirements(requirements);
         setMaterialAvailability(matReqData.summary);
-      } else {
+      } catch {
         // FALLBACK: Use the MRP requirements endpoint
-        const res = await fetch(
-          `${API_URL}/api/v1/mrp/requirements?product_id=${productId}`,
-          {
-            credentials: "include",
-          }
-        );
-
-        if (res.ok) {
-          const data = await res.json();
+        try {
+          const data = await api.get(
+            `/api/v1/mrp/requirements?product_id=${productId}`
+          );
 
           const scaled = (data.requirements || []).map((req) => {
             const gross_qty = parseFloat(req.gross_quantity || 0) * quantity;
@@ -292,17 +243,12 @@ export default function OrderDetail() {
             };
           });
           setMaterialRequirements(scaled);
-        } else {
+        } catch {
           // If MRP endpoint fails, try BOM explosion directly
-          const bomRes = await fetch(
-            `${API_URL}/api/v1/mrp/explode-bom/${productId}?quantity=${quantity}`,
-            {
-              credentials: "include",
-            }
-          );
-
-          if (bomRes.ok) {
-            const bomData = await bomRes.json();
+          try {
+            const bomData = await api.get(
+              `/api/v1/mrp/explode-bom/${productId}?quantity=${quantity}`
+            );
 
             const requirements = (bomData.components || []).map((comp) => ({
               product_id: comp.product_id,
@@ -318,38 +264,34 @@ export default function OrderDetail() {
               material_source: "bom",
             }));
             setMaterialRequirements(requirements);
+          } catch {
+            // All BOM endpoints failed - material requirements section will be empty
           }
         }
       }
 
       // Get routing for capacity requirements (optional)
       try {
-        const routingRes = await fetch(
-          `${API_URL}/api/v1/routings/product/${productId}`,
-          {
-            credentials: "include",
-          }
+        const routing = await api.get(
+          `/api/v1/routings/product/${productId}`
         );
 
-        if (routingRes.ok) {
-          const routing = await routingRes.json();
-          if (routing.operations && routing.operations.length > 0) {
-            const capacity = routing.operations.map((op) => {
-              const setupTime = parseFloat(op.setup_time_minutes) || 0;
-              const runTime = parseFloat(op.run_time_minutes) || 0;
-              return {
-                ...op,
-                setup_time_minutes: setupTime,
-                run_time_minutes: runTime,
-                total_time_minutes: setupTime + runTime * quantity,
-                work_center_name:
-                  op.work_center?.name || op.work_center_name || "N/A",
-                operation_name:
-                  op.operation_name || op.operation_code || "Operation",
-              };
-            });
-            setCapacityRequirements(capacity);
-          }
+        if (routing.operations && routing.operations.length > 0) {
+          const capacity = routing.operations.map((op) => {
+            const setupTime = parseFloat(op.setup_time_minutes) || 0;
+            const runTime = parseFloat(op.run_time_minutes) || 0;
+            return {
+              ...op,
+              setup_time_minutes: setupTime,
+              run_time_minutes: runTime,
+              total_time_minutes: setupTime + runTime * quantity,
+              work_center_name:
+                op.work_center?.name || op.work_center_name || "N/A",
+              operation_name:
+                op.operation_name || op.operation_code || "Operation",
+            };
+          });
+          setCapacityRequirements(capacity);
         }
       } catch {
         // Routing is optional - don't fail
@@ -371,21 +313,9 @@ export default function OrderDetail() {
     }
 
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${orderId}/generate-production-orders`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
+      await api.post(
+        `/api/v1/sales-orders/${orderId}/generate-production-orders`
       );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to create production order");
-      }
 
       toast.success("Production order created successfully!");
       fetchProductionOrders();
@@ -403,24 +333,12 @@ export default function OrderDetail() {
 
   const handleCreateWorkOrder = async (materialReq) => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/production-orders`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          product_id: materialReq.product_id,
-          quantity_ordered: Math.ceil(materialReq.net_shortage || 1),
-          sales_order_id: parseInt(orderId),
-          notes: `Created from SO ${order.order_number} for sub-assembly`,
-        }),
+      await api.post(`/api/v1/production-orders`, {
+        product_id: materialReq.product_id,
+        quantity_ordered: Math.ceil(materialReq.net_shortage || 1),
+        sales_order_id: parseInt(orderId),
+        notes: `Created from SO ${order.order_number} for sub-assembly`,
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to create work order");
-      }
 
       toast.success(`Work order created for ${materialReq.product_name}`);
       fetchOrder();
@@ -436,26 +354,13 @@ export default function OrderDetail() {
 
   const handleCancelOrder = async (cancellationReason) => {
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/sales-orders/${orderId}/cancel`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ cancellation_reason: cancellationReason }),
-        }
-      );
+      await api.post(`/api/v1/sales-orders/${orderId}/cancel`, {
+        cancellation_reason: cancellationReason,
+      });
 
-      if (res.ok) {
-        toast.success(`Order ${order.order_number} cancelled`);
-        setShowCancelModal(false);
-        fetchOrder();
-      } else {
-        const errorData = await res.json();
-        toast.error(errorData.detail || "Failed to cancel order");
-      }
+      toast.success(`Order ${order.order_number} cancelled`);
+      setShowCancelModal(false);
+      fetchOrder();
     } catch (err) {
       toast.error(err.message || "Failed to cancel order");
     }
@@ -463,28 +368,10 @@ export default function OrderDetail() {
 
   const handleDeleteOrder = async () => {
     try {
-      const res = await fetch(`${API_URL}/api/v1/sales-orders/${orderId}`, {
-        method: "DELETE",
-        credentials: "include",
-      });
+      await api.del(`/api/v1/sales-orders/${orderId}`);
 
-      if (res.ok || res.status === 204) {
-        toast.success(`Order ${order.order_number} deleted`);
-        navigate("/admin/orders");
-      } else {
-        let errorMsg = "Failed to delete order";
-        const contentType = res.headers.get("content-type") || "";
-        const text = await res.text();
-        if (text && contentType.includes("application/json")) {
-          try {
-            const errorData = JSON.parse(text);
-            errorMsg = errorData.detail || errorMsg;
-          } catch {
-            // Ignore JSON parse error
-          }
-        }
-        toast.error(errorMsg);
-      }
+      toast.success(`Order ${order.order_number} deleted`);
+      navigate("/admin/orders");
     } catch (err) {
       toast.error(err.message || "Failed to delete order");
     }
@@ -517,16 +404,13 @@ export default function OrderDetail() {
       if (productionOrders.length > 0) {
         const availabilityChecks = await Promise.all(
           productionOrders.map(async (po) => {
-            const res = await fetch(
-              `${API_URL}/api/v1/production-orders/${po.id}/material-availability`,
-              {
-                credentials: "include",
-              }
-            );
-            if (res.ok) {
-              return await res.json();
+            try {
+              return await api.get(
+                `/api/v1/production-orders/${po.id}/material-availability`
+              );
+            } catch {
+              return null;
             }
-            return null;
           })
         );
         setMaterialAvailability(availabilityChecks.filter(Boolean));

--- a/frontend/src/pages/admin/ProductionOrderDetail.jsx
+++ b/frontend/src/pages/admin/ProductionOrderDetail.jsx
@@ -9,7 +9,7 @@
  */
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import BlockingIssuesPanel from "../../components/orders/BlockingIssuesPanel";
 import {
@@ -24,24 +24,22 @@ import { PRODUCTION_ORDER_COLORS, getStatusColor } from "../../lib/statusColors.
  */
 function OperationsTimelineWrapper({ productionOrderId }) {
   const [operations, setOperations] = useState([]);
+  const api = useApi();
 
   useEffect(() => {
     const fetchOps = async () => {
       if (!productionOrderId) return;
       try {
-        const res = await fetch(
-          `${API_URL}/api/v1/production-orders/${productionOrderId}/operations`,
-          { credentials: "include" }
+        const data = await api.get(
+          `/api/v1/production-orders/${productionOrderId}/operations`
         );
-        if (res.ok) {
-          const data = await res.json();
-          setOperations(Array.isArray(data) ? data : data.operations || []);
-        }
+        setOperations(Array.isArray(data) ? data : data.operations || []);
       } catch (err) {
         console.error('Failed to fetch operations for timeline:', err);
       }
     };
     fetchOps();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [productionOrderId]);
 
   if (operations.length === 0) return null;
@@ -53,6 +51,7 @@ export default function ProductionOrderDetail() {
   const { orderId } = useParams();
   const navigate = useNavigate();
   const toast = useToast();
+  const api = useApi();
 
   const [order, setOrder] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -73,15 +72,7 @@ export default function ProductionOrderDetail() {
     setError(null);
 
     try {
-      const res = await fetch(`${API_URL}/api/v1/production-orders/${orderId}`, {
-        credentials: "include",
-      });
-
-      if (!res.ok) {
-        throw new Error(`Failed to fetch production order: ${res.statusText}`);
-      }
-
-      const data = await res.json();
+      const data = await api.get(`/api/v1/production-orders/${orderId}`);
       setOrder(data);
     } catch (err) {
       setError(err.message);
@@ -93,18 +84,7 @@ export default function ProductionOrderDetail() {
   const handleStatusUpdate = async (action) => {
     setUpdating(true);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/production-orders/${orderId}/${action}`,
-        {
-          method: "POST",
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || `Failed to ${action} order`);
-      }
+      await api.post(`/api/v1/production-orders/${orderId}/${action}`);
 
       toast.success(`Order ${action} successfully`);
       fetchOrder();

--- a/frontend/src/pages/admin/quality/MaterialTraceability.jsx
+++ b/frontend/src/pages/admin/quality/MaterialTraceability.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { API_URL } from "../../../config/api";
+import { useApi } from "../../../hooks/useApi";
 import { useToast } from "../../../components/Toast";
 
 /**
@@ -11,6 +11,7 @@ import { useToast } from "../../../components/Toast";
  * - DHR export
  */
 export default function MaterialTraceability() {
+  const api = useApi();
   const [activeTab, setActiveTab] = useState("forward");
   const [spools, setSpools] = useState([]);
   const [loadingSpools, setLoadingSpools] = useState(false);
@@ -21,17 +22,8 @@ export default function MaterialTraceability() {
       const fetchSpools = async () => {
         setLoadingSpools(true);
         try {
-          const res = await fetch(`${API_URL}/api/v1/spools?limit=200`, {
-            credentials: "include",
-          });
-          const data = await res.json();
-          // Handle error responses and ensure we always set an array
-          if (data.detail || data.error) {
-            console.error("API error:", data.detail || data.error);
-            setSpools([]);
-          } else {
-            setSpools(Array.isArray(data) ? data : (data.items || []));
-          }
+          const data = await api.get(`/api/v1/spools?limit=200`);
+          setSpools(Array.isArray(data) ? data : (data.items || []));
         } catch (err) {
           console.error("Failed to fetch spools:", err);
           setSpools([]);
@@ -41,7 +33,7 @@ export default function MaterialTraceability() {
       };
       fetchSpools();
     }
-  }, [activeTab, spools.length]);
+  }, [activeTab, spools.length, api]);
 
   return (
     <div className="space-y-6 p-6">
@@ -87,6 +79,7 @@ export default function MaterialTraceability() {
  * Forward Trace - Spool → Products → Customers
  */
 function ForwardTrace({ spools, loadingSpools }) {
+  const api = useApi();
   const toast = useToast();
   const [spoolId, setSpoolId] = useState("");
   const [loading, setLoading] = useState(false);
@@ -103,21 +96,8 @@ function ForwardTrace({ spools, loadingSpools }) {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/traceability/forward/spool/${spoolId}`,
-        {
-          credentials: "include",
-        }
-      );
-
-      if (res.ok) {
-        const data = await res.json();
-        setResult(data);
-      } else {
-        const errorData = await res.json();
-        setError(errorData.detail || "Failed to trace spool");
-        toast.error(errorData.detail || "Failed to trace spool");
-      }
+      const data = await api.get(`/api/v1/traceability/forward/spool/${spoolId}`);
+      setResult(data);
     } catch (err) {
       setError(err.message);
       toast.error(`Error: ${err.message}`);
@@ -294,6 +274,7 @@ function ForwardTrace({ spools, loadingSpools }) {
  * Backward Trace - Product → Materials → Vendors
  */
 function BackwardTrace() {
+  const api = useApi();
   const toast = useToast();
   const [traceType, setTraceType] = useState("serial");
   const [searchValue, setSearchValue] = useState("");
@@ -316,18 +297,8 @@ function BackwardTrace() {
           ? `/api/v1/traceability/backward/serial/${encodeURIComponent(searchValue)}`
           : `/api/v1/traceability/backward/sales-order/${searchValue}`;
 
-      const res = await fetch(`${API_URL}${endpoint}`, {
-        credentials: "include",
-      });
-
-      if (res.ok) {
-        const data = await res.json();
-        setResult(data);
-      } else {
-        const errorData = await res.json();
-        setError(errorData.detail || "Failed to trace");
-        toast.error(errorData.detail || "Failed to trace");
-      }
+      const data = await api.get(endpoint);
+      setResult(data);
     } catch (err) {
       setError(err.message);
       toast.error(`Error: ${err.message}`);


### PR DESCRIPTION
## Summary
- **New `useApi` hook**: Singleton wrapper around `apiClient` with memoized `{ get, post, put, patch, del }` methods
- **New `useCRUD` hook**: Generic CRUD with automatic loading/error state, fetch-on-mount, and mutation helpers
- **24 admin pages migrated** from manual `fetch()` + `useState` boilerplate to shared hooks
- **Net -996 lines** of duplicated fetch/state management code removed
- **Bundle size reduced** from 1,389 kB to 1,374 kB (-16 kB)

## What Changed
Every `Admin*.jsx` page, plus `OrderDetail`, `ProductionOrderDetail`, and `MaterialTraceability` now use `useApi()` or `useCRUD()` instead of raw `fetch()` with `API_URL`. Pages that need `API_URL` for non-JSON operations (PDF downloads, FormData uploads, image URLs) retain it alongside the hooks.

## Test plan
- [x] `npm run build` — production build passes cleanly
- [x] `npx vitest run` — all 56 component tests pass
- [ ] Manual smoke test: navigate all admin pages, verify data loads, create/edit/delete operations work

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced API infrastructure with centralized request handling and improved error management across admin dashboard features. All existing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->