### PR TITLE
fix: prevent stack trace exposure in API error responses

### DIFF
--- a/backend/app/api/v1/endpoints/admin/customers.py
+++ b/backend/app/api/v1/endpoints/admin/customers.py
@@ -322,4 +322,8 @@ async def import_customers(
     if text.startswith('\ufeff'):
         text = text[1:]
 
-    return svc.import_customers(db, text, current_admin.id)
+    try:
+        return svc.import_customers(db, text, current_admin.id)
+    except Exception as e:
+        logger.error(f"Customer import failed: {e}")
+        raise HTTPException(status_code=500, detail="Customer import failed. Check server logs for details.")

--- a/backend/app/api/v1/endpoints/admin/fulfillment_queue.py
+++ b/backend/app/api/v1/endpoints/admin/fulfillment_queue.py
@@ -11,8 +11,11 @@ Handles production queue management:
 
 Split from fulfillment.py — shipping endpoints are in fulfillment_shipping.py.
 """
+import logging
 from datetime import datetime, timezone
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -1296,7 +1299,8 @@ async def bulk_update_status(
 
             updated.append({"id": po_id, "code": po.code, "old_status": old_status, "new_status": request.new_status})
         except Exception as e:
-            errors.append({"id": po_id, "error": str(e)})
+            logger.error(f"Bulk update failed for production order {po_id}: {e}")
+            errors.append({"id": po_id, "error": "Update failed"})
 
     db.commit()
 

--- a/backend/app/api/v1/endpoints/security.py
+++ b/backend/app/api/v1/endpoints/security.py
@@ -300,7 +300,7 @@ async def get_security_status(
         logger.error(f"Failed to get security status: {e}")
         return {
             "status": "error",
-            "message": f"Could not check security status: {str(e)}",
+            "message": "Could not check security status. Check server logs for details.",
             "summary": None,
             "checked_at": datetime.now().isoformat()
         }

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -366,7 +366,8 @@ def _test_anthropic_connection(api_key: str) -> tuple[bool, str]:
     except ImportError:
         return False, "anthropic package not installed"
     except Exception as e:
-        return False, str(e)
+        logger.error(f"Anthropic connection test failed: {e}")
+        return False, "Connection test failed"
 
 
 def _test_ollama_connection(url: str, model: str) -> tuple[bool, str]:
@@ -391,7 +392,8 @@ def _test_ollama_connection(url: str, model: str) -> tuple[bool, str]:
     except requests.exceptions.Timeout:
         return False, "Connection timed out"
     except Exception as e:
-        return False, str(e)
+        logger.error(f"Ollama connection test failed: {e}")
+        return False, "Connection test failed"
 
 
 @router.get("/ai", response_model=AISettingsResponse)
@@ -608,7 +610,7 @@ async def start_ollama(
         logger.error(f"Failed to start Ollama: {e}")
         return {
             "success": False,
-            "message": f"Could not start Ollama: {str(e)}"
+            "message": "Could not start Ollama. Check logs for details."
         }
 
 


### PR DESCRIPTION
## Summary

- Replace `str(e)` patterns in exception handlers that leak internal stack traces and error details to API consumers
- Errors are now logged server-side with full context and generic messages returned to clients
- Resolves 6 CodeQL code scanning alerts (#7, #10, #12, #13, #14, #15)

## Changes

| File | Alert(s) | Fix |
|------|----------|-----|
| `settings.py` | #13, #14, #15 | Anthropic/Ollama connection test + start errors |
| `security.py` | #12 | Security status check error |
| `fulfillment_queue.py` | #10 | Bulk production order update errors |
| `customers.py` | #7 | CSV customer import errors |

### CodeQL Alerts NOT fixed (by design)

| Alert | Rule | Reason |
|-------|------|--------|
| #1, #2 | `py/clear-text-logging-sensitive-data` | Admin email in audit logs — intentional for audit trail |
| #3 | `py/clear-text-logging-sensitive-data` | DB URL is logged but password is already masked by `_mask_password()` |
| #4 | `py/bind-socket-all-network-interfaces` | SSDP/UDP discovery must bind all interfaces to find printers on LAN |
| #5, #6 | `py/path-injection` | Already sanitized via `Path(filename).name` + extension validation |
| #16 | `py/weak-sensitive-data-hashing` | SHA-256 is pre-hash step before bcrypt (Dropbox pattern), not the final hash |

## Test plan

- [x] 687 tests passed, 0 failures (tests matching customer/security/settings/fulfillment)
- [x] 3 pre-existing test failures in `test_resource_scheduling.py` are unrelated (naive/aware datetime mismatch in DB columns — tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized error messages across API endpoints for improved user experience and clarity.
  * Enhanced server-side logging for better troubleshooting and diagnostics of system operations.
  * Sensitive technical details are no longer exposed to users; error responses now direct administrators to server logs for technical information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->