### PR TITLE
fix: set PostgreSQL session timezone to UTC for consistent datetime handling

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -17,11 +17,14 @@ connection_string = settings.database_url
 logger.info(f"Database connection: {settings.DB_HOST}:{settings.DB_PORT}/{settings.DB_NAME} (PostgreSQL)")
 
 # Create engine
+# Set session timezone to UTC so TIMESTAMP WITHOUT TIME ZONE columns behave
+# consistently regardless of the server's or OS's local timezone setting.
 engine = create_engine(
     connection_string,
     echo=False,  # Set to True for SQL query logging
     pool_pre_ping=True,  # Verify connections before using
     pool_recycle=3600,  # Recycle connections after 1 hour
+    connect_args={"options": "-c timezone=utc"},
 )
 
 # Create session factory

--- a/backend/app/services/resource_scheduling.py
+++ b/backend/app/services/resource_scheduling.py
@@ -205,10 +205,17 @@ def find_next_available_slot(
         # No scheduled ops - can start immediately
         return after
 
+    # DB columns are TIMESTAMP WITHOUT TIME ZONE, so values come back naive.
+    # Treat them as UTC to allow arithmetic with tz-aware `after`.
+    def _as_utc(dt):
+        if dt is not None and dt.tzinfo is None and after.tzinfo is not None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+
     # Check if there's a gap before the first scheduled op
     first_op = scheduled_ops[0]
     if first_op.scheduled_start:
-        gap_before_first = (first_op.scheduled_start - after).total_seconds() / 60
+        gap_before_first = (_as_utc(first_op.scheduled_start) - after).total_seconds() / 60
         if gap_before_first >= duration_minutes:
             return after
 
@@ -218,15 +225,15 @@ def find_next_available_slot(
         next_op = scheduled_ops[i + 1]
 
         if current_op.scheduled_end and next_op.scheduled_start:
-            gap_start = current_op.scheduled_end
-            gap_duration = (next_op.scheduled_start - gap_start).total_seconds() / 60
+            gap_start = _as_utc(current_op.scheduled_end)
+            gap_duration = (_as_utc(next_op.scheduled_start) - gap_start).total_seconds() / 60
             if gap_duration >= duration_minutes:
                 return max(gap_start, after)
 
     # No gap found - schedule after the last operation
     last_op = scheduled_ops[-1]
     if last_op.scheduled_end:
-        return max(last_op.scheduled_end, after)
+        return max(_as_utc(last_op.scheduled_end), after)
 
     # Fallback: start 1 hour from now
     return after + timedelta(hours=1)


### PR DESCRIPTION
## Summary
- Set `timezone=utc` on SQLAlchemy engine connect_args so TIMESTAMP WITHOUT TIME ZONE columns behave consistently regardless of OS/server timezone
- Add naive-to-aware datetime normalization in `find_next_available_slot` for Python-level arithmetic with DB-returned values

## Problem
3 tests in `test_resource_scheduling.py` failed on every CI run (and all 20 open PRs) with:
```
TypeError: can't subtract offset-naive and offset-aware datetimes
```
Root cause: PostgreSQL session timezone was `America/Indianapolis`, causing tz-aware datetimes written to `TIMESTAMP WITHOUT TIME ZONE` columns to be shifted by -5h on storage, then returned as naive — breaking arithmetic with tz-aware Python datetimes.

## Test plan
- [x] All 25 resource scheduling tests pass (3 were previously failing)
- [x] Full backend suite: 603 passed (1 pre-existing unrelated failure in inventory summary)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database session configuration to ensure consistent and reliable timezone handling across different deployment environments, preventing potential timestamp inconsistencies and data integrity issues.
  * Enhanced resource scheduling and availability detection by fixing timezone handling in gap calculations between scheduled operations, ensuring consistently accurate results regardless of system timezone configuration or location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->