### PR TITLE
feat(#534): wire filament diameter — materials API + PrinterModal checkboxes

### DIFF
--- a/backend/app/api/v1/endpoints/materials.py
+++ b/backend/app/api/v1/endpoints/materials.py
@@ -4,7 +4,7 @@ Material API Endpoints
 Provides material type and color options for the quote portal.
 Uses material_service for business logic (ARCHITECT-003).
 """
-from typing import List
+from typing import List, Literal
 from fastapi import APIRouter, Depends, HTTPException, File, UploadFile, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session, contains_eager
@@ -115,7 +115,7 @@ class MaterialTypeItem(BaseModel):
 
 class MaterialTypePatch(BaseModel):
     """Payload for PATCH /types/{code}"""
-    filament_diameter: float
+    filament_diameter: Literal[1.75, 2.85]
 
 
 class MaterialTypesResponse(BaseModel):

--- a/backend/app/api/v1/endpoints/materials.py
+++ b/backend/app/api/v1/endpoints/materials.py
@@ -110,6 +110,12 @@ class MaterialTypeItem(BaseModel):
     price_multiplier: float
     strength_rating: int | None
     requires_enclosure: bool
+    filament_diameter: float = 1.75
+
+
+class MaterialTypePatch(BaseModel):
+    """Payload for PATCH /types/{code}"""
+    filament_diameter: float
 
 
 class MaterialTypesResponse(BaseModel):
@@ -218,12 +224,45 @@ def list_material_types(
                     "price_multiplier": float(m.price_multiplier),
                     "strength_rating": m.strength_rating,
                     "requires_enclosure": m.requires_enclosure,
+                    "filament_diameter": float(m.filament_diameter),
                 }
                 for m in materials
             ]
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch("/types/{material_type_code}", response_model=MaterialTypeItem)
+def update_material_type(
+    material_type_code: str,
+    body: MaterialTypePatch,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> MaterialTypeItem:
+    """Update a material type's attributes (admin only). Currently supports filament_diameter."""
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    from app.models.material import MaterialType
+    mt = db.query(MaterialType).filter(MaterialType.code == material_type_code).first()
+    if not mt:
+        raise HTTPException(status_code=404, detail=f"Material type not found: {material_type_code}")
+
+    mt.filament_diameter = body.filament_diameter
+    db.commit()
+    db.refresh(mt)
+
+    return MaterialTypeItem(
+        code=mt.code,
+        name=mt.name,
+        base_material=mt.base_material,
+        description=mt.description,
+        price_multiplier=float(mt.price_multiplier),
+        strength_rating=mt.strength_rating,
+        requires_enclosure=mt.requires_enclosure,
+        filament_diameter=float(mt.filament_diameter),
+    )
 
 
 @router.get("/types/{material_type_code}/colors", response_model=ColorsResponse)

--- a/frontend/src/components/printers/PrinterModal.jsx
+++ b/frontend/src/components/printers/PrinterModal.jsx
@@ -63,13 +63,14 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
 
       // Build payload with connection_config for brand-specific settings
       const { access_code, filament_diameters, ...rest } = form;
+      const capabilities = { ...(printer?.capabilities || {}) };
+      if (filament_diameters.length > 0) {
+        capabilities.filament_diameters = filament_diameters;
+      }
       const payload = {
         ...rest,
         connection_config: access_code ? { access_code } : {},
-        capabilities: {
-          ...(printer?.capabilities || {}),
-          filament_diameters,
-        },
+        capabilities,
       };
 
       const res = await fetch(url, {

--- a/frontend/src/components/printers/PrinterModal.jsx
+++ b/frontend/src/components/printers/PrinterModal.jsx
@@ -25,6 +25,7 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
     work_center_id: printer?.work_center_id || "",
     notes: printer?.notes || "",
     active: printer?.active !== false,
+    filament_diameters: printer?.capabilities?.filament_diameters || [],
   });
 
   const isEdit = !!printer;
@@ -61,10 +62,14 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
         : `${API_URL}/api/v1/printers`;
 
       // Build payload with connection_config for brand-specific settings
-      const { access_code, ...rest } = form;
+      const { access_code, filament_diameters, ...rest } = form;
       const payload = {
         ...rest,
         connection_config: access_code ? { access_code } : {},
+        capabilities: {
+          ...(printer?.capabilities || {}),
+          filament_diameters,
+        },
       };
 
       const res = await fetch(url, {
@@ -88,6 +93,15 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
     } finally {
       setLoading(false);
     }
+  };
+
+  const toggleDiameter = (d) => {
+    setForm((f) => ({
+      ...f,
+      filament_diameters: f.filament_diameters.includes(d)
+        ? f.filament_diameters.filter((x) => x !== d)
+        : [...f.filament_diameters, d],
+    }));
   };
 
   const generateCode = async () => {
@@ -264,6 +278,24 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo }) {
                 <option key={wc.id} value={wc.id}>{wc.name}</option>
               ))}
             </select>
+          </div>
+
+          {/* Supported Filament Diameters */}
+          <div>
+            <label className="block text-sm text-gray-300 mb-2">Supported Diameters</label>
+            <div className="flex gap-6">
+              {[1.75, 2.85].map((d) => (
+                <label key={d} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={form.filament_diameters.includes(d)}
+                    onChange={() => toggleDiameter(d)}
+                    className="w-4 h-4 rounded bg-gray-800 border-gray-700 text-blue-500 focus:ring-blue-500"
+                  />
+                  <span className="text-sm text-gray-300">{d} mm</span>
+                </label>
+              ))}
+            </div>
           </div>
 
           {/* Notes */}


### PR DESCRIPTION
## Summary

Closes #534

- **Backend:** expose `filament_diameter` in `GET /materials/types` response and add `PATCH /materials/types/{code}` endpoint so admins can set it. No migration needed — `MaterialType.filament_diameter` already has `server_default='1.75'`.
- **Frontend:** add 1.75 mm / 2.85 mm checkboxes to `PrinterModal`. Values round-trip through `printer.capabilities.filament_diameters` and merge with any other capability flags on save.
- **Compatibility warnings:** the `OperationSchedulerModal` already calls `check_material_printer()` which reads `capabilities.filament_diameters` — no changes needed there. Warnings appear automatically once printers have diameters set.

## Test plan

- [ ] Add a printer → check 1.75 mm and save → edit the same printer → both checkboxes reflect saved state
- [ ] Add a printer with 2.85 mm only → schedule a job with a 1.75 mm material type → verify compatibility warning surfaces in `OperationSchedulerModal`
- [ ] `GET /api/v1/materials/types` returns `filament_diameter` on each type
- [ ] `PATCH /api/v1/materials/types/PLA_BASIC` with `{"filament_diameter": 2.85}` returns updated item
- [ ] `PATCH` returns 403 for non-admin user
- [ ] `PATCH` returns 404 for unknown code
- [ ] Backend: `python -m ruff check app/api/v1/endpoints/materials.py` passes clean
- [ ] Frontend: `npm run test:unit` — 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Material types now include a filament diameter property (default 1.75 mm).
  * Admins can update a material type's filament diameter via a new update endpoint.
  * Printer configuration modal now offers a "Supported Diameters" selector for 1.75 mm and 2.85 mm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->