### PR TITLE
fix: copy routing when duplicating an item

### DIFF
--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.logging_config import get_logger
 from app.models import Product, ItemCategory, Inventory, BOM, BOMLine
-from app.models.manufacturing import Routing
+from app.models.manufacturing import Routing, RoutingOperation, RoutingOperationMaterial
 from app.core.utils import get_or_404, check_unique_or_400
 from app.core.uom_config import DEFAULT_MATERIAL_UOM, get_default_material_sku_prefix
 
@@ -1946,8 +1946,105 @@ def duplicate_item(
         new_item.has_bom = True
         bom_id = new_bom.id
 
+    # Copy active routing if source has one
+    routing_id = None
+    active_routing = (
+        db.query(Routing)
+        .filter(Routing.product_id == source.id, Routing.is_active.is_(True))
+        .first()
+    )
+
+    if active_routing:
+        new_routing = Routing(
+            product_id=new_item.id,
+            code=f"RTG-{new_sku_upper}"[:50],
+            name=f"Routing for {new_item.name}"[:200],
+            is_template=False,
+            version=1,
+            revision="1.0",
+            is_active=True,
+            effective_date=active_routing.effective_date,
+            notes=f"Duplicated from {source.sku}",
+        )
+        db.add(new_routing)
+        db.flush()
+
+        # Copy operations — track old_id -> new_id for predecessor remapping
+        op_id_map: dict[int, int] = {}
+        source_ops = (
+            db.query(RoutingOperation)
+            .filter(RoutingOperation.routing_id == active_routing.id)
+            .order_by(RoutingOperation.sequence)
+            .all()
+        )
+
+        for op in source_ops:
+            new_op = RoutingOperation(
+                routing_id=new_routing.id,
+                work_center_id=op.work_center_id,
+                sequence=op.sequence,
+                operation_code=op.operation_code,
+                operation_name=op.operation_name,
+                description=op.description,
+                setup_time_minutes=op.setup_time_minutes,
+                run_time_minutes=op.run_time_minutes,
+                wait_time_minutes=op.wait_time_minutes,
+                move_time_minutes=op.move_time_minutes,
+                runtime_source=op.runtime_source,
+                slicer_file_path=op.slicer_file_path,
+                units_per_cycle=op.units_per_cycle,
+                scrap_rate_percent=op.scrap_rate_percent,
+                labor_rate_override=op.labor_rate_override,
+                machine_rate_override=op.machine_rate_override,
+                can_overlap=op.can_overlap,
+                is_active=op.is_active,
+                # predecessor_operation_id set in second pass below
+            )
+            db.add(new_op)
+            db.flush()
+            op_id_map[op.id] = new_op.id
+
+            # Copy operation materials with component overrides
+            for mat in op.materials:
+                component_id = override_map.get(mat.component_id, mat.component_id) if active_bom else mat.component_id
+                new_mat = RoutingOperationMaterial(
+                    routing_operation_id=new_op.id,
+                    component_id=component_id,
+                    quantity=mat.quantity,
+                    quantity_per=mat.quantity_per,
+                    unit=mat.unit,
+                    scrap_factor=mat.scrap_factor,
+                    is_cost_only=mat.is_cost_only,
+                    is_optional=mat.is_optional,
+                    notes=mat.notes,
+                )
+                db.add(new_mat)
+
+        # Second pass: remap predecessor_operation_id references
+        for old_op in source_ops:
+            if old_op.predecessor_operation_id and old_op.predecessor_operation_id in op_id_map:
+                new_op_id = op_id_map[old_op.id]
+                db.query(RoutingOperation).filter(
+                    RoutingOperation.id == new_op_id
+                ).update({
+                    "predecessor_operation_id": op_id_map[old_op.predecessor_operation_id]
+                })
+
+        db.flush()
+        new_routing.recalculate_totals()
+        routing_id = new_routing.id
+
     db.commit()
     db.refresh(new_item)
+
+    # Build summary message
+    parts = [f"Duplicated from {source.sku}"]
+    if active_bom:
+        parts.append(f"with BOM ({len(source_lines)} lines)")
+    if active_routing:
+        parts.append(f"routing ({len(source_ops)} operations)")
+    if not active_bom and not active_routing:
+        parts.append("(no BOM or routing)")
 
     return {
         "id": new_item.id,
@@ -1955,6 +2052,6 @@ def duplicate_item(
         "name": new_item.name,
         "has_bom": new_item.has_bom,
         "bom_id": bom_id,
-        "message": f"Duplicated from {source.sku}"
-            + (f" with BOM ({len(source_lines)} lines)" if active_bom else " (no BOM)"),
+        "routing_id": routing_id,
+        "message": " ".join(parts),
     }

--- a/backend/tests/test_duplicate_item.py
+++ b/backend/tests/test_duplicate_item.py
@@ -4,6 +4,8 @@ from fastapi import HTTPException
 
 from app.services import item_service
 from app.models.bom import BOM, BOMLine
+from app.models.manufacturing import Routing, RoutingOperation, RoutingOperationMaterial
+from app.models.work_center import WorkCenter
 
 
 class TestDuplicateItemBasic:
@@ -292,3 +294,146 @@ class TestDuplicateItemWithBOM:
         assert float(new_line.scrap_factor) == 5.0
         assert new_line.is_cost_only is True
         assert new_line.notes == "Handle with care"
+
+
+class TestDuplicateItemWithRouting:
+    """Test item duplication with routing copy."""
+
+    def _make_work_center(self, db, code="WC-DUP-TEST"):
+        """Helper to create a work center for tests."""
+        wc = db.query(WorkCenter).filter(WorkCenter.code == code).first()
+        if not wc:
+            wc = WorkCenter(code=code, name="Dup Test WC", center_type="production")
+            db.add(wc)
+            db.flush()
+        return wc
+
+    def test_duplicate_copies_routing(self, db):
+        """Duplicate an item with a routing — operations should be copied."""
+        source = item_service.create_item(db, data={
+            "sku": "DUP-RTG-SRC",
+            "name": "Source With Routing",
+            "procurement_type": "make",
+        })
+        wc = self._make_work_center(db)
+
+        routing = Routing(product_id=source.id, code="DUP-RTG-SRC-RTG", name="Test RTG", is_active=True)
+        db.add(routing)
+        db.flush()
+        db.add(RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id,
+            sequence=10, operation_code="PRINT", operation_name="Print Part",
+            setup_time_minutes=5, run_time_minutes=30,
+        ))
+        db.add(RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id,
+            sequence=20, operation_code="QC", operation_name="Inspect",
+            setup_time_minutes=0, run_time_minutes=5,
+        ))
+        db.commit()
+
+        result = item_service.duplicate_item(
+            db, source.id,
+            new_sku="DUP-RTG-CLN",
+            new_name="Clone With Routing",
+        )
+
+        assert result["routing_id"] is not None
+        new_routing = db.query(Routing).filter(Routing.id == result["routing_id"]).first()
+        assert new_routing.product_id == result["id"]
+        assert new_routing.is_active is True
+
+        new_ops = (
+            db.query(RoutingOperation)
+            .filter(RoutingOperation.routing_id == new_routing.id)
+            .order_by(RoutingOperation.sequence)
+            .all()
+        )
+        assert len(new_ops) == 2
+        assert new_ops[0].operation_code == "PRINT"
+        assert float(new_ops[0].run_time_minutes) == 30.0
+        assert new_ops[1].operation_code == "QC"
+
+    def test_duplicate_copies_routing_materials_with_override(self, db):
+        """Routing operation materials should be copied and swapped like BOM lines."""
+        source = item_service.create_item(db, data={
+            "sku": "DUP-RTGMAT-SRC",
+            "name": "Routing Material Source",
+            "procurement_type": "make",
+        })
+        fil_red = item_service.create_item(db, data={
+            "sku": "DUP-RTGM-RED",
+            "name": "PLA Red (rtg test)",
+            "item_type": "supply",
+        })
+        fil_blue = item_service.create_item(db, data={
+            "sku": "DUP-RTGM-BLU",
+            "name": "PLA Blue (rtg test)",
+            "item_type": "supply",
+        })
+        wc = self._make_work_center(db, code="WC-DUP-MAT")
+
+        # Create BOM (needed so override_map is populated)
+        bom = BOM(product_id=source.id, code="DUP-RTGMAT-BOM", name="BOM", active=True)
+        db.add(bom)
+        db.flush()
+        db.add(BOMLine(bom_id=bom.id, component_id=fil_red.id, quantity=25, unit="G", sequence=1))
+        source.has_bom = True
+
+        # Create routing with operation material referencing same component
+        routing = Routing(product_id=source.id, code="DUP-RTGMAT-RTG", name="RTG", is_active=True)
+        db.add(routing)
+        db.flush()
+        op = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id,
+            sequence=10, operation_code="PRINT", operation_name="Print",
+            setup_time_minutes=5, run_time_minutes=45,
+        )
+        db.add(op)
+        db.flush()
+        db.add(RoutingOperationMaterial(
+            routing_operation_id=op.id, component_id=fil_red.id,
+            quantity=25, unit="G", quantity_per="unit",
+        ))
+        db.commit()
+
+        result = item_service.duplicate_item(
+            db, source.id,
+            new_sku="DUP-RTGMAT-CLN",
+            new_name="Routing Material Clone",
+            bom_line_overrides=[{
+                "original_component_id": fil_red.id,
+                "new_component_id": fil_blue.id,
+            }],
+        )
+
+        # Verify routing material was swapped to blue
+        new_ops = (
+            db.query(RoutingOperation)
+            .filter(RoutingOperation.routing_id == result["routing_id"])
+            .all()
+        )
+        assert len(new_ops) == 1
+        new_mats = (
+            db.query(RoutingOperationMaterial)
+            .filter(RoutingOperationMaterial.routing_operation_id == new_ops[0].id)
+            .all()
+        )
+        assert len(new_mats) == 1
+        assert new_mats[0].component_id == fil_blue.id
+        assert float(new_mats[0].quantity) == 25.0
+
+    def test_duplicate_no_routing(self, db):
+        """Item without routing should have routing_id=None in result."""
+        source = item_service.create_item(db, data={
+            "sku": "DUP-NORTG-SRC",
+            "name": "No Routing Source",
+        })
+
+        result = item_service.duplicate_item(
+            db, source.id,
+            new_sku="DUP-NORTG-CLN",
+            new_name="No Routing Clone",
+        )
+
+        assert result["routing_id"] is None


### PR DESCRIPTION
## Summary
- Duplicate item now copies the active **routing** (operations + operation materials) in addition to BOM lines
- Component overrides (e.g., PLA Red → PLA Blue) propagate to both BOM lines **and** routing operation materials
- Predecessor operation references are remapped to the new routing's operations
- 3 new tests covering routing copy, material override, and no-routing case (12 total passing)

## Test plan
- [x] `pytest tests/test_duplicate_item.py` — 12/12 passing
- [ ] Live test: duplicate an item with routing, verify operations appear on cloned BOM view
- [ ] Verify component swap applies to routing materials (not just BOM lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item duplication now automatically copies associated manufacturing routing and operations to the new item.
  * Manufacturing operation dependencies and routing materials (including component overrides) are preserved during duplication.
  * Duplication response includes routing identification and a detailed summary of all copied elements.

* **Tests**
  * Added comprehensive test coverage for item duplication with routing and material overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->