### PR TITLE
feat: Print Cost Estimation Engine

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1040,7 +1040,13 @@ async def estimate_cost(
     """Re-estimate costs for a production order from its routing and BOM.
 
     Updates estimated_material_cost, estimated_labor_cost, and estimated_total_cost
-    on the production order using current work center rates and material prices.
+    on the production order using current work center rates and material prices
+    (always from planned/required quantities).
+
+    Returns:
+        Full cost breakdown using best-available data: consumed quantities for
+        materials with status 'consumed', required quantities otherwise; actual
+        times where recorded, planned times otherwise.
     """
     from app.services.cost_estimation_service import estimate_production_order_cost
 
@@ -1052,7 +1058,6 @@ async def estimate_cost(
     db.commit()
     db.refresh(order)
 
-    # Return the full cost breakdown which now reflects the freshly saved estimates
     return production_order_service.get_cost_breakdown(db, order_id)
 
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1050,7 +1050,9 @@ async def estimate_cost(
 
     estimate_production_order_cost(db, order)
     db.commit()
+    db.refresh(order)
 
+    # Return the full cost breakdown which now reflects the freshly saved estimates
     return production_order_service.get_cost_breakdown(db, order_id)
 
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1031,6 +1031,29 @@ async def get_cost_breakdown(
     return production_order_service.get_cost_breakdown(db, order_id)
 
 
+@router.post("/{order_id}/estimate-cost", response_model=CostBreakdownResponse)
+async def estimate_cost(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CostBreakdownResponse:
+    """Re-estimate costs for a production order from its routing and BOM.
+
+    Updates estimated_material_cost, estimated_labor_cost, and estimated_total_cost
+    on the production order using current work center rates and material prices.
+    """
+    from app.services.cost_estimation_service import estimate_production_order_cost
+
+    order = production_order_service.get_production_order(db, order_id)
+    if not order.operations:
+        raise HTTPException(status_code=400, detail="No operations to estimate — assign a routing first")
+
+    estimate_production_order_cost(db, order)
+    db.commit()
+
+    return production_order_service.get_cost_breakdown(db, order_id)
+
+
 # =============================================================================
 # Spool Management
 # =============================================================================

--- a/backend/app/services/cost_estimation_service.py
+++ b/backend/app/services/cost_estimation_service.py
@@ -13,14 +13,11 @@ Uses get_effective_cost_per_inventory_unit() for material pricing (single source
 Uses work center rates (machine + labor + overhead) for labor/machine pricing.
 """
 from decimal import Decimal
-from typing import Optional
 
 from sqlalchemy.orm import Session
 
 from app.logging_config import get_logger
 from app.models import ProductionOrder, Product
-from app.models.manufacturing import RoutingOperation
-from app.models.production_order import ProductionOrderOperationMaterial
 from app.services.inventory_service import get_effective_cost_per_inventory_unit
 
 logger = get_logger(__name__)

--- a/backend/app/services/cost_estimation_service.py
+++ b/backend/app/services/cost_estimation_service.py
@@ -1,0 +1,190 @@
+"""
+Cost Estimation Service — Automated cost calculation for production orders.
+
+Calculates estimated costs from BOM materials and routing operations using
+actual work center rates (machine + labor + overhead) instead of hardcoded values.
+
+Cost formula per production order:
+  Material Cost = Σ(material_qty × cost_per_inventory_unit) across all operations
+  Labor Cost = Σ(operation_minutes / 60 × work_center_hourly_rate) across all operations
+  Total Cost = Material Cost + Labor Cost
+
+Uses get_effective_cost_per_inventory_unit() for material pricing (single source of truth).
+Uses work center rates (machine + labor + overhead) for labor/machine pricing.
+"""
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.logging_config import get_logger
+from app.models import ProductionOrder, Product
+from app.models.manufacturing import RoutingOperation
+from app.models.production_order import ProductionOrderOperationMaterial
+from app.services.inventory_service import get_effective_cost_per_inventory_unit
+
+logger = get_logger(__name__)
+
+
+def estimate_material_cost(db: Session, order: ProductionOrder) -> Decimal:
+    """
+    Calculate estimated material cost for a production order.
+
+    Walks all operation materials and prices them using the product's
+    effective cost per inventory unit (respects cost method hierarchy:
+    average → last → standard with proper UOM conversion).
+
+    Returns:
+        Total estimated material cost as Decimal.
+    """
+    total = Decimal("0")
+
+    for op in order.operations:
+        for mat in op.materials:
+            component = db.query(Product).filter(Product.id == mat.component_id).first()
+            if not component:
+                continue
+
+            cost_per_unit = get_effective_cost_per_inventory_unit(component)
+            if cost_per_unit is None:
+                cost_per_unit = Decimal("0")
+
+            qty = mat.quantity_required or Decimal("0")
+            total += Decimal(str(qty)) * cost_per_unit
+
+    return total
+
+
+def estimate_labor_cost(order: ProductionOrder) -> Decimal:
+    """
+    Calculate estimated labor cost for a production order.
+
+    Uses the work center's component rates (machine + labor + overhead)
+    for each operation. Falls back to the work center's simplified
+    hourly_rate if component rates are all zero.
+
+    Returns:
+        Total estimated labor cost as Decimal.
+    """
+    total = Decimal("0")
+
+    for op in order.operations:
+        minutes = Decimal(str(op.planned_run_minutes or 0)) + Decimal(str(op.planned_setup_minutes or 0))
+        hours = minutes / Decimal("60")
+
+        wc = op.work_center
+        if wc:
+            # Use component rates if available
+            machine = Decimal(str(wc.machine_rate_per_hour or 0))
+            labor = Decimal(str(wc.labor_rate_per_hour or 0))
+            overhead = Decimal(str(wc.overhead_rate_per_hour or 0))
+            combined = machine + labor + overhead
+
+            # Fall back to simplified hourly_rate if component rates are all zero
+            if combined == Decimal("0"):
+                combined = Decimal(str(wc.hourly_rate or 0))
+
+            total += hours * combined
+        # If no work center, cost is zero (don't use hardcoded fallback)
+
+    return total
+
+
+def estimate_production_order_cost(db: Session, order: ProductionOrder) -> dict:
+    """
+    Calculate and store estimated costs on a production order.
+
+    Populates:
+      - order.estimated_material_cost
+      - order.estimated_labor_cost
+      - order.estimated_total_cost
+
+    Returns:
+        Dict with material_cost, labor_cost, total_cost (all Decimal).
+    """
+    material_cost = estimate_material_cost(db, order)
+    labor_cost = estimate_labor_cost(order)
+    total_cost = material_cost + labor_cost
+
+    order.estimated_material_cost = material_cost
+    order.estimated_labor_cost = labor_cost
+    order.estimated_total_cost = total_cost
+
+    logger.info(
+        "Estimated costs for %s: material=%s, labor=%s, total=%s",
+        order.code, material_cost, labor_cost, total_cost,
+    )
+
+    return {
+        "material_cost": material_cost,
+        "labor_cost": labor_cost,
+        "total_cost": total_cost,
+    }
+
+
+def recalculate_actual_cost(db: Session, order: ProductionOrder) -> dict:
+    """
+    Calculate actual costs from consumed quantities and actual times.
+
+    Called after production completes. Uses actual_run_minutes and
+    quantity_consumed where available, falling back to planned values.
+
+    Populates:
+      - order.actual_material_cost
+      - order.actual_labor_cost
+      - order.actual_total_cost
+
+    Returns:
+        Dict with material_cost, labor_cost, total_cost (all Decimal).
+    """
+    # Actual material cost — use consumed quantities
+    material_cost = Decimal("0")
+    for op in order.operations:
+        for mat in op.materials:
+            component = db.query(Product).filter(Product.id == mat.component_id).first()
+            if not component:
+                continue
+
+            cost_per_unit = get_effective_cost_per_inventory_unit(component)
+            if cost_per_unit is None:
+                cost_per_unit = Decimal("0")
+
+            # Prefer consumed qty, fall back to required
+            qty = mat.quantity_consumed if mat.quantity_consumed and mat.quantity_consumed > 0 else mat.quantity_required
+            qty = Decimal(str(qty or 0))
+            material_cost += qty * cost_per_unit
+
+    # Actual labor cost — use actual run times
+    labor_cost = Decimal("0")
+    for op in order.operations:
+        actual_minutes = op.actual_run_minutes or op.planned_run_minutes or 0
+        setup_minutes = op.actual_setup_minutes if hasattr(op, 'actual_setup_minutes') and op.actual_setup_minutes else (op.planned_setup_minutes or 0)
+        minutes = Decimal(str(actual_minutes)) + Decimal(str(setup_minutes))
+        hours = minutes / Decimal("60")
+
+        wc = op.work_center
+        if wc:
+            machine = Decimal(str(wc.machine_rate_per_hour or 0))
+            labor = Decimal(str(wc.labor_rate_per_hour or 0))
+            overhead = Decimal(str(wc.overhead_rate_per_hour or 0))
+            combined = machine + labor + overhead
+            if combined == Decimal("0"):
+                combined = Decimal(str(wc.hourly_rate or 0))
+            labor_cost += hours * combined
+
+    total_cost = material_cost + labor_cost
+
+    order.actual_material_cost = material_cost
+    order.actual_labor_cost = labor_cost
+    order.actual_total_cost = total_cost
+
+    logger.info(
+        "Actual costs for %s: material=%s, labor=%s, total=%s",
+        order.code, material_cost, labor_cost, total_cost,
+    )
+
+    return {
+        "material_cost": material_cost,
+        "labor_cost": labor_cost,
+        "total_cost": total_cost,
+    }

--- a/backend/app/services/cost_estimation_service.py
+++ b/backend/app/services/cost_estimation_service.py
@@ -146,16 +146,16 @@ def recalculate_actual_cost(db: Session, order: ProductionOrder) -> dict:
             if cost_per_unit is None:
                 cost_per_unit = Decimal("0")
 
-            # Prefer consumed qty, fall back to required
-            qty = mat.quantity_consumed if mat.quantity_consumed and mat.quantity_consumed > 0 else mat.quantity_required
+            # Prefer consumed qty, fall back to required (qty_consumed is initialized as 0, not None)
+            qty = mat.quantity_consumed if mat.quantity_consumed else mat.quantity_required
             qty = Decimal(str(qty or 0))
             material_cost += qty * cost_per_unit
 
     # Actual labor cost — use actual run times
     labor_cost = Decimal("0")
     for op in order.operations:
-        actual_minutes = op.actual_run_minutes or op.planned_run_minutes or 0
-        setup_minutes = op.actual_setup_minutes if hasattr(op, 'actual_setup_minutes') and op.actual_setup_minutes else (op.planned_setup_minutes or 0)
+        actual_minutes = op.actual_run_minutes if op.actual_run_minutes is not None else (op.planned_run_minutes or 0)
+        setup_minutes = op.actual_setup_minutes if op.actual_setup_minutes is not None else (op.planned_setup_minutes or 0)
         minutes = Decimal(str(actual_minutes)) + Decimal(str(setup_minutes))
         hours = minutes / Decimal("60")
 

--- a/backend/app/services/cost_estimation_service.py
+++ b/backend/app/services/cost_estimation_service.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from sqlalchemy.orm import Session
 
 from app.logging_config import get_logger
-from app.models import ProductionOrder, Product
+from app.models import ProductionOrder
 from app.services.inventory_service import get_effective_cost_per_inventory_unit
 
 logger = get_logger(__name__)
@@ -28,8 +28,8 @@ def estimate_material_cost(db: Session, order: ProductionOrder) -> Decimal:
     Calculate estimated material cost for a production order.
 
     Walks all operation materials and prices them using the product's
-    effective cost per inventory unit (respects cost method hierarchy:
-    average → last → standard with proper UOM conversion).
+    effective cost per inventory unit (respects the product's configured
+    cost method with proper UOM conversion).
 
     Returns:
         Total estimated material cost as Decimal.
@@ -38,11 +38,10 @@ def estimate_material_cost(db: Session, order: ProductionOrder) -> Decimal:
 
     for op in order.operations:
         for mat in op.materials:
-            component = db.query(Product).filter(Product.id == mat.component_id).first()
-            if not component:
+            if not mat.component:
                 continue
 
-            cost_per_unit = get_effective_cost_per_inventory_unit(component)
+            cost_per_unit = get_effective_cost_per_inventory_unit(mat.component)
             if cost_per_unit is None:
                 cost_per_unit = Decimal("0")
 
@@ -138,16 +137,15 @@ def recalculate_actual_cost(db: Session, order: ProductionOrder) -> dict:
     material_cost = Decimal("0")
     for op in order.operations:
         for mat in op.materials:
-            component = db.query(Product).filter(Product.id == mat.component_id).first()
-            if not component:
+            if not mat.component:
                 continue
 
-            cost_per_unit = get_effective_cost_per_inventory_unit(component)
+            cost_per_unit = get_effective_cost_per_inventory_unit(mat.component)
             if cost_per_unit is None:
                 cost_per_unit = Decimal("0")
 
-            # Prefer consumed qty, fall back to required (qty_consumed is initialized as 0, not None)
-            qty = mat.quantity_consumed if mat.quantity_consumed else mat.quantity_required
+            # Use status field to determine if material was consumed
+            qty = mat.quantity_consumed if mat.status == "consumed" else mat.quantity_required
             qty = Decimal(str(qty or 0))
             material_cost += qty * cost_per_unit
 

--- a/backend/app/services/order_status.py
+++ b/backend/app/services/order_status.py
@@ -257,6 +257,12 @@ class OrderStatusService:
                 pass  # Auto-closable
             else:
                 wo.qc_status = "pending"
+            # Recalculate actual costs from consumed quantities and actual times
+            try:
+                from app.services.cost_estimation_service import recalculate_actual_cost
+                recalculate_actual_cost(db, wo)
+            except Exception as e:
+                logger.warning("Actual cost recalculation failed for %s: %s", wo.code, e)
         elif new_status == "closed":
             wo.completed_at = datetime.now(timezone.utc)
         elif new_status == "scrapped":

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -256,6 +256,14 @@ def create_production_order(
         created_by=created_by,
     )
 
+    # Auto-estimate costs if operations exist
+    if order.operations:
+        from app.services.cost_estimation_service import estimate_production_order_cost
+        try:
+            estimate_production_order_cost(db, order)
+        except Exception as e:
+            logger.warning("Cost estimation failed for %s: %s", order.code, e)
+
     return order
 
 
@@ -1525,10 +1533,16 @@ def get_required_orders(db: Session, order_id: int) -> dict:
 # =============================================================================
 
 def get_cost_breakdown(db: Session, order_id: int) -> dict:
-    """Get cost breakdown for a production order."""
+    """Get cost breakdown for a production order.
+
+    Uses get_effective_cost_per_inventory_unit() for material pricing and
+    work center rates (machine + labor + overhead) for labor/machine costing.
+    """
+    from app.services.inventory_service import get_effective_cost_per_inventory_unit
+
     order = get_production_order(db, order_id)
 
-    # Material costs
+    # Material costs — use proper UOM-aware cost per inventory unit
     material_costs = []
     total_material_cost = Decimal("0")
 
@@ -1536,12 +1550,9 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
         for mat in op.materials:
             component = db.query(Product).filter(Product.id == mat.component_id).first()
             if component:
-                # Product model has standard_cost, average_cost, last_cost (not unit_cost)
-                unit_cost = Decimal(str(
-                    component.standard_cost or component.average_cost or component.last_cost or 0
-                ))
+                unit_cost = get_effective_cost_per_inventory_unit(component) or Decimal("0")
                 qty = mat.quantity_consumed or mat.quantity_required
-                line_cost = unit_cost * qty
+                line_cost = unit_cost * Decimal(str(qty))
                 total_material_cost += line_cost
 
                 material_costs.append({
@@ -1552,20 +1563,35 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
                     "total_cost": float(line_cost),
                 })
 
-    # Labor costs (estimated from operation times)
+    # Labor costs — use work center rates instead of hardcoded value
     labor_costs = []
     total_labor_cost = Decimal("0")
-    hourly_rate = Decimal("25")  # Default rate
 
     for op in order.operations:
         minutes = op.actual_run_minutes or op.planned_run_minutes or 0
-        hours = Decimal(str(minutes)) / Decimal("60")
+        setup = op.actual_setup_minutes if hasattr(op, 'actual_setup_minutes') and op.actual_setup_minutes else (op.planned_setup_minutes or 0)
+        total_minutes = Decimal(str(minutes)) + Decimal(str(setup))
+        hours = total_minutes / Decimal("60")
+
+        # Get rate from work center (machine + labor + overhead)
+        wc = op.work_center
+        if wc:
+            machine = Decimal(str(wc.machine_rate_per_hour or 0))
+            labor = Decimal(str(wc.labor_rate_per_hour or 0))
+            overhead = Decimal(str(wc.overhead_rate_per_hour or 0))
+            hourly_rate = machine + labor + overhead
+            # Fall back to simplified hourly_rate if component rates are all zero
+            if hourly_rate == Decimal("0"):
+                hourly_rate = Decimal(str(wc.hourly_rate or 0))
+        else:
+            hourly_rate = Decimal("0")
+
         cost = hours * hourly_rate
         total_labor_cost += cost
 
         labor_costs.append({
             "operation": op.operation_name,
-            "minutes": float(minutes),
+            "minutes": float(total_minutes),
             "hourly_rate": float(hourly_rate),
             "cost": float(cost),
         })

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -497,6 +497,13 @@ def complete_production_order(
                 if not op.actual_end:
                     op.actual_end = datetime.now(timezone.utc)
 
+        # Recalculate actual costs from consumed quantities and actual times
+        try:
+            from app.services.cost_estimation_service import recalculate_actual_cost
+            recalculate_actual_cost(db, order)
+        except Exception as e:
+            logger.warning("Actual cost recalculation failed for %s: %s", order.code, e)
+
     if notes:
         if order.notes:
             order.notes = f"{order.notes}\n[{datetime.now(timezone.utc).isoformat()}] {notes}"
@@ -1551,7 +1558,7 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
             component = db.query(Product).filter(Product.id == mat.component_id).first()
             if component:
                 unit_cost = get_effective_cost_per_inventory_unit(component) or Decimal("0")
-                qty = mat.quantity_consumed or mat.quantity_required
+                qty = mat.quantity_consumed if mat.quantity_consumed else mat.quantity_required
                 line_cost = unit_cost * Decimal(str(qty))
                 total_material_cost += line_cost
 
@@ -1568,8 +1575,8 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
     total_labor_cost = Decimal("0")
 
     for op in order.operations:
-        minutes = op.actual_run_minutes or op.planned_run_minutes or 0
-        setup = op.actual_setup_minutes if hasattr(op, 'actual_setup_minutes') and op.actual_setup_minutes else (op.planned_setup_minutes or 0)
+        minutes = op.actual_run_minutes if op.actual_run_minutes is not None else (op.planned_run_minutes or 0)
+        setup = op.actual_setup_minutes if op.actual_setup_minutes is not None else (op.planned_setup_minutes or 0)
         total_minutes = Decimal(str(minutes)) + Decimal(str(setup))
         hours = total_minutes / Decimal("60")
 

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -261,8 +261,8 @@ def create_production_order(
         from app.services.cost_estimation_service import estimate_production_order_cost
         try:
             estimate_production_order_cost(db, order)
-        except Exception as e:
-            logger.warning("Cost estimation failed for %s: %s", order.code, e)
+        except Exception:
+            logger.exception("Cost estimation failed for production order id=%s code=%s", order.id, order.code)
 
     return order
 
@@ -1555,16 +1555,15 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
 
     for op in order.operations:
         for mat in op.materials:
-            component = db.query(Product).filter(Product.id == mat.component_id).first()
-            if component:
-                unit_cost = get_effective_cost_per_inventory_unit(component) or Decimal("0")
-                qty = mat.quantity_consumed if mat.quantity_consumed else mat.quantity_required
+            if mat.component:
+                unit_cost = get_effective_cost_per_inventory_unit(mat.component) or Decimal("0")
+                qty = mat.quantity_consumed if mat.status == "consumed" else mat.quantity_required
                 line_cost = unit_cost * Decimal(str(qty))
                 total_material_cost += line_cost
 
                 material_costs.append({
-                    "component_sku": component.sku,
-                    "component_name": component.name,
+                    "component_sku": mat.component.sku,
+                    "component_name": mat.component.name,
                     "quantity": float(qty),
                     "unit_cost": float(unit_cost),
                     "total_cost": float(line_cost),

--- a/backend/tests/services/test_cost_estimation_service.py
+++ b/backend/tests/services/test_cost_estimation_service.py
@@ -1,0 +1,263 @@
+"""
+Tests for app/services/cost_estimation_service.py
+
+Covers:
+- estimate_material_cost: Material cost from BOM components
+- estimate_labor_cost: Labor cost from work center rates
+- estimate_production_order_cost: Full estimation + order field population
+- recalculate_actual_cost: Actual cost from consumed quantities / actual times
+"""
+import pytest
+from decimal import Decimal
+
+from app.models import ProductionOrder
+from app.models.production_order import (
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
+from app.models.work_center import WorkCenter
+from app.services import production_order_service as po_svc
+from app.services.cost_estimation_service import (
+    estimate_material_cost,
+    estimate_labor_cost,
+    estimate_production_order_cost,
+    recalculate_actual_cost,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_order(db, product, *, quantity=10, status="draft"):
+    code = po_svc.generate_production_order_code(db)
+    order = ProductionOrder(
+        code=code,
+        product_id=product.id,
+        quantity_ordered=quantity,
+        quantity_completed=0,
+        quantity_scrapped=0,
+        source="manual",
+        status=status,
+        priority=3,
+        created_by="test@filaops.dev",
+    )
+    db.add(order)
+    db.flush()
+    return order
+
+
+def _add_operation(db, order, *, planned_run=60, planned_setup=0, actual_run=None, actual_setup=None, status="pending"):
+    op = ProductionOrderOperation(
+        production_order_id=order.id,
+        work_center_id=1,
+        sequence=10,
+        operation_code="PRINT",
+        operation_name="Print",
+        planned_setup_minutes=planned_setup,
+        planned_run_minutes=planned_run,
+        actual_run_minutes=actual_run,
+        actual_setup_minutes=actual_setup,
+        status=status,
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+def _add_material(db, op, component, *, qty_required=500, qty_consumed=0, mat_status="pending"):
+    mat = ProductionOrderOperationMaterial(
+        production_order_operation_id=op.id,
+        component_id=component.id,
+        quantity_required=Decimal(str(qty_required)),
+        unit="G",
+        quantity_allocated=Decimal("0"),
+        quantity_consumed=Decimal(str(qty_consumed)),
+        status=mat_status,
+    )
+    db.add(mat)
+    db.flush()
+    return mat
+
+
+# =============================================================================
+# estimate_material_cost
+# =============================================================================
+
+class TestEstimateMaterialCost:
+    def test_empty_order(self, db, finished_good):
+        """Order with no operations returns zero."""
+        order = _make_order(db, finished_good)
+        assert estimate_material_cost(db, order) == Decimal("0")
+
+    def test_uses_quantity_required(self, db, finished_good, raw_material):
+        """Should price materials using quantity_required and effective cost."""
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order)
+        _add_material(db, op, raw_material, qty_required=500)
+
+        cost = estimate_material_cost(db, order)
+        # raw_material: average_cost=0.02/G, qty=500G → 10.00
+        assert cost == pytest.approx(Decimal("10"), abs=Decimal("0.01"))
+
+
+# =============================================================================
+# estimate_labor_cost
+# =============================================================================
+
+class TestEstimateLaborCost:
+    def test_empty_order(self, db, finished_good):
+        """Order with no operations returns zero."""
+        order = _make_order(db, finished_good)
+        assert estimate_labor_cost(order) == Decimal("0")
+
+    def test_uses_planned_minutes(self, db, finished_good, raw_material):
+        """Should calculate from planned_run_minutes + planned_setup_minutes."""
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("30")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
+        order = _make_order(db, finished_good)
+        _add_operation(db, order, planned_run=120, planned_setup=0)
+
+        cost = estimate_labor_cost(order)
+        # 120 min = 2 hours × $30/hr = $60
+        assert cost == pytest.approx(Decimal("60"), abs=Decimal("0.01"))
+
+    def test_falls_back_to_hourly_rate(self, db, finished_good):
+        """When component rates are zero, uses simplified hourly_rate."""
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("0")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        wc.hourly_rate = Decimal("50")
+        db.flush()
+
+        order = _make_order(db, finished_good)
+        _add_operation(db, order, planned_run=60)
+
+        cost = estimate_labor_cost(order)
+        # 60 min = 1 hour × $50/hr = $50
+        assert cost == pytest.approx(Decimal("50"), abs=Decimal("0.01"))
+
+
+
+# =============================================================================
+# estimate_production_order_cost
+# =============================================================================
+
+class TestEstimateProductionOrderCost:
+    def test_populates_order_fields(self, db, finished_good, raw_material):
+        """Should set estimated_material_cost, estimated_labor_cost, estimated_total_cost."""
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("25")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order, planned_run=60)
+        _add_material(db, op, raw_material, qty_required=500)
+
+        result = estimate_production_order_cost(db, order)
+
+        # Material: 500G × 0.02 = 10.00, Labor: 1hr × $25 = 25.00
+        assert result["material_cost"] == pytest.approx(Decimal("10"), abs=Decimal("0.01"))
+        assert result["labor_cost"] == pytest.approx(Decimal("25"), abs=Decimal("0.01"))
+        assert result["total_cost"] == pytest.approx(Decimal("35"), abs=Decimal("0.01"))
+
+        # Verify fields populated on order object
+        assert order.estimated_material_cost == pytest.approx(Decimal("10"), abs=Decimal("0.01"))
+        assert order.estimated_labor_cost == pytest.approx(Decimal("25"), abs=Decimal("0.01"))
+        assert order.estimated_total_cost == pytest.approx(Decimal("35"), abs=Decimal("0.01"))
+
+
+# =============================================================================
+# recalculate_actual_cost
+# =============================================================================
+
+class TestRecalculateActualCost:
+    def test_uses_consumed_qty_when_status_consumed(self, db, finished_good, raw_material):
+        """Materials with status 'consumed' should use quantity_consumed."""
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order, actual_run=90)
+        _add_material(
+            db, op, raw_material,
+            qty_required=500,
+            qty_consumed=450,
+            mat_status="consumed",
+        )
+
+        result = recalculate_actual_cost(db, order)
+        # 450G × 0.02 = 9.00
+        assert result["material_cost"] == pytest.approx(Decimal("9"), abs=Decimal("0.01"))
+
+    def test_falls_back_to_required_when_pending(self, db, finished_good, raw_material):
+        """Materials with status 'pending' should use quantity_required."""
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order, actual_run=60)
+        _add_material(
+            db, op, raw_material,
+            qty_required=500,
+            qty_consumed=0,
+            mat_status="pending",
+        )
+
+        result = recalculate_actual_cost(db, order)
+        # 500G × 0.02 = 10.00 (required, not consumed)
+        assert result["material_cost"] == pytest.approx(Decimal("10"), abs=Decimal("0.01"))
+
+    def test_zero_consumed_qty_with_consumed_status(self, db, finished_good, raw_material):
+        """Edge case: status is 'consumed' but quantity_consumed is 0 (zero actual usage)."""
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order, actual_run=60)
+        _add_material(
+            db, op, raw_material,
+            qty_required=500,
+            qty_consumed=0,
+            mat_status="consumed",
+        )
+
+        result = recalculate_actual_cost(db, order)
+        # Status is consumed → uses quantity_consumed (0), so material cost = 0
+        assert result["material_cost"] == Decimal("0")
+
+    def test_uses_actual_run_minutes(self, db, finished_good):
+        """Should prefer actual_run_minutes over planned when available."""
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("30")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
+        order = _make_order(db, finished_good)
+        _add_operation(db, order, planned_run=60, actual_run=Decimal("90"))
+
+        result = recalculate_actual_cost(db, order)
+        # 90 min = 1.5 hours × $30/hr = $45
+        assert result["labor_cost"] == pytest.approx(Decimal("45"), abs=Decimal("0.01"))
+
+    def test_populates_actual_fields(self, db, finished_good, raw_material):
+        """Should set actual_material_cost, actual_labor_cost, actual_total_cost."""
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("25")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
+        order = _make_order(db, finished_good)
+        op = _add_operation(db, order, planned_run=60, actual_run=Decimal("120"))
+        _add_material(
+            db, op, raw_material,
+            qty_required=500,
+            qty_consumed=480,
+            mat_status="consumed",
+        )
+
+        recalculate_actual_cost(db, order)
+
+        assert order.actual_material_cost == pytest.approx(Decimal("9.60"), abs=Decimal("0.01"))
+        assert order.actual_labor_cost == pytest.approx(Decimal("50"), abs=Decimal("0.01"))
+        assert order.actual_total_cost == pytest.approx(Decimal("59.60"), abs=Decimal("0.01"))

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -1761,7 +1761,14 @@ class TestGetCostBreakdown:
         assert len(result["material_costs"]) == 1
 
     def test_cost_breakdown_labor_costs(self, db, finished_good):
-        """Should calculate labor costs from operation planned run minutes."""
+        """Should calculate labor costs from work center rates × operation time."""
+        # Set up work center with known rates
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("25")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
         order = _make_production_order(db, finished_good, quantity=10)
         op = ProductionOrderOperation(
             production_order_id=order.id,
@@ -1782,6 +1789,13 @@ class TestGetCostBreakdown:
 
     def test_cost_breakdown_unit_cost(self, db, finished_good):
         """Should calculate per-unit cost."""
+        # Set up work center with known rates
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("25")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
         order = _make_production_order(db, finished_good, quantity=10)
         op = ProductionOrderOperation(
             production_order_id=order.id,
@@ -1824,6 +1838,13 @@ class TestGetCostBreakdown:
 
     def test_cost_breakdown_uses_actual_run_minutes_when_available(self, db, finished_good):
         """Should use actual_run_minutes over planned when actual is set."""
+        # Set up work center with known rates
+        wc = db.query(WorkCenter).filter(WorkCenter.id == 1).first()
+        wc.labor_rate_per_hour = Decimal("25")
+        wc.machine_rate_per_hour = Decimal("0")
+        wc.overhead_rate_per_hour = Decimal("0")
+        db.flush()
+
         order = _make_production_order(db, finished_good, quantity=10)
         op = ProductionOrderOperation(
             production_order_id=order.id,


### PR DESCRIPTION
## Summary

Adds automated cost estimation for production orders, replacing the hardcoded `$25/hr` labor rate with actual work center rates and fixing material cost calculations to use proper UOM conversion.

## Changes

### New: `cost_estimation_service.py`
- `estimate_material_cost()` — Prices materials via `get_effective_cost_per_inventory_unit()` for UOM-aware costing (e.g. $/KG → $/G for filament)
- `estimate_labor_cost()` — Uses work center component rates (machine + labor + overhead) with `hourly_rate` fallback
- `estimate_production_order_cost()` — Auto-populates `estimated_*` fields on PO creation
- `recalculate_actual_cost()` — Populates `actual_*` fields using consumed quantities and actual run times on PO completion

### Fixed: `get_cost_breakdown()`
- **Bug**: Labor cost used hardcoded `Decimal("25")` instead of work center rates
- **Bug**: Material cost used raw `standard_cost`/`average_cost` without UOM conversion
- Now uses work center `machine_rate_per_hour + labor_rate_per_hour + overhead_rate_per_hour` with `hourly_rate` fallback
- Setup time now included in labor cost calculation

### Hooks
- Auto-estimate on `create_production_order()` (after routing copy + material reservation)
- Auto-actual cost on completion transition in `order_status.py`
- New endpoint: `POST /{order_id}/estimate-cost` for on-demand re-estimation

### Tests
- Updated 3 cost breakdown tests to set explicit work center rates instead of relying on hardcoded value
- All 184 service tests pass

## Test Results
```
tests/services/test_production_order_service.py — 184 passed
tests/unit/test_production_order_service.py — 15 passed
```

Co-authored-by: Claude <claude@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual re-estimate endpoint to trigger a production order cost estimate.
  * Automatic recalculation of actual costs when an order is completed.
  * New cost estimation logic: uses current material unit costs, includes setup time, prefers consumed quantities/actual times, and combines labor/machine/overhead rates for more accurate totals.

* **Tests**
  * Added tests for cost estimation behaviors and updated tests to explicitly set work center rates for consistent labor-cost assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->