### PR TITLE
fix: add mobile responsive tables, filters, and modals (#105)

### DIFF
--- a/frontend/src/pages/admin/AdminBOM.jsx
+++ b/frontend/src/pages/admin/AdminBOM.jsx
@@ -142,7 +142,7 @@ export default function AdminBOM() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Bill of Materials</h1>
           <p className="text-gray-400 mt-1">
@@ -158,7 +158,7 @@ export default function AdminBOM() {
       </div>
 
       {/* Filters */}
-      <div className="flex gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="flex flex-col sm:flex-row gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
         <div className="flex-1">
           <input
             type="text"
@@ -196,7 +196,8 @@ export default function AdminBOM() {
       {/* BOM List */}
       {!loading && (
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead className="bg-gray-800/50">
               <tr>
                 <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
@@ -289,6 +290,7 @@ export default function AdminBOM() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -137,7 +137,7 @@ export default function AdminCustomers() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Customers</h1>
           <p className="text-gray-400 mt-1">
@@ -167,7 +167,7 @@ export default function AdminCustomers() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <StatCard variant="simple" title="Total Customers" value={stats.total} color="neutral" />
         <StatCard variant="simple" title="Active" value={stats.active} color="success" />
         <StatCard variant="simple" title="With Orders" value={stats.withOrders} color="secondary" />
@@ -180,7 +180,7 @@ export default function AdminCustomers() {
       </div>
 
       {/* Filters */}
-      <div className="flex gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="flex flex-col sm:flex-row gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
         <div className="flex-1">
           <input
             type="text"
@@ -221,7 +221,8 @@ export default function AdminCustomers() {
       {/* Customers Table */}
       {!loading && (
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead className="bg-gray-800/50">
               <tr>
                 <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
@@ -314,6 +315,7 @@ export default function AdminCustomers() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/admin/AdminLocations.jsx
+++ b/frontend/src/pages/admin/AdminLocations.jsx
@@ -155,7 +155,7 @@ export default function AdminLocations() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Inventory Locations</h1>
           <p className="text-gray-400 mt-1">
@@ -192,7 +192,8 @@ export default function AdminLocations() {
       </div>
 
       {/* Locations Table */}
-      <Table>
+      <div className="overflow-x-auto">
+      <Table className="min-w-[640px]">
         <TableHeader>
           <TableRow>
             <TableHead>Code</TableHead>
@@ -269,6 +270,7 @@ export default function AdminLocations() {
           )}
         </TableBody>
       </Table>
+      </div>
 
       {/* Modal */}
       {showModal && (
@@ -308,7 +310,7 @@ function LocationModal({ location, locations, onSave, onClose }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-gray-900 rounded-lg border border-gray-800 w-full max-w-md p-6">
+      <div className="bg-gray-900 rounded-lg border border-gray-800 w-full max-w-md mx-4 p-6">
         <h2 className="text-xl font-bold text-white mb-4">
           {location ? "Edit Location" : "Add Location"}
         </h2>

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -134,7 +134,7 @@ export default function AdminManufacturing() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Manufacturing</h1>
           <p className="text-gray-400 mt-1">
@@ -274,7 +274,8 @@ export default function AdminManufacturing() {
             </div>
           ) : (
             <div className="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
-              <table className="w-full">
+              <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px]">
                 <thead>
                   <tr className="border-b border-gray-800 text-left text-sm text-gray-400">
                     <th className="px-4 py-3">Code</th>
@@ -357,6 +358,7 @@ export default function AdminManufacturing() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -226,7 +226,7 @@ export default function AdminOrders() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Order Management</h1>
           <p className="text-gray-400 mt-1">View and manage sales orders</p>

--- a/frontend/src/pages/admin/AdminPayments.jsx
+++ b/frontend/src/pages/admin/AdminPayments.jsx
@@ -146,7 +146,7 @@ export default function AdminPayments() {
   return (
     <div className="p-6 max-w-7xl mx-auto">
       {/* Header */}
-      <div className="flex justify-between items-center mb-6">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4 mb-6">
         <div>
           <h1 className="text-2xl font-bold text-white">Payments</h1>
           <p className="text-gray-400 text-sm">
@@ -366,7 +366,8 @@ export default function AdminPayments() {
           </div>
         ) : (
           <>
-            <table className="w-full">
+            <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px]">
               <thead className="bg-gray-900/50">
                 <tr>
                   <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
@@ -475,6 +476,7 @@ export default function AdminPayments() {
                 ))}
               </tbody>
             </table>
+            </div>
 
             {/* Pagination */}
             {pagination.totalPages > 1 && (

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -403,7 +403,7 @@ export default function AdminProduction() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Production</h1>
           <p className="text-gray-400 mt-1">
@@ -429,7 +429,7 @@ export default function AdminProduction() {
       </div>
 
       {/* Stats */}
-          <div className="grid grid-cols-6 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
               <p className="text-gray-400 text-sm">Draft</p>
               <p className="text-2xl font-bold text-gray-400">

--- a/frontend/src/pages/admin/AdminPurchasing.jsx
+++ b/frontend/src/pages/admin/AdminPurchasing.jsx
@@ -530,7 +530,7 @@ export default function AdminPurchasing() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-start">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Purchasing</h1>
           <p className="text-gray-400 mt-1">
@@ -630,7 +630,7 @@ export default function AdminPurchasing() {
 
       {/* Filters - hide on import and low-stock tabs */}
       {activeTab !== "import" && activeTab !== "low-stock" && (
-        <div className="flex gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
+        <div className="flex flex-col sm:flex-row gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
           <div className="flex-1">
             <input
               type="text"

--- a/frontend/src/pages/admin/AdminQuotes.jsx
+++ b/frontend/src/pages/admin/AdminQuotes.jsx
@@ -251,7 +251,7 @@ export default function AdminQuotes() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Quote Management</h1>
           <p className="text-gray-400 mt-1">Create and manage customer quotes</p>
@@ -340,7 +340,7 @@ export default function AdminQuotes() {
       )}
 
       {/* Filters */}
-      <div className="flex gap-4">
+      <div className="flex flex-col sm:flex-row gap-4">
         <div className="flex-1 relative">
           <input
             type="text"
@@ -384,7 +384,8 @@ export default function AdminQuotes() {
         </div>
       ) : (
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead>
               <tr className="border-b border-gray-800 bg-gray-800/50">
                 <th className="text-left px-4 py-3 text-gray-400 font-medium text-sm">Quote #</th>
@@ -522,6 +523,7 @@ export default function AdminQuotes() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/admin/AdminScrapReasons.jsx
+++ b/frontend/src/pages/admin/AdminScrapReasons.jsx
@@ -82,7 +82,7 @@ export default function AdminScrapReasons() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Scrap Reasons</h1>
           <p className="text-gray-400 mt-1">
@@ -141,7 +141,8 @@ export default function AdminScrapReasons() {
 
       {/* Reasons Table */}
       <div className="bg-gray-900 rounded-lg border border-gray-800 overflow-hidden">
-        <table className="w-full">
+        <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px]">
           <thead className="bg-gray-800/50">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
@@ -270,6 +271,7 @@ export default function AdminScrapReasons() {
             )}
           </tbody>
         </table>
+        </div>
       </div>
 
       {/* Modal */}
@@ -351,7 +353,7 @@ function ScrapReasonModal({ reason, onSave, onClose }) {
       onClick={handleBackdropClick}
     >
       <div
-        className="bg-gray-900 rounded-lg border border-gray-800 w-full max-w-md p-6"
+        className="bg-gray-900 rounded-lg border border-gray-800 w-full max-w-md mx-4 p-6"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -539,7 +539,7 @@ export default function AdminShipping() {
   return (
     <div className="space-y-4">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-xl font-bold text-white">Shipping</h1>
           <p className="text-gray-500 text-sm">Package, label, and ship orders</p>
@@ -563,7 +563,7 @@ export default function AdminShipping() {
       </div>
 
       {/* Metrics Row - Compact */}
-      <div className="grid grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
         <div className="bg-gray-900 border border-gray-800 rounded-lg p-3">
           <p className="text-gray-500 text-xs">Total Pending</p>
           <p className="text-xl font-bold text-white">{orders.length}</p>
@@ -625,7 +625,8 @@ export default function AdminShipping() {
       {/* Orders Table */}
       {!loading && (
         <div className="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
             <thead className="bg-gray-800/50">
               <tr className="text-left text-gray-400 text-xs uppercase">
                 <th className="px-4 py-3 font-medium">Order</th>
@@ -832,6 +833,7 @@ export default function AdminShipping() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -86,7 +86,7 @@ export default function AdminSpools() {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Material Spools</h1>
           <p className="text-gray-400 mt-1">Manage filament spools and material tracking</p>
@@ -103,7 +103,7 @@ export default function AdminSpools() {
       </div>
 
       {/* Filters */}
-      <div className="flex gap-4">
+      <div className="flex flex-col sm:flex-row gap-4">
         <input
           type="text"
           placeholder="Search spools..."
@@ -138,7 +138,8 @@ export default function AdminSpools() {
         <div className="text-center py-12 text-gray-400">No spools found</div>
       ) : (
         <div className="bg-gray-800 rounded-lg overflow-hidden">
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead className="bg-gray-900">
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-400 uppercase">
@@ -229,6 +230,7 @@ export default function AdminSpools() {
               })}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 
@@ -310,7 +312,7 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
 
   return (
     <div className="fixed inset-0 z-50 overflow-auto bg-black/60 flex items-center justify-center p-4">
-      <div className="bg-gray-800 rounded-lg max-w-2xl w-full p-6">
+      <div className="bg-gray-800 rounded-lg max-w-2xl w-full mx-4 p-6">
         <h2 className="text-xl font-bold text-white mb-4">
           {spool ? "Edit Spool" : "Add Spool"}
         </h2>

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -172,7 +172,7 @@ export default function AdminUsers() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-white">Team Members</h1>
           <p className="text-gray-400 mt-1">
@@ -191,7 +191,7 @@ export default function AdminUsers() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
           <p className="text-gray-400 text-sm">Total Active</p>
           <p className="text-2xl font-bold text-white">
@@ -213,7 +213,7 @@ export default function AdminUsers() {
       </div>
 
       {/* Filters */}
-      <div className="flex gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="flex flex-col sm:flex-row gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
         <div className="flex-1">
           <input
             type="text"
@@ -265,7 +265,8 @@ export default function AdminUsers() {
       {/* Users Table */}
       {!loading && (
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead className="bg-gray-800/50">
               <tr>
                 <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase">
@@ -380,6 +381,7 @@ export default function AdminUsers() {
               )}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Added `overflow-x-auto` wrappers with `min-w-[640px]` to all admin table components that were missing horizontal scroll on mobile
- Made filter/toolbar bars responsive with `flex-col sm:flex-row` stacking
- Made page headers responsive with stacking on mobile
- Added `mx-4` to modal containers for mobile margin safety

## Files Modified (13 pages)
- AdminBOM, AdminCustomers, AdminLocations, AdminManufacturing, AdminOrders, AdminPayments, AdminProduction, AdminPurchasing, AdminQuotes, AdminScrapReasons, AdminShipping, AdminSpools, AdminUsers

## Test plan
- [x] `vite build` passes
- [ ] Visual check at 375px viewport (iPhone SE)
- [ ] Tables scroll horizontally without clipping
- [ ] Filter bars stack vertically on mobile
- [ ] Modals don't clip on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced responsive headers, filters and stats grids across admin pages for better mobile/tablet layouts.
  * Added a new Revenue/Total Revenue stat in customers view and improved KPI card responsiveness.
  * Enabled horizontal scrolling for wide tables by wrapping them and enforcing a minimum table width.
* **Style**
  * Adjusted spacing and modal margins for improved presentation on small viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->