### PR TITLE
fix: pin flatted to 3.4.2 (CVE-2026-33228)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4132,9 +4132,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,9 @@
     "react-router": "^7.13.1",
     "react-router-dom": "^7.13.1"
   },
+  "overrides": {
+    "flatted": "3.4.2"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## Summary
- Adds `overrides.flatted = "3.4.2"` to `frontend/package.json` to force the patched version across the transitive chain `eslint → file-entry-cache → flat-cache → flatted`
- Dev dependency only — not included in the production bundle
- `npm audit` reports 0 vulnerabilities after the fix

## Security advisory
[GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) — Prototype Pollution via `parse()` in flatted ≤ 3.4.1 (CVE-2026-33228, High). Attacker-controlled input can cause `__proto__` to be used as an array index, leaking a live reference to `Array.prototype` and enabling downstream prototype pollution.

Resolves Dependabot alert: https://github.com/Blb3D/filaops/security/dependabot/23

## Test plan
- [ ] CI passes (no regressions in frontend lint/unit/e2e)
- [ ] `npm ls flatted` resolves to `3.4.2 overridden`
- [ ] Dependabot alert #23 closes automatically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)