### PR TITLE
fix: product customer_id FK + configurable DB pool size

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -62,6 +62,8 @@ class Settings(BaseSettings):
     DATABASE_URL: Optional[str] = Field(
         default=None, description="Full database URL (overrides DB_* settings)"
     )
+    DB_POOL_SIZE: int = Field(default=5, description="SQLAlchemy connection pool size")
+    DB_MAX_OVERFLOW: int = Field(default=10, description="Max connections above pool_size")
 
     @property
     def database_url(self) -> str:

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -24,6 +24,8 @@ engine = create_engine(
     echo=False,  # Set to True for SQL query logging
     pool_pre_ping=True,  # Verify connections before using
     pool_recycle=3600,  # Recycle connections after 1 hour
+    pool_size=settings.DB_POOL_SIZE,
+    max_overflow=settings.DB_MAX_OVERFLOW,
     connect_args={"options": "-c timezone=utc"},
 )
 

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -93,7 +93,7 @@ class Product(Base):
     # Visibility & Sales Channels
     is_public = Column(Boolean, default=True)  # Show on public storefront?
     sales_channel = Column(String(20), default='public')  # 'public' | 'b2b' | 'internal'
-    customer_id = Column(Integer, ForeignKey('users.id', ondelete='SET NULL'), nullable=True, index=True)  # Restrict to specific customer (B2B)
+    customer_id = Column(Integer, ForeignKey('customers.id', ondelete='SET NULL'), nullable=True, index=True)  # Restrict to specific customer (B2B)
 
     # Flags
     is_raw_material = Column(Boolean, default=False)

--- a/backend/migrations/versions/061_fix_product_customer_fk.py
+++ b/backend/migrations/versions/061_fix_product_customer_fk.py
@@ -1,0 +1,45 @@
+"""Fix product.customer_id FK to reference customers table instead of users.
+
+The customer_id column on products is meant for B2B customer restriction,
+so it should reference the customers table (not users).
+
+Issue: https://github.com/Blb3D/filaops/issues/310
+"""
+from alembic import op
+
+
+revision = '061'
+down_revision = '060'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop old FK referencing users.id
+    # Convention: fk_<table>_<column>_<referenced_table>
+    # SQLAlchemy auto-generates constraint names; use batch mode for safety
+    with op.batch_alter_table('products') as batch_op:
+        batch_op.drop_constraint(
+            'fk_products_customer', type_='foreignkey'
+        )
+        batch_op.create_foreign_key(
+            'fk_products_customer',
+            'customers',
+            ['customer_id'],
+            ['id'],
+            ondelete='SET NULL',
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('products') as batch_op:
+        batch_op.drop_constraint(
+            'fk_products_customer', type_='foreignkey'
+        )
+        batch_op.create_foreign_key(
+            'fk_products_customer',
+            'users',
+            ['customer_id'],
+            ['id'],
+            ondelete='SET NULL',
+        )


### PR DESCRIPTION
## Summary
- **#310**: Fix `product.customer_id` FK to reference `customers.id` instead of `users.id` — the column is for B2B customer restriction, not user accounts. Includes Alembic migration 061.
- **#315 item 4**: Add `DB_POOL_SIZE` and `DB_MAX_OVERFLOW` env-configurable settings (defaults match SQLAlchemy: 5/10) wired into `session.py`.

Closes #310, closes #315

## Test plan
- [x] 603/604 tests pass (1 pre-existing failure unrelated)
- [x] Verified no products have `customer_id` set — safe FK swap
- [x] Verified actual constraint name (`fk_products_customer`) before writing migration
- [ ] Run migration 061 on dev DB after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)