### PR TITLE
fix: PO modal product dropdown empty on first open

### DIFF
--- a/frontend/src/components/purchasing/POCreateModal.jsx
+++ b/frontend/src/components/purchasing/POCreateModal.jsx
@@ -18,7 +18,7 @@ import { convertUOM } from "../../lib/uom";
 export default function POCreateModal({
   po,
   vendors,
-  products,
+  products = [],
   onClose,
   onSave,
   onProductsRefresh,
@@ -32,9 +32,10 @@ export default function POCreateModal({
   const [localProducts, setLocalProducts] = useState(products);
   const [taxOverridden, setTaxOverridden] = useState(false); // Track if user manually changed tax
 
-  // Sync localProducts when parent fetches products after modal mount
+  // Sync localProducts only on initial load (when still empty) to avoid
+  // overwriting items added via Quick Create while a fetch is in-flight
   useEffect(() => {
-    if (products.length > 0) {
+    if (products.length > 0 && localProducts.length === 0) {
       setLocalProducts(products);
     }
   }, [products]);


### PR DESCRIPTION
## Summary
- **Root cause:** `POCreateModal` used `useState(products)` to initialize its local product list, but since [bb87eb9](https://github.com/Blb3D/filaops/commit/bb87eb9) (Feb 6) moved product fetching to lazy-load when the modal opens, the modal mounts *before* the fetch completes — so `localProducts` was always `[]` on first open
- **Fix:** Added a `useEffect` to sync `localProducts` when the parent's `products` prop updates after the async fetch completes
- **No performance regression:** Lazy-loading behavior is preserved — products still only fetch when the modal opens, not on page load

## Test plan
- [x] Frontend tests pass (33/33)
- [ ] Open New PO modal → products should appear immediately on first open (no close/reopen needed)
- [ ] Create a PO → open New PO modal again → products should still appear on first open
- [ ] Low Stock → "Create PO" flow → products should be pre-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase Order creation modal no longer overwrites items added via Quick Create while product data is still loading.
  * Ensures the modal loads parent product updates on first load without clearing locally added products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->