### PR TITLE
feat: Portal Admin button in admin header (PRO-only)

### DIFF
--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -624,7 +624,14 @@ export default function AdminLayout() {
   const handleOpenPortalAdmin = async () => {
     setPortalLinkLoading(true);
     // Open window synchronously to avoid popup blocker (must be in user-click call stack)
+    // NOTE: Cannot use noopener here — it causes window.open to return null,
+    // which prevents navigating the window after the fetch completes.
     const portalWindow = window.open("about:blank", "_blank");
+    if (!portalWindow) {
+      alert("Popup blocked. Please allow popups for this site and try again.");
+      setPortalLinkLoading(false);
+      return;
+    }
     try {
       const res = await fetch(`${API_URL}/api/v1/pro/portal/admin-link`, {
         credentials: "include",
@@ -632,12 +639,10 @@ export default function AdminLayout() {
       if (!res.ok) throw new Error("Failed to get portal link");
       const data = await res.json();
       if (!data.url) throw new Error("No portal URL returned");
-      if (portalWindow) {
-        portalWindow.location.href = data.url;
-      }
+      portalWindow.location.href = data.url;
     } catch (err) {
       console.error("Portal admin link failed:", err);
-      if (portalWindow) portalWindow.close();
+      portalWindow.close();
       alert("Could not open Portal Admin. Please try again.");
     } finally {
       setPortalLinkLoading(false);


### PR DESCRIPTION
## Summary
- Adds a **Portal Admin** button to the Core admin header, next to the user name
- Only visible when `isPro === true` AND user is an admin (feature-flagged, hidden from community users)
- Clicking it calls `GET /api/v1/pro/portal/admin-link` (filaops-pro route) which generates a 60-second signed token
- Opens the hosted portal admin (`blb3d.portal.blb3dprinting.com/admin/auto-login?token=...`) in a new tab
- Admin is auto-authenticated on the portal — no password re-entry needed

## How it works
1. Button calls the filaops-pro endpoint (authenticated via existing Core session cookie)
2. filaops-pro signs a JWT with the tenant's sync key (shared secret with portal-api)
3. Portal's `/admin/auto-login` page exchanges the token for a real admin JWT
4. Redirects to the admin dashboard

## Dependencies
- Requires filaops-ecosystem PR #18 (`fix/portal-sync-catalogs-pricelevels`) for:
  - `POST /api/v1/auth/auto-login` endpoint on portal-api
  - `GET /api/v1/pro/portal/admin-link` route in filaops-pro
  - Portal SPA auto-login page

## Test plan
- [ ] Verify button is hidden when `isPro` is false (community tier)
- [ ] Verify button is hidden for non-admin users
- [ ] Verify button appears for PRO admin users
- [ ] Click button → opens portal admin in new tab, auto-authenticated
- [ ] Verify loading state ("Opening...") while fetching link
- [ ] Verify graceful failure if portal hosting not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Portal Admin button for administrators on Pro plans — opens the admin portal in a new tab, provides clear accessible and visual loading feedback (disabled state, "Opening..." label and icon) while the portal is being opened, handles errors gracefully, and ensures the UI reflects the in-progress state until the portal loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->