### PR TITLE
feat: add inventory adjustment reason codes (#24)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/inventory_transactions.py
+++ b/backend/app/api/v1/endpoints/admin/inventory_transactions.py
@@ -114,6 +114,33 @@ class BatchUpdateResponse(BaseModel):
 # ENDPOINTS
 # ============================================================================
 
+@router.get("/adjustment-reasons")
+async def list_adjustment_reasons(
+    include_inactive: bool = False,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_staff_user),
+):
+    """List all adjustment reasons for dropdown selection."""
+    from app.models.adjustment_reason import AdjustmentReason
+
+    query = db.query(AdjustmentReason)
+    if not include_inactive:
+        query = query.filter(AdjustmentReason.active.is_(True))
+    reasons = query.order_by(AdjustmentReason.sequence).all()
+
+    return [
+        {
+            "id": r.id,
+            "code": r.code,
+            "name": r.name,
+            "description": r.description,
+            "active": r.active,
+            "sequence": r.sequence,
+        }
+        for r in reasons
+    ]
+
+
 @router.get("", response_model=List[TransactionResponse])
 async def list_transactions(
     product_id: Optional[int] = Query(None, description="Filter by product"),

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -24,6 +24,7 @@ from app.models.company_settings import CompanySettings
 from app.models.uom import UnitOfMeasure
 from app.models.uom import UnitOfMeasure as UOM
 from app.models.scrap_reason import ScrapReason
+from app.models.adjustment_reason import AdjustmentReason
 from app.models.order_event import OrderEvent
 from app.models.purchasing_event import PurchasingEvent
 from app.models.shipping_event import ShippingEvent
@@ -95,6 +96,8 @@ __all__ = [
     "UOM",
     # Scrap Reasons
     "ScrapReason",
+    # Adjustment Reasons
+    "AdjustmentReason",
     # Order Events (Activity Timeline)
     "OrderEvent",
     "PurchasingEvent",

--- a/backend/app/models/adjustment_reason.py
+++ b/backend/app/models/adjustment_reason.py
@@ -1,0 +1,35 @@
+"""
+Adjustment Reason Model
+
+Stores configurable reasons for inventory adjustments.
+Allows shops to define their own adjustment categories for accounting compliance.
+"""
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text
+from datetime import datetime
+
+from app.db.base import Base
+
+
+class AdjustmentReason(Base):
+    """
+    A reason for adjusting inventory quantities.
+
+    Examples:
+    - physical_count: Discrepancy found during physical count
+    - damaged: Item damaged in warehouse
+    - correction: Data entry correction
+    """
+    __tablename__ = "adjustment_reasons"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(50), unique=True, nullable=False, index=True)
+    name = Column(String(100), nullable=False)
+    description = Column(Text, nullable=True)
+    active = Column(Boolean, default=True, nullable=False)
+    sequence = Column(Integer, default=0)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<AdjustmentReason {self.code}: {self.name}>"

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -99,6 +99,7 @@ class InventoryTransaction(Base):
 
     # Notes
     notes = Column(Text, nullable=True)
+    reason_code = Column(String(50), nullable=True)  # Links to adjustment_reasons.code
 
     # Negative Inventory Approval (for transactions that would cause negative inventory)
     requires_approval = Column(Boolean, default=False, nullable=False)

--- a/backend/app/services/inventory_transaction_service.py
+++ b/backend/app/services/inventory_transaction_service.py
@@ -20,6 +20,7 @@ from sqlalchemy import desc, or_
 from sqlalchemy.orm import Session
 
 from app.logging_config import get_logger
+from app.models.adjustment_reason import AdjustmentReason
 from app.models.inventory import Inventory, InventoryLocation, InventoryTransaction
 from app.models.product import Product
 from app.services.inventory_helpers import is_material
@@ -332,6 +333,7 @@ def create_transaction(
     serial_number: Optional[str] = None,
     notes: Optional[str] = None,
     to_location_id: Optional[int] = None,
+    reason_code: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create an inventory transaction and update inventory.
 
@@ -397,6 +399,7 @@ def create_transaction(
             serial_number=serial_number,
             notes=f"Transfer to {to_location.name if to_location else 'location'}: {notes or ''}",
             created_by=created_by,
+            reason_code=reason_code,
         )
         db.add(from_transaction)
 
@@ -417,6 +420,7 @@ def create_transaction(
             serial_number=serial_number,
             notes=f"Transfer from {location.name}: {notes or ''}",
             created_by=created_by,
+            reason_code=reason_code,
         )
         db.add(to_transaction)
 
@@ -441,6 +445,7 @@ def create_transaction(
             serial_number=serial_number,
             notes=notes,
             created_by=created_by,
+            reason_code=reason_code,
         )
         db.add(transaction)
 
@@ -574,6 +579,13 @@ def batch_update_inventory(
                 location_id=location.id,
                 user_id=admin_id,
             )
+
+            # Store reason_code if the reason matches a known adjustment reason code
+            known_reason = db.query(AdjustmentReason).filter(
+                AdjustmentReason.code == reason
+            ).first()
+            if known_reason:
+                inv_txn.reason_code = reason
 
             inventory.last_counted = datetime.now(timezone.utc)
             db.flush()

--- a/backend/migrations/versions/058_create_adjustment_reasons.py
+++ b/backend/migrations/versions/058_create_adjustment_reasons.py
@@ -1,0 +1,55 @@
+"""
+Create adjustment_reasons table and seed default data.
+
+Provides configurable reasons for inventory adjustments,
+similar to scrap_reasons for production scrapping.
+
+Revision ID: 058_adjustment_reasons
+Revises: 057_seed_scrap_reasons
+Create Date: 2026-02-08
+"""
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers
+revision = '058_adjustment_reasons'
+down_revision = '057_seed_scrap_reasons'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create adjustment_reasons table and seed default data."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS adjustment_reasons (
+            id SERIAL PRIMARY KEY,
+            code VARCHAR(50) UNIQUE NOT NULL,
+            name VARCHAR(100) NOT NULL,
+            description TEXT,
+            active BOOLEAN DEFAULT TRUE NOT NULL,
+            sequence INTEGER DEFAULT 0,
+            created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+            updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS ix_adjustment_reasons_code ON adjustment_reasons (code);
+        CREATE INDEX IF NOT EXISTS ix_adjustment_reasons_id ON adjustment_reasons (id);
+    """)
+
+    op.execute("""
+        INSERT INTO adjustment_reasons (code, name, description, sequence) VALUES
+        ('physical_count', 'Physical Count', 'Discrepancy found during physical inventory count', 10),
+        ('cycle_count', 'Cycle Count', 'Adjustment from cycle counting process', 20),
+        ('correction', 'Data Correction', 'Correcting a data entry error', 30),
+        ('damaged', 'Damaged Goods', 'Item damaged in storage or handling', 40),
+        ('found', 'Found Inventory', 'Previously unaccounted inventory discovered', 50),
+        ('theft_loss', 'Theft/Loss', 'Inventory missing due to theft or unexplained loss', 60),
+        ('expired', 'Expired/Obsolete', 'Item past usable life or obsolete', 70),
+        ('reclassification', 'Reclassification', 'Item moved to different category or account', 80),
+        ('other', 'Other', 'Other adjustment reason - specify in notes', 90)
+        ON CONFLICT (code) DO NOTHING;
+    """)
+
+
+def downgrade():
+    """Drop adjustment_reasons table."""
+    op.execute("DROP TABLE IF EXISTS adjustment_reasons;")

--- a/backend/migrations/versions/059_add_reason_code_to_transactions.py
+++ b/backend/migrations/versions/059_add_reason_code_to_transactions.py
@@ -1,0 +1,31 @@
+"""
+Add reason_code column to inventory_transactions.
+
+Stores the adjustment reason code for inventory adjustments,
+linking to adjustment_reasons.code without a FK constraint.
+
+Revision ID: 059_reason_code
+Revises: 058_adjustment_reasons
+Create Date: 2026-02-08
+"""
+from alembic import op
+
+# revision identifiers
+revision = '059_reason_code'
+down_revision = '058_adjustment_reasons'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add reason_code column to inventory_transactions."""
+    op.execute("""
+        ALTER TABLE inventory_transactions ADD COLUMN IF NOT EXISTS reason_code VARCHAR(50);
+    """)
+
+
+def downgrade():
+    """Remove reason_code column from inventory_transactions."""
+    op.execute("""
+        ALTER TABLE inventory_transactions DROP COLUMN IF EXISTS reason_code;
+    """)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -45,9 +45,17 @@ def setup_database():
 
     Base.metadata.create_all(bind=engine)
 
+    # Patch columns that create_all() won't add to pre-existing tables
+    from sqlalchemy import text
+    with engine.connect() as conn:
+        conn.execute(text(
+            "ALTER TABLE inventory_transactions "
+            "ADD COLUMN IF NOT EXISTS reason_code VARCHAR(50)"
+        ))
+        conn.commit()
+
     # Seed required data
     from sqlalchemy.orm import Session as SASession
-    from sqlalchemy import text
     from app.models.inventory import InventoryLocation
     from app.models.user import User
     from app.models.work_center import WorkCenter

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -7,6 +7,7 @@ export default function AdminInventoryTransactions() {
   const [transactions, setTransactions] = useState([]);
   const [products, setProducts] = useState([]);
   const [locations, setLocations] = useState([]);
+  const [adjustmentReasons, setAdjustmentReasons] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showForm, setShowForm] = useState(false);
@@ -22,6 +23,7 @@ export default function AdminInventoryTransactions() {
     serial_number: "",
     notes: "",
     to_location_id: "",
+    reason_code: "",
   });
   const [filters, setFilters] = useState({
     product_id: "",
@@ -34,6 +36,13 @@ export default function AdminInventoryTransactions() {
     fetchProducts();
     fetchLocations();
   }, [filters]);
+
+  // Fetch adjustment reasons for dropdown
+  useEffect(() => {
+    api.get("/api/v1/admin/inventory/transactions/adjustment-reasons")
+      .then(data => setAdjustmentReasons(data))
+      .catch(() => {}); // Non-critical, will fallback to empty dropdown
+  }, []);
 
   const fetchTransactions = async () => {
     try {
@@ -93,6 +102,7 @@ export default function AdminInventoryTransactions() {
           formData.transaction_type === "transfer" && formData.to_location_id
             ? parseInt(formData.to_location_id)
             : null,
+        ...(formData.reason_code && { reason_code: formData.reason_code }),
       };
 
       await api.post(`/api/v1/admin/inventory/transactions`, payload);
@@ -110,6 +120,7 @@ export default function AdminInventoryTransactions() {
         serial_number: "",
         notes: "",
         to_location_id: "",
+        reason_code: "",
       });
       setShowForm(false);
       fetchTransactions();
@@ -371,6 +382,28 @@ export default function AdminInventoryTransactions() {
               />
             </div>
 
+            {formData.transaction_type === "adjustment" && (
+              <div>
+                <label className="block text-sm font-medium text-gray-400 mb-1">
+                  Adjustment Reason
+                </label>
+                <select
+                  value={formData.reason_code}
+                  onChange={(e) =>
+                    setFormData({ ...formData, reason_code: e.target.value })
+                  }
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white"
+                >
+                  <option value="">Select reason...</option>
+                  {adjustmentReasons.map((r) => (
+                    <option key={r.code} value={r.code}>
+                      {r.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
             <div className="flex gap-4">
               <button
                 type="submit"
@@ -492,6 +525,9 @@ export default function AdminInventoryTransactions() {
                 <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
                   Notes
                 </th>
+                <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
+                  Reason
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -560,11 +596,14 @@ export default function AdminInventoryTransactions() {
                     <td className="py-3 px-4 text-gray-500 text-sm max-w-xs truncate">
                       {txn.notes || "-"}
                     </td>
+                    <td className="py-3 px-4 text-gray-500 text-sm">
+                      {txn.reason_code || "-"}
+                    </td>
                   </tr>
                 ))
               ) : (
                 <tr>
-                  <td colSpan={10} className="py-8 text-center text-gray-500">
+                  <td colSpan={11} className="py-8 text-center text-gray-500">
                     No transactions found
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- New `AdjustmentReason` model following the existing `ScrapReason` pattern
- 9 seeded reasons: physical_count, cycle_count, correction, damaged, found, theft_loss, expired, reclassification, other
- `reason_code` column added to `inventory_transactions` table
- New endpoint `GET /inventory/transactions/adjustment-reasons` for dropdown population
- Frontend dropdown appears when transaction type is "adjustment"

## Test plan
- [x] Backend imports cleanly
- [x] 35 inventory transaction tests pass (2 pre-existing summary failures from stale test data)
- [x] Frontend build passes
- [ ] Manual test: create adjustment transaction, verify reason dropdown appears and submits

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Adjustment Reason dropdown when creating inventory adjustment transactions with predefined common reasons.
  * Inventory transaction records now display their associated adjustment reason in the transactions table.
  * Adjustment reasons are configurable and pre-populated with standard options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->