### PR TITLE
fix: resolve 3 critical bugs (UOM, seed crash, empty pages)

### DIFF
--- a/backend/app/api/v1/endpoints/setup.py
+++ b/backend/app/api/v1/endpoints/setup.py
@@ -162,6 +162,7 @@ def create_initial_admin(
 class SeedDataResponse(BaseModel):
     """Response after seeding example data"""
     message: str
+    uoms_created: int = 0
     items_created: int
     items_skipped: int
     materials_created: int

--- a/backend/app/services/seed_service.py
+++ b/backend/app/services/seed_service.py
@@ -7,7 +7,7 @@ Wraps script functions in a single atomic transaction (#290).
 from sqlalchemy.orm import Session
 
 from app.logging_config import get_logger
-from scripts.seed_example_data import seed_example_items, seed_materials
+from scripts.seed_example_data import seed_uoms, seed_example_items, seed_materials
 
 logger = get_logger(__name__)
 
@@ -24,6 +24,7 @@ def seed_example_data(db: Session) -> dict:
     """
     savepoint = db.begin_nested()
     try:
+        uoms_created = seed_uoms(db)
         items_created, items_skipped = seed_example_items(db)
         mt_created, colors_created, links_created, mat_products_created = seed_materials(db)
         savepoint.commit()
@@ -34,10 +35,11 @@ def seed_example_data(db: Session) -> dict:
         raise
 
     logger.info(
-        "Seed complete: %d items created, %d skipped, %d materials, %d colors, %d links",
-        items_created, items_skipped, mt_created, colors_created, links_created,
+        "Seed complete: %d UOMs, %d items created, %d skipped, %d materials, %d colors, %d links",
+        uoms_created, items_created, items_skipped, mt_created, colors_created, links_created,
     )
     return {
+        "uoms_created": uoms_created,
         "items_created": items_created,
         "items_skipped": items_skipped,
         "materials_created": mt_created,

--- a/backend/scripts/seed_example_data.py
+++ b/backend/scripts/seed_example_data.py
@@ -2,8 +2,9 @@
 Seed Example Data for FilaOps
 
 This script seeds the database with:
-1. Example items for each category (one per category)
-2. Comprehensive materials list (material types + colors)
+1. Standard units of measure (12 UOMs with correct conversion factors)
+2. Example items for each category (one per category)
+3. Comprehensive materials list (material types + colors)
 
 Run with: python -m backend.scripts.seed_example_data
 """
@@ -22,6 +23,92 @@ from app.db.session import SessionLocal
 from app.models.item_category import ItemCategory
 from app.models.product import Product
 from app.models.material import MaterialType, Color, MaterialColor
+from app.models.uom import UnitOfMeasure
+
+
+def seed_uoms(db: Session) -> int:
+    """Seed standard units of measure with correct conversion factors.
+
+    Creates 12 UOMs in 4 classes (quantity, weight, length, time).
+    Each class has a base unit (factor=1) and derived units with
+    their to_base_factor set correctly.
+
+    Ported from the retired SQL Server migration 005_units_of_measure.
+    Idempotent: skips any UOM that already exists by code.
+
+    Returns:
+        Number of UOMs created.
+    """
+    print("\nSeeding standard units of measure...")
+
+    # Base units first (no base_unit_id)
+    base_units = [
+        ("EA", "Each", "ea", "quantity"),
+        ("KG", "Kilogram", "kg", "weight"),
+        ("M", "Meter", "m", "length"),
+        ("HR", "Hour", "hr", "time"),
+    ]
+
+    created = 0
+    base_ids = {}
+
+    for code, name, symbol, uom_class in base_units:
+        existing = db.query(UnitOfMeasure).filter(UnitOfMeasure.code == code).first()
+        if existing:
+            base_ids[code] = existing.id
+            print(f"  Skipped {code} (already exists)")
+            continue
+
+        uom = UnitOfMeasure(
+            code=code,
+            name=name,
+            symbol=symbol,
+            uom_class=uom_class,
+            base_unit_id=None,
+            to_base_factor=Decimal("1"),
+            active=True,
+        )
+        db.add(uom)
+        db.flush()
+        base_ids[code] = uom.id
+        created += 1
+        print(f"  Created base unit: {code} ({name})")
+
+    # Derived units (reference a base unit)
+    derived_units = [
+        # (code, name, symbol, class, base_code, to_base_factor)
+        ("G",   "Gram",        "g",   "weight", "KG", Decimal("0.001")),
+        ("LB",  "Pound",       "lb",  "weight", "KG", Decimal("0.453592")),
+        ("OZ",  "Ounce",       "oz",  "weight", "KG", Decimal("0.0283495")),
+        ("CM",  "Centimeter",  "cm",  "length", "M",  Decimal("0.01")),
+        ("MM",  "Millimeter",  "mm",  "length", "M",  Decimal("0.001")),
+        ("FT",  "Foot",        "ft",  "length", "M",  Decimal("0.3048")),
+        ("IN",  "Inch",        "in",  "length", "M",  Decimal("0.0254")),
+        ("MIN", "Minute",      "min", "time",   "HR", Decimal("0.01666667")),
+    ]
+
+    for code, name, symbol, uom_class, base_code, factor in derived_units:
+        existing = db.query(UnitOfMeasure).filter(UnitOfMeasure.code == code).first()
+        if existing:
+            print(f"  Skipped {code} (already exists)")
+            continue
+
+        uom = UnitOfMeasure(
+            code=code,
+            name=name,
+            symbol=symbol,
+            uom_class=uom_class,
+            base_unit_id=base_ids.get(base_code),
+            to_base_factor=factor,
+            active=True,
+        )
+        db.add(uom)
+        created += 1
+        print(f"  Created derived unit: {code} ({name}, factor={factor})")
+
+    db.flush()
+    print(f"\n  UOM seed complete: {created} created, {12 - created} skipped")
+    return created
 
 
 def get_or_create_category(db: Session, code: str, name: str, parent_code: Optional[str] = None, sort_order: int = 0) -> ItemCategory:
@@ -49,7 +136,7 @@ def get_or_create_category(db: Session, code: str, name: str, parent_code: Optio
 
 def ensure_categories_exist(db: Session):
     """Ensure all required categories exist, create them if missing"""
-    print("\n📁 Ensuring categories exist...")
+    print("\nEnsuring categories exist...")
     
     categories_to_create = [
         # Root categories
@@ -89,7 +176,7 @@ def ensure_categories_exist(db: Session):
                     updated_at=datetime.utcnow()
                 )
                 db.add(category)
-                print(f"  ✅ Created category: {cat_data['code']}")
+                print(f"  Created category: {cat_data['code']}")
 
     db.flush()
 
@@ -110,16 +197,16 @@ def ensure_categories_exist(db: Session):
                         updated_at=datetime.utcnow()
                     )
                     db.add(category)
-                    print(f"  ✅ Created category: {cat_data['code']} (under {cat_data['parent_code']})")
+                    print(f"  Created category: {cat_data['code']} (under {cat_data['parent_code']})")
                 else:
-                    print(f"  ⚠️  Parent category {cat_data['parent_code']} not found for {cat_data['code']}")
+                    print(f"  WARNING: Parent category {cat_data['parent_code']} not found for {cat_data['code']}")
 
     db.flush()
 
 
 def seed_example_items(db: Session):
     """Seed one example item per category"""
-    print("\n📦 Seeding example items by category...")
+    print("\nSeeding example items by category...")
     
     # Ensure categories exist first
     ensure_categories_exist(db)
@@ -241,14 +328,14 @@ def seed_example_items(db: Session):
         # Check if SKU already exists
         existing = db.query(Product).filter(Product.sku == example["sku"]).first()
         if existing:
-            print(f"  ⏭️  Skipped {example['sku']} (already exists)")
+            print(f"  Skipped {example['sku']} (already exists)")
             skipped += 1
             continue
         
         # Get category (should exist after ensure_categories_exist)
         category = db.query(ItemCategory).filter(ItemCategory.code == example["category_code"]).first()
         if not category:
-            print(f"  ❌ ERROR: Category {example['category_code']} not found after ensuring categories exist!")
+            print(f"  ERROR: Category {example['category_code']} not found after ensuring categories exist!")
             print(f"     This should not happen. Skipping {example['sku']}")
             skipped += 1
             continue
@@ -270,16 +357,16 @@ def seed_example_items(db: Session):
         )
         db.add(product)
         created += 1
-        print(f"  ✅ Created {example['sku']}: {example['name']}")
+        print(f"  Created {example['sku']}: {example['name']}")
     
     db.flush()
-    print(f"\n  📊 Created {created} example items, skipped {skipped}")
+    print(f"\n  Summary: Created {created} example items, skipped {skipped}")
     return created, skipped
 
 
 def seed_materials(db: Session):
     """Seed basic materials list (material types only, no colors/products)"""
-    print("\n🎨 Seeding basic material types (colors and products should be imported via CSV)...")
+    print("\nSeeding basic material types (colors and products should be imported via CSV)...")
     
     # Basic BambuLab material types - just the types, no colors
     # Users should import their full material+color list via CSV
@@ -494,7 +581,7 @@ def seed_materials(db: Session):
     for mt_data in material_types:
         existing = db.query(MaterialType).filter(MaterialType.code == mt_data["code"]).first()
         if existing:
-            print(f"  ⏭️  Material type {mt_data['code']} already exists")
+            print(f"  Skipped material type {mt_data['code']} already exists")
             material_type_objs[mt_data["code"]] = existing
             continue
         
@@ -518,7 +605,7 @@ def seed_materials(db: Session):
         db.flush()
         material_type_objs[mt_data["code"]] = mt
         created_types += 1
-        print(f"  ✅ Created material type: {mt_data['name']}")
+        print(f"  Created material type: {mt_data['name']}")
 
     db.flush()
 
@@ -564,7 +651,7 @@ def seed_materials(db: Session):
         db.flush()
         color_objs[color_data["code"]] = color
         created_colors += 1
-        print(f"  ✅ Created color: {color_data['name']}")
+        print(f"  Created color: {color_data['name']}")
 
     db.flush()
 
@@ -601,8 +688,8 @@ def seed_materials(db: Session):
 
     db.flush()
 
-    print(f"\n  📊 Created {created_types} material types, {created_colors} colors, {created_links} material-color links")
-    print("  💡 Tip: Import additional materials via CSV or use 'Create new color' in the material form")
+    print(f"\n  Summary: Created {created_types} material types, {created_colors} colors, {created_links} material-color links")
+    print("  Tip: Import additional materials via CSV or use 'Create new color' in the material form")
 
     return created_types, created_colors, created_links, 0  # types, colors, links, products
 
@@ -625,18 +712,18 @@ def main():
         db.commit()
 
         print("\n" + "=" * 60)
-        print("✅ Seeding complete!")
+        print("Seeding complete!")
         print("=" * 60)
         print("\nSummary:")
-        print(f"  📦 Example Items: {items_created} created, {items_skipped} skipped")
-        print(f"  🎨 Materials: {mt_created} types, {colors_created} colors, {links_created} links")
-        print(f"  📦 Material Products: {mat_products_created} SKUs created (0 on-hand)")
-        print("\n💡 Tip: You can now see example items in each category!")
-        print("💡 Tip: All material+color combinations are ready - just update inventory quantities!")
-        print(f"💡 Tip: Material SKUs follow format: MAT-{'{MATERIAL_CODE}'}-{'{COLOR_CODE}'}")
+        print(f" Example Items: {items_created} created, {items_skipped} skipped")
+        print(f" Materials: {mt_created} types, {colors_created} colors, {links_created} links")
+        print(f" Material Products: {mat_products_created} SKUs created (0 on-hand)")
+        print("\nTip: You can now see example items in each category!")
+        print("Tip: All material+color combinations are ready - just update inventory quantities!")
+        print(f"Tip: Material SKUs follow format: MAT-{'{MATERIAL_CODE}'}-{'{COLOR_CODE}'}")
         
     except Exception as e:
-        print(f"\n❌ Error: {e}")
+        print(f"\nError: {e}")
         db.rollback()
         raise
     finally:

--- a/frontend/src/hooks/useCRUD.js
+++ b/frontend/src/hooks/useCRUD.js
@@ -21,8 +21,17 @@ export function useCRUD(endpoint, options = {}) {
   const [loading, setLoading] = useState(immediate);
   const [error, setError] = useState(null);
   const mountedRef = useRef(true);
+  const didFetchRef = useRef(false);
+
+  // Keep latest values in refs so fetchAll closure doesn't go stale
+  // but also doesn't cause re-creation on every render.
+  const defaultParamsRef = useRef(defaultParams);
+  defaultParamsRef.current = defaultParams;
+  const extractKeyRef = useRef(extractKey);
+  extractKeyRef.current = extractKey;
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => { mountedRef.current = false; };
   }, []);
 
@@ -30,18 +39,19 @@ export function useCRUD(endpoint, options = {}) {
     setLoading(true);
     setError(null);
     try {
-      const merged = { ...defaultParams, ...params };
+      const merged = { ...defaultParamsRef.current, ...params };
       const qs = Object.keys(merged).length
         ? "?" + new URLSearchParams(merged).toString()
         : "";
       const data = await api.get(`${endpoint}${qs}`);
       if (!mountedRef.current) return data;
 
+      const key = extractKeyRef.current;
       let result;
       if (Array.isArray(data)) {
         result = data;
-      } else if (extractKey && data?.[extractKey]) {
-        result = data[extractKey];
+      } else if (key && data?.[key]) {
+        result = data[key];
       } else {
         result = Array.isArray(data) ? data : [];
       }
@@ -53,7 +63,7 @@ export function useCRUD(endpoint, options = {}) {
     } finally {
       if (mountedRef.current) setLoading(false);
     }
-  }, [api, endpoint, defaultParams, extractKey]);
+  }, [api, endpoint]);
 
   const create = useCallback(async (body) => {
     const data = await api.post(endpoint, body);
@@ -74,8 +84,10 @@ export function useCRUD(endpoint, options = {}) {
   // Convenience: refetch with last params
   const refresh = useCallback(() => fetchAll(), [fetchAll]);
 
+  // Initial fetch — fires once on mount, not on every fetchAll identity change.
   useEffect(() => {
-    if (immediate) {
+    if (immediate && !didFetchRef.current) {
+      didFetchRef.current = true;
       fetchAll().catch(() => {});
     }
   }, [immediate, fetchAll]);

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -20,7 +20,10 @@ export default function AdminCustomers() {
     error,
     fetchAll: fetchCustomers,
     refresh,
-  } = useCRUD("/api/v1/admin/customers", { extractKey: null, immediate: false });
+  } = useCRUD("/api/v1/admin/customers", {
+    extractKey: null,
+    defaultParams: { limit: "200" },
+  });
   const [filters, setFilters] = useState({
     search: "",
     status: "all",
@@ -50,11 +53,12 @@ export default function AdminCustomers() {
     }
   }, [searchParams, setSearchParams]);
 
+  // Re-fetch when status filter changes (initial load handled by useCRUD immediate:true)
   useEffect(() => {
-    const params = { limit: "200" };
-    if (filters.status !== "all") params.status = filters.status;
-    fetchCustomers(params).catch(() => {});
-  }, [filters.status, fetchCustomers]);
+    if (filters.status !== "all") {
+      fetchCustomers({ status: filters.status }).catch(() => {});
+    }
+  }, [filters.status]);
 
   const filteredCustomers = customers.filter((customer) => {
     if (!filters.search) return true;

--- a/frontend/src/pages/admin/AdminLocations.jsx
+++ b/frontend/src/pages/admin/AdminLocations.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useToast } from "../../components/Toast";
 import { useCRUD } from "../../hooks/useCRUD";
 import { Badge, Button, Input, Select } from "../../components/ui";
@@ -91,7 +91,7 @@ export default function AdminLocations() {
   };
 
   // Refetch when includeInactive changes
-  useState(() => { refetch(); });
+  useEffect(() => { refetch(); }, [includeInactive]);
 
   const handleSave = async (locationData) => {
     try {

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -36,7 +36,10 @@ export default function AdminUsers() {
     error,
     fetchAll: fetchUsers,
     refresh,
-  } = useCRUD("/api/v1/admin/users", { extractKey: null, immediate: false });
+  } = useCRUD("/api/v1/admin/users", {
+    extractKey: null,
+    defaultParams: { limit: "200" },
+  });
   const [filters, setFilters] = useState({
     search: "",
     role: "all",
@@ -51,12 +54,15 @@ export default function AdminUsers() {
   const [savingUser, setSavingUser] = useState(false);
   const [resettingPassword, setResettingPassword] = useState(false);
 
+  // Re-fetch when filters change (initial load handled by useCRUD immediate:true)
   useEffect(() => {
-    const params = { limit: "200" };
+    const params = {};
     if (filters.role !== "all") params.account_type = filters.role;
     if (filters.includeInactive) params.include_inactive = "true";
-    fetchUsers(params).catch(() => {});
-  }, [filters.role, filters.includeInactive, fetchUsers]);
+    if (Object.keys(params).length > 0) {
+      fetchUsers(params).catch(() => {});
+    }
+  }, [filters.role, filters.includeInactive]);
 
   const filteredUsers = users.filter((user) => {
     if (!filters.search) return true;


### PR DESCRIPTION
## Summary
- Fix BUG-001: Remove emoji from seed script that crashes on Windows (cp1252 encoding)
- Fix BUG-004: Add 12 standard UOMs to seed service (conversions were broken — no seed data)
- Fix BUG-005: Fix React Strict Mode race condition in useCRUD.js, fix AdminCustomers, AdminUsers, AdminLocations stuck loading

## Changes
| File | Change |
|------|--------|
| backend/scripts/seed_example_data.py | Added seed_uoms() (12 UOMs), removed all emoji |
| backend/app/services/seed_service.py | Calls seed_uoms() before items/materials |
| backend/app/api/v1/endpoints/setup.py | Added uoms_created to response model |
| frontend/src/hooks/useCRUD.js | Fixed Strict Mode race, added didFetchRef, params/extractKey to refs |
| frontend/src/pages/admin/AdminCustomers.jsx | immediate: true with defaultParams |
| frontend/src/pages/admin/AdminUsers.jsx | Same pattern fix |
| frontend/src/pages/admin/AdminLocations.jsx | useState to useEffect |

## Testing
- [x] Manual browser validation (eyes and mouse) on working directory
- [x] API endpoint tested (UOM: 1.5 KG to 1500 G)
- [x] Fresh database tested (drop/create, migrate, seed, validate all pages)
- [x] Verified on Windows (no emoji crash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Units of measure are now seeded during example data setup.
  * Seed response now includes count of units of measure created.

* **Bug Fixes**
  * Improved data fetching behavior in admin pages with optimized parameter handling.
  * Fixed unnecessary re-fetch behavior in admin location filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->