### PR TITLE
fix: routing cost review followup — Decimal consistency, N+1, currency precision

### DIFF
--- a/backend/app/models/manufacturing.py
+++ b/backend/app/models/manufacturing.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
+from decimal import Decimal
 
 from app.db.base import Base
 
@@ -115,18 +116,20 @@ class Routing(Base):
         """Recalculate total times and cost from operations.
 
         Cost includes setup + run time labor AND operation material costs.
+        All accumulation uses Decimal to match the service function and
+        avoid float drift on Numeric(18,4) columns.
         """
-        total_setup = 0
-        total_run = 0
-        total_cost = 0
+        total_setup = Decimal("0")
+        total_run = Decimal("0")
+        total_cost = Decimal("0")
 
         for op in self.operations:
             if not op.is_active:
                 continue
-            total_setup += float(op.setup_time_minutes or 0)
-            total_run += float(op.run_time_minutes or 0)
-            total_run += float(op.wait_time_minutes or 0)
-            total_run += float(op.move_time_minutes or 0)
+            total_setup += Decimal(str(op.setup_time_minutes or 0))
+            total_run += Decimal(str(op.run_time_minutes or 0))
+            total_run += Decimal(str(op.wait_time_minutes or 0))
+            total_run += Decimal(str(op.move_time_minutes or 0))
 
             # Delegate to operation properties — single source of truth
             total_cost += op.calculated_cost
@@ -135,6 +138,7 @@ class Routing(Base):
         self.total_setup_time_minutes = total_setup
         self.total_run_time_minutes = total_run
         self.total_cost = total_cost
+        self.updated_at = datetime.now(timezone.utc)
         self.updated_at = datetime.now(timezone.utc)
 
 
@@ -206,33 +210,36 @@ class RoutingOperation(Base):
             float(self.move_time_minutes or 0)
         )
 
+    @property
     def effective_hourly_rate(self):
         """Component-wise hourly rate, applying per-component overrides.
 
         Overhead has no override — it always comes from the work center.
         This is intentional: overhead is a facility-level cost, not
         something operators adjust per-operation.
+
+        Returns Decimal for consistent accumulation in cost totals.
         """
         wc = self.work_center
         machine = (
-            float(self.machine_rate_override)
+            Decimal(str(self.machine_rate_override))
             if self.machine_rate_override is not None
-            else float(wc.machine_rate_per_hour or 0) if wc else 0.0
+            else Decimal(str(wc.machine_rate_per_hour or 0)) if wc else Decimal("0")
         )
         labor = (
-            float(self.labor_rate_override)
+            Decimal(str(self.labor_rate_override))
             if self.labor_rate_override is not None
-            else float(wc.labor_rate_per_hour or 0) if wc else 0.0
+            else Decimal(str(wc.labor_rate_per_hour or 0)) if wc else Decimal("0")
         )
-        overhead = float(wc.overhead_rate_per_hour or 0) if wc else 0.0
+        overhead = Decimal(str(wc.overhead_rate_per_hour or 0)) if wc else Decimal("0")
         return machine + labor + overhead
 
     @property
     def calculated_cost(self):
         """Time-based cost for this operation (setup + run at combined hourly rate)"""
-        total_minutes = float(self.setup_time_minutes or 0) + float(self.run_time_minutes or 0)
-        hours = total_minutes / 60
-        return hours * self.effective_hourly_rate()
+        total_minutes = Decimal(str(self.setup_time_minutes or 0)) + Decimal(str(self.run_time_minutes or 0))
+        hours = total_minutes / Decimal("60")
+        return hours * self.effective_hourly_rate
 
     @property
     def material_cost(self):
@@ -241,12 +248,14 @@ class RoutingOperation(Base):
         Only includes quantity_per='unit' (or unset, defaulting to per-unit).
         Batch/order materials are not per-unit costs and would inflate
         the routing template cost incorrectly if included.
+
+        Returns Decimal for consistent accumulation in cost totals.
         """
-        total = 0
+        total = Decimal("0")
         for mat in self.materials:
             if mat.quantity_per and str(mat.quantity_per).strip().lower() != "unit":
                 continue
-            total += mat.extended_cost or 0
+            total += mat.extended_cost or Decimal("0")
         return total
 
 
@@ -299,7 +308,7 @@ class RoutingOperationMaterial(Base):
     @property
     def unit_cost(self):
         """
-        Cost per STORAGE unit of this material.
+        Cost per STORAGE unit of this material (Decimal).
 
         Component costs are stored per PURCHASE unit (e.g., $/KG for filament).
         Must divide by purchase_factor to get cost per STORAGE unit (e.g., $/G).
@@ -309,18 +318,18 @@ class RoutingOperationMaterial(Base):
           - Hardware: $5/EA  ÷ 1    = $5/EA
         """
         if not self.component:
-            return 0
+            return Decimal("0")
         cost = self.component.standard_cost or self.component.average_cost or self.component.last_cost
         if not cost:
-            return 0
-        purchase_factor = float(self.component.purchase_factor or 1)
-        return float(cost) / purchase_factor
+            return Decimal("0")
+        purchase_factor = Decimal(str(self.component.purchase_factor or 1))
+        return Decimal(str(cost)) / purchase_factor
 
     @property
     def extended_cost(self):
-        """Total cost for this material line (quantity × unit_cost)"""
-        qty = float(self.quantity or 0)
-        scrap = float(self.scrap_factor or 0) / 100
+        """Total cost for this material line (quantity × unit_cost). Returns Decimal."""
+        qty = Decimal(str(self.quantity or 0))
+        scrap = Decimal(str(self.scrap_factor or 0)) / Decimal("100")
         qty_with_scrap = qty * (1 + scrap)
         return qty_with_scrap * self.unit_cost
 

--- a/backend/app/services/bom_management_service.py
+++ b/backend/app/services/bom_management_service.py
@@ -323,16 +323,13 @@ def build_bom_response(bom: BOM, db: Session) -> dict:
 def recalculate_bom_cost(
     bom: BOM,
     db: Session,
-    exclude_component_ids: set[int] | None = None,
     only_component_ids: set[int] | None = None,
 ) -> Decimal:
     """Recalculate total BOM cost from component costs, with UOM conversion.
 
     Args:
-        exclude_component_ids: Component IDs to skip (e.g., materials already
-            costed via routing operations, to avoid double-counting).
         only_component_ids: If set, only include these component IDs (used to
-            compute the overlap cost without a full second pass).
+            compute the overlap cost for routing material deduplication).
     """
     from app.services.inventory_helpers import is_material
 
@@ -345,8 +342,6 @@ def recalculate_bom_cost(
 
     total = Decimal("0")
     for line in bom.lines:
-        if exclude_component_ids and line.component_id in exclude_component_ids:
-            continue
         if only_component_ids and line.component_id not in only_component_ids:
             continue
         component = components_by_id.get(line.component_id)

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -2068,6 +2068,7 @@ def duplicate_item(
         op_id_map: dict[int, int] = {}
         source_ops = (
             db.query(RoutingOperation)
+            .options(joinedload(RoutingOperation.materials))
             .filter(RoutingOperation.routing_id == active_routing.id)
             .order_by(RoutingOperation.sequence)
             .all()
@@ -2126,7 +2127,9 @@ def duplicate_item(
                 })
 
         db.flush()
-        new_routing.recalculate_totals()
+        # Use service function (does its own eager-loading) to avoid N+1
+        from app.services.routing_service import recalculate_routing_totals
+        recalculate_routing_totals(new_routing, db)
         routing_id = new_routing.id
 
     db.commit()

--- a/backend/app/services/routing_service.py
+++ b/backend/app/services/routing_service.py
@@ -631,9 +631,9 @@ def recalculate_routing_totals(routing: Routing, db: Session) -> None:
             + (op.move_time_minutes or Decimal("0"))
         )
 
-        # Delegate to model properties — single source of truth for rate logic
-        total_cost += Decimal(str(op.calculated_cost))
-        total_cost += Decimal(str(op.material_cost))
+        # Delegate to model properties (return Decimal natively)
+        total_cost += op.calculated_cost
+        total_cost += op.material_cost
 
     routing.total_setup_time_minutes = total_setup
     routing.total_run_time_minutes = total_run

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -950,6 +950,13 @@ class TestRoutingCostDeduplication:
 
         # Also put material on a routing operation
         wc = db.query(WorkCenter).first()
+        if not wc:
+            wc = WorkCenter(
+                name=f"WC-{uuid4().hex[:8]}", code=f"WC-{uuid4().hex[:8]}",
+                center_type="assembly",
+            )
+            db.add(wc)
+            db.flush()
         routing = Routing(
             product_id=fg.id, code=f"RTG-DEDUP-{uuid4().hex[:8]}", name="Test",
             is_active=True, version=1,
@@ -1014,7 +1021,7 @@ class TestEffectiveHourlyRate:
             is_active=True,
         )
         op.work_center = wc
-        assert op.effective_hourly_rate() == pytest.approx(30.0)
+        assert op.effective_hourly_rate == pytest.approx(30.0)
         # 30min setup + 60min run = 90min = 1.5hr × $30 = $45
         assert op.calculated_cost == pytest.approx(45.0)
 
@@ -1040,7 +1047,7 @@ class TestEffectiveHourlyRate:
         )
         op.work_center = wc
         # Labor overridden to $20, machine $10 + overhead $5 from WC
-        assert op.effective_hourly_rate() == pytest.approx(35.0)
+        assert op.effective_hourly_rate == pytest.approx(35.0)
 
     def test_zero_override_is_respected(self, db):
         from app.models.manufacturing import RoutingOperation
@@ -1064,7 +1071,7 @@ class TestEffectiveHourlyRate:
         )
         op.work_center = wc
         # Labor zeroed, machine $10 + overhead $5
-        assert op.effective_hourly_rate() == pytest.approx(15.0)
+        assert op.effective_hourly_rate == pytest.approx(15.0)
 
 
 class TestRecostItem:

--- a/frontend/src/components/routing/RoutingEditorContent.jsx
+++ b/frontend/src/components/routing/RoutingEditorContent.jsx
@@ -500,7 +500,8 @@ export default function RoutingEditorContent({
     if (op.calculated_cost != null) {
       laborCost = parseFloat(op.calculated_cost);
     } else {
-      // Fallback for newly-added operations not yet saved to backend
+      // Fallback for newly-added operations not yet saved to backend.
+      // Uses work center total_rate (rate overrides not applied until save).
       const totalMinutes = (parseFloat(op.setup_time_minutes) || 0) + (parseFloat(op.run_time_minutes) || 0);
       const rate = parseFloat(op.hourly_rate) || 0;
       laborCost = (totalMinutes / 60) * rate;

--- a/frontend/src/hooks/useFormatCurrency.js
+++ b/frontend/src/hooks/useFormatCurrency.js
@@ -15,13 +15,19 @@ export function useFormatCurrency() {
   const { currency_code, locale } = useLocale();
 
   return useCallback(
-    (n) => {
+    (n, { maxDecimals } = {}) => {
       if (n == null || !Number.isFinite(Number(n))) return "";
+      // Show up to 4 decimals for sub-dollar values (e.g., $0.0642/ea
+      // from $8.99 / 140pcs), but keep $5.00 clean at currency default.
+      // Don't force minimumFractionDigits — let Intl use the currency's
+      // native minor-unit default (2 for USD, 0 for JPY, etc.).
+      const val = Number(n);
+      const max = maxDecimals ?? (Math.abs(val) < 1 && val !== 0 ? 4 : 2);
       return new Intl.NumberFormat(locale, {
         style: "currency",
         currency: currency_code,
-        maximumFractionDigits: 2,
-      }).format(Number(n));
+        maximumFractionDigits: max,
+      }).format(val);
     },
     [currency_code, locale]
   );


### PR DESCRIPTION
## Summary

Post-merge code review followup for #441. **Clean rebuild** after cross-session contamination incident (variant-matrix session's `is_variable` column leaked via shared working tree).

### Review items addressed

| # | Issue | Fix |
|---|-------|-----|
| 1 | Float vs Decimal drift | Model properties return Decimal natively throughout the chain |
| 2 | `effective_hourly_rate` inconsistently a method | Now a `@property` |
| 3 | `recalculate_totals` missing `updated_at` | Added |
| 4 | N+1 in `duplicate_item` | Use service function + eager-load source_ops.materials |
| 5 | Dead `exclude_component_ids` param | Removed |
| 6 | Fragile `WorkCenter.first()` in test | Creates WC if none exists |
| 7 | Currency truncation | Sub-dollar shows 4 decimals, JPY-safe (no forced minimumFractionDigits) |

### Incident note

PR #445 (now closed) had `is_variable` from the variant-matrix session leak in via cherry-pick. This branch was rebuilt fresh from main with zero variant-matrix code. See `docs/plans/t-rex-session-coordination.md` for the design to prevent this class of issue.

## Test plan
- [x] Backend: 252 passed
- [x] Frontend: 33/33 passed
- [x] Ruff: clean
- [x] Verified: `grep -rn "is_variable|parent_product_id|variant_count" backend/app/` shows zero variant contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced precision in manufacturing cost calculations and bill of materials operations throughout the system.
  * Optimized item duplication to improve data handling and performance.

* **Enhancements**
  * Currency formatter now intelligently adjusts decimal precision based on amount—displaying more detail for fractional units while keeping standard currency values cleanly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->