### PR TITLE
fix: pass X-Forwarded-Proto from upstream proxy in nginx config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,12 @@
+# Sanitize the upstream X-Forwarded-Proto header so only "http" or "https"
+# are forwarded to the backend. Anything else (e.g. attacker-injected values)
+# falls back to nginx's local $scheme, preventing insecure redirect manipulation.
+map $http_x_forwarded_proto $forwarded_proto {
+    ~^(?i:https)$  https;
+    ~^(?i:http)$   http;
+    default        $scheme;
+}
+
 server {
     listen 8080;
     server_name localhost;
@@ -21,7 +30,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         # Use the proto forwarded by the upstream proxy (e.g. Cloudflare) rather
         # than nginx's local scheme, which is always http behind a TLS terminator.
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # $forwarded_proto is sanitized by the map block above (only http/https allowed).
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
     # Proxy static uploads (product images etc.) from the backend
@@ -43,7 +53,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
     # Cache static assets

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,7 +19,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        # Use the proto forwarded by the upstream proxy (e.g. Cloudflare) rather
+        # than nginx's local scheme, which is always http behind a TLS terminator.
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
     # Proxy static uploads (product images etc.) from the backend
@@ -41,7 +43,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
     # Cache static assets


### PR DESCRIPTION
## Summary

- `nginx`'s `$scheme` variable is always `http` when the container sits behind a TLS-terminating reverse proxy (Cloudflare Tunnel, Caddy, AWS ALB, etc.)
- This caused FastAPI's automatic trailing-slash redirects (`307`) to generate `http://` redirect URLs
- Browsers followed the redirect but the auth token was stripped in the process, booting users back to the login page ~10 seconds after signing in
- Fix: use `$http_x_forwarded_proto` to pass through the protocol the upstream proxy already set correctly

## Affected deployments

Any self-hosted instance running behind a TLS terminator — which is the recommended production setup. Bare `docker compose up` on localhost (HTTP only) is unaffected since `$http_x_forwarded_proto` falls back to empty and uvicorn generates relative redirects.

## Test plan

- [x] Reproduced on local VM behind Cloudflare Tunnel — login kicked user out after ~10s
- [x] Applied fix via nginx config volume mount — login now persists correctly
- [ ] Verify on a clean docker compose stack behind Caddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse-proxy forwarding of protocol information so backend services reliably receive a sanitized HTTP/HTTPS value from upstream proxies. This ensures correct handling of secure connections for API and portal traffic behind load balancers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->