### PR TITLE
fix: routing material unit_cost double-divides by purchase_factor

### DIFF
--- a/backend/app/models/manufacturing.py
+++ b/backend/app/models/manufacturing.py
@@ -314,20 +314,15 @@ class RoutingOperationMaterial(Base):
         """
         Cost per STORAGE unit of this material (Decimal).
 
-        Component costs are stored per PURCHASE unit (e.g., $/KG for filament).
-        Must divide by purchase_factor to get cost per STORAGE unit (e.g., $/G).
-
-        Examples:
-          - Filament: $20/KG ÷ 1000 = $0.02/G
-          - Hardware: $5/EA  ÷ 1    = $5/EA
+        Component standard_cost is already stored per storage unit
+        (e.g., $/G for filament, $/EA for hardware). No conversion needed.
         """
         if not self.component:
             return Decimal("0")
         cost = self.component.standard_cost or self.component.average_cost or self.component.last_cost
         if not cost:
             return Decimal("0")
-        purchase_factor = Decimal(str(self.component.purchase_factor or 1))
-        return Decimal(str(cost)) / purchase_factor
+        return Decimal(str(cost))
 
     @property
     def extended_cost(self):

--- a/backend/migrations/versions/068_add_unique_constraint_bom_and_routing_materials.py
+++ b/backend/migrations/versions/068_add_unique_constraint_bom_and_routing_materials.py
@@ -12,12 +12,12 @@ beyond the first (lowest id) for each duplicate group are deleted. This prevents
 the migration from failing on existing environments that already contain duplicates.
 
 Revision ID: 068
-Revises: 066
+Revises: 067
 """
 from alembic import op
 
 revision = "068"
-down_revision = "066"
+down_revision = "067"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

- `RoutingOperationMaterial.unit_cost` divided `standard_cost` by `purchase_factor` (1000 for filament), but costs are already stored per storage unit ($0.02/g, not $20/kg). This made filament material costs 1000x too low in routing totals.
- Also fixes migration 068 `down_revision` from 066 to 067 (was causing multiple heads after variant matrix merge)

## Impact

Every routing that includes filament materials has been undercosting by ~1000x on the material portion. Labor costs were unaffected.

## Test plan

- [x] 109 item/variant tests pass
- [x] Manual verification: 100g PLA @ $0.02/g = $2.00 (was showing $0.002)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected component cost calculations in manufacturing routing operations to apply standard costs directly without conversion between unit types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->