### PR TITLE
feat: add packing slip PDF generation (#21)

### DIFF
--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -455,6 +455,38 @@ async def get_sales_order_details(
 
 
 # =============================================================================
+# PDF Generation
+# =============================================================================
+
+@router.get("/{order_id}/packing-slip/pdf")
+async def get_packing_slip_pdf(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Generate and return a packing slip PDF for a sales order."""
+    from starlette.responses import StreamingResponse
+
+    is_admin = getattr(current_user, "account_type", None) == "admin" or getattr(current_user, "is_admin", False)
+    if not is_admin:
+        raise HTTPException(status_code=403, detail="Only administrators can generate packing slips")
+
+    pdf_buffer = sales_order_service.generate_packing_slip_pdf(db, order_id)
+
+    # Get order number for filename
+    order = db.query(SalesOrder).filter(SalesOrder.id == order_id).first()
+    filename = f"packing-slip-{order.order_number}.pdf" if order else f"packing-slip-{order_id}.pdf"
+
+    return StreamingResponse(
+        pdf_buffer,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'inline; filename="{filename}"'
+        },
+    )
+
+
+# =============================================================================
 # MRP / Requirements Endpoints
 # =============================================================================
 

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -3,6 +3,7 @@ Sales Order Service — CRUD, status management, production orders, and fulfillm
 
 Extracted from sales_orders.py (ARCHITECT-003).
 """
+import io
 import math
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -1877,3 +1878,305 @@ def add_order_event(
 
     db.add(event)
     return event
+
+
+# =============================================================================
+# Packing Slip PDF
+# =============================================================================
+
+def generate_packing_slip_pdf(db: Session, order_id: int) -> io.BytesIO:
+    """Generate a packing slip PDF for a sales order using ReportLab.
+
+    The packing slip includes:
+    - Company header (logo, name, address, phone, email)
+    - "PACKING SLIP" title
+    - Order info (order number, order date, ship date)
+    - Ship-to address
+    - Items table (SKU, Description, Qty Ordered, Qty Shipped)
+    - Notes (if any)
+    - Footer
+
+    Returns the BytesIO buffer positioned at the start.
+    """
+    from xml.sax.saxutils import escape as _xml_escape
+
+    def esc(value: Optional[str]) -> str:
+        """Escape user-provided text for ReportLab Paragraph XML."""
+        return _xml_escape(value) if value else ""
+
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import inch
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Paragraph,
+        Spacer,
+        Table,
+        TableStyle,
+        Image,
+    )
+
+    order = db.query(SalesOrder).filter(SalesOrder.id == order_id).first()
+    if not order:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Sales order {order_id} not found",
+        )
+
+    # Get company settings
+    company_settings = (
+        db.query(CompanySettings).filter(CompanySettings.id == 1).first()
+    )
+
+    # Create PDF buffer
+    pdf_buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        pdf_buffer,
+        pagesize=letter,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+    )
+
+    # Styles
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "Title",
+        parent=styles["Heading1"],
+        fontSize=24,
+        textColor=colors.HexColor("#2563eb"),
+    )
+    heading_style = ParagraphStyle(
+        "Heading",
+        parent=styles["Heading2"],
+        fontSize=12,
+        textColor=colors.gray,
+    )
+    normal_style = styles["Normal"]
+
+    # Build content
+    content = []
+
+    # ---- Company Header ----
+    if company_settings and company_settings.logo_data:
+        try:
+            logo_buffer = io.BytesIO(company_settings.logo_data)
+            logo_img = Image(logo_buffer, width=1.5 * inch, height=1.5 * inch)
+            logo_img.hAlign = "LEFT"
+
+            company_info = []
+            if company_settings.company_name:
+                company_info.append(
+                    f"<b>{esc(company_settings.company_name)}</b>"
+                )
+            if company_settings.company_address_line1:
+                company_info.append(esc(company_settings.company_address_line1))
+            if company_settings.company_city or company_settings.company_state:
+                city_state = (
+                    f"{esc(company_settings.company_city or '')}, "
+                    f"{esc(company_settings.company_state or '')} "
+                    f"{esc(company_settings.company_zip or '')}"
+                ).strip(", ")
+                company_info.append(city_state)
+            if company_settings.company_phone:
+                company_info.append(esc(company_settings.company_phone))
+            if company_settings.company_email:
+                company_info.append(esc(company_settings.company_email))
+
+            header_data = [
+                [logo_img, Paragraph("<br/>".join(company_info), normal_style)]
+            ]
+            header_table = Table(
+                header_data, colWidths=[2 * inch, 4.5 * inch]
+            )
+            header_table.setStyle(
+                TableStyle([("VALIGN", (0, 0), (-1, -1), "TOP")])
+            )
+            content.append(header_table)
+            content.append(Spacer(1, 0.3 * inch))
+        except Exception:
+            # If logo fails, continue without it
+            pass
+    elif company_settings and company_settings.company_name:
+        content.append(
+            Paragraph(
+                f"<b>{esc(company_settings.company_name)}</b>", title_style
+            )
+        )
+        content.append(Spacer(1, 0.2 * inch))
+
+    # ---- Title ----
+    content.append(Paragraph("PACKING SLIP", title_style))
+    content.append(Spacer(1, 0.2 * inch))
+
+    # ---- Order Info ----
+    content.append(Paragraph("ORDER INFORMATION", heading_style))
+    content.append(Spacer(1, 0.05 * inch))
+
+    order_date_str = (
+        order.created_at.strftime("%B %d, %Y") if order.created_at else "N/A"
+    )
+    ship_date_str = (
+        order.shipped_at.strftime("%B %d, %Y") if order.shipped_at else "N/A"
+    )
+
+    order_info_data = [
+        ["Order Number:", esc(order.order_number)],
+        ["Order Date:", order_date_str],
+        ["Ship Date:", ship_date_str],
+    ]
+    order_info_table = Table(
+        order_info_data, colWidths=[1.5 * inch, 4 * inch]
+    )
+    order_info_table.setStyle(
+        TableStyle(
+            [
+                ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ]
+        )
+    )
+    content.append(order_info_table)
+    content.append(Spacer(1, 0.2 * inch))
+
+    # ---- Ship To ----
+    content.append(Paragraph("SHIP TO", heading_style))
+    content.append(Spacer(1, 0.05 * inch))
+
+    ship_to_parts = []
+    if order.customer_name:
+        ship_to_parts.append(f"<b>{esc(order.customer_name)}</b>")
+    if order.shipping_address_line1:
+        ship_to_parts.append(esc(order.shipping_address_line1))
+    if order.shipping_address_line2:
+        ship_to_parts.append(esc(order.shipping_address_line2))
+    city_state_zip = ""
+    if order.shipping_city:
+        city_state_zip += esc(order.shipping_city)
+    if order.shipping_state:
+        city_state_zip += f", {esc(order.shipping_state)}"
+    if order.shipping_zip:
+        city_state_zip += f" {esc(order.shipping_zip)}"
+    if city_state_zip:
+        ship_to_parts.append(city_state_zip)
+    if order.shipping_country and order.shipping_country != "USA":
+        ship_to_parts.append(esc(order.shipping_country))
+
+    if ship_to_parts:
+        content.append(
+            Paragraph("<br/>".join(ship_to_parts), normal_style)
+        )
+    else:
+        content.append(Paragraph("No shipping address on file", normal_style))
+    content.append(Spacer(1, 0.2 * inch))
+
+    # ---- Items Table ----
+    content.append(Paragraph("ITEMS", heading_style))
+    content.append(Spacer(1, 0.1 * inch))
+
+    table_data = [["SKU", "Description", "Qty Ordered", "Qty Shipped"]]
+
+    # Eagerly load lines for multi-line orders
+    lines = (
+        db.query(SalesOrderLine)
+        .filter(SalesOrderLine.sales_order_id == order.id)
+        .all()
+    )
+
+    if lines:
+        # Multi-line order
+        for line in lines:
+            product = (
+                db.query(Product)
+                .filter(Product.id == line.product_id)
+                .first()
+            )
+            sku = product.sku if product else ""
+            description = product.name if product else ""
+            qty_ordered = str(int(line.quantity)) if line.quantity else "0"
+            qty_shipped = (
+                str(int(line.shipped_quantity))
+                if line.shipped_quantity
+                else qty_ordered
+            )
+            table_data.append(
+                [sku, esc(description), qty_ordered, qty_shipped]
+            )
+    else:
+        # Single-product order (quote-based)
+        product = None
+        if order.product_id:
+            product = (
+                db.query(Product)
+                .filter(Product.id == order.product_id)
+                .first()
+            )
+        sku = product.sku if product else ""
+        description = esc(
+            order.product_name or (product.name if product else "")
+        )
+        qty_ordered = str(order.quantity or 0)
+        qty_shipped = qty_ordered  # Assume full shipment for single-product
+        table_data.append([sku, description, qty_ordered, qty_shipped])
+
+    items_table = Table(
+        table_data,
+        colWidths=[1.5 * inch, 3 * inch, 1 * inch, 1 * inch],
+    )
+    items_table.setStyle(
+        TableStyle(
+            [
+                # Header row
+                (
+                    "BACKGROUND",
+                    (0, 0),
+                    (-1, 0),
+                    colors.HexColor("#f3f4f6"),
+                ),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, 0), 10),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 12),
+                # Data rows
+                ("FONTSIZE", (0, 1), (-1, -1), 10),
+                ("BOTTOMPADDING", (0, 1), (-1, -1), 8),
+                # Grid
+                (
+                    "LINEBELOW",
+                    (0, 0),
+                    (-1, 0),
+                    1,
+                    colors.HexColor("#e5e7eb"),
+                ),
+                (
+                    "LINEBELOW",
+                    (0, 1),
+                    (-1, -1),
+                    0.5,
+                    colors.HexColor("#e5e7eb"),
+                ),
+                # Center-align quantity columns
+                ("ALIGN", (2, 0), (-1, -1), "CENTER"),
+            ]
+        )
+    )
+    content.append(items_table)
+    content.append(Spacer(1, 0.3 * inch))
+
+    # ---- Notes ----
+    if order.customer_notes:
+        content.append(Paragraph("NOTES", heading_style))
+        content.append(Paragraph(esc(order.customer_notes), normal_style))
+        content.append(Spacer(1, 0.2 * inch))
+
+    # ---- Footer ----
+    content.append(Spacer(1, 0.3 * inch))
+    content.append(Paragraph("Thank you for your business!", normal_style))
+
+    # Build PDF
+    doc.build(content)
+    pdf_buffer.seek(0)
+
+    return pdf_buffer

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
+import { API_URL } from "../../config/api";
 
 // Shipping Trend Chart Component
 function ShippingChart({ data, period, onPeriodChange, loading }) {
@@ -490,6 +491,10 @@ export default function AdminShipping() {
     }
   };
 
+  const handlePackingSlip = (orderId) => {
+    window.open(`${API_URL}/api/v1/sales-orders/${orderId}/packing-slip/pdf`, "_blank");
+  };
+
   // Categorize orders into workflow stages
   const categorizeOrders = () => {
     const packaging = []; // Production not complete
@@ -697,24 +702,51 @@ export default function AdminShipping() {
                     <td className="px-4 py-3 text-right">
                       <div className="flex gap-2 justify-end">
                         {activeTab === "packaging" && (
-                          <span className="text-gray-500 text-xs italic">Awaiting production</span>
+                          <>
+                            <button
+                              onClick={() => handlePackingSlip(order.id)}
+                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              title="Print packing slip"
+                            >
+                              Packing Slip
+                            </button>
+                            <span className="text-gray-500 text-xs italic">Awaiting production</span>
+                          </>
                         )}
                         {activeTab === "needs_label" && (
-                          <button
-                            onClick={() => setExpandedOrder(isExpanded ? null : order.id)}
-                            className="px-3 py-1 bg-yellow-600 text-white rounded text-xs hover:bg-yellow-700"
-                          >
-                            {isExpanded ? "Cancel" : "Add Label"}
-                          </button>
+                          <>
+                            <button
+                              onClick={() => handlePackingSlip(order.id)}
+                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              title="Print packing slip"
+                            >
+                              Packing Slip
+                            </button>
+                            <button
+                              onClick={() => setExpandedOrder(isExpanded ? null : order.id)}
+                              className="px-3 py-1 bg-yellow-600 text-white rounded text-xs hover:bg-yellow-700"
+                            >
+                              {isExpanded ? "Cancel" : "Add Label"}
+                            </button>
+                          </>
                         )}
                         {activeTab === "ready_to_ship" && (
-                          <button
-                            onClick={() => handleMarkShipped(order.id)}
-                            disabled={saving}
-                            className="px-3 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700 disabled:opacity-50"
-                          >
-                            {saving ? "..." : "Ship"}
-                          </button>
+                          <>
+                            <button
+                              onClick={() => handlePackingSlip(order.id)}
+                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              title="Print packing slip"
+                            >
+                              Packing Slip
+                            </button>
+                            <button
+                              onClick={() => handleMarkShipped(order.id)}
+                              disabled={saving}
+                              className="px-3 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700 disabled:opacity-50"
+                            >
+                              {saving ? "..." : "Ship"}
+                            </button>
+                          </>
                         )}
                       </div>
                     </td>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -11,6 +11,7 @@ import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
+import { API_URL } from "../../config/api";
 import RecordPaymentModal from "../../components/payments/RecordPaymentModal";
 import ActivityTimeline from "../../components/ActivityTimeline";
 import ShippingTimeline from "../../components/ShippingTimeline";
@@ -455,6 +456,18 @@ export default function OrderDetail() {
             title="Refresh order data"
           >
             {refreshing ? "Refreshing..." : "\u21BB Refresh"}
+          </button>
+          <button
+            onClick={() =>
+              window.open(
+                `${API_URL}/api/v1/sales-orders/${order.id}/packing-slip/pdf`,
+                "_blank"
+              )
+            }
+            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            title="Print packing slip PDF"
+          >
+            Print Packing Slip
           </button>
           {order.status !== "shipped" && order.status !== "delivered" && (
             <button


### PR DESCRIPTION
## Summary
- New `generate_packing_slip_pdf()` service function using ReportLab (same pattern as quote PDF)
- Includes: company header/logo, ship-to address, items table (SKU, description, qty ordered/shipped), notes, footer
- New endpoint: `GET /sales-orders/{id}/packing-slip/pdf` returns StreamingResponse PDF
- "Packing Slip" button added to AdminShipping (all tabs) and OrderDetail pages
- Supports both single-product orders and multi-line orders

## Test plan
- [x] 302 sales order tests pass
- [x] Frontend build passes
- [ ] Manual test: open a sales order, click "Print Packing Slip", verify PDF renders

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented packing slip PDF generation and download functionality integrated into order management workflows
  * Added "Packing Slip" action buttons to the Admin Shipping dashboard and Order Detail page for quick document generation and printing
  * Packing slip documents include complete order information, shipping details, itemized product lists, special order notes, and company branding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->