### PR TITLE
fix: remove LICENSE_SERVER_URL passthrough from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,8 @@ services:
       DB_USER: ${DB_USER:-postgres}
       DB_PASSWORD: ${DB_PASSWORD:-changeme}
       SECRET_KEY: ${SECRET_KEY:-change-in-production}
-      # PRO — entrypoint uses this to auto-download the plugin
+      # PRO — set FILAOPS_LICENSE_KEY in .env to activate PRO features
       FILAOPS_LICENSE_KEY: ${FILAOPS_LICENSE_KEY:-}
-      LICENSE_SERVER_URL: ${LICENSE_SERVER_URL:-}
       DATABASE_URL: postgresql+psycopg://${DB_USER:-postgres}:${DB_PASSWORD:-changeme}@db:5432/${DB_NAME:-filaops}
     depends_on:
       db:
@@ -62,9 +61,8 @@ services:
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost}
       FILAOPS_VERSION: ${FILAOPS_VERSION:-}
-      # PRO — entrypoint uses this to auto-download the plugin
+      # PRO — set FILAOPS_LICENSE_KEY in .env to activate PRO features
       FILAOPS_LICENSE_KEY: ${FILAOPS_LICENSE_KEY:-}
-      LICENSE_SERVER_URL: ${LICENSE_SERVER_URL:-}
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
## Problem

`docker-compose.yml` was passing `LICENSE_SERVER_URL: ${LICENSE_SERVER_URL:-}` to containers. When not set in `.env`, this injects an empty string into the container environment. An empty string is not the same as an unset variable — it overrides the default URL in `filaops_pro.register()`, causing:

```
License validation error: Request URL is missing an 'http://' or 'https://' protocol.
```

## Fix

Remove `LICENSE_SERVER_URL` from docker-compose env passthrough. `filaops_pro.register()` has a built-in default (`https://license.blb3dprinting.com`) that applies when the var is **unset**. If a customer needs to override it, they can set it in `.env` and it will still reach the container via the existing `FILAOPS_LICENSE_KEY` path.

## Testing

On VM with `FILAOPS_LICENSE_KEY` set and no `LICENSE_SERVER_URL` in `.env`:
- License validates against `https://license.blb3dprinting.com` using default
- PRO registers successfully

## Note

`LICENSE_SERVER_URL` is still available as an override — customers can set it in `.env` if they need to point at a different license server. The change only removes the empty-string injection when unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PRO feature activation instructions to direct users to configure FILAOPS_LICENSE_KEY environment variable in their deployment setup for enabling premium features.

* **Chores**
  * Removed deprecated license server URL configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->