### PR TITLE
chore: gitignore internal T-REX reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ frontend/tests/sme/
 # PRO features (never in public core — lives in private repo only)
 backend/app/pro/
 .claude/dependabot-upgrade-plan.md
+
+# Internal reports (not for public repo)
+docs/T-REX-Implementation-Report.md
+docs/T-REX-Implementation-Report.pdf
+docs/AI_Agent_Governance_Gap_Analysis.pdf
+docs/BLIND_TEST_RECOVERY.md


### PR DESCRIPTION
## Summary
- Adds `.gitignore` entries for internal governance documents that should not be tracked in the public repo
- Covers: T-REX Implementation Report (.md/.pdf), AI Agent Governance Gap Analysis (.pdf), Blind Test Recovery doc

## Test plan
- [x] Verify listed files no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude internal report files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->