### PR TITLE
feat: upgrade bcrypt 4→5 with SHA-256 pre-hash

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -35,6 +35,7 @@ from app.services.email_service import email_service
 from app.core.security import (
     hash_password,
     verify_password,
+    needs_rehash,
     create_access_token,
     create_refresh_token,
     get_user_from_token,
@@ -187,6 +188,10 @@ async def login_user(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="User account is inactive"
             )
+
+        # Transparent rehash: upgrade legacy bcrypt hashes to SHA-256 pre-hash
+        if needs_rehash(form_data.password, user.password_hash):  # type: ignore[arg-type]
+            user.password_hash = hash_password(form_data.password)  # type: ignore[assignment]
 
         # Update last login timestamp
         user.last_login_at = datetime.now(timezone.utc)  # type: ignore[assignment]

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -62,9 +62,18 @@ def validate_password_strength(password: str) -> tuple[bool, str]:
 # PASSWORD HASHING (using bcrypt directly)
 # ============================================================================
 
+def _prehash(password: str) -> bytes:
+    """SHA-256 pre-hash to normalize passwords to 64 bytes before bcrypt.
+
+    Bcrypt truncates at 72 bytes; pre-hashing avoids that silently
+    losing entropy.  This is the Dropbox pattern.
+    """
+    return hashlib.sha256(password.encode('utf-8')).hexdigest().encode('utf-8')
+
+
 def hash_password(password: str) -> str:
     """
-    Hash a password using bcrypt
+    Hash a password using SHA-256 pre-hash + bcrypt.
 
     Args:
         password: Plain text password
@@ -72,17 +81,17 @@ def hash_password(password: str) -> str:
     Returns:
         Hashed password (bcrypt format, 60 chars)
     """
-    # bcrypt requires bytes
-    password_bytes = password.encode('utf-8')
-    # Generate salt and hash
     salt = bcrypt.gensalt(rounds=12)
-    hashed = bcrypt.hashpw(password_bytes, salt)
+    hashed = bcrypt.hashpw(_prehash(password), salt)
     return hashed.decode('utf-8')
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
-    Verify a password against its hash
+    Verify a password against its hash.
+
+    Tries SHA-256 pre-hash first (new method), then falls back to
+    legacy direct-bcrypt for passwords hashed before the upgrade.
 
     Args:
         plain_password: Plain text password to verify
@@ -91,10 +100,26 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     Returns:
         True if password matches, False otherwise
     """
+    hashed_bytes = hashed_password.encode('utf-8')
+    # New method (SHA-256 pre-hash)
     try:
-        password_bytes = plain_password.encode('utf-8')
-        hashed_bytes = hashed_password.encode('utf-8')
-        return bcrypt.checkpw(password_bytes, hashed_bytes)
+        if bcrypt.checkpw(_prehash(plain_password), hashed_bytes):
+            return True
+    except Exception:
+        pass
+    # Legacy fallback (direct bcrypt, for pre-upgrade hashes)
+    try:
+        if bcrypt.checkpw(plain_password.encode('utf-8'), hashed_bytes):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def needs_rehash(plain_password: str, hashed_password: str) -> bool:
+    """Return True if the hash was created with the legacy (non-prehashed) method."""
+    try:
+        return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
     except Exception:
         return False
 

--- a/backend/preflight.py
+++ b/backend/preflight.py
@@ -13,7 +13,7 @@ mods = [
     # config & validation
     "pydantic", "pydantic_settings", "email_validator",
     # auth & forms
-    "jwt", "cryptography", "passlib", "multipart",
+    "jwt", "cryptography", "multipart",
     # requests
     "requests",
     # Postgres driver

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,9 +6,7 @@ python_functions = test_*
 
 # Filter known warnings that are not actionable
 filterwarnings =
-    ignore::DeprecationWarning:passlib.*:
     ignore::DeprecationWarning:datetime.*:
-    ignore:.*bcrypt.*:UserWarning
     ignore:.*utcnow.*:DeprecationWarning
     # SQLAlchemy 2.0 migration warning
     ignore::sqlalchemy.exc.MovedIn20Warning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ pydantic==2.10.5
 pydantic-settings==2.12.0
 email-validator==2.2.0
 PyJWT==2.11.0
-bcrypt==4.0.1
+bcrypt>=5.0.0,<6
 python-dotenv==1.2.1
 slowapi==0.1.9
 python-dateutil==2.9.0.post0

--- a/backend/requirements.win-postgres.txt
+++ b/backend/requirements.win-postgres.txt
@@ -11,7 +11,6 @@ email-validator==2.*
 
 python-multipart==0.*
 
-passlib[bcrypt]==1.7.*
 
 python-jose[cryptography]==3.*
 
@@ -21,7 +20,6 @@ cryptography==43.*
 
 python-multipart==0.*
 
-passlib[bcrypt]==1.7.*
 
 requests==2.*
 

--- a/backend/scripts/security_audit.py
+++ b/backend/scripts/security_audit.py
@@ -478,9 +478,7 @@ class SecurityAuditor:
         try:
             from app.db.session import SessionLocal
             from app.models import User
-            from passlib.context import CryptContext
-
-            pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+            from app.core.security import verify_password
 
             db = SessionLocal()
             # Find users with admin account_type
@@ -502,7 +500,7 @@ class SecurityAuditor:
             for admin_user in admin_users:
                 for pwd in default_passwords:
                     try:
-                        if pwd_context.verify(pwd, admin_user.password_hash):
+                        if verify_password(pwd, admin_user.password_hash):
                             self.results.append(CheckResult(
                                 id=check_id, name=name, category=category,
                                 status=CheckStatus.FAIL,


### PR DESCRIPTION
## Summary
Closes #286

- **SHA-256 pre-hash (Dropbox pattern):** All passwords are now hashed with SHA-256 before bcrypt, normalizing them to 64-byte hex. This prevents bcrypt 5's new `ValueError` for passwords > 72 bytes.
- **Backward-compatible:** `verify_password()` tries the new pre-hash method first, then falls back to legacy direct-bcrypt for existing password hashes.
- **Transparent rehash:** On successful login, legacy hashes are automatically upgraded to the new format via `needs_rehash()`.
- **passlib removed:** The only usage (in `security_audit.py`) now uses `verify_password()` directly. Removed from `requirements.win-postgres.txt`, `preflight.py`, and `pytest.ini` warning filters.

## Files changed
- `backend/app/core/security.py` — Added `_prehash()`, `needs_rehash()`, rewrote `hash_password()` and `verify_password()`
- `backend/app/api/v1/endpoints/auth.py` — Import `needs_rehash`, auto-rehash on login
- `backend/scripts/security_audit.py` — Replace passlib with `verify_password()`
- `backend/requirements.txt` — `bcrypt==4.0.1` → `bcrypt>=5.0.0,<6`
- `backend/requirements.win-postgres.txt` — Remove `passlib[bcrypt]`
- `backend/preflight.py` — Remove passlib from module check
- `backend/pytest.ini` — Remove passlib/bcrypt warning filters

## Test plan
- [x] All 37 auth tests pass
- [x] Full backend suite: 4499 passed (4 pre-existing inventory summary failures unrelated)
- [x] Manual verification: new hash round-trip, legacy backward compat, needs_rehash detection, 100+ char passwords
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced password encryption with an improved hashing algorithm for stronger account protection
  * Automatic, seamless password migration for existing user accounts—triggered on next login, no user action required

* **Dependency Updates**
  * Updated core authentication and encryption libraries to latest stable versions
  * Removed an obsolete password hashing dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->