### PR TITLE
fix: BUG-009 MRP demand detection + X-Frame-Options

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -241,7 +241,7 @@ class Settings(BaseSettings):
     # ===================
     # MRP Settings (safe defaults)
     # ===================
-    INCLUDE_SALES_ORDERS_IN_MRP: bool = False
+    INCLUDE_SALES_ORDERS_IN_MRP: bool = True
     AUTO_MRP_ON_ORDER_CREATE: bool = False
     AUTO_MRP_ON_SHIPMENT: bool = False
     AUTO_MRP_ON_CONFIRMATION: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,7 +58,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         # Prevent clickjacking
-        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
         # Prevent MIME type sniffing
         response.headers["X-Content-Type-Options"] = "nosniff"
         # XSS protection (legacy)

--- a/backend/app/services/mrp.py
+++ b/backend/app/services/mrp.py
@@ -778,9 +778,13 @@ class MRPService:
         if include_draft:
             statuses.append("draft")
 
+        from sqlalchemy import or_
         return self.db.query(ProductionOrder).filter(
             ProductionOrder.status.in_(statuses),
-            ProductionOrder.due_date <= horizon_date if ProductionOrder.due_date else True
+            or_(
+                ProductionOrder.due_date <= horizon_date,
+                ProductionOrder.due_date.is_(None)
+            )
         ).all()
 
     def _get_inventory_levels(


### PR DESCRIPTION
## Summary
- **BUG-009a**: `INCLUDE_SALES_ORDERS_IN_MRP` defaulted to `False` — MRP engine ignored all sales order demand, producing zero planned orders
- **BUG-009b**: Production order horizon filter used Python ternary (`if/else`) instead of SQLAlchemy `or_()` — silently dropped orders with NULL `due_date` since the column object is always truthy at query-build time
- **X-Frame-Options**: Standardized from `DENY` to `SAMEORIGIN` to prevent admin UI embedding issues

## Files Changed (3)
- `backend/app/core/settings.py` — flip MRP default to True
- `backend/app/services/mrp.py` — proper `or_()` filter for NULL due_dates
- `backend/app/main.py` — X-Frame-Options SAMEORIGIN

## Test Plan
- [x] SME domain test suite: 46/46 tests pass (10 domains, all green)
- [x] MRP domain specifically validates demand detection end-to-end
- [x] Eyes-and-mouse verification: Low Stock page shows MRP-driven shortages

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Sales orders are now included by default in MRP calculations

* **Security**
  * Updated frame options to allow same-origin framing

* **Bug Fixes**
  * Improved handling of production orders without specified due dates in MRP calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->