### PR TITLE
fix(startup): remove create_all(), run alembic upgrade head in entrypoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -89,6 +89,7 @@ def init_database():
         logger.info("Database connection verified")
     except Exception as e:
         logger.error(f"Database connection check failed: {e}", exc_info=True)
+        raise
 
 
 def seed_default_data():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,16 +74,20 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 def init_database():
-    """Initialize database tables on startup (idempotent)."""
+    """Verify database connectivity on startup.
+
+    Schema management is handled exclusively by Alembic migrations
+    (run via `alembic upgrade head` in the Docker entrypoint before uvicorn
+    starts). create_all() is intentionally absent here — running it at startup
+    races with Alembic and causes DuplicateTable errors on every upgrade.
+    """
     try:
         from app.db.session import engine
-        from app.db.base import Base
-        import app.models  # noqa: F401
-        logger.info("Checking database tables...")
-        Base.metadata.create_all(bind=engine)
-        logger.info("Database tables ready")
+        with engine.connect() as conn:
+            conn.execute(__import__("sqlalchemy").text("SELECT 1"))
+        logger.info("Database connection verified")
     except Exception as e:
-        logger.error(f"Database initialization failed: {e}")
+        logger.error(f"Database connection check failed: {e}")
 
 
 def seed_default_data():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,11 +83,12 @@ def init_database():
     """
     try:
         from app.db.session import engine
+        from sqlalchemy import text
         with engine.connect() as conn:
-            conn.execute(__import__("sqlalchemy").text("SELECT 1"))
+            conn.execute(text("SELECT 1"))
         logger.info("Database connection verified")
     except Exception as e:
-        logger.error(f"Database connection check failed: {e}")
+        logger.error(f"Database connection check failed: {e}", exc_info=True)
 
 
 def seed_default_data():

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -54,6 +54,14 @@ if [ -n "$FILAOPS_LICENSE_KEY" ]; then
     fi
 fi
 
+# ─── Database Migrations ───
+# Run Alembic migrations before starting the app. This is the authoritative
+# schema management step — create_all() has been removed from app startup to
+# prevent DuplicateTable races on upgrades (see issue #516).
+echo "FilaOps: Running database migrations..."
+python -m alembic upgrade head
+echo "FilaOps: Migrations complete."
+
 # ─── Run Command ───
 if [ $# -gt 0 ]; then
     exec env FILAOPS_PRO_MODULE="$FILAOPS_PRO_MODULE" "$@"

--- a/backend/scripts/docker-entrypoint.sh
+++ b/backend/scripts/docker-entrypoint.sh
@@ -54,17 +54,16 @@ if [ -n "$FILAOPS_LICENSE_KEY" ]; then
     fi
 fi
 
-# ─── Database Migrations ───
-# Run Alembic migrations before starting the app. This is the authoritative
-# schema management step — create_all() has been removed from app startup to
-# prevent DuplicateTable races on upgrades (see issue #516).
-echo "FilaOps: Running database migrations..."
-python -m alembic upgrade head
-echo "FilaOps: Migrations complete."
-
 # ─── Run Command ───
 if [ $# -gt 0 ]; then
     exec env FILAOPS_PRO_MODULE="$FILAOPS_PRO_MODULE" "$@"
 else
+    # ─── Database Migrations ───
+    # Only run on the default uvicorn startup path. Custom commands (e.g. the
+    # migrate service running docker-migrate.sh) handle their own migrations with
+    # full error recovery and PRO plugin migration steps.
+    echo "FilaOps: Running database migrations..."
+    python -m alembic upgrade head
+    echo "FilaOps: Migrations complete."
     exec env FILAOPS_PRO_MODULE="$FILAOPS_PRO_MODULE" uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips '*'
 fi

--- a/frontend/src/pages/admin/AdminFilaFarm.jsx
+++ b/frontend/src/pages/admin/AdminFilaFarm.jsx
@@ -28,46 +28,6 @@ const JOB_STATUS_COLORS = {
   cancelled: "text-gray-500",
 };
 
-// Brand display names + default model suggestions
-const BRANDS = [
-  {
-    value: "bambulab",
-    label: "Bambu Lab",
-    models: ["A1", "A1 Mini", "P1S", "P1P", "X1C", "X1E"],
-  },
-  {
-    value: "klipper",
-    label: "Klipper / Moonraker",
-    models: ["Voron 2.4", "Voron Trident", "Creality K1", "Creality K1 Max", "Custom"],
-  },
-  {
-    value: "octoprint",
-    label: "OctoPrint",
-    models: ["Ender 3", "Ender 5", "CR-10", "Custom"],
-  },
-  {
-    value: "prusa",
-    label: "Prusa (PrusaLink)",
-    models: ["MK4", "MK3.9", "XL", "MINI+"],
-  },
-  {
-    value: "generic",
-    label: "Other / Generic",
-    models: ["Custom"],
-  },
-];
-
-const EMPTY_FORM = {
-  brand: "bambulab",
-  name: "",
-  model: "",
-  ip_address: "",
-  serial_number: "",
-  location: "",
-  notes: "",
-  connection_config: {},
-};
-
 function formatTime(seconds) {
   if (seconds == null) return "--";
   const h = Math.floor(seconds / 3600);
@@ -75,457 +35,7 @@ function formatTime(seconds) {
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
-// ─── Brand-specific connection fields ──────────────────────────────────────
-
-function BambuFields({ cfg, onChange }) {
-  return (
-    <>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          Serial Number <span className="text-red-400">*</span>
-          <span className="text-gray-500 ml-1">(from printer LCD or Bambu app)</span>
-        </label>
-        <input
-          type="text"
-          value={cfg.serial_number || ""}
-          onChange={(e) => onChange("serial_number", e.target.value)}
-          placeholder="e.g. 01P00A123456789"
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-        />
-      </div>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          Access Code <span className="text-red-400">*</span>
-          <span className="text-gray-500 ml-1">(8-char code from printer LCD)</span>
-        </label>
-        <input
-          type="text"
-          value={cfg.connection_config?.access_code || ""}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, access_code: e.target.value })
-          }
-          placeholder="e.g. 12345678"
-          maxLength={8}
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
-        />
-      </div>
-    </>
-  );
-}
-
-function KlipperFields({ cfg, onChange }) {
-  return (
-    <>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          Moonraker Port
-          <span className="text-gray-500 ml-1">(default 7125)</span>
-        </label>
-        <input
-          type="number"
-          value={cfg.connection_config?.port || 7125}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 7125 })
-          }
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-        />
-      </div>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          API Key
-          <span className="text-gray-500 ml-1">(optional — leave blank if not required)</span>
-        </label>
-        <input
-          type="text"
-          value={cfg.connection_config?.api_key || ""}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, api_key: e.target.value })
-          }
-          placeholder="Moonraker API key"
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-        />
-      </div>
-    </>
-  );
-}
-
-function OctoPrintFields({ cfg, onChange }) {
-  return (
-    <>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          OctoPrint Port
-          <span className="text-gray-500 ml-1">(default 5000)</span>
-        </label>
-        <input
-          type="number"
-          value={cfg.connection_config?.port || 5000}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 5000 })
-          }
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-        />
-      </div>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          API Key <span className="text-red-400">*</span>
-        </label>
-        <input
-          type="text"
-          value={cfg.connection_config?.api_key || ""}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, api_key: e.target.value })
-          }
-          placeholder="OctoPrint API key"
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-        />
-      </div>
-    </>
-  );
-}
-
-function PrusaFields({ cfg, onChange }) {
-  return (
-    <>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          PrusaLink Port
-          <span className="text-gray-500 ml-1">(default 8080)</span>
-        </label>
-        <input
-          type="number"
-          value={cfg.connection_config?.port || 8080}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 8080 })
-          }
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-        />
-      </div>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">Username</label>
-        <input
-          type="text"
-          value={cfg.connection_config?.username || "maker"}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, username: e.target.value })
-          }
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-        />
-      </div>
-      <div>
-        <label className="block text-xs text-gray-400 mb-1">
-          Password <span className="text-red-400">*</span>
-        </label>
-        <input
-          type="password"
-          value={cfg.connection_config?.password || ""}
-          onChange={(e) =>
-            onChange("connection_config", { ...cfg.connection_config, password: e.target.value })
-          }
-          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-        />
-      </div>
-    </>
-  );
-}
-
-// ─── Add / Edit Modal ──────────────────────────────────────────────────────
-
-function PrinterModal({ printer, onClose, onSave }) {
-  const api = useApi();
-  const toast = useToast();
-
-  const [form, setForm] = useState(
-    printer
-      ? {
-          brand: printer.brand || "bambulab",
-          name: printer.name || "",
-          model: printer.model || "",
-          ip_address: printer.ip_address || "",
-          serial_number: printer.serial_number || "",
-          location: printer.location || "",
-          notes: printer.notes || "",
-          connection_config: printer.connection_config || {},
-        }
-      : { ...EMPTY_FORM }
-  );
-
-  const [testResult, setTestResult] = useState(null); // {reachable, message, latency_ms}
-  const [testing, setTesting] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  const isEdit = !!printer;
-
-  const setField = (key, value) => setForm((prev) => ({ ...prev, [key]: value }));
-
-  const handleBrandChange = (brand) => {
-    setForm((prev) => ({
-      ...prev,
-      brand,
-      model: "",             // reset model on brand switch
-      connection_config: {}, // reset brand-specific extras
-    }));
-    setTestResult(null);
-  };
-
-  const handleTest = async () => {
-    if (!printer?.id) {
-      toast.error("Save the printer first, then test the connection.");
-      return;
-    }
-    setTesting(true);
-    setTestResult(null);
-    try {
-      const res = await api.post(
-        `/api/v1/pro/filafarm/printers/${printer.id}/test-connection`
-      );
-      setTestResult(res);
-    } catch (err) {
-      setTestResult({ reachable: false, message: err.message });
-    } finally {
-      setTesting(false);
-    }
-  };
-
-  const handleSave = async () => {
-    if (!form.name.trim()) {
-      toast.error("Printer name is required");
-      return;
-    }
-    if (!form.model.trim()) {
-      toast.error("Printer model is required");
-      return;
-    }
-    if (!form.ip_address.trim()) {
-      toast.error("IP address is required");
-      return;
-    }
-    if (form.brand === "bambulab") {
-      if (!form.serial_number.trim()) {
-        toast.error("Serial number is required for Bambu Lab printers");
-        return;
-      }
-      if (!form.connection_config?.access_code?.trim()) {
-        toast.error("Access code is required for Bambu Lab printers");
-        return;
-      }
-    }
-
-    setSaving(true);
-    try {
-      const payload = {
-        brand: form.brand,
-        name: form.name.trim(),
-        model: form.model.trim(),
-        ip_address: form.ip_address.trim(),
-        serial_number: form.serial_number.trim() || null,
-        location: form.location.trim() || null,
-        notes: form.notes.trim() || null,
-        connection_config: form.connection_config || {},
-      };
-
-      if (isEdit) {
-        await api.put(`/api/v1/pro/filafarm/printers/${printer.id}`, payload);
-        toast.success(`${form.name} updated`);
-      } else {
-        await api.post("/api/v1/pro/filafarm/printers", payload);
-        toast.success(`${form.name} added — connecting to fleet...`);
-      }
-      onSave();
-      onClose();
-    } catch (err) {
-      toast.error(err.message);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const brandMeta = BRANDS.find((b) => b.value === form.brand);
-
-  return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-700">
-          <h2 className="text-lg font-semibold text-white">
-            {isEdit ? "Edit Printer" : "Add Printer"}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-white text-xl leading-none"
-          >
-            ×
-          </button>
-        </div>
-
-        <div className="px-6 py-5 space-y-4">
-          {/* Brand selector — only shown when adding */}
-          {!isEdit && (
-            <div>
-              <label className="block text-xs text-gray-400 mb-1">Brand</label>
-              <div className="grid grid-cols-2 gap-2">
-                {BRANDS.map((b) => (
-                  <button
-                    key={b.value}
-                    type="button"
-                    onClick={() => handleBrandChange(b.value)}
-                    className={`px-3 py-2 rounded text-sm text-left transition-colors ${
-                      form.brand === b.value
-                        ? "bg-blue-600 text-white"
-                        : "bg-gray-700 text-gray-300 hover:bg-gray-600"
-                    }`}
-                  >
-                    {b.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Common fields */}
-          <div>
-            <label className="block text-xs text-gray-400 mb-1">
-              Printer Name <span className="text-red-400">*</span>
-            </label>
-            <input
-              type="text"
-              value={form.name}
-              onChange={(e) => setField("name", e.target.value)}
-              placeholder="e.g. BLB-A1-01"
-              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-            />
-          </div>
-
-          <div>
-            <label className="block text-xs text-gray-400 mb-1">
-              Model <span className="text-red-400">*</span>
-            </label>
-            {brandMeta?.models.length > 1 ? (
-              <select
-                value={form.model}
-                onChange={(e) => setField("model", e.target.value)}
-                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
-              >
-                <option value="">Select model…</option>
-                {brandMeta.models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-                <option value="__custom">Custom…</option>
-              </select>
-            ) : (
-              <input
-                type="text"
-                value={form.model}
-                onChange={(e) => setField("model", e.target.value)}
-                placeholder="Printer model"
-                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-              />
-            )}
-            {form.model === "__custom" && (
-              <input
-                type="text"
-                autoFocus
-                placeholder="Enter model name"
-                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-                onChange={(e) => setField("model", e.target.value)}
-              />
-            )}
-          </div>
-
-          <div>
-            <label className="block text-xs text-gray-400 mb-1">
-              IP Address <span className="text-red-400">*</span>
-            </label>
-            <input
-              type="text"
-              value={form.ip_address}
-              onChange={(e) => setField("ip_address", e.target.value)}
-              placeholder="e.g. 192.168.1.42"
-              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
-            />
-          </div>
-
-          {/* Brand-specific fields */}
-          {form.brand === "bambulab" && (
-            <BambuFields cfg={form} onChange={setField} />
-          )}
-          {form.brand === "klipper" && (
-            <KlipperFields cfg={form} onChange={setField} />
-          )}
-          {form.brand === "octoprint" && (
-            <OctoPrintFields cfg={form} onChange={setField} />
-          )}
-          {form.brand === "prusa" && (
-            <PrusaFields cfg={form} onChange={setField} />
-          )}
-
-          {/* Optional fields */}
-          <div>
-            <label className="block text-xs text-gray-400 mb-1">
-              Location
-              <span className="text-gray-500 ml-1">(optional — e.g. "Farm Room A")</span>
-            </label>
-            <input
-              type="text"
-              value={form.location}
-              onChange={(e) => setField("location", e.target.value)}
-              placeholder="Room / area"
-              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
-            />
-          </div>
-
-          {/* Test connection result */}
-          {testResult && (
-            <div
-              className={`rounded px-3 py-2 text-sm ${
-                testResult.reachable
-                  ? "bg-emerald-900/30 border border-emerald-700 text-emerald-300"
-                  : "bg-red-900/30 border border-red-700 text-red-300"
-              }`}
-            >
-              {testResult.reachable ? "✓ " : "✗ "}
-              {testResult.message}
-            </div>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-700 gap-3">
-          {isEdit && (
-            <button
-              onClick={handleTest}
-              disabled={testing}
-              className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600 disabled:opacity-50"
-            >
-              {testing ? "Testing…" : "Test Connection"}
-            </button>
-          )}
-          <div className="flex gap-2 ml-auto">
-            <button
-              onClick={onClose}
-              className="px-4 py-1.5 text-sm text-gray-400 hover:text-white rounded"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50"
-            >
-              {saving ? "Saving…" : isEdit ? "Save Changes" : "Add Printer"}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Printer card ──────────────────────────────────────────────────────────
-
-function PrinterCard({ printer, onCommand, onEdit, onRemove }) {
+function PrinterCard({ printer, onCommand }) {
   const colors = STATUS_COLORS[printer.status] || STATUS_COLORS.offline;
   const isPrinting = printer.status === "printing";
 
@@ -533,35 +43,17 @@ function PrinterCard({ printer, onCommand, onEdit, onRemove }) {
     <div
       className={`${colors.bg} border border-gray-700 rounded-lg p-4 hover:border-gray-500 transition-colors`}
     >
-      <div className="flex items-start justify-between mb-2">
-        <div className="flex-1 min-w-0">
-          <h3 className="font-medium text-white truncate">{printer.name}</h3>
-          <p className="text-xs text-gray-500 mt-0.5">{printer.model}</p>
-        </div>
-        <div className="flex items-center gap-2 ml-2 shrink-0">
-          <span className={`flex items-center gap-1.5 text-xs ${colors.text}`}>
-            <span
-              className={`w-2 h-2 rounded-full ${colors.dot} ${isPrinting ? "animate-pulse" : ""}`}
-            />
-            {printer.status}
-          </span>
-          {/* Edit / Remove */}
-          <button
-            onClick={() => onEdit(printer)}
-            title="Edit printer"
-            className="text-gray-500 hover:text-gray-300 text-xs p-0.5"
-          >
-            ✎
-          </button>
-          <button
-            onClick={() => onRemove(printer)}
-            title="Remove printer"
-            className="text-gray-600 hover:text-red-400 text-xs p-0.5"
-          >
-            ✕
-          </button>
-        </div>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-medium text-white truncate">{printer.name}</h3>
+        <span className={`flex items-center gap-1.5 text-xs ${colors.text}`}>
+          <span
+            className={`w-2 h-2 rounded-full ${colors.dot} ${isPrinting ? "animate-pulse" : ""}`}
+          />
+          {printer.status}
+        </span>
       </div>
+
+      <p className="text-xs text-gray-500 mb-3">{printer.model}</p>
 
       {/* Temps */}
       <div className="flex gap-4 text-xs text-gray-400 mb-2">
@@ -637,39 +129,6 @@ function PrinterCard({ printer, onCommand, onEdit, onRemove }) {
   );
 }
 
-// ─── Remove confirmation dialog ────────────────────────────────────────────
-
-function RemoveConfirm({ printer, onConfirm, onCancel }) {
-  return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-sm p-6">
-        <h3 className="text-base font-semibold text-white mb-2">Remove Printer</h3>
-        <p className="text-sm text-gray-400 mb-6">
-          Remove <span className="text-white font-medium">{printer.name}</span> from
-          FilaFarm? Print job history is kept. This can be undone by re-adding the
-          printer.
-        </p>
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onCancel}
-            className="px-4 py-1.5 text-sm text-gray-400 hover:text-white rounded"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={onConfirm}
-            className="px-4 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-500"
-          >
-            Remove
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Job row ───────────────────────────────────────────────────────────────
-
 function JobRow({ job }) {
   const statusColor = JOB_STATUS_COLORS[job.status] || "text-gray-400";
   return (
@@ -690,26 +149,17 @@ function JobRow({ job }) {
   );
 }
 
-// ─── Main page ─────────────────────────────────────────────────────────────
-
 export default function AdminFilaFarm() {
   const api = useApi();
   const toast = useToast();
   const { isPro, hasFeature, loading: flagsLoading } = useFeatureFlags();
   const hasFilaFarmAccess = isPro && hasFeature("filafarm");
-
   const [printers, setPrinters] = useState([]);
   const [jobs, setJobs] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState("printers");
-
-  // Modal state
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [editingPrinter, setEditingPrinter] = useState(null);   // printer object or null
-  const [removingPrinter, setRemovingPrinter] = useState(null); // printer object or null
-
   const refreshRef = useRef(null);
   const commandTimeoutRef = useRef(null);
 
@@ -767,18 +217,6 @@ export default function AdminFilaFarm() {
     }
   };
 
-  const handleRemoveConfirm = async () => {
-    if (!removingPrinter) return;
-    try {
-      await api.del(`/api/v1/pro/filafarm/printers/${removingPrinter.id}`);
-      toast.success(`${removingPrinter.name} removed`);
-      setRemovingPrinter(null);
-      fetchData();
-    } catch (err) {
-      toast.error(err.message);
-    }
-  };
-
   if (flagsLoading) {
     return (
       <div className="p-6 flex justify-center">
@@ -819,25 +257,6 @@ export default function AdminFilaFarm() {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Modals */}
-      {(showAddModal || editingPrinter) && (
-        <PrinterModal
-          printer={editingPrinter}
-          onClose={() => {
-            setShowAddModal(false);
-            setEditingPrinter(null);
-          }}
-          onSave={fetchData}
-        />
-      )}
-      {removingPrinter && (
-        <RemoveConfirm
-          printer={removingPrinter}
-          onConfirm={handleRemoveConfirm}
-          onCancel={() => setRemovingPrinter(null)}
-        />
-      )}
-
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -846,20 +265,12 @@ export default function AdminFilaFarm() {
             Printer automation & job management
           </p>
         </div>
-        <div className="flex gap-2">
-          <button
-            onClick={fetchData}
-            className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600"
-          >
-            ↻ Refresh
-          </button>
-          <button
-            onClick={() => setShowAddModal(true)}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-500"
-          >
-            + Add Printer
-          </button>
-        </div>
+        <button
+          onClick={fetchData}
+          className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600"
+        >
+          ↻ Refresh
+        </button>
       </div>
 
       {/* Stats row */}
@@ -931,34 +342,18 @@ export default function AdminFilaFarm() {
         <div>
           {printers.length === 0 ? (
             <div className="bg-gray-800 rounded-lg p-8 text-center">
-              <svg
-                className="w-10 h-10 text-gray-600 mx-auto mb-3"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M17 17H7a2 2 0 01-2-2V9a2 2 0 012-2h10a2 2 0 012 2v6a2 2 0 01-2 2zM12 12h.01"
-                />
-              </svg>
-              <p className="text-gray-300 font-medium mb-1">No printers yet</p>
-              <p className="text-gray-500 text-sm mb-4">
-                Add your first printer to start automating your print farm.
+              <p className="text-gray-400">No printers connected</p>
+              <p className="text-gray-500 text-sm mt-2">
+                Configure printers in FilaFarm edge service, then connect via
+                MQTT.
               </p>
-              <button
-                onClick={() => setShowAddModal(true)}
-                className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-500"
-              >
-                + Add Printer
-              </button>
             </div>
           ) : (
             <>
               <div className="flex gap-4 mb-4 text-sm">
-                <span className="text-emerald-400">{printingCount} printing</span>
+                <span className="text-emerald-400">
+                  {printingCount} printing
+                </span>
                 <span className="text-gray-400">{idleCount} idle</span>
                 {errorCount > 0 && (
                   <span className="text-red-400">{errorCount} error</span>
@@ -970,8 +365,6 @@ export default function AdminFilaFarm() {
                     key={printer.id}
                     printer={printer}
                     onCommand={handleCommand}
-                    onEdit={setEditingPrinter}
-                    onRemove={setRemovingPrinter}
                   />
                 ))}
               </div>
@@ -992,12 +385,24 @@ export default function AdminFilaFarm() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-gray-700 text-left">
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Job</th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Status</th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Printer</th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Progress</th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Est. Time</th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Priority</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Job
+                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Status
+                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Printer
+                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Progress
+                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Est. Time
+                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
+                      Priority
+                    </th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/pages/admin/AdminFilaFarm.jsx
+++ b/frontend/src/pages/admin/AdminFilaFarm.jsx
@@ -28,6 +28,46 @@ const JOB_STATUS_COLORS = {
   cancelled: "text-gray-500",
 };
 
+// Brand display names + default model suggestions
+const BRANDS = [
+  {
+    value: "bambulab",
+    label: "Bambu Lab",
+    models: ["A1", "A1 Mini", "P1S", "P1P", "X1C", "X1E"],
+  },
+  {
+    value: "klipper",
+    label: "Klipper / Moonraker",
+    models: ["Voron 2.4", "Voron Trident", "Creality K1", "Creality K1 Max", "Custom"],
+  },
+  {
+    value: "octoprint",
+    label: "OctoPrint",
+    models: ["Ender 3", "Ender 5", "CR-10", "Custom"],
+  },
+  {
+    value: "prusa",
+    label: "Prusa (PrusaLink)",
+    models: ["MK4", "MK3.9", "XL", "MINI+"],
+  },
+  {
+    value: "generic",
+    label: "Other / Generic",
+    models: ["Custom"],
+  },
+];
+
+const EMPTY_FORM = {
+  brand: "bambulab",
+  name: "",
+  model: "",
+  ip_address: "",
+  serial_number: "",
+  location: "",
+  notes: "",
+  connection_config: {},
+};
+
 function formatTime(seconds) {
   if (seconds == null) return "--";
   const h = Math.floor(seconds / 3600);
@@ -35,7 +75,457 @@ function formatTime(seconds) {
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
-function PrinterCard({ printer, onCommand }) {
+// ─── Brand-specific connection fields ──────────────────────────────────────
+
+function BambuFields({ cfg, onChange }) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          Serial Number <span className="text-red-400">*</span>
+          <span className="text-gray-500 ml-1">(from printer LCD or Bambu app)</span>
+        </label>
+        <input
+          type="text"
+          value={cfg.serial_number || ""}
+          onChange={(e) => onChange("serial_number", e.target.value)}
+          placeholder="e.g. 01P00A123456789"
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          Access Code <span className="text-red-400">*</span>
+          <span className="text-gray-500 ml-1">(8-char code from printer LCD)</span>
+        </label>
+        <input
+          type="text"
+          value={cfg.connection_config?.access_code || ""}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, access_code: e.target.value })
+          }
+          placeholder="e.g. 12345678"
+          maxLength={8}
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
+        />
+      </div>
+    </>
+  );
+}
+
+function KlipperFields({ cfg, onChange }) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          Moonraker Port
+          <span className="text-gray-500 ml-1">(default 7125)</span>
+        </label>
+        <input
+          type="number"
+          value={cfg.connection_config?.port || 7125}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 7125 })
+          }
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          API Key
+          <span className="text-gray-500 ml-1">(optional — leave blank if not required)</span>
+        </label>
+        <input
+          type="text"
+          value={cfg.connection_config?.api_key || ""}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, api_key: e.target.value })
+          }
+          placeholder="Moonraker API key"
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+        />
+      </div>
+    </>
+  );
+}
+
+function OctoPrintFields({ cfg, onChange }) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          OctoPrint Port
+          <span className="text-gray-500 ml-1">(default 5000)</span>
+        </label>
+        <input
+          type="number"
+          value={cfg.connection_config?.port || 5000}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 5000 })
+          }
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          API Key <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="text"
+          value={cfg.connection_config?.api_key || ""}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, api_key: e.target.value })
+          }
+          placeholder="OctoPrint API key"
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+        />
+      </div>
+    </>
+  );
+}
+
+function PrusaFields({ cfg, onChange }) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          PrusaLink Port
+          <span className="text-gray-500 ml-1">(default 8080)</span>
+        </label>
+        <input
+          type="number"
+          value={cfg.connection_config?.port || 8080}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, port: parseInt(e.target.value) || 8080 })
+          }
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Username</label>
+        <input
+          type="text"
+          value={cfg.connection_config?.username || "maker"}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, username: e.target.value })
+          }
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">
+          Password <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="password"
+          value={cfg.connection_config?.password || ""}
+          onChange={(e) =>
+            onChange("connection_config", { ...cfg.connection_config, password: e.target.value })
+          }
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+        />
+      </div>
+    </>
+  );
+}
+
+// ─── Add / Edit Modal ──────────────────────────────────────────────────────
+
+function PrinterModal({ printer, onClose, onSave }) {
+  const api = useApi();
+  const toast = useToast();
+
+  const [form, setForm] = useState(
+    printer
+      ? {
+          brand: printer.brand || "bambulab",
+          name: printer.name || "",
+          model: printer.model || "",
+          ip_address: printer.ip_address || "",
+          serial_number: printer.serial_number || "",
+          location: printer.location || "",
+          notes: printer.notes || "",
+          connection_config: printer.connection_config || {},
+        }
+      : { ...EMPTY_FORM }
+  );
+
+  const [testResult, setTestResult] = useState(null); // {reachable, message, latency_ms}
+  const [testing, setTesting] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = !!printer;
+
+  const setField = (key, value) => setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleBrandChange = (brand) => {
+    setForm((prev) => ({
+      ...prev,
+      brand,
+      model: "",             // reset model on brand switch
+      connection_config: {}, // reset brand-specific extras
+    }));
+    setTestResult(null);
+  };
+
+  const handleTest = async () => {
+    if (!printer?.id) {
+      toast.error("Save the printer first, then test the connection.");
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await api.post(
+        `/api/v1/pro/filafarm/printers/${printer.id}/test-connection`
+      );
+      setTestResult(res);
+    } catch (err) {
+      setTestResult({ reachable: false, message: err.message });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      toast.error("Printer name is required");
+      return;
+    }
+    if (!form.model.trim()) {
+      toast.error("Printer model is required");
+      return;
+    }
+    if (!form.ip_address.trim()) {
+      toast.error("IP address is required");
+      return;
+    }
+    if (form.brand === "bambulab") {
+      if (!form.serial_number.trim()) {
+        toast.error("Serial number is required for Bambu Lab printers");
+        return;
+      }
+      if (!form.connection_config?.access_code?.trim()) {
+        toast.error("Access code is required for Bambu Lab printers");
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      const payload = {
+        brand: form.brand,
+        name: form.name.trim(),
+        model: form.model.trim(),
+        ip_address: form.ip_address.trim(),
+        serial_number: form.serial_number.trim() || null,
+        location: form.location.trim() || null,
+        notes: form.notes.trim() || null,
+        connection_config: form.connection_config || {},
+      };
+
+      if (isEdit) {
+        await api.put(`/api/v1/pro/filafarm/printers/${printer.id}`, payload);
+        toast.success(`${form.name} updated`);
+      } else {
+        await api.post("/api/v1/pro/filafarm/printers", payload);
+        toast.success(`${form.name} added — connecting to fleet...`);
+      }
+      onSave();
+      onClose();
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const brandMeta = BRANDS.find((b) => b.value === form.brand);
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-700">
+          <h2 className="text-lg font-semibold text-white">
+            {isEdit ? "Edit Printer" : "Add Printer"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white text-xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          {/* Brand selector — only shown when adding */}
+          {!isEdit && (
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">Brand</label>
+              <div className="grid grid-cols-2 gap-2">
+                {BRANDS.map((b) => (
+                  <button
+                    key={b.value}
+                    type="button"
+                    onClick={() => handleBrandChange(b.value)}
+                    className={`px-3 py-2 rounded text-sm text-left transition-colors ${
+                      form.brand === b.value
+                        ? "bg-blue-600 text-white"
+                        : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+                    }`}
+                  >
+                    {b.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Common fields */}
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              Printer Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setField("name", e.target.value)}
+              placeholder="e.g. BLB-A1-01"
+              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              Model <span className="text-red-400">*</span>
+            </label>
+            {brandMeta?.models.length > 1 ? (
+              <select
+                value={form.model}
+                onChange={(e) => setField("model", e.target.value)}
+                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+              >
+                <option value="">Select model…</option>
+                {brandMeta.models.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+                <option value="__custom">Custom…</option>
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={form.model}
+                onChange={(e) => setField("model", e.target.value)}
+                placeholder="Printer model"
+                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+              />
+            )}
+            {form.model === "__custom" && (
+              <input
+                type="text"
+                autoFocus
+                placeholder="Enter model name"
+                className="mt-1 w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                onChange={(e) => setField("model", e.target.value)}
+              />
+            )}
+          </div>
+
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              IP Address <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={form.ip_address}
+              onChange={(e) => setField("ip_address", e.target.value)}
+              placeholder="e.g. 192.168.1.42"
+              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono"
+            />
+          </div>
+
+          {/* Brand-specific fields */}
+          {form.brand === "bambulab" && (
+            <BambuFields cfg={form} onChange={setField} />
+          )}
+          {form.brand === "klipper" && (
+            <KlipperFields cfg={form} onChange={setField} />
+          )}
+          {form.brand === "octoprint" && (
+            <OctoPrintFields cfg={form} onChange={setField} />
+          )}
+          {form.brand === "prusa" && (
+            <PrusaFields cfg={form} onChange={setField} />
+          )}
+
+          {/* Optional fields */}
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">
+              Location
+              <span className="text-gray-500 ml-1">(optional — e.g. "Farm Room A")</span>
+            </label>
+            <input
+              type="text"
+              value={form.location}
+              onChange={(e) => setField("location", e.target.value)}
+              placeholder="Room / area"
+              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          {/* Test connection result */}
+          {testResult && (
+            <div
+              className={`rounded px-3 py-2 text-sm ${
+                testResult.reachable
+                  ? "bg-emerald-900/30 border border-emerald-700 text-emerald-300"
+                  : "bg-red-900/30 border border-red-700 text-red-300"
+              }`}
+            >
+              {testResult.reachable ? "✓ " : "✗ "}
+              {testResult.message}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-700 gap-3">
+          {isEdit && (
+            <button
+              onClick={handleTest}
+              disabled={testing}
+              className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600 disabled:opacity-50"
+            >
+              {testing ? "Testing…" : "Test Connection"}
+            </button>
+          )}
+          <div className="flex gap-2 ml-auto">
+            <button
+              onClick={onClose}
+              className="px-4 py-1.5 text-sm text-gray-400 hover:text-white rounded"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50"
+            >
+              {saving ? "Saving…" : isEdit ? "Save Changes" : "Add Printer"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Printer card ──────────────────────────────────────────────────────────
+
+function PrinterCard({ printer, onCommand, onEdit, onRemove }) {
   const colors = STATUS_COLORS[printer.status] || STATUS_COLORS.offline;
   const isPrinting = printer.status === "printing";
 
@@ -43,17 +533,35 @@ function PrinterCard({ printer, onCommand }) {
     <div
       className={`${colors.bg} border border-gray-700 rounded-lg p-4 hover:border-gray-500 transition-colors`}
     >
-      <div className="flex items-center justify-between mb-2">
-        <h3 className="font-medium text-white truncate">{printer.name}</h3>
-        <span className={`flex items-center gap-1.5 text-xs ${colors.text}`}>
-          <span
-            className={`w-2 h-2 rounded-full ${colors.dot} ${isPrinting ? "animate-pulse" : ""}`}
-          />
-          {printer.status}
-        </span>
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium text-white truncate">{printer.name}</h3>
+          <p className="text-xs text-gray-500 mt-0.5">{printer.model}</p>
+        </div>
+        <div className="flex items-center gap-2 ml-2 shrink-0">
+          <span className={`flex items-center gap-1.5 text-xs ${colors.text}`}>
+            <span
+              className={`w-2 h-2 rounded-full ${colors.dot} ${isPrinting ? "animate-pulse" : ""}`}
+            />
+            {printer.status}
+          </span>
+          {/* Edit / Remove */}
+          <button
+            onClick={() => onEdit(printer)}
+            title="Edit printer"
+            className="text-gray-500 hover:text-gray-300 text-xs p-0.5"
+          >
+            ✎
+          </button>
+          <button
+            onClick={() => onRemove(printer)}
+            title="Remove printer"
+            className="text-gray-600 hover:text-red-400 text-xs p-0.5"
+          >
+            ✕
+          </button>
+        </div>
       </div>
-
-      <p className="text-xs text-gray-500 mb-3">{printer.model}</p>
 
       {/* Temps */}
       <div className="flex gap-4 text-xs text-gray-400 mb-2">
@@ -129,6 +637,39 @@ function PrinterCard({ printer, onCommand }) {
   );
 }
 
+// ─── Remove confirmation dialog ────────────────────────────────────────────
+
+function RemoveConfirm({ printer, onConfirm, onCancel }) {
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl w-full max-w-sm p-6">
+        <h3 className="text-base font-semibold text-white mb-2">Remove Printer</h3>
+        <p className="text-sm text-gray-400 mb-6">
+          Remove <span className="text-white font-medium">{printer.name}</span> from
+          FilaFarm? Print job history is kept. This can be undone by re-adding the
+          printer.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-4 py-1.5 text-sm text-gray-400 hover:text-white rounded"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-500"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Job row ───────────────────────────────────────────────────────────────
+
 function JobRow({ job }) {
   const statusColor = JOB_STATUS_COLORS[job.status] || "text-gray-400";
   return (
@@ -149,17 +690,26 @@ function JobRow({ job }) {
   );
 }
 
+// ─── Main page ─────────────────────────────────────────────────────────────
+
 export default function AdminFilaFarm() {
   const api = useApi();
   const toast = useToast();
   const { isPro, hasFeature, loading: flagsLoading } = useFeatureFlags();
   const hasFilaFarmAccess = isPro && hasFeature("filafarm");
+
   const [printers, setPrinters] = useState([]);
   const [jobs, setJobs] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState("printers");
+
+  // Modal state
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [editingPrinter, setEditingPrinter] = useState(null);   // printer object or null
+  const [removingPrinter, setRemovingPrinter] = useState(null); // printer object or null
+
   const refreshRef = useRef(null);
   const commandTimeoutRef = useRef(null);
 
@@ -217,6 +767,18 @@ export default function AdminFilaFarm() {
     }
   };
 
+  const handleRemoveConfirm = async () => {
+    if (!removingPrinter) return;
+    try {
+      await api.del(`/api/v1/pro/filafarm/printers/${removingPrinter.id}`);
+      toast.success(`${removingPrinter.name} removed`);
+      setRemovingPrinter(null);
+      fetchData();
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
   if (flagsLoading) {
     return (
       <div className="p-6 flex justify-center">
@@ -257,6 +819,25 @@ export default function AdminFilaFarm() {
 
   return (
     <div className="p-6 space-y-6">
+      {/* Modals */}
+      {(showAddModal || editingPrinter) && (
+        <PrinterModal
+          printer={editingPrinter}
+          onClose={() => {
+            setShowAddModal(false);
+            setEditingPrinter(null);
+          }}
+          onSave={fetchData}
+        />
+      )}
+      {removingPrinter && (
+        <RemoveConfirm
+          printer={removingPrinter}
+          onConfirm={handleRemoveConfirm}
+          onCancel={() => setRemovingPrinter(null)}
+        />
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -265,12 +846,20 @@ export default function AdminFilaFarm() {
             Printer automation & job management
           </p>
         </div>
-        <button
-          onClick={fetchData}
-          className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600"
-        >
-          ↻ Refresh
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={fetchData}
+            className="px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600"
+          >
+            ↻ Refresh
+          </button>
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-500"
+          >
+            + Add Printer
+          </button>
+        </div>
       </div>
 
       {/* Stats row */}
@@ -342,18 +931,34 @@ export default function AdminFilaFarm() {
         <div>
           {printers.length === 0 ? (
             <div className="bg-gray-800 rounded-lg p-8 text-center">
-              <p className="text-gray-400">No printers connected</p>
-              <p className="text-gray-500 text-sm mt-2">
-                Configure printers in FilaFarm edge service, then connect via
-                MQTT.
+              <svg
+                className="w-10 h-10 text-gray-600 mx-auto mb-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M17 17H7a2 2 0 01-2-2V9a2 2 0 012-2h10a2 2 0 012 2v6a2 2 0 01-2 2zM12 12h.01"
+                />
+              </svg>
+              <p className="text-gray-300 font-medium mb-1">No printers yet</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Add your first printer to start automating your print farm.
               </p>
+              <button
+                onClick={() => setShowAddModal(true)}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-500"
+              >
+                + Add Printer
+              </button>
             </div>
           ) : (
             <>
               <div className="flex gap-4 mb-4 text-sm">
-                <span className="text-emerald-400">
-                  {printingCount} printing
-                </span>
+                <span className="text-emerald-400">{printingCount} printing</span>
                 <span className="text-gray-400">{idleCount} idle</span>
                 {errorCount > 0 && (
                   <span className="text-red-400">{errorCount} error</span>
@@ -365,6 +970,8 @@ export default function AdminFilaFarm() {
                     key={printer.id}
                     printer={printer}
                     onCommand={handleCommand}
+                    onEdit={setEditingPrinter}
+                    onRemove={setRemovingPrinter}
                   />
                 ))}
               </div>
@@ -385,24 +992,12 @@ export default function AdminFilaFarm() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-gray-700 text-left">
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Job
-                    </th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Status
-                    </th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Printer
-                    </th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Progress
-                    </th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Est. Time
-                    </th>
-                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">
-                      Priority
-                    </th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Job</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Status</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Printer</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Progress</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Est. Time</th>
+                    <th className="py-2 px-3 text-xs font-medium text-gray-500 uppercase">Priority</th>
                   </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary

Fixes the `DuplicateTable` error that required a manual `alembic stamp head` workaround on every version upgrade.

**Root cause**: `create_all()` ran at app startup before Alembic, creating tables directly. When `alembic upgrade head` ran next, Postgres rejected the `CREATE TABLE` statements with `DuplicateTable` because the tables already existed.

## Changes

- **`backend/app/main.py`**: Replaced `create_all()` with a lightweight `SELECT 1` connectivity check. Schema management is now exclusively Alembic's responsibility. Comment explains why `create_all()` is absent (to prevent future well-meaning re-additions).
- **`backend/scripts/docker-entrypoint.sh`**: Added `python -m alembic upgrade head` before `exec uvicorn`, so migrations are always current before the app accepts traffic.

## What stays the same
- Test fixtures (`conftest.py`) still use `create_all()` for the test DB — that's the correct and appropriate use.
- `seed_default_data()` is unchanged — that's data seeding, not schema creation.
- Dev (`uvicorn` direct) still works — just run `alembic upgrade head` manually once, same as before.

## Test plan
- [x] `python -c "from app.main import init_database, app"` — imports clean
- [x] Endpoint test suite passes (exit 0)
- [x] `ruff check backend/app/main.py` — clean

Closes #516

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Startup now verifies database connectivity and runs schema migrations before the app launches; the application no longer attempts in-process schema creation at runtime.
* **New Features**
  * Admin UI: brand-aware printer management with add/edit/remove flows, brand-specific connection fields, inline edit/remove controls, remove confirmation, and test-connection support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->