### PR TITLE
fix: bulk update status not applying — field name mismatch

### DIFF
--- a/frontend/src/components/items/BulkUpdateModal.jsx
+++ b/frontend/src/components/items/BulkUpdateModal.jsx
@@ -28,7 +28,7 @@ export default function BulkUpdateModal({
     if (categoryId) updateData.category_id = parseInt(categoryId);
     if (itemType) updateData.item_type = itemType;
     if (procurementType) updateData.procurement_type = procurementType;
-    if (active !== "") updateData.active = active === "true";
+    if (active !== "") updateData.is_active = active === "true";
     onSave(updateData);
   };
 


### PR DESCRIPTION
## Summary
- **Bug**: Selecting items and bulk-updating status to Inactive had no effect
- **Root cause**: `BulkUpdateModal` sent `active` in the request body, but the backend Pydantic schema (`ItemBulkUpdateRequest`) expects `is_active`. Pydantic silently drops unknown fields, so the status update was never applied.
- **Fix**: Changed `updateData.active` → `updateData.is_active` in `BulkUpdateModal.jsx`

## Test plan
- [ ] Select items on Admin Items page, bulk update to Inactive — verify status changes
- [ ] With "Active only" filter checked, verify inactive items disappear from list
- [ ] Bulk update back to Active — verify items reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with bulk updating status fields in modal dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->