### PR TITLE
fix: consistent PRO upgrade card on Access Requests page

### DIFF
--- a/frontend/src/pages/admin/AdminAccessRequests.jsx
+++ b/frontend/src/pages/admin/AdminAccessRequests.jsx
@@ -133,10 +133,26 @@ export default function AdminAccessRequests() {
 
   if (!isPro) {
     return (
-      <div className="p-6">
-        <div className="bg-gray-800 rounded-lg p-8 text-center">
-          <h2 className="text-xl font-semibold text-white mb-2">PRO Feature</h2>
-          <p className="text-gray-400">Access request management requires FilaOps PRO.</p>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Access Requests</h1>
+          <p className="text-gray-400 mt-1">
+            Review and approve B2B portal access applications
+          </p>
+        </div>
+        <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6 text-center">
+          <svg className="w-12 h-12 text-blue-400 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+          <h3 className="text-lg font-semibold text-white mb-2">PRO Feature</h3>
+          <p className="text-gray-400 mb-4">
+            Access Requests let you review, approve, and manage B2B portal
+            registration applications. Resend setup links or revoke access
+            for any customer.
+          </p>
+          <a href="/pricing" className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors">
+            Upgrade to PRO
+          </a>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Replace bare-bones gray "PRO Feature" box on Access Requests with the same styled upgrade card used by Catalogs and Price Levels
- Adds lock icon, feature description, and "Upgrade to PRO" link
- Found during v3.4.0 manual testing

## Test plan
- [x] Navigate to Access Requests as community user — see blue upgrade card with link
- [x] Verify Catalogs and Price Levels still show matching cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the Access Requests non-PRO interface with an enhanced two-part promotional banner including a feature description and upgrade call-to-action button, replacing the previous simple message display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->