### PR TITLE
revert: restore purchase_factor division in routing material unit_cost

### DIFF
--- a/backend/app/models/manufacturing.py
+++ b/backend/app/models/manufacturing.py
@@ -314,15 +314,20 @@ class RoutingOperationMaterial(Base):
         """
         Cost per STORAGE unit of this material (Decimal).
 
-        Component standard_cost is already stored per storage unit
-        (e.g., $/G for filament, $/EA for hardware). No conversion needed.
+        Component costs are stored per PURCHASE unit (e.g., $/KG for filament).
+        Must divide by purchase_factor to get cost per STORAGE unit (e.g., $/G).
+
+        Examples:
+          - Filament: $20/KG ÷ 1000 = $0.02/G
+          - Hardware: $5/EA  ÷ 1    = $5/EA
         """
         if not self.component:
             return Decimal("0")
         cost = self.component.standard_cost or self.component.average_cost or self.component.last_cost
         if not cost:
             return Decimal("0")
-        return Decimal(str(cost))
+        purchase_factor = Decimal(str(self.component.purchase_factor or 1))
+        return Decimal(str(cost)) / purchase_factor
 
     @property
     def extended_cost(self):


### PR DESCRIPTION
## Summary
- Reverts the unit_cost change from #459 which removed `purchase_factor` division
- `standard_cost` is stored per **purchase unit** ($/KG), not per storage unit ($/G)
- The dev DB had anomalous pre-converted values; production follows the UOM spec
- Production costs were 1000x too high after #459

## Test plan
- [x] Verified prod stores $/KG, dev had $/G (data issue, not code)
- [ ] CI passes
- [ ] Recost on VM returns to correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unit cost calculations in manufacturing operations to properly account for the conversion between purchase and storage unit bases, ensuring accurate pricing computations based on component unit conversion factors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->