### PR TITLE
fix: silent token refresh on 401 — no more mid-form logouts

### DIFF
--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -3,10 +3,29 @@
  *
  * Auth: Uses httpOnly cookies (credentials: 'include'). No manual token handling.
  * Usage: const api = createApiClient({ baseUrl: API_URL });
+ *
+ * Token refresh: on 401, attempts a silent /auth/refresh before giving up.
+ * Single-flight guard prevents duplicate refresh requests when multiple calls
+ * fail simultaneously.
  */
 import { emit } from "./events";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Shared refresh state — module-level so all client instances share it
+let _refreshPromise = null;
+
+async function attemptTokenRefresh(baseUrl) {
+  if (_refreshPromise) return _refreshPromise;
+  _refreshPromise = fetch(`${baseUrl}/api/v1/auth/refresh`, {
+    method: "POST",
+    credentials: "include",
+  })
+    .then((res) => res.ok)
+    .catch(() => false)
+    .finally(() => { _refreshPromise = null; });
+  return _refreshPromise;
+}
 
 export class ApiError extends Error {
   /** @param {number} status @param {any} payload */
@@ -57,9 +76,16 @@ export function createApiClient(/** @type {ApiConfig} */ cfg) {
         text: async () => String(e?.message || "Network error"),
       }));
 
-      // 401: clear auth state and redirect to login
-      if (res.status === 401 && cfg.onUnauthorized) {
-        await cfg.onUnauthorized();
+      // 401: try a silent token refresh first, then retry the original request.
+      // Only attempt refresh once per request (don't refresh if refresh itself 401s).
+      if (res.status === 401 && !init._refreshed) {
+        const refreshed = await attemptTokenRefresh(base);
+        if (refreshed) {
+          // Token renewed — retry the original request exactly once
+          return doFetch(path, { ...init, _refreshed: true });
+        }
+        // Refresh failed — session is genuinely expired
+        if (cfg.onUnauthorized) await cfg.onUnauthorized();
       }
 
       if (res.ok) {

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -78,14 +78,17 @@ export function createApiClient(/** @type {ApiConfig} */ cfg) {
 
       // 401: try a silent token refresh first, then retry the original request.
       // Only attempt refresh once per request (don't refresh if refresh itself 401s).
-      if (res.status === 401 && !init._refreshed) {
-        const refreshed = await attemptTokenRefresh(base);
-        if (refreshed) {
-          // Token renewed — retry the original request exactly once
-          return doFetch(path, { ...init, _refreshed: true });
+      if (res.status === 401) {
+        if (!init._refreshed) {
+          const refreshed = await attemptTokenRefresh(base);
+          if (refreshed) {
+            // Token renewed — retry the original request exactly once
+            return doFetch(path, { ...init, _refreshed: true });
+          }
         }
-        // Refresh failed — session is genuinely expired
+        // Refresh failed (or already retried) — session is genuinely expired
         if (cfg.onUnauthorized) await cfg.onUnauthorized();
+        return;
       }
 
       if (res.ok) {


### PR DESCRIPTION
## Problem

Filling out a long form (PO with 10 items, etc.) could result in the user getting kicked to the login screen on submit if the 30-minute access token expired while they were working.

The proactive `useActivityTokenRefresh` hook (refreshes every 10 min while active) was already in place but didn't cover the case where a user was idle for >10 min then submitted — the token would be expired when the request hit the backend.

## Fix

Added a silent token refresh step inside `apiClient.js` `doFetch()`:

1. Request returns 401
2. Attempt `POST /api/v1/auth/refresh` silently
3. If refresh succeeds → retry the original request transparently (user never knows)
4. If refresh fails (session truly expired) → navigate to login as before

**Single-flight guard** (`_refreshPromise`) ensures that if multiple requests fail with 401 simultaneously, only one refresh POST is sent — the others await the same promise.

## What wasn't changed

- `useActivityTokenRefresh` hook — already present, already working, no changes needed
- `useApi.js` `onUnauthorized` handler — now only fires after refresh fails, not on every 401
- No backend changes required

## Test plan

- [ ] Log in, wait 30+ min without activity, submit a form — should refresh silently and succeed
- [ ] Log in, open two tabs, expire session on one — both should recover
- [ ] Verify that logout still works (refresh endpoint returns 401 → navigate to login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling: the app now silently attempts to refresh expired authentication tokens and will retry a failed request once on 401 responses. This reduces unexpected logouts and improves continuity when tokens expire; if refresh fails, the existing sign-out/redirect behavior still applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->