### PR TITLE
feat: Breadcrumb Navigation for Admin Layout

### DIFF
--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, NavLink, useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
+import Breadcrumbs from "./Breadcrumbs";
 import SecurityBadge from "./SecurityBadge";
 import useActivityTokenRefresh from "../hooks/useActivityTokenRefresh";
 import {
@@ -1070,6 +1071,7 @@ export default function AdminLayout() {
             className="flex-1 p-6 overflow-auto grid-pattern"
             tabIndex="-1"
           >
+            <Breadcrumbs />
             <Outlet />
           </main>
         </div>

--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -1,0 +1,178 @@
+import { Link, useLocation } from "react-router-dom";
+
+/**
+ * Route path → human-readable label map.
+ * Intermediate paths (e.g. /admin/inventory) that aren't real pages
+ * are included so the breadcrumb trail remains complete.
+ */
+const ROUTE_LABELS = {
+  "/admin": "Dashboard",
+  // Sales
+  "/admin/orders": "Orders",
+  "/admin/orders/import": "Import Orders",
+  "/admin/quotes": "Quotes",
+  "/admin/payments": "Payments",
+  "/admin/invoices": "Invoices",
+  "/admin/customers": "Customers",
+  "/admin/messages": "Messages",
+  // Inventory
+  "/admin/items": "Items",
+  "/admin/bom": "Bill of Materials",
+  "/admin/materials": "Materials",
+  "/admin/materials/import": "Import Materials",
+  "/admin/inventory": "Inventory",
+  "/admin/inventory/transactions": "Transactions",
+  "/admin/inventory/cycle-count": "Cycle Count",
+  "/admin/locations": "Locations",
+  "/admin/spools": "Material Spools",
+  // Operations
+  "/admin/production": "Production",
+  "/admin/manufacturing": "Manufacturing",
+  "/admin/printers": "Printers",
+  "/admin/filafarm": "FilaFarm",
+  "/admin/purchasing": "Purchasing",
+  "/admin/shipping": "Shipping",
+  // Quality
+  "/admin/quality": "Quality",
+  "/admin/quality/traceability": "Material Traceability",
+  // B2B Portal
+  "/admin/access-requests": "Access Requests",
+  "/admin/catalogs": "Catalogs",
+  "/admin/price-levels": "Price Levels",
+  // Admin
+  "/admin/accounting": "Accounting",
+  "/admin/users": "Team Members",
+  "/admin/scrap-reasons": "Scrap Reasons",
+  "/admin/analytics": "Analytics",
+  "/admin/settings": "Settings",
+  "/admin/security": "Security Audit",
+  "/admin/command-center": "Command Center",
+};
+
+const HomeIcon = () => (
+  <svg
+    className="w-4 h-4 shrink-0"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1h-2z"
+    />
+  </svg>
+);
+
+const ChevronIcon = () => (
+  <svg
+    className="w-4 h-4 shrink-0"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    style={{ color: "var(--text-muted)" }}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 5l7 7-7 7"
+    />
+  </svg>
+);
+
+/**
+ * Checks if a path segment looks like a dynamic ID (numeric or UUID-like).
+ */
+function isDynamicSegment(segment) {
+  return /^\d+$/.test(segment) || /^[0-9a-f-]{36}$/i.test(segment);
+}
+
+/**
+ * Build breadcrumb items from the current URL pathname.
+ * Returns an array of { label, path, isLast }.
+ */
+function buildBreadcrumbs(pathname) {
+  // Strip trailing slash
+  const cleanPath = pathname.replace(/\/$/, "") || "/admin";
+
+  // Don't show breadcrumbs on dashboard
+  if (cleanPath === "/admin") return [];
+
+  const segments = cleanPath.split("/").filter(Boolean); // ['admin', 'orders', '123']
+  const crumbs = [];
+
+  // Always start with Dashboard
+  crumbs.push({ label: "Dashboard", path: "/admin" });
+
+  // Build cumulative paths from segments (skip 'admin' since it's the root)
+  for (let i = 1; i < segments.length; i++) {
+    const cumulativePath = "/" + segments.slice(0, i + 1).join("/");
+    const segment = segments[i];
+
+    if (isDynamicSegment(segment)) {
+      crumbs.push({ label: `#${segment}`, path: cumulativePath });
+    } else {
+      const label =
+        ROUTE_LABELS[cumulativePath] ||
+        segment
+          .split("-")
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" ");
+      crumbs.push({ label, path: cumulativePath });
+    }
+  }
+
+  // Mark the last item
+  if (crumbs.length > 0) {
+    crumbs[crumbs.length - 1].isLast = true;
+  }
+
+  return crumbs;
+}
+
+export default function Breadcrumbs() {
+  const { pathname } = useLocation();
+  const crumbs = buildBreadcrumbs(pathname);
+
+  // Don't render anything on the dashboard
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4">
+      <ol className="flex items-center gap-1.5 text-sm">
+        {crumbs.map((crumb, index) => (
+          <li key={crumb.path} className="flex items-center gap-1.5">
+            {index > 0 && <ChevronIcon />}
+            {crumb.isLast ? (
+              <span
+                className="font-medium"
+                style={{ color: "var(--text-primary)" }}
+                aria-current="page"
+              >
+                {index === 0 && <HomeIcon />}
+                {index === 0 ? null : crumb.label}
+              </span>
+            ) : (
+              <Link
+                to={crumb.path}
+                className="transition-colors hover:underline"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {index === 0 ? (
+                  <HomeIcon />
+                ) : (
+                  crumb.label
+                )}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+// Exported for testing
+export { buildBreadcrumbs, ROUTE_LABELS };

--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -162,8 +162,7 @@ export default function Breadcrumbs() {
                 style={{ color: "var(--text-primary)" }}
                 aria-current="page"
               >
-                {index === 0 && <HomeIcon />}
-                {index === 0 ? null : crumb.label}
+                {crumb.label}
               </span>
             ) : NON_NAVIGABLE_PATHS.has(crumb.path) ? (
               <span

--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -1,6 +1,15 @@
 import { Link, useLocation } from "react-router-dom";
 
 /**
+ * Paths that appear in breadcrumb trails but don't map to real pages.
+ * These are rendered as plain text instead of links to avoid 404s.
+ */
+const NON_NAVIGABLE_PATHS = new Set([
+  "/admin/inventory",
+  "/admin/quality",
+]);
+
+/**
  * Route path → human-readable label map.
  * Intermediate paths (e.g. /admin/inventory) that aren't real pages
  * are included so the breadcrumb trail remains complete.
@@ -55,6 +64,7 @@ const HomeIcon = () => (
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
+    aria-hidden="true"
   >
     <path
       strokeLinecap="round"
@@ -72,6 +82,7 @@ const ChevronIcon = () => (
     stroke="currentColor"
     viewBox="0 0 24 24"
     style={{ color: "var(--text-muted)" }}
+    aria-hidden="true"
   >
     <path
       strokeLinecap="round"
@@ -154,11 +165,18 @@ export default function Breadcrumbs() {
                 {index === 0 && <HomeIcon />}
                 {index === 0 ? null : crumb.label}
               </span>
+            ) : NON_NAVIGABLE_PATHS.has(crumb.path) ? (
+              <span
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {crumb.label}
+              </span>
             ) : (
               <Link
                 to={crumb.path}
                 className="transition-colors hover:underline"
                 style={{ color: "var(--text-secondary)" }}
+                {...(index === 0 ? { "aria-label": "Dashboard" } : {})}
               >
                 {index === 0 ? (
                   <HomeIcon />
@@ -175,4 +193,4 @@ export default function Breadcrumbs() {
 }
 
 // Exported for testing
-export { buildBreadcrumbs, ROUTE_LABELS };
+export { buildBreadcrumbs, ROUTE_LABELS, NON_NAVIGABLE_PATHS };

--- a/frontend/src/components/__tests__/Breadcrumbs.test.jsx
+++ b/frontend/src/components/__tests__/Breadcrumbs.test.jsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import Breadcrumbs, { buildBreadcrumbs, ROUTE_LABELS } from "../Breadcrumbs";
+
+function renderAtPath(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Breadcrumbs />
+    </MemoryRouter>
+  );
+}
+
+describe("buildBreadcrumbs", () => {
+  it("returns empty array for dashboard root", () => {
+    expect(buildBreadcrumbs("/admin")).toEqual([]);
+    expect(buildBreadcrumbs("/admin/")).toEqual([]);
+  });
+
+  it("builds crumbs for a top-level page", () => {
+    const crumbs = buildBreadcrumbs("/admin/orders");
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[0]).toEqual({ label: "Dashboard", path: "/admin" });
+    expect(crumbs[1]).toEqual({
+      label: "Orders",
+      path: "/admin/orders",
+      isLast: true,
+    });
+  });
+
+  it("builds crumbs for a nested page", () => {
+    const crumbs = buildBreadcrumbs("/admin/inventory/transactions");
+    expect(crumbs).toHaveLength(3);
+    expect(crumbs[0].label).toBe("Dashboard");
+    expect(crumbs[1].label).toBe("Inventory");
+    expect(crumbs[1].path).toBe("/admin/inventory");
+    expect(crumbs[2].label).toBe("Transactions");
+    expect(crumbs[2].isLast).toBe(true);
+  });
+
+  it("handles dynamic ID segments", () => {
+    const crumbs = buildBreadcrumbs("/admin/orders/42");
+    expect(crumbs).toHaveLength(3);
+    expect(crumbs[2].label).toBe("#42");
+    expect(crumbs[2].isLast).toBe(true);
+  });
+
+  it("handles UUID-like dynamic segments", () => {
+    const crumbs = buildBreadcrumbs(
+      "/admin/orders/550e8400-e29b-41d4-a716-446655440000"
+    );
+    expect(crumbs[2].label).toBe(
+      "#550e8400-e29b-41d4-a716-446655440000"
+    );
+  });
+
+  it("title-cases unknown segments", () => {
+    const crumbs = buildBreadcrumbs("/admin/some-new-feature");
+    expect(crumbs[1].label).toBe("Some New Feature");
+  });
+
+  it("builds crumbs for quality/traceability", () => {
+    const crumbs = buildBreadcrumbs("/admin/quality/traceability");
+    expect(crumbs).toHaveLength(3);
+    expect(crumbs[1].label).toBe("Quality");
+    expect(crumbs[2].label).toBe("Material Traceability");
+  });
+});
+
+describe("Breadcrumbs component", () => {
+  it("renders nothing on dashboard", () => {
+    const { container } = renderAtPath("/admin");
+    expect(container.querySelector("nav")).toBeNull();
+  });
+
+  it("renders breadcrumb nav for a page", () => {
+    renderAtPath("/admin/orders");
+    const nav = screen.getByLabelText("Breadcrumb");
+    expect(nav).toBeInTheDocument();
+  });
+
+  it("renders dashboard as a link and current page as text", () => {
+    renderAtPath("/admin/quotes");
+    // Dashboard is a link (home icon)
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/admin");
+    // Current page not a link
+    expect(screen.getByText("Quotes")).toBeInTheDocument();
+    expect(screen.getByText("Quotes").closest("a")).toBeNull();
+  });
+
+  it("marks the last crumb with aria-current=page", () => {
+    renderAtPath("/admin/settings");
+    const current = screen.getByText("Settings");
+    expect(current).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders nested breadcrumbs with intermediate links", () => {
+    renderAtPath("/admin/inventory/cycle-count");
+    // Dashboard link + Inventory link + Cycle Count (text)
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[1]).toHaveAttribute("href", "/admin/inventory");
+    expect(screen.getByText("Cycle Count")).toBeInTheDocument();
+  });
+
+  it("renders dynamic segment as #ID", () => {
+    renderAtPath("/admin/production/99");
+    expect(screen.getByText("#99")).toBeInTheDocument();
+  });
+});
+
+describe("ROUTE_LABELS coverage", () => {
+  it("has labels for all main nav routes", () => {
+    const expectedPaths = [
+      "/admin/orders",
+      "/admin/quotes",
+      "/admin/payments",
+      "/admin/invoices",
+      "/admin/customers",
+      "/admin/items",
+      "/admin/bom",
+      "/admin/purchasing",
+      "/admin/manufacturing",
+      "/admin/production",
+      "/admin/shipping",
+      "/admin/settings",
+      "/admin/accounting",
+      "/admin/printers",
+    ];
+    for (const path of expectedPaths) {
+      expect(ROUTE_LABELS[path]).toBeDefined();
+    }
+  });
+});

--- a/frontend/src/components/__tests__/Breadcrumbs.test.jsx
+++ b/frontend/src/components/__tests__/Breadcrumbs.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect } from "vitest";
-import Breadcrumbs, { buildBreadcrumbs, ROUTE_LABELS } from "../Breadcrumbs";
+import Breadcrumbs, { buildBreadcrumbs, ROUTE_LABELS, NON_NAVIGABLE_PATHS } from "../Breadcrumbs";
 
 function renderAtPath(path) {
   return render(
@@ -79,12 +79,13 @@ describe("Breadcrumbs component", () => {
     expect(nav).toBeInTheDocument();
   });
 
-  it("renders dashboard as a link and current page as text", () => {
+  it("renders dashboard as a link with aria-label and current page as text", () => {
     renderAtPath("/admin/quotes");
-    // Dashboard is a link (home icon)
+    // Dashboard is a link (home icon) with accessible name
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute("href", "/admin");
+    expect(links[0]).toHaveAttribute("aria-label", "Dashboard");
     // Current page not a link
     expect(screen.getByText("Quotes")).toBeInTheDocument();
     expect(screen.getByText("Quotes").closest("a")).toBeNull();
@@ -96,13 +97,22 @@ describe("Breadcrumbs component", () => {
     expect(current).toHaveAttribute("aria-current", "page");
   });
 
-  it("renders nested breadcrumbs with intermediate links", () => {
+  it("renders non-navigable intermediate crumbs as plain text", () => {
     renderAtPath("/admin/inventory/cycle-count");
-    // Dashboard link + Inventory link + Cycle Count (text)
+    // Dashboard link + Cycle Count (text), but Inventory is non-navigable (plain text)
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1); // Only Dashboard link
+    expect(screen.getByText("Inventory")).toBeInTheDocument();
+    expect(screen.getByText("Inventory").closest("a")).toBeNull();
+    expect(screen.getByText("Cycle Count")).toBeInTheDocument();
+  });
+
+  it("renders navigable intermediate crumbs as links", () => {
+    renderAtPath("/admin/orders/42");
+    // Dashboard link + Orders link + #42 (text)
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(2);
-    expect(links[1]).toHaveAttribute("href", "/admin/inventory");
-    expect(screen.getByText("Cycle Count")).toBeInTheDocument();
+    expect(links[1]).toHaveAttribute("href", "/admin/orders");
   });
 
   it("renders dynamic segment as #ID", () => {
@@ -112,24 +122,54 @@ describe("Breadcrumbs component", () => {
 });
 
 describe("ROUTE_LABELS coverage", () => {
-  it("has labels for all main nav routes", () => {
+  it("has labels for all sidebar nav routes", () => {
     const expectedPaths = [
+      // Sales
       "/admin/orders",
       "/admin/quotes",
       "/admin/payments",
       "/admin/invoices",
       "/admin/customers",
+      "/admin/messages",
+      // Inventory
       "/admin/items",
       "/admin/bom",
-      "/admin/purchasing",
-      "/admin/manufacturing",
+      "/admin/materials",
+      "/admin/locations",
+      "/admin/inventory",
+      "/admin/inventory/transactions",
+      "/admin/inventory/cycle-count",
+      "/admin/spools",
+      // Operations
       "/admin/production",
-      "/admin/shipping",
-      "/admin/settings",
-      "/admin/accounting",
+      "/admin/manufacturing",
       "/admin/printers",
+      "/admin/filafarm",
+      "/admin/purchasing",
+      "/admin/shipping",
+      // Quality
+      "/admin/quality",
+      "/admin/quality/traceability",
+      // B2B Portal
+      "/admin/access-requests",
+      "/admin/catalogs",
+      "/admin/price-levels",
+      // Admin
+      "/admin/accounting",
+      "/admin/users",
+      "/admin/scrap-reasons",
+      "/admin/analytics",
+      "/admin/settings",
+      "/admin/security",
+      "/admin/command-center",
     ];
     for (const path of expectedPaths) {
+      expect(ROUTE_LABELS[path]).toBeDefined();
+    }
+  });
+
+  it("non-navigable paths are a subset of ROUTE_LABELS", () => {
+    for (const path of NON_NAVIGABLE_PATHS) {
       expect(ROUTE_LABELS[path]).toBeDefined();
     }
   });


### PR DESCRIPTION
## Feature 4: Breadcrumb Navigation

Adds a breadcrumb navigation component to the admin layout, providing users with clear wayfinding context as they navigate through the ERP.

### What's New

- **`Breadcrumbs` component** (`frontend/src/components/Breadcrumbs.jsx`)
  - Route-to-label mapping covering all ~35 admin routes
  - Nested path support (e.g., Dashboard > Inventory > Transactions)
  - Dynamic ID segments displayed as `#123` for detail pages (orders, production orders)
  - Auto-hides on dashboard root (no redundant single crumb)
  - Home icon for Dashboard link, chevron separators
  - Graceful fallback: unknown routes get title-cased segment names

- **AdminLayout integration**
  - Breadcrumbs render inside `<main>` above `<Outlet />`, scrolling with page content
  - Styled with CSS variables matching the neo-* dark theme

### Accessibility
- `<nav aria-label="Breadcrumb">` for landmark navigation
- `aria-current="page"` on the active (last) crumb
- Proper link semantics — all intermediate crumbs are navigable links

### Tests
- **14 tests** covering:
  - `buildBreadcrumbs()` logic: root, top-level, nested, dynamic IDs, UUIDs, unknown segments
  - Component rendering: hidden on dashboard, aria attributes, link structure, nested navigation
  - Route label coverage verification

### Results
- All 171 frontend unit tests pass (22 files)
- Zero regressions

Co-authored-by: Claude <claude@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation on admin pages to show your current location and provide quick links back through the hierarchy. Breadcrumbs are hidden on the admin dashboard and display dynamic IDs as “#ID” for clarity.
  * Certain intermediate items are rendered as plain text when not navigable.
* **Tests**
  * Added UI tests to verify breadcrumb labels, links, accessibility, and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->