### PR TITLE
fix: setup wizard auth fails behind nginx proxy

### DIFF
--- a/backend/app/api/v1/endpoints/setup.py
+++ b/backend/app/api/v1/endpoints/setup.py
@@ -4,6 +4,8 @@ First-run setup endpoint for FilaOps
 Allows creating the initial admin account when no users exist.
 This endpoint is disabled once any user has been created.
 """
+from datetime import timedelta
+
 from fastapi import APIRouter, HTTPException, Depends, Response
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
@@ -130,16 +132,20 @@ def create_initial_admin(
 
     if settings.AUTH_MODE.lower() == "cookie":
         set_auth_cookies(response, access_token)
-        # SECURITY: token is intentionally included in the response body even in
-        # cookie mode.  This endpoint only works when ZERO users exist (line 84),
-        # so there is no session to hijack and no other user to impersonate.
-        # The onboarding wizard needs the token for Authorization headers because
-        # httpOnly cookies are not reliably forwarded through nginx reverse proxies
-        # on immediate same-page requests.
+        # The full-duration token lives in the httpOnly cookie (not JS-accessible).
+        # The response body gets a short-lived token (5 min) for the onboarding
+        # wizard, which needs Authorization headers because httpOnly cookies are
+        # not reliably forwarded through nginx reverse proxies on immediate
+        # same-page requests.  5 minutes is enough for the wizard to complete,
+        # and this endpoint only works when zero users exist (line 85).
+        setup_token = create_access_token(
+            user_id=admin.id,
+            expires_delta=timedelta(minutes=5),
+        )
         return {
             "message": "Admin account created successfully! Welcome to FilaOps.",
             "email": admin.email,
-            "access_token": access_token,
+            "setup_token": setup_token,
             "token_type": "cookie",
         }
 

--- a/frontend/src/pages/Onboarding.jsx
+++ b/frontend/src/pages/Onboarding.jsx
@@ -160,18 +160,20 @@ export default function Onboarding() {
         throw new Error(data.detail || "Setup failed");
       }
 
-      // Save token for subsequent wizard steps (works through nginx proxies
-      // where cookies alone may not be forwarded reliably)
-      if (data.access_token) {
-        setSetupToken(data.access_token);
+      // Save short-lived setup token (5 min) for subsequent wizard steps.
+      // The full-duration token is in the httpOnly cookie; this one is just
+      // for the wizard to use as an Authorization header through nginx.
+      const token = data.setup_token || data.access_token;
+      if (token) {
+        setSetupToken(token);
       }
 
       // Fetch and store user data so AdminLayout knows the user is an admin
       try {
         const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
           credentials: "include",
-          headers: data.access_token
-            ? { Authorization: `Bearer ${data.access_token}` }
+          headers: token
+            ? { Authorization: `Bearer ${token}` }
             : {},
         });
         if (meRes.ok) {


### PR DESCRIPTION
## Summary

Fixes #283 — the onboarding wizard's "Could not validate credentials" error on steps 2–6 when running behind nginx in Docker.

- **Backend**: Return `access_token` in the `/initial-admin` response body even in cookie mode. No security impact — this endpoint only works when zero users exist.
- **Frontend**: Store the token in React state from step 1 and pass it as an `Authorization` header on all subsequent wizard fetch calls. Cookies remain as fallback.

## Root cause

In cookie mode, the `/initial-admin` endpoint set an httpOnly cookie but omitted the token from the response body. When served through nginx (`location /api { proxy_pass ... }`), the cookie isn't reliably forwarded on subsequent same-page requests. The setup wizard fires authenticated requests immediately without a page transition, so the browser/proxy don't always propagate the cookie in time.

Normal login works because it goes through a full page transition where the cookie is properly established.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Backend tests pass (`pytest -k setup`)
- [ ] Fresh Docker deploy: complete full onboarding wizard (all 7 steps) without "Could not validate credentials"
- [ ] Verify normal login flow still works after setup
- [ ] Verify skipping steps still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding now returns a short-lived setup token (in addition to the existing cookie) after initial admin creation.
  * The onboarding flow stores and uses this token for subsequent actions (data seeding, product/customer/order imports, inventory import, and profile fetch).
  * Authorization headers are added only when the token is present, preserving prior behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->