### PR TITLE
fix: allow PO receiving for non-material items with incompatible purchase unit

### DIFF
--- a/backend/app/services/purchase_order_service.py
+++ b/backend/app/services/purchase_order_service.py
@@ -535,6 +535,9 @@ def receive_purchase_order(
         quantity_received_decimal = Decimal(str(qty_received))
         quantity_for_inventory = quantity_received_decimal
         cost_per_unit_for_inventory = line.unit_cost
+        # Track whether we fell back to purchase_unit due to incompatible product unit.
+        # Used below so the inventory transaction is labeled with the correct unit.
+        effective_unit = product_unit
 
         if purchase_unit != product_unit:
             logger.info(
@@ -547,26 +550,40 @@ def receive_purchase_order(
             )
 
             if not conversion_success:
-                logger.error(
-                    f"UOM conversion FAILED for PO {po.po_number} line {line.line_number}. "
-                    f"Purchase unit: '{purchase_unit}', Product unit: '{product_unit}', "
-                    f"Quantity received: {quantity_received_decimal}. "
-                    f"Cannot convert incompatible units - this will cause incorrect inventory!"
+                if is_mat:
+                    # Materials MUST convert — mass-based cost math requires it.
+                    logger.error(
+                        f"UOM conversion FAILED for PO {po.po_number} line {line.line_number}. "
+                        f"Purchase unit: '{purchase_unit}', Product unit: '{product_unit}', "
+                        f"Quantity received: {quantity_received_decimal}. "
+                        f"Cannot convert incompatible units - this will cause incorrect inventory!"
+                    )
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"Cannot convert {quantity_received_decimal} {purchase_unit} to {product_unit} "
+                            f"for product {product.sku}. "
+                            f"Units are incompatible. Supported conversions: G↔KG, LB↔KG, OZ↔KG, etc."
+                        ),
+                    )
+                else:
+                    # Non-material items (supplies, maintenance parts, etc.): receive as-is
+                    # in the purchase unit. No cost normalisation needed — cost is already
+                    # per-purchase-unit (e.g. $/M of PTFE tubing purchased in metres).
+                    logger.warning(
+                        f"UOM conversion not available for PO {po.po_number} line {line.line_number}: "
+                        f"'{purchase_unit}' → '{product_unit}' (product: {product.sku}). "
+                        f"Non-material item — receiving quantity as-is in {purchase_unit}."
+                    )
+                    effective_unit = purchase_unit  # record inventory in purchase unit
+                    # Skip quantity_for_inventory update — keep original quantity as-is.
+                    # Skip to cost section; no cost conversion needed either.
+            else:
+                quantity_for_inventory = converted_qty
+                logger.info(
+                    f"Conversion successful: {quantity_received_decimal} {purchase_unit} "
+                    f"= {quantity_for_inventory} {product_unit}"
                 )
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"Cannot convert {quantity_received_decimal} {purchase_unit} to {product_unit} "
-                        f"for product {product.sku}. "
-                        f"Units are incompatible. Supported conversions: G↔KG, LB↔KG, OZ↔KG, etc."
-                    ),
-                )
-
-            quantity_for_inventory = converted_qty
-            logger.info(
-                f"Conversion successful: {quantity_received_decimal} {purchase_unit} "
-                f"= {quantity_for_inventory} {product_unit}"
-            )
 
             # Convert cost_per_unit
             if is_mat:
@@ -640,8 +657,8 @@ def receive_purchase_order(
             logger.info(
                 f"UOM conversion for PO {po.po_number} line {line.line_number}: "
                 f"{qty_received} {purchase_unit} @ ${line.unit_cost}/{purchase_unit} -> "
-                f"{quantity_for_inventory} {product_unit} @ ${cost_per_unit_for_inventory}/"
-                f"{'G' if is_mat else product_unit} (material: {is_mat})"
+                f"{quantity_for_inventory} {effective_unit} @ ${cost_per_unit_for_inventory}/"
+                f"{'G' if is_mat else effective_unit} (material: {is_mat})"
             )
 
         # Convert to transaction unit (GRAMS for materials, native for others)
@@ -697,7 +714,7 @@ def receive_purchase_order(
                     )
 
         # Collect for TransactionService
-        transaction_unit = "G" if is_mat else product_unit
+        transaction_unit = "G" if is_mat else effective_unit
         receipt_items_for_service.append(
             ReceiptItem(
                 product_id=line.product_id,

--- a/backend/app/services/purchase_order_service.py
+++ b/backend/app/services/purchase_order_service.py
@@ -729,7 +729,11 @@ def receive_purchase_order(
         # When the same product appears on multiple lines in one receipt, the DB
         # on_hand_quantity doesn't reflect earlier lines yet (no commit between lines).
         # Use product_receipt_accum to track cumulative receipt within this batch.
-        if product:
+        #
+        # Skip if units are incompatible and we fell back to purchase_unit — the
+        # cost is in the purchase unit (e.g. $/M), not in the product unit (e.g.
+        # per-EA), so writing it to average_cost/last_cost would corrupt costing.
+        if product and effective_unit == product_unit:
             pid = product.id
 
             if pid not in product_receipt_accum:

--- a/backend/tests/services/test_purchase_order_service.py
+++ b/backend/tests/services/test_purchase_order_service.py
@@ -44,7 +44,7 @@ from app.services.purchase_order_service import (
 )
 from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine
 from app.models.product import Product
-from app.models.inventory import Inventory, InventoryLocation
+from app.models.inventory import Inventory, InventoryLocation, InventoryTransaction
 
 
 # =============================================================================
@@ -1708,8 +1708,23 @@ class TestReceivePurchaseOrder:
         assert result["total_quantity"] == Decimal("5")
         assert result["inventory_updated"] is True
 
+        # Full receipt of only line → PO moves to received
+        db.refresh(po)
+        assert po.status == "received"
+
         db.refresh(line)
         assert line.quantity_received == Decimal("5")
+
+        # Inventory transaction must be labeled in purchase unit (M) with original cost ($/M)
+        txn_id = result["transactions_created"][0]
+        txn = db.query(InventoryTransaction).filter(InventoryTransaction.id == txn_id).one()
+        assert txn.unit == "M"
+        assert txn.cost_per_unit == Decimal("2.50")
+
+        # Product costs must NOT be updated — $/M is meaningless on an EA product
+        db.refresh(product)
+        assert product.average_cost is None or product.average_cost == 0
+        assert product.last_cost is None or product.last_cost == 0
 
     def test_material_incompatible_units_still_raises(
         self, db, make_vendor, make_purchase_order, make_product

--- a/backend/tests/services/test_purchase_order_service.py
+++ b/backend/tests/services/test_purchase_order_service.py
@@ -1678,8 +1678,65 @@ class TestReceivePurchaseOrder:
         assert result["lines_received"] == 2
         assert result["total_quantity"] == Decimal("30")
 
-        db.refresh(po)
-        assert po.status == "received"
+    def test_non_material_incompatible_units_receives_as_is(
+        self, db, make_vendor, make_purchase_order, make_product
+    ):
+        """
+        Non-material items can be received even when purchase_unit and product_unit
+        are incompatible (e.g. PTFE tubing ordered in M but product unit is EA).
+
+        Regression test for: PO receiving blocked for maintenance/supply items
+        where the purchase UOM differs from the product's default unit.
+        """
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        # Maintenance item: product unit is EA (default), purchased in metres
+        product = make_product(unit="EA", item_type="supply", purchase_uom="M")
+        line = _add_po_line(
+            db, po, product, Decimal("5"), Decimal("2.50"), purchase_unit="M"
+        )
+        db.commit()
+
+        # Must NOT raise — should fall through and receive quantity as-is
+        result = receive_purchase_order(
+            db, po.id,
+            lines=[{"line_id": line.id, "quantity_received": Decimal("5")}],
+            user_id=1,
+            user_email="test@filaops.dev",
+        )
+        assert result["lines_received"] == 1
+        assert result["total_quantity"] == Decimal("5")
+        assert result["inventory_updated"] is True
+
+        db.refresh(line)
+        assert line.quantity_received == Decimal("5")
+
+    def test_material_incompatible_units_still_raises(
+        self, db, make_vendor, make_purchase_order, make_product
+    ):
+        """
+        Material items (filament etc.) with incompatible units STILL raise 400 —
+        mass-based cost math requires a valid conversion.
+        """
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        # Material (filament): purchased in EA — incompatible with KG product unit
+        product = make_product(unit="KG", item_type="material", purchase_uom="KG")
+        # Force incompatible purchase_unit directly on the line
+        line = _add_po_line(
+            db, po, product, Decimal("5"), Decimal("20.00"), purchase_unit="EA"
+        )
+        db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            receive_purchase_order(
+                db, po.id,
+                lines=[{"line_id": line.id, "quantity_received": Decimal("5")}],
+                user_id=1,
+                user_email="test@filaops.dev",
+            )
+        assert exc_info.value.status_code == 400
+        assert "incompatible" in str(exc_info.value.detail).lower()
 
     def test_partial_then_remaining(self, db, make_vendor, make_purchase_order, make_product):
         """Partial receipt followed by remaining quantity completes the PO."""


### PR DESCRIPTION
## Summary

- **Bug:** Receiving a PO line for a non-material item (supply, maintenance part) raises HTTP 400 when `purchase_unit` and `product_unit` are in different measurement classes. Reproduced with PTFE tubing purchased in metres (`M`) where the product's default unit is `EA`.
- **Root cause:** `receive_purchase_order()` in `purchase_order_service.py` raises for all items on UOM conversion failure — including items where conversion is not required for correct accounting.
- **Fix:** Split the conversion-failure path by item type:
  - **Materials** (filament, sheet stock, etc.): still raise 400 — mass-based cost normalisation ($/KG → $/G) requires a valid conversion.
  - **Non-materials** (supplies, maintenance): fall through, receive quantity as-is in `purchase_unit`, keep cost as-is (cost is already expressed per purchase unit, e.g. $/M).

## Changes

- [`purchase_order_service.py`](backend/app/services/purchase_order_service.py): introduce `effective_unit` tracker; split `if not conversion_success` by `is_mat`; use `effective_unit` for `transaction_unit` and log output
- Two new regression tests in `TestReceivePurchaseOrder`

## Test plan
- [ ] Create a supply/maintenance product with unit `EA`, add to a PO with `purchase_unit = M`, receive — should succeed and create inventory record in `M`
- [ ] Material product (unit `KG`) with incompatible `purchase_unit = EA` — still raises 400 with "incompatible" in message
- [ ] All 4644 backend tests pass

Reported against v3.6.0 (production OCI deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Agent-Session: fix-po-uom-nonmaterial-20260407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-material (supply) purchase lines with incompatible units now receive successfully using the original purchase unit and preserve reported quantities; material lines still enforce unit compatibility and error on failure.
  * Receipt and inventory transaction records now label and report the unit actually used during receipt processing, and product cost updates are skipped when unit incompatibility prevents reliable conversion.

* **Tests**
  * Added unit tests covering non-material fallback behavior and material unit-validation failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->