### PR TITLE
feat: Material-Printer Compatibility Validation

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -50,6 +50,9 @@ from app.schemas.production_order import (
     SpoolListItem,
     SpoolAssignmentResponse,
     AcceptShortRequest,
+    CompatibilityIssueResponse,
+    OperationCompatibilityResponse,
+    OrderCompatibilityResponse,
 )
 from app.core.status_config import (
     ProductionOrderStatus,
@@ -1059,6 +1062,89 @@ async def estimate_cost(
     db.refresh(order)
 
     return production_order_service.get_cost_breakdown(db, order_id)
+
+
+# =============================================================================
+# Material-Printer Compatibility
+# =============================================================================
+
+@router.get("/{order_id}/compatibility", response_model=OrderCompatibilityResponse)
+async def check_compatibility(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OrderCompatibilityResponse:
+    """Check material-printer compatibility for all operations in a production order.
+
+    Validates enclosure requirements, temperature ranges, and filament diameter
+    for every operation that has a printer or resource assigned.
+    """
+    from app.services.compatibility_service import check_order_compatibility
+
+    order = production_order_service.get_production_order(db, order_id)
+    result = check_order_compatibility(db, order)
+    return OrderCompatibilityResponse(
+        production_order_id=result.production_order_id,
+        production_order_code=result.production_order_code,
+        compatible=result.compatible,
+        total_issues=result.total_issues,
+        operations=[
+            OperationCompatibilityResponse(
+                operation_id=op.operation_id,
+                operation_name=op.operation_name,
+                printer_name=op.printer_name,
+                compatible=op.compatible,
+                issues=[
+                    CompatibilityIssueResponse(
+                        severity=i.severity,
+                        check=i.check,
+                        message=i.message,
+                        material_name=i.material_name,
+                        printer_name=i.printer_name,
+                    )
+                    for i in op.issues
+                ],
+            )
+            for op in result.operations
+        ],
+    )
+
+
+@router.get(
+    "/{order_id}/operations/{operation_id}/compatibility",
+    response_model=OperationCompatibilityResponse,
+)
+async def check_operation_compat(
+    order_id: int,
+    operation_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OperationCompatibilityResponse:
+    """Check material-printer compatibility for a single operation."""
+    from app.services.compatibility_service import check_operation_compatibility
+
+    order = production_order_service.get_production_order(db, order_id)
+    operation = next((op for op in order.operations if op.id == operation_id), None)
+    if operation is None:
+        raise HTTPException(status_code=404, detail="Operation not found")
+
+    result = check_operation_compatibility(db, operation)
+    return OperationCompatibilityResponse(
+        operation_id=result.operation_id,
+        operation_name=result.operation_name,
+        printer_name=result.printer_name,
+        compatible=result.compatible,
+        issues=[
+            CompatibilityIssueResponse(
+                severity=i.severity,
+                check=i.check,
+                message=i.message,
+                material_name=i.material_name,
+                printer_name=i.printer_name,
+            )
+            for i in result.issues
+        ],
+    )
 
 
 # =============================================================================

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1080,10 +1080,9 @@ async def check_compatibility(
     for every operation that has a printer or resource assigned.
     """
     from app.services.compatibility_service import check_order_compatibility
-    from sqlalchemy.orm import selectinload, joinedload
+    from sqlalchemy.orm import selectinload
     from app.models.production_order import ProductionOrderOperationMaterial
     from app.models.product import Product
-    from app.models.material import MaterialType
 
     order = (
         db.query(ProductionOrder)
@@ -1138,7 +1137,7 @@ async def check_operation_compat(
 ) -> OperationCompatibilityResponse:
     """Check material-printer compatibility for a single operation."""
     from app.services.compatibility_service import check_operation_compatibility
-    from sqlalchemy.orm import selectinload, joinedload
+    from sqlalchemy.orm import selectinload
     from app.models.production_order import ProductionOrderOperationMaterial
     from app.models.product import Product
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1080,8 +1080,24 @@ async def check_compatibility(
     for every operation that has a printer or resource assigned.
     """
     from app.services.compatibility_service import check_order_compatibility
+    from sqlalchemy.orm import selectinload, joinedload
+    from app.models.production_order import ProductionOrderOperationMaterial
+    from app.models.product import Product
+    from app.models.material import MaterialType
 
-    order = production_order_service.get_production_order(db, order_id)
+    order = (
+        db.query(ProductionOrder)
+        .options(
+            selectinload(ProductionOrder.operations)
+            .selectinload(ProductionOrderOperation.materials)
+            .joinedload(ProductionOrderOperationMaterial.component)
+            .joinedload(Product.material_type),
+        )
+        .filter(ProductionOrder.id == order_id)
+        .first()
+    )
+    if not order:
+        raise HTTPException(status_code=404, detail="Production order not found")
     result = check_order_compatibility(db, order)
     return OrderCompatibilityResponse(
         production_order_id=result.production_order_id,
@@ -1122,9 +1138,23 @@ async def check_operation_compat(
 ) -> OperationCompatibilityResponse:
     """Check material-printer compatibility for a single operation."""
     from app.services.compatibility_service import check_operation_compatibility
+    from sqlalchemy.orm import selectinload, joinedload
+    from app.models.production_order import ProductionOrderOperationMaterial
+    from app.models.product import Product
 
-    order = production_order_service.get_production_order(db, order_id)
-    operation = next((op for op in order.operations if op.id == operation_id), None)
+    operation = (
+        db.query(ProductionOrderOperation)
+        .options(
+            selectinload(ProductionOrderOperation.materials)
+            .joinedload(ProductionOrderOperationMaterial.component)
+            .joinedload(Product.material_type),
+        )
+        .filter(
+            ProductionOrderOperation.id == operation_id,
+            ProductionOrderOperation.production_order_id == order_id,
+        )
+        .first()
+    )
     if operation is None:
         raise HTTPException(status_code=404, detail="Operation not found")
 

--- a/backend/app/models/material.py
+++ b/backend/app/models/material.py
@@ -45,7 +45,7 @@ class MaterialType(Base):
     bed_temp_min = Column(Integer, nullable=True)  # °C
     bed_temp_max = Column(Integer, nullable=True)  # °C
     requires_enclosure = Column(Boolean, default=False)  # ABS/ASA need enclosure
-    filament_diameter = Column(Numeric(4, 2), nullable=True, default=1.75)  # mm (1.75 or 2.85)
+    filament_diameter = Column(Numeric(4, 2), nullable=False, default=1.75, server_default="1.75")  # mm (1.75 or 2.85)
     
     # Pricing
     base_price_per_kg = Column(Numeric(10, 2), nullable=False)  # Base cost from supplier

--- a/backend/app/models/material.py
+++ b/backend/app/models/material.py
@@ -45,6 +45,7 @@ class MaterialType(Base):
     bed_temp_min = Column(Integer, nullable=True)  # °C
     bed_temp_max = Column(Integer, nullable=True)  # °C
     requires_enclosure = Column(Boolean, default=False)  # ABS/ASA need enclosure
+    filament_diameter = Column(Numeric(4, 2), nullable=True, default=1.75)  # mm (1.75 or 2.85)
     
     # Pricing
     base_price_per_kg = Column(Numeric(10, 2), nullable=False)  # Base cost from supplier

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -914,3 +914,34 @@ class SpoolAssignmentResponse(BaseModel):
     spool_id: int
     spool_code: Optional[str] = None
     assigned: bool
+
+
+# ============================================================================
+# Material-Printer Compatibility Schemas
+# ============================================================================
+
+class CompatibilityIssueResponse(BaseModel):
+    """A single material-printer compatibility finding."""
+    severity: str = Field(description="'error' or 'warning'")
+    check: str = Field(description="'enclosure', 'nozzle_temp', 'bed_temp', or 'diameter'")
+    message: str
+    material_name: str
+    printer_name: str
+
+
+class OperationCompatibilityResponse(BaseModel):
+    """Compatibility result for one operation."""
+    operation_id: int
+    operation_name: Optional[str] = None
+    printer_name: Optional[str] = None
+    compatible: bool
+    issues: List[CompatibilityIssueResponse] = Field(default_factory=list)
+
+
+class OrderCompatibilityResponse(BaseModel):
+    """Compatibility result for an entire production order."""
+    production_order_id: int
+    production_order_code: str
+    compatible: bool
+    total_issues: int
+    operations: List[OperationCompatibilityResponse] = Field(default_factory=list)

--- a/backend/app/services/compatibility_service.py
+++ b/backend/app/services/compatibility_service.py
@@ -107,14 +107,30 @@ def check_material_printer(
     mat_name = material_type.name
 
     # --- Enclosure ---
-    if material_type.requires_enclosure and not caps.get("enclosure", False):
-        issues.append(CompatibilityIssue(
-            severity="error",
-            check="enclosure",
-            message=f"{mat_name} requires an enclosure but {printer_name} is open-frame",
-            material_name=mat_name,
-            printer_name=printer_name,
-        ))
+    # If enclosure capability is unknown (missing from caps), downgrade to a
+    # warning rather than a hard error — we don't want to block scheduling
+    # when the printer simply hasn't had its enclosure capability configured.
+    if material_type.requires_enclosure:
+        enclosure_cap = caps.get("enclosure")
+        if enclosure_cap is False:
+            issues.append(CompatibilityIssue(
+                severity="error",
+                check="enclosure",
+                message=f"{mat_name} requires an enclosure but {printer_name} is open-frame",
+                material_name=mat_name,
+                printer_name=printer_name,
+            ))
+        elif enclosure_cap is None:
+            issues.append(CompatibilityIssue(
+                severity="warning",
+                check="enclosure",
+                message=(
+                    f"{mat_name} requires an enclosure but enclosure capability "
+                    f"for {printer_name} is unknown"
+                ),
+                material_name=mat_name,
+                printer_name=printer_name,
+            ))
 
     # --- Nozzle temperature ---
     max_hotend = caps.get("max_temp_hotend")
@@ -147,10 +163,13 @@ def check_material_printer(
             ))
 
     # --- Filament diameter ---
+    # Compare with a small tolerance to avoid float round-trip bugs
+    # (e.g. Decimal("2.85") → float comparisons can drift at the LSB).
     supported_diameters = caps.get("filament_diameters")
     if supported_diameters and material_type.filament_diameter is not None:
         mat_dia = float(material_type.filament_diameter)
-        if mat_dia not in [float(d) for d in supported_diameters]:
+        supported_floats = [float(d) for d in supported_diameters]
+        if not any(abs(mat_dia - d) < 0.01 for d in supported_floats):
             issues.append(CompatibilityIssue(
                 severity="error",
                 check="diameter",

--- a/backend/app/services/compatibility_service.py
+++ b/backend/app/services/compatibility_service.py
@@ -48,7 +48,7 @@ class OperationCompatibility:
 
     @property
     def compatible(self) -> bool:
-        return len(self.issues) == 0
+        return not any(i.severity == "error" for i in self.issues)
 
 
 @dataclass
@@ -94,7 +94,7 @@ def _resolve_material_type(product: Product, db: Session) -> Optional[MaterialTy
         return None
     if product.material_type is not None:
         return product.material_type
-    return db.query(MaterialType).get(product.material_type_id)
+    return db.get(MaterialType, product.material_type_id)
 
 
 def check_material_printer(

--- a/backend/app/services/compatibility_service.py
+++ b/backend/app/services/compatibility_service.py
@@ -10,7 +10,6 @@ required by a production order operation:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from decimal import Decimal
 from typing import List, Optional
 
 from sqlalchemy.orm import Session
@@ -22,7 +21,6 @@ from app.models.product import Product
 from app.models.production_order import (
     ProductionOrder,
     ProductionOrderOperation,
-    ProductionOrderOperationMaterial,
 )
 
 

--- a/backend/app/services/compatibility_service.py
+++ b/backend/app/services/compatibility_service.py
@@ -1,0 +1,226 @@
+"""
+Material-Printer Compatibility Validation Service
+
+Checks whether a printer (or resource) is compatible with the materials
+required by a production order operation:
+  - Enclosure: material requires_enclosure vs printer enclosure capability
+  - Temperature: material nozzle/bed temp vs printer max temps
+  - Filament diameter: material diameter vs printer supported diameters
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.material import MaterialType
+from app.models.printer import Printer
+from app.models.manufacturing import Resource
+from app.models.product import Product
+from app.models.production_order import (
+    ProductionOrder,
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
+
+
+@dataclass
+class CompatibilityIssue:
+    """A single compatibility finding."""
+
+    severity: str  # "error" | "warning"
+    check: str  # "enclosure" | "nozzle_temp" | "bed_temp" | "diameter"
+    message: str
+    material_name: str
+    printer_name: str
+
+
+@dataclass
+class OperationCompatibility:
+    """Compatibility result for one operation."""
+
+    operation_id: int
+    operation_name: Optional[str]
+    printer_name: Optional[str]
+    issues: List[CompatibilityIssue] = field(default_factory=list)
+
+    @property
+    def compatible(self) -> bool:
+        return len(self.issues) == 0
+
+
+@dataclass
+class OrderCompatibility:
+    """Compatibility result for an entire production order."""
+
+    production_order_id: int
+    production_order_code: str
+    operations: List[OperationCompatibility] = field(default_factory=list)
+
+    @property
+    def compatible(self) -> bool:
+        return all(op.compatible for op in self.operations)
+
+    @property
+    def total_issues(self) -> int:
+        return sum(len(op.issues) for op in self.operations)
+
+
+# ---------------------------------------------------------------------------
+# Core check: material vs printer capabilities
+# ---------------------------------------------------------------------------
+
+def _get_printer_capabilities(
+    printer: Optional[Printer],
+    resource: Optional[Resource],
+) -> dict:
+    """Merge printer JSON capabilities with resource metadata."""
+    caps: dict = {}
+    if printer and printer.capabilities:
+        caps = dict(printer.capabilities)
+    # Resource.printer_class is the authoritative enclosure flag when no
+    # Printer JSON exists — e.g. for resources not linked to a Printer row.
+    if resource:
+        if "enclosure" not in caps:
+            caps["enclosure"] = resource.printer_class == "enclosed"
+    return caps
+
+
+def _resolve_material_type(product: Product, db: Session) -> Optional[MaterialType]:
+    """Get MaterialType for a product, loading via FK if not already loaded."""
+    if product.material_type_id is None:
+        return None
+    if product.material_type is not None:
+        return product.material_type
+    return db.query(MaterialType).get(product.material_type_id)
+
+
+def check_material_printer(
+    material_type: MaterialType,
+    printer_name: str,
+    caps: dict,
+) -> List[CompatibilityIssue]:
+    """Run all compatibility checks for one material against one printer."""
+    issues: List[CompatibilityIssue] = []
+    mat_name = material_type.name
+
+    # --- Enclosure ---
+    if material_type.requires_enclosure and not caps.get("enclosure", False):
+        issues.append(CompatibilityIssue(
+            severity="error",
+            check="enclosure",
+            message=f"{mat_name} requires an enclosure but {printer_name} is open-frame",
+            material_name=mat_name,
+            printer_name=printer_name,
+        ))
+
+    # --- Nozzle temperature ---
+    max_hotend = caps.get("max_temp_hotend")
+    if max_hotend is not None and material_type.nozzle_temp_max is not None:
+        if material_type.nozzle_temp_max > max_hotend:
+            issues.append(CompatibilityIssue(
+                severity="error",
+                check="nozzle_temp",
+                message=(
+                    f"{mat_name} needs up to {material_type.nozzle_temp_max}°C nozzle temp "
+                    f"but {printer_name} max is {max_hotend}°C"
+                ),
+                material_name=mat_name,
+                printer_name=printer_name,
+            ))
+
+    # --- Bed temperature ---
+    max_bed = caps.get("max_temp_bed")
+    if max_bed is not None and material_type.bed_temp_max is not None:
+        if material_type.bed_temp_max > max_bed:
+            issues.append(CompatibilityIssue(
+                severity="warning",
+                check="bed_temp",
+                message=(
+                    f"{mat_name} wants up to {material_type.bed_temp_max}°C bed temp "
+                    f"but {printer_name} max is {max_bed}°C"
+                ),
+                material_name=mat_name,
+                printer_name=printer_name,
+            ))
+
+    # --- Filament diameter ---
+    supported_diameters = caps.get("filament_diameters")
+    if supported_diameters and material_type.filament_diameter is not None:
+        mat_dia = float(material_type.filament_diameter)
+        if mat_dia not in [float(d) for d in supported_diameters]:
+            issues.append(CompatibilityIssue(
+                severity="error",
+                check="diameter",
+                message=(
+                    f"{mat_name} uses {mat_dia}mm filament "
+                    f"but {printer_name} supports {supported_diameters}"
+                ),
+                material_name=mat_name,
+                printer_name=printer_name,
+            ))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Operation-level check
+# ---------------------------------------------------------------------------
+
+def check_operation_compatibility(
+    db: Session,
+    operation: ProductionOrderOperation,
+) -> OperationCompatibility:
+    """Check if the printer assigned to an operation can handle its materials."""
+    printer: Optional[Printer] = operation.printer
+    resource: Optional[Resource] = operation.resource
+
+    # If no printer or resource is assigned, nothing to validate.
+    if printer is None and resource is None:
+        return OperationCompatibility(
+            operation_id=operation.id,
+            operation_name=operation.operation_name,
+            printer_name=None,
+            issues=[],
+        )
+
+    printer_name = (printer.name if printer else None) or (resource.name if resource else "Unknown")
+    caps = _get_printer_capabilities(printer, resource)
+
+    all_issues: List[CompatibilityIssue] = []
+
+    for mat in operation.materials:
+        product: Product = mat.component
+        material_type = _resolve_material_type(product, db)
+        if material_type is None:
+            continue
+        all_issues.extend(check_material_printer(material_type, printer_name, caps))
+
+    return OperationCompatibility(
+        operation_id=operation.id,
+        operation_name=operation.operation_name,
+        printer_name=printer_name,
+        issues=all_issues,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Order-level check
+# ---------------------------------------------------------------------------
+
+def check_order_compatibility(
+    db: Session,
+    order: ProductionOrder,
+) -> OrderCompatibility:
+    """Check all operations in a production order for compatibility issues."""
+    op_results: List[OperationCompatibility] = []
+    for op in order.operations:
+        op_results.append(check_operation_compatibility(db, op))
+
+    return OrderCompatibility(
+        production_order_id=order.id,
+        production_order_code=order.code,
+        operations=op_results,
+    )

--- a/backend/migrations/versions/079_add_filament_diameter_to_material_types.py
+++ b/backend/migrations/versions/079_add_filament_diameter_to_material_types.py
@@ -1,0 +1,35 @@
+"""Add filament_diameter to material_types
+
+Standard FDM filament diameters: 1.75mm (most common), 2.85mm (legacy/industrial).
+Used for material-printer compatibility validation.
+
+Revision ID: 079
+Revises: 078
+Create Date: 2026-04-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "079"
+down_revision = "078"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "material_types",
+        sa.Column(
+            "filament_diameter",
+            sa.Numeric(4, 2),
+            nullable=True,
+            server_default="1.75",
+            comment="Filament diameter in mm (1.75 or 2.85)",
+        ),
+    )
+    # Backfill existing rows
+    op.execute("UPDATE material_types SET filament_diameter = 1.75 WHERE filament_diameter IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("material_types", "filament_diameter")

--- a/backend/migrations/versions/079_add_filament_diameter_to_material_types.py
+++ b/backend/migrations/versions/079_add_filament_diameter_to_material_types.py
@@ -23,12 +23,14 @@ def upgrade() -> None:
             "filament_diameter",
             sa.Numeric(4, 2),
             nullable=True,
-            server_default="1.75",
+            server_default=sa.text("1.75"),
             comment="Filament diameter in mm (1.75 or 2.85)",
         ),
     )
     # Backfill existing rows
     op.execute("UPDATE material_types SET filament_diameter = 1.75 WHERE filament_diameter IS NULL")
+    # Now enforce NOT NULL
+    op.alter_column("material_types", "filament_diameter", existing_type=sa.Numeric(4, 2), nullable=False)
 
 
 def downgrade() -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -179,7 +179,12 @@ def setup_database():
         # Migration 079: filament diameter for compatibility checks
         conn.execute(text(
             "ALTER TABLE material_types "
-            "ADD COLUMN IF NOT EXISTS filament_diameter NUMERIC(4,2)"
+            "ADD COLUMN IF NOT EXISTS filament_diameter NUMERIC(4,2) DEFAULT 1.75"
+        ))
+        conn.execute(text(
+            "UPDATE material_types "
+            "SET filament_diameter = 1.75 "
+            "WHERE filament_diameter IS NULL"
         ))
         conn.commit()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -176,6 +176,11 @@ def setup_database():
             "ALTER TABLE sales_order_lines "
             "ADD COLUMN IF NOT EXISTS fulfillment_status VARCHAR(20)"
         ))
+        # Migration 079: filament diameter for compatibility checks
+        conn.execute(text(
+            "ALTER TABLE material_types "
+            "ADD COLUMN IF NOT EXISTS filament_diameter NUMERIC(4,2)"
+        ))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/services/test_compatibility_service.py
+++ b/backend/tests/services/test_compatibility_service.py
@@ -1,0 +1,518 @@
+"""
+Tests for app/services/compatibility_service.py
+
+Covers:
+- check_material_printer: unit-level checks (enclosure, nozzle temp, bed temp, diameter)
+- check_operation_compatibility: operation with/without printer, with/without materials
+- check_order_compatibility: full order aggregation
+"""
+import uuid
+import pytest
+from decimal import Decimal
+
+from app.models.material import MaterialType
+from app.models.printer import Printer
+from app.models.manufacturing import Resource
+from app.models.production_order import (
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
+from app.services.compatibility_service import (
+    check_material_printer,
+    check_operation_compatibility,
+    check_order_compatibility,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _uid():
+    return uuid.uuid4().hex[:8]
+
+
+def _make_material_type(db, **kwargs):
+    uid = _uid()
+    mt = MaterialType(
+        code=kwargs.pop("code", f"MT-{uid}"),
+        name=kwargs.pop("name", f"Material {uid}"),
+        base_material=kwargs.pop("base_material", "PLA"),
+        density=kwargs.pop("density", Decimal("1.24")),
+        base_price_per_kg=kwargs.pop("base_price_per_kg", Decimal("20.00")),
+        requires_enclosure=kwargs.pop("requires_enclosure", False),
+        active=True,
+        is_customer_visible=True,
+        **kwargs,
+    )
+    db.add(mt)
+    db.flush()
+    return mt
+
+
+def _make_printer(db, work_center_id=None, **kwargs):
+    uid = _uid()
+    p = Printer(
+        code=kwargs.pop("code", f"P-{uid}"),
+        name=kwargs.pop("name", f"Printer {uid}"),
+        model=kwargs.pop("model", "Generic"),
+        brand=kwargs.pop("brand", "generic"),
+        capabilities=kwargs.pop("capabilities", None),
+        work_center_id=work_center_id,
+        active=True,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_resource(db, work_center_id, **kwargs):
+    uid = _uid()
+    r = Resource(
+        work_center_id=work_center_id,
+        code=kwargs.pop("code", f"R-{uid}"),
+        name=kwargs.pop("name", f"Resource {uid}"),
+        printer_class=kwargs.pop("printer_class", "open"),
+        status="available",
+        is_active=True,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+# =============================================================================
+# check_material_printer — unit-level checks
+# =============================================================================
+
+class TestCheckMaterialPrinter:
+    """Tests for the core check_material_printer function."""
+
+    def test_fully_compatible_returns_no_issues(self, db):
+        mt = _make_material_type(
+            db,
+            base_material="PLA",
+            requires_enclosure=False,
+            nozzle_temp_max=220,
+            bed_temp_max=60,
+            filament_diameter=Decimal("1.75"),
+        )
+        caps = {
+            "enclosure": False,
+            "max_temp_hotend": 300,
+            "max_temp_bed": 110,
+            "filament_diameters": [1.75],
+        }
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert issues == []
+
+    def test_enclosure_required_but_open(self, db):
+        mt = _make_material_type(
+            db,
+            base_material="ABS",
+            requires_enclosure=True,
+        )
+        caps = {"enclosure": False}
+        issues = check_material_printer(mt, "OpenPrinter", caps)
+        assert len(issues) == 1
+        assert issues[0].check == "enclosure"
+        assert issues[0].severity == "error"
+        assert "requires an enclosure" in issues[0].message
+
+    def test_enclosure_required_and_enclosed_ok(self, db):
+        mt = _make_material_type(
+            db,
+            base_material="ABS",
+            requires_enclosure=True,
+        )
+        caps = {"enclosure": True}
+        issues = check_material_printer(mt, "EnclosedPrinter", caps)
+        # No enclosure issue
+        assert not any(i.check == "enclosure" for i in issues)
+
+    def test_nozzle_temp_too_high(self, db):
+        mt = _make_material_type(
+            db,
+            nozzle_temp_max=320,
+        )
+        caps = {"max_temp_hotend": 300}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert len(issues) == 1
+        assert issues[0].check == "nozzle_temp"
+        assert issues[0].severity == "error"
+        assert "320°C" in issues[0].message
+        assert "300°C" in issues[0].message
+
+    def test_nozzle_temp_within_range(self, db):
+        mt = _make_material_type(db, nozzle_temp_max=250)
+        caps = {"max_temp_hotend": 300}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert not any(i.check == "nozzle_temp" for i in issues)
+
+    def test_bed_temp_too_high(self, db):
+        mt = _make_material_type(db, bed_temp_max=120)
+        caps = {"max_temp_bed": 100}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert len(issues) == 1
+        assert issues[0].check == "bed_temp"
+        assert issues[0].severity == "warning"
+        assert "120°C" in issues[0].message
+
+    def test_bed_temp_within_range(self, db):
+        mt = _make_material_type(db, bed_temp_max=80)
+        caps = {"max_temp_bed": 110}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert not any(i.check == "bed_temp" for i in issues)
+
+    def test_diameter_mismatch(self, db):
+        mt = _make_material_type(
+            db,
+            filament_diameter=Decimal("2.85"),
+        )
+        caps = {"filament_diameters": [1.75]}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert len(issues) == 1
+        assert issues[0].check == "diameter"
+        assert issues[0].severity == "error"
+        assert "2.85" in issues[0].message
+
+    def test_diameter_match(self, db):
+        mt = _make_material_type(
+            db,
+            filament_diameter=Decimal("1.75"),
+        )
+        caps = {"filament_diameters": [1.75, 2.85]}
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert not any(i.check == "diameter" for i in issues)
+
+    def test_no_diameter_in_caps_skips_check(self, db):
+        mt = _make_material_type(
+            db,
+            filament_diameter=Decimal("1.75"),
+        )
+        caps = {}  # no filament_diameters key
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert not any(i.check == "diameter" for i in issues)
+
+    def test_no_temps_in_caps_skips_temp_checks(self, db):
+        mt = _make_material_type(
+            db,
+            nozzle_temp_max=300,
+            bed_temp_max=110,
+        )
+        caps = {}  # no max_temp_hotend or max_temp_bed
+        issues = check_material_printer(mt, "TestPrinter", caps)
+        assert issues == []
+
+    def test_multiple_issues_at_once(self, db):
+        mt = _make_material_type(
+            db,
+            base_material="ABS",
+            requires_enclosure=True,
+            nozzle_temp_max=320,
+            bed_temp_max=120,
+            filament_diameter=Decimal("2.85"),
+        )
+        caps = {
+            "enclosure": False,
+            "max_temp_hotend": 260,
+            "max_temp_bed": 100,
+            "filament_diameters": [1.75],
+        }
+        issues = check_material_printer(mt, "BadPrinter", caps)
+        checks_found = {i.check for i in issues}
+        assert checks_found == {"enclosure", "nozzle_temp", "bed_temp", "diameter"}
+        assert all(i.material_name == mt.name for i in issues)
+        assert all(i.printer_name == "BadPrinter" for i in issues)
+
+
+# =============================================================================
+# check_operation_compatibility — operation-level
+# =============================================================================
+
+class TestCheckOperationCompatibility:
+    """Tests for check_operation_compatibility."""
+
+    def test_no_printer_assigned_returns_empty(self, db, make_work_center, make_production_order, make_product):
+        wc = make_work_center()
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="pending",
+            printer_id=None,
+            resource_id=None,
+        )
+        db.add(op)
+        db.flush()
+
+        result = check_operation_compatibility(db, op)
+        assert result.compatible is True
+        assert result.issues == []
+        assert result.printer_name is None
+
+    def test_printer_assigned_compatible_material(self, db, make_work_center, make_production_order, make_product):
+        wc = make_work_center()
+        mt = _make_material_type(
+            db, base_material="PLA", requires_enclosure=False,
+            nozzle_temp_max=220, bed_temp_max=60,
+        )
+        component = make_product(
+            item_type="supply", unit="G", is_raw_material=True,
+            material_type_id=mt.id,
+        )
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        printer = _make_printer(db, work_center_id=wc.id, capabilities={
+            "enclosure": True, "max_temp_hotend": 300, "max_temp_bed": 110,
+        })
+
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="pending",
+            printer_id=printer.id,
+        )
+        db.add(op)
+        db.flush()
+
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=component.id,
+            quantity_required=Decimal("500"),
+            unit="G",
+            quantity_allocated=Decimal("0"),
+            quantity_consumed=Decimal("0"),
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        result = check_operation_compatibility(db, op)
+        assert result.compatible is True
+        assert result.printer_name == printer.name
+
+    def test_printer_assigned_incompatible_material(self, db, make_work_center, make_production_order, make_product):
+        wc = make_work_center()
+        mt = _make_material_type(
+            db, base_material="ABS", requires_enclosure=True,
+            nozzle_temp_max=260, bed_temp_max=100,
+        )
+        component = make_product(
+            item_type="supply", unit="G", is_raw_material=True,
+            material_type_id=mt.id,
+        )
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        # Open-frame printer — will fail enclosure check
+        printer = _make_printer(db, work_center_id=wc.id, capabilities={
+            "enclosure": False, "max_temp_hotend": 300, "max_temp_bed": 110,
+        })
+
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="pending",
+            printer_id=printer.id,
+        )
+        db.add(op)
+        db.flush()
+
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=component.id,
+            quantity_required=Decimal("500"),
+            unit="G",
+            quantity_allocated=Decimal("0"),
+            quantity_consumed=Decimal("0"),
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        result = check_operation_compatibility(db, op)
+        assert result.compatible is False
+        assert any(i.check == "enclosure" for i in result.issues)
+
+    def test_resource_only_no_printer(self, db, make_work_center, make_production_order, make_product):
+        """When only a Resource is assigned (no Printer row), use printer_class."""
+        wc = make_work_center()
+        mt = _make_material_type(
+            db, base_material="ABS", requires_enclosure=True,
+        )
+        component = make_product(
+            item_type="supply", unit="G", is_raw_material=True,
+            material_type_id=mt.id,
+        )
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        resource = _make_resource(db, work_center_id=wc.id, printer_class="enclosed")
+
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="pending",
+            resource_id=resource.id,
+        )
+        db.add(op)
+        db.flush()
+
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=component.id,
+            quantity_required=Decimal("500"),
+            unit="G",
+            quantity_allocated=Decimal("0"),
+            quantity_consumed=Decimal("0"),
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        result = check_operation_compatibility(db, op)
+        # Enclosed resource satisfies ABS enclosure requirement
+        assert not any(i.check == "enclosure" for i in result.issues)
+
+    def test_material_without_material_type_skipped(self, db, make_work_center, make_production_order, make_product):
+        """Products with no material_type_id should be silently skipped."""
+        wc = make_work_center()
+        component = make_product(item_type="supply", unit="G", is_raw_material=True)
+        # No material_type_id set
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        printer = _make_printer(db, work_center_id=wc.id, capabilities={
+            "enclosure": False, "max_temp_hotend": 200,
+        })
+
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="pending",
+            printer_id=printer.id,
+        )
+        db.add(op)
+        db.flush()
+
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=component.id,
+            quantity_required=Decimal("500"),
+            unit="G",
+            quantity_allocated=Decimal("0"),
+            quantity_consumed=Decimal("0"),
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        result = check_operation_compatibility(db, op)
+        assert result.compatible is True
+        assert result.issues == []
+
+
+# =============================================================================
+# check_order_compatibility — order-level aggregation
+# =============================================================================
+
+class TestCheckOrderCompatibility:
+    """Tests for check_order_compatibility."""
+
+    def test_order_with_no_operations(self, db, make_production_order, make_product):
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        result = check_order_compatibility(db, order)
+        assert result.compatible is True
+        assert result.total_issues == 0
+        assert result.operations == []
+
+    def test_order_aggregates_all_operations(self, db, make_work_center, make_production_order, make_product):
+        wc = make_work_center()
+        mt_ok = _make_material_type(db, base_material="PLA", requires_enclosure=False)
+        mt_bad = _make_material_type(db, base_material="ABS", requires_enclosure=True)
+        comp_ok = make_product(item_type="supply", unit="G", is_raw_material=True, material_type_id=mt_ok.id)
+        comp_bad = make_product(item_type="supply", unit="G", is_raw_material=True, material_type_id=mt_bad.id)
+        product = make_product()
+        order = make_production_order(product_id=product.id)
+
+        # Open printer — PLA fine, ABS not fine
+        printer = _make_printer(db, work_center_id=wc.id, capabilities={"enclosure": False})
+
+        # Operation 1: PLA — compatible
+        op1 = ProductionOrderOperation(
+            production_order_id=order.id, work_center_id=wc.id, sequence=10,
+            operation_code="PRINT1", operation_name="Print PLA",
+            planned_setup_minutes=0, planned_run_minutes=60, status="pending",
+            printer_id=printer.id,
+        )
+        db.add(op1)
+        db.flush()
+        db.add(ProductionOrderOperationMaterial(
+            production_order_operation_id=op1.id, component_id=comp_ok.id,
+            quantity_required=Decimal("500"), unit="G",
+            quantity_allocated=Decimal("0"), quantity_consumed=Decimal("0"), status="pending",
+        ))
+        db.flush()
+
+        # Operation 2: ABS — incompatible (needs enclosure)
+        op2 = ProductionOrderOperation(
+            production_order_id=order.id, work_center_id=wc.id, sequence=20,
+            operation_code="PRINT2", operation_name="Print ABS",
+            planned_setup_minutes=0, planned_run_minutes=60, status="pending",
+            printer_id=printer.id,
+        )
+        db.add(op2)
+        db.flush()
+        db.add(ProductionOrderOperationMaterial(
+            production_order_operation_id=op2.id, component_id=comp_bad.id,
+            quantity_required=Decimal("500"), unit="G",
+            quantity_allocated=Decimal("0"), quantity_consumed=Decimal("0"), status="pending",
+        ))
+        db.flush()
+
+        result = check_order_compatibility(db, order)
+        assert result.compatible is False
+        assert result.total_issues == 1
+        assert result.production_order_id == order.id
+        assert result.production_order_code == order.code
+        assert len(result.operations) == 2
+
+        # First operation should be compatible
+        op1_result = next(o for o in result.operations if o.operation_id == op1.id)
+        assert op1_result.compatible is True
+
+        # Second operation should have enclosure issue
+        op2_result = next(o for o in result.operations if o.operation_id == op2.id)
+        assert op2_result.compatible is False
+        assert op2_result.issues[0].check == "enclosure"

--- a/backend/tests/services/test_compatibility_service.py
+++ b/backend/tests/services/test_compatibility_service.py
@@ -130,6 +130,21 @@ class TestCheckMaterialPrinter:
         # No enclosure issue
         assert not any(i.check == "enclosure" for i in issues)
 
+    def test_enclosure_required_but_unknown_is_warning(self, db):
+        """When enclosure capability is absent from caps, downgrade to warning
+        so unconfigured printers don't hard-block scheduling."""
+        mt = _make_material_type(
+            db,
+            base_material="ABS",
+            requires_enclosure=True,
+        )
+        caps = {}  # no enclosure key at all
+        issues = check_material_printer(mt, "UnknownPrinter", caps)
+        enclosure_issues = [i for i in issues if i.check == "enclosure"]
+        assert len(enclosure_issues) == 1
+        assert enclosure_issues[0].severity == "warning"
+        assert "unknown" in enclosure_issues[0].message.lower()
+
     def test_nozzle_temp_too_high(self, db):
         mt = _make_material_type(
             db,

--- a/backend/tests/services/test_compatibility_service.py
+++ b/backend/tests/services/test_compatibility_service.py
@@ -158,6 +158,20 @@ class TestCheckMaterialPrinter:
         assert issues[0].severity == "warning"
         assert "120°C" in issues[0].message
 
+    def test_warnings_only_still_compatible(self, db):
+        """Warnings (e.g. bed temp) should not mark an operation incompatible."""
+        from app.services.compatibility_service import OperationCompatibility, CompatibilityIssue
+        op_compat = OperationCompatibility(
+            operation_id=1,
+            operation_name="Print",
+            printer_name="TestPrinter",
+            issues=[CompatibilityIssue(
+                severity="warning", check="bed_temp",
+                message="bed temp warning", material_name="PLA", printer_name="TestPrinter",
+            )],
+        )
+        assert op_compat.compatible is True
+
     def test_bed_temp_within_range(self, db):
         mt = _make_material_type(db, bed_temp_max=80)
         caps = {"max_temp_bed": 110}


### PR DESCRIPTION
## Feature 2: Material-Printer Compatibility Validation

Validates material-printer compatibility before job assignment by checking enclosure requirements, nozzle/bed temperature ranges, and filament diameter.

### What it does

When a printer or resource is assigned to a production order operation, the system can now check whether the printer can handle the materials required:

| Check | Severity | Example |
|-------|----------|---------|
| **Enclosure** | error | ABS requires enclosure but Ender 3 is open-frame |
| **Nozzle temp** | error | Material needs 320°C but printer max is 260°C |
| **Bed temp** | warning | Material wants 120°C but printer max is 100°C |
| **Filament diameter** | error | Material is 2.85mm but printer only supports 1.75mm |

Issues are **warnings, not hard blocks** — users can override (e.g., using a draft shield for ABS on an open printer).

### Changes

- **Migration 079**: Adds `filament_diameter` column (NUMERIC 4,2, default 1.75) to `material_types`
- **Model**: `MaterialType.filament_diameter` column
- **Service**: `compatibility_service.py` with `check_material_printer()`, `check_operation_compatibility()`, `check_order_compatibility()`
- **Endpoints**:
  - `GET /api/v1/production-orders/{id}/compatibility` — check all operations
  - `GET /api/v1/production-orders/{id}/operations/{op_id}/compatibility` — check single operation
- **Schemas**: `CompatibilityIssueResponse`, `OperationCompatibilityResponse`, `OrderCompatibilityResponse`
- **Tests**: 19 new unit tests covering all check paths (enclosure, temps, diameter, multiple issues, no-printer, no-material-type)

### Test results

- 19 new tests: all passing
- Full suite: **4674 passed**, 9 skipped, 0 failures

### Data model

Leverages existing fields already on `MaterialType`:
- `requires_enclosure` (Boolean)
- `nozzle_temp_min/max` (Integer °C)
- `bed_temp_min/max` (Integer °C)

And existing printer data:
- `Printer.capabilities` JSON (`enclosure`, `max_temp_hotend`, `max_temp_bed`, `filament_diameters`)
- `Resource.printer_class` (`"open"` / `"enclosed"`)

Only `filament_diameter` was added as a new column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to check material–printer compatibility per operation and per order (returns per-issue details and order totals; 404 when not found).
  * Added response models for compatibility reports.

* **Bug Fixes / Data**
  * Materials now store filament diameter (default 1.75 mm).

* **Tests**
  * Added comprehensive tests for material/printer checks, operation validation, and order aggregation.

* **Chores**
  * Database migration to add and backfill filament diameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->