### PR TITLE
fix: price level assignment shows current tier, supports reassignment

### DIFF
--- a/frontend/src/pages/admin/AdminPriceLevels.jsx
+++ b/frontend/src/pages/admin/AdminPriceLevels.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useCRUD } from "../../hooks/useCRUD";
 import { useToast } from "../../components/Toast";
@@ -530,12 +530,15 @@ function AssignCustomersModal({ level, allLevels = [], onAssign, onUnassign, onC
   }, [onClose]);
 
   // Build map: customer_id → { levelName, levelId } for ALL tiers
-  const customerTierMap = new Map();
-  for (const lvl of allLevels) {
-    for (const c of lvl.customers || []) {
-      customerTierMap.set(c.customer_id, { levelName: lvl.name, levelId: lvl.id });
+  const customerTierMap = useMemo(() => {
+    const map = new Map();
+    for (const lvl of allLevels) {
+      for (const c of lvl.customers || []) {
+        map.set(c.customer_id, { levelName: lvl.name, levelId: lvl.id });
+      }
     }
-  }
+    return map;
+  }, [allLevels]);
 
   const assignedIds = new Set(
     (level.customers || []).map((c) => c.customer_id)


### PR DESCRIPTION
## Summary

- Customer assignment modal now shows which tier a customer is currently on (amber label: "— Tier A")
- Action button shows "Move" for customers already on another tier, "Add" for unassigned customers
- Prevents confusion when managing customers across multiple price levels

## Context

Each customer can only belong to one price level. The backend already handles reassignment (moves the customer instead of erroring), but the UI didn't indicate a customer was already assigned to a different tier. This led to confusion about whether reassignment was needed.

## Test plan

- [ ] Open Price Levels, click manage customers on any tier
- [ ] Verify customers already on another tier show the amber "— Tier Name" label
- [ ] Verify clicking a customer on another tier reassigns them (toast: "reassigned")
- [ ] Verify unassigned customers show "Add" label and assign normally
- [ ] Verify removing a customer from a tier works (X button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price tier information now displays when managing customer assignments, showing which tier each customer is currently assigned to
  * Action button text intelligently updates to "Move" when reassigning customers to different tiers versus "Add" for unassigned customers

* **Improvements**
  * Customer search now matches against display name, company name, and email for better discoverability
  * Unassigned customer list filtering refined to ensure accurate results when searching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->