### PR TITLE
feat(printers): redesign fleet dashboard with Tailwind cards + summary stats

### DIFF
--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -61,12 +61,14 @@ function stateLabel(status) {
 
 function getActiveAmsSlot(amsSlots) {
   if (!amsSlots?.length) return { material: "Unknown", slot: "No AMS" };
-  // TODO: BambuFleetManager should report the active slot index.
-  // For now, show the first slot's material as a reasonable default.
+  // TODO: BambuFleetManager should report the active slot index (tray_now in
+  // Bambu MQTT). Until then, fall back to slot 0. Mark multi-slot printers as
+  // "(estimated)" so operators know the value isn't authoritative.
   const active = amsSlots[0];
+  const slotLabel = `Slot ${active.slot ?? 1}`;
   return {
     material: active.material || "Unknown",
-    slot: `Slot ${active.slot ?? 1}`,
+    slot: amsSlots.length > 1 ? `${slotLabel} (estimated)` : slotLabel,
   };
 }
 
@@ -126,13 +128,15 @@ export default function PrinterCard({
   }
   actions.push({ label: "Edit", primary: false, onClick: () => onEdit?.(printer) });
 
-  // Heartbeat text
+  // Heartbeat text — an online idle printer should read "Connected" even if
+  // it has a historic last_seen timestamp, so the idle check comes before the
+  // last_seen fallback.
   const heartbeat = isPrinting
     ? "Live now"
-    : printer.last_seen
-    ? `Last seen ${new Date(printer.last_seen).toLocaleString()}`
     : status === "idle"
     ? "Connected"
+    : printer.last_seen
+    ? `Last seen ${new Date(printer.last_seen).toLocaleString()}`
     : "—";
 
   return (

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -43,10 +43,13 @@ function fmtTemp(value) {
 }
 
 function fmtEta(minutes) {
-  if (minutes == null || minutes <= 0) return null;
+  // Coerce + guard — telemetry can arrive as string, null, or garbage;
+  // never render NaN to users.
+  const n = Number(minutes);
+  if (!Number.isFinite(n) || n <= 0) return null;
   // Round first so fractional telemetry doesn't render as "1h 30.5m".
   // Integer division naturally carries a rounded-up 60 into the hour column.
-  const total = Math.round(minutes);
+  const total = Math.round(n);
   const h = Math.floor(total / 60);
   const m = total % 60;
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
@@ -83,7 +86,13 @@ export default function PrinterCard({
   const status = (printer.status || "offline").toLowerCase();
   const isActive = status === "printing" || status === "paused";
   const isPrinting = status === "printing";
-  const progress = Math.max(0, Math.min(100, Number(printer.progress ?? 0)));
+  // Coerce + clamp — non-numeric telemetry (null/NaN/"--") must never leak into
+  // width styles or aria-valuenow.
+  const progressRaw = Number(printer.progress);
+  const progress = Number.isFinite(progressRaw)
+    ? Math.max(0, Math.min(100, progressRaw))
+    : 0;
+  const hasProgress = Number.isFinite(progressRaw);
   const eta = fmtEta(printer.remaining_minutes ?? printer.mc_remaining_time);
   const ams = getActiveAmsSlot(printer.ams_slots);
 
@@ -192,7 +201,7 @@ export default function PrinterCard({
                 </div>
               )}
             </div>
-            {printer.progress != null && (
+            {hasProgress && (
               <div className="mt-4">
                 <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
                   <span>Progress</span>

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -44,8 +44,11 @@ function fmtTemp(value) {
 
 function fmtEta(minutes) {
   if (minutes == null || minutes <= 0) return null;
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
+  // Round first so fractional telemetry doesn't render as "1h 30.5m".
+  // Integer division naturally carries a rounded-up 60 into the hour column.
+  const total = Math.round(minutes);
+  const h = Math.floor(total / 60);
+  const m = total % 60;
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
@@ -243,9 +246,9 @@ export default function PrinterCard({
         <div className="text-sm text-slate-500">{heartbeat}</div>
         <div className="flex gap-2">
           {actions.map((action) => {
-            // Only the Test action uses a "Testing..." busy label; fleet commands
-            // stay labeled and just go disabled while in-flight.
-            const busyLabel = action.label === "Test" && action.disabled ? "Testing..." : action.label;
+            // "Testing..." busy label only when actually probing — a Test button
+            // disabled because IP is missing should still read "Test".
+            const busyLabel = action.label === "Test" && testing ? "Testing..." : action.label;
             return (
               <button
                 key={action.label}

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -92,7 +92,15 @@ export default function PrinterCard({
     actions.push({ label: "Cancel", primary: false, onClick: () => onCommand(printer.id, "cancel") });
   }
   if (status === "offline") {
-    actions.push({ label: "Test", primary: true, onClick: () => onTest?.(printer), disabled: testing });
+    // Disable Test when printer has no IP — there's nothing to probe.
+    const hasIp = Boolean(printer.ip_address);
+    actions.push({
+      label: "Test",
+      primary: true,
+      onClick: () => onTest?.(printer),
+      disabled: testing || !hasIp,
+      title: hasIp ? undefined : "Add an IP address to test this printer",
+    });
   }
   actions.push({ label: "Edit", primary: false, onClick: () => onEdit?.(printer) });
 
@@ -133,9 +141,10 @@ export default function PrinterCard({
         </span>
       </div>
 
-      {/* Job section */}
+      {/* Job section — active job UI is driven by status (printing/paused), not by
+          the presence of telemetry. Progress bar renders only when progress is reported. */}
       <div className="mb-5 rounded-2xl border border-slate-800/80 bg-slate-950/80 p-4">
-        {isActive && printer.progress != null ? (
+        {isActive ? (
           <>
             <div className="flex items-center justify-between gap-3">
               <div>
@@ -157,26 +166,28 @@ export default function PrinterCard({
                 </div>
               )}
             </div>
-            <div className="mt-4">
-              <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
-                <span>Progress</span>
-                <span>{progress}%</span>
-              </div>
-              <div
-                className="h-2.5 rounded-full bg-slate-800"
-                role="progressbar"
-                aria-valuenow={progress}
-                aria-valuemin={0}
-                aria-valuemax={100}
-              >
+            {printer.progress != null && (
+              <div className="mt-4">
+                <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
+                  <span>Progress</span>
+                  <span>{progress}%</span>
+                </div>
                 <div
-                  className={`h-2.5 rounded-full transition-all duration-1000 ${
-                    PROGRESS_COLORS[status] || "bg-slate-500"
-                  }`}
-                  style={{ width: `${progress}%` }}
-                />
+                  className="h-2.5 rounded-full bg-slate-800"
+                  role="progressbar"
+                  aria-valuenow={progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                >
+                  <div
+                    className={`h-2.5 rounded-full transition-all duration-1000 ${
+                      PROGRESS_COLORS[status] || "bg-slate-500"
+                    }`}
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
               </div>
-            </div>
+            )}
           </>
         ) : (
           <>

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -1,0 +1,244 @@
+/**
+ * PrinterCard — Rich printer card for the fleet dashboard.
+ *
+ * Replaces the old inline-styled PrinterCardHUD with a Tailwind-based
+ * design featuring metric tiles, job details, contextual actions, and
+ * gradient borders for active printers. Consumes the merged printer
+ * data from fetchPrinters() (Core + PRO telemetry overlay).
+ *
+ * Props:
+ *   printer   — Merged printer object (Core fields + PRO telemetry when available)
+ *   onEdit    — (printer) => void
+ *   onCommand — (printerId, command) => void | undefined (PRO fleet control)
+ *   onTest    — (printer) => void
+ *   testing   — boolean (is this printer currently being connection-tested)
+ */
+import { brandLabels } from "./constants";
+
+const STATUS_STYLES = {
+  printing:
+    "bg-emerald-500/15 text-emerald-300 ring-1 ring-inset ring-emerald-400/30",
+  idle: "bg-blue-500/15 text-blue-300 ring-1 ring-inset ring-blue-400/30",
+  offline:
+    "bg-slate-500/15 text-slate-300 ring-1 ring-inset ring-slate-400/20",
+  maintenance:
+    "bg-amber-500/15 text-amber-300 ring-1 ring-inset ring-amber-400/30",
+  error: "bg-red-500/15 text-red-300 ring-1 ring-inset ring-red-400/30",
+  paused:
+    "bg-yellow-500/15 text-yellow-300 ring-1 ring-inset ring-yellow-400/30",
+  unknown:
+    "bg-slate-500/15 text-slate-400 ring-1 ring-inset ring-slate-400/20",
+};
+
+const PROGRESS_COLORS = {
+  printing: "bg-emerald-400",
+  paused: "bg-yellow-400",
+  error: "bg-red-400",
+};
+
+function fmtTemp(value) {
+  if (value == null || value === 0) return "—";
+  return `${Math.round(value)}°C`;
+}
+
+function fmtEta(minutes) {
+  if (minutes == null || minutes <= 0) return null;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function stateLabel(status) {
+  if (status === "offline") return "Not responding";
+  if (status === "maintenance") return "Service attention needed";
+  if (status === "error") return "Error — check printer";
+  return "Ready";
+}
+
+function getActiveAmsSlot(amsSlots) {
+  if (!amsSlots?.length) return { material: "Unknown", slot: "No AMS" };
+  // TODO: BambuFleetManager should report the active slot index.
+  // For now, show the first slot's material as a reasonable default.
+  const active = amsSlots[0];
+  return {
+    material: active.material || "Unknown",
+    slot: `Slot ${active.slot ?? 1}`,
+  };
+}
+
+export default function PrinterCard({
+  printer,
+  onEdit,
+  onCommand,
+  onTest,
+  testing,
+}) {
+  const status = (printer.status || "offline").toLowerCase();
+  const isActive = status === "printing" || status === "paused";
+  const isPrinting = status === "printing";
+  const progress = Math.max(0, Math.min(100, Number(printer.progress ?? 0)));
+  const eta = fmtEta(printer.remaining_minutes ?? printer.mc_remaining_time);
+  const ams = getActiveAmsSlot(printer.ams_slots);
+
+  // Build contextual actions based on printer state
+  const actions = [];
+  if (isPrinting && onCommand) {
+    actions.push({ label: "Pause", primary: true, onClick: () => onCommand(printer.id, "pause") });
+  }
+  if (status === "paused" && onCommand) {
+    actions.push({ label: "Resume", primary: true, onClick: () => onCommand(printer.id, "resume") });
+  }
+  if (isActive && onCommand) {
+    actions.push({ label: "Cancel", primary: false, onClick: () => onCommand(printer.id, "cancel") });
+  }
+  if (status === "offline") {
+    actions.push({ label: "Test", primary: true, onClick: () => onTest?.(printer), disabled: testing });
+  }
+  actions.push({ label: "Edit", primary: false, onClick: () => onEdit?.(printer) });
+
+  // Heartbeat text
+  const heartbeat = isPrinting
+    ? "Live now"
+    : printer.last_seen
+    ? `Last seen ${new Date(printer.last_seen).toLocaleString()}`
+    : status === "idle"
+    ? "Connected"
+    : "—";
+
+  return (
+    <article
+      className={`rounded-[28px] border p-5 shadow-2xl shadow-black/20 transition hover:-translate-y-0.5 ${
+        isPrinting
+          ? "border-emerald-500/30 bg-gradient-to-br from-slate-900 via-slate-900 to-emerald-950/30"
+          : status === "error"
+          ? "border-red-500/30 bg-gradient-to-br from-slate-900 via-slate-900 to-red-950/20"
+          : "border-slate-800 bg-slate-900/75"
+      }`}
+    >
+      {/* Header: name + status badge */}
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">{printer.name}</h2>
+          <div className="mt-1 text-sm text-slate-400">
+            {brandLabels[printer.brand] || printer.brand} {printer.model}
+            {printer.location && ` • ${printer.location}`}
+          </div>
+        </div>
+        <span
+          className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${
+            STATUS_STYLES[status] || STATUS_STYLES.unknown
+          }`}
+        >
+          {status}
+        </span>
+      </div>
+
+      {/* Job section */}
+      <div className="mb-5 rounded-2xl border border-slate-800/80 bg-slate-950/80 p-4">
+        {isActive && printer.progress != null ? (
+          <>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.16em] text-slate-500">
+                  Current Job
+                </div>
+                <div className="mt-1 text-sm font-medium text-white">
+                  {printer.current_job || (isPrinting ? "Printing" : "Paused")}
+                </div>
+              </div>
+              {eta && (
+                <div className="text-right">
+                  <div className="text-xs uppercase tracking-[0.16em] text-slate-500">
+                    ETA
+                  </div>
+                  <div className="mt-1 text-sm font-medium text-slate-200">
+                    {eta}
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="mt-4">
+              <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
+                <span>Progress</span>
+                <span>{progress}%</span>
+              </div>
+              <div
+                className="h-2.5 rounded-full bg-slate-800"
+                role="progressbar"
+                aria-valuenow={progress}
+                aria-valuemin={0}
+                aria-valuemax={100}
+              >
+                <div
+                  className={`h-2.5 rounded-full transition-all duration-1000 ${
+                    PROGRESS_COLORS[status] || "bg-slate-500"
+                  }`}
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-xs uppercase tracking-[0.16em] text-slate-500">
+                  Current State
+                </div>
+                <div className="mt-1 text-sm font-medium text-white">
+                  {stateLabel(status)}
+                </div>
+              </div>
+              <div className="text-right text-sm text-slate-400">
+                {heartbeat}
+              </div>
+            </div>
+            <div className="mt-4 rounded-2xl border border-dashed border-slate-800 px-3 py-3 text-sm text-slate-400">
+              No active print job.
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Metric tiles */}
+      <div className="grid grid-cols-2 gap-3">
+        <Metric label="Nozzle" value={fmtTemp(printer.nozzle_temp)} />
+        <Metric label="Bed" value={fmtTemp(printer.bed_temp)} />
+        <Metric label="Filament" value={ams.material} />
+        <Metric label="Feed" value={ams.slot} />
+      </div>
+
+      {/* Footer: heartbeat + actions */}
+      <div className="mt-5 flex items-center justify-between gap-3 border-t border-slate-800 pt-4">
+        <div className="text-sm text-slate-500">{heartbeat}</div>
+        <div className="flex gap-2">
+          {actions.map((action) => (
+            <button
+              key={action.label}
+              onClick={action.onClick}
+              disabled={action.disabled}
+              className={`rounded-xl px-3 py-2 text-sm font-medium transition ${
+                action.primary
+                  ? "bg-white text-slate-950 hover:bg-slate-200 disabled:opacity-50"
+                  : "border border-slate-700 bg-slate-900 text-slate-200 hover:border-slate-600 hover:bg-slate-800"
+              }`}
+            >
+              {action.disabled ? "Testing..." : action.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Metric({ label, value }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-3">
+      <div className="text-[11px] uppercase tracking-[0.16em] text-slate-500">
+        {label}
+      </div>
+      <div className="mt-2 text-sm font-medium text-slate-100">{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -7,11 +7,12 @@
  * data from fetchPrinters() (Core + PRO telemetry overlay).
  *
  * Props:
- *   printer   — Merged printer object (Core fields + PRO telemetry when available)
- *   onEdit    — (printer) => void
- *   onCommand — (printerId, command) => void | undefined (PRO fleet control)
- *   onTest    — (printer) => void
- *   testing   — boolean (is this printer currently being connection-tested)
+ *   printer        — Merged printer object (Core fields + PRO telemetry when available)
+ *   onEdit         — (printer) => void
+ *   onCommand      — (printerId, command) => void | undefined (PRO fleet control)
+ *   onTest         — (printer) => void
+ *   testing        — boolean (is this printer currently being connection-tested)
+ *   commandPending — boolean (is a fleet command currently in-flight for this printer)
  */
 import { brandLabels } from "./constants";
 
@@ -72,6 +73,7 @@ export default function PrinterCard({
   onCommand,
   onTest,
   testing,
+  commandPending,
 }) {
   const status = (printer.status || "offline").toLowerCase();
   const isActive = status === "printing" || status === "paused";
@@ -80,16 +82,33 @@ export default function PrinterCard({
   const eta = fmtEta(printer.remaining_minutes ?? printer.mc_remaining_time);
   const ams = getActiveAmsSlot(printer.ams_slots);
 
-  // Build contextual actions based on printer state
+  // Build contextual actions based on printer state.
+  // While a command is in-flight for this printer, disable pause/resume/cancel
+  // so a double-click can't fire duplicate requests.
   const actions = [];
   if (isPrinting && onCommand) {
-    actions.push({ label: "Pause", primary: true, onClick: () => onCommand(printer.id, "pause") });
+    actions.push({
+      label: "Pause",
+      primary: true,
+      onClick: () => onCommand(printer.id, "pause"),
+      disabled: commandPending,
+    });
   }
   if (status === "paused" && onCommand) {
-    actions.push({ label: "Resume", primary: true, onClick: () => onCommand(printer.id, "resume") });
+    actions.push({
+      label: "Resume",
+      primary: true,
+      onClick: () => onCommand(printer.id, "resume"),
+      disabled: commandPending,
+    });
   }
   if (isActive && onCommand) {
-    actions.push({ label: "Cancel", primary: false, onClick: () => onCommand(printer.id, "cancel") });
+    actions.push({
+      label: "Cancel",
+      primary: false,
+      onClick: () => onCommand(printer.id, "cancel"),
+      disabled: commandPending,
+    });
   }
   if (status === "offline") {
     // Disable Test when printer has no IP — there's nothing to probe.
@@ -223,20 +242,26 @@ export default function PrinterCard({
       <div className="mt-5 flex items-center justify-between gap-3 border-t border-slate-800 pt-4">
         <div className="text-sm text-slate-500">{heartbeat}</div>
         <div className="flex gap-2">
-          {actions.map((action) => (
-            <button
-              key={action.label}
-              onClick={action.onClick}
-              disabled={action.disabled}
-              className={`rounded-xl px-3 py-2 text-sm font-medium transition ${
-                action.primary
-                  ? "bg-white text-slate-950 hover:bg-slate-200 disabled:opacity-50"
-                  : "border border-slate-700 bg-slate-900 text-slate-200 hover:border-slate-600 hover:bg-slate-800"
-              }`}
-            >
-              {action.disabled ? "Testing..." : action.label}
-            </button>
-          ))}
+          {actions.map((action) => {
+            // Only the Test action uses a "Testing..." busy label; fleet commands
+            // stay labeled and just go disabled while in-flight.
+            const busyLabel = action.label === "Test" && action.disabled ? "Testing..." : action.label;
+            return (
+              <button
+                key={action.label}
+                onClick={action.onClick}
+                disabled={action.disabled}
+                title={action.title}
+                className={`rounded-xl px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                  action.primary
+                    ? "bg-white text-slate-950 hover:bg-slate-200"
+                    : "border border-slate-700 bg-slate-900 text-slate-200 hover:border-slate-600 hover:bg-slate-800"
+                }`}
+              >
+                {busyLabel}
+              </button>
+            );
+          })}
         </div>
       </div>
     </article>

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -60,6 +60,10 @@ export default function AdminPrinters() {
   // Connection testing state
   const [testingConnection, setTestingConnection] = useState(null); // printer id being tested
 
+  // Per-printer fleet-command in-flight set (pause/resume/cancel).
+  // Prevents double-firing when a user double-clicks a card action.
+  const [pendingCommands, setPendingCommands] = useState(() => new Set());
+
   // Active work tracking
   const [activeWork, setActiveWork] = useState({}); // printer_id -> work info
 
@@ -290,6 +294,13 @@ export default function AdminPrinters() {
   };
 
   const handleCommand = async (printerId, command) => {
+    // Guard against double-firing when a user double-clicks a card action.
+    if (pendingCommands.has(printerId)) return;
+    setPendingCommands((prev) => {
+      const next = new Set(prev);
+      next.add(printerId);
+      return next;
+    });
     try {
       await api.post(`/api/v1/pro/filafarm/printers/${printerId}/command`, { command });
       toast.success(`${command} sent`);
@@ -297,6 +308,12 @@ export default function AdminPrinters() {
       setTimeout(() => fetchPrinters({ silent: true }), 1000);
     } catch (err) {
       toast.error(err.message);
+    } finally {
+      setPendingCommands((prev) => {
+        const next = new Set(prev);
+        next.delete(printerId);
+        return next;
+      });
     }
   };
 
@@ -520,15 +537,22 @@ export default function AdminPrinters() {
             // summary stats, contextual actions, and gradient accents.
             <div className="space-y-6">
               {/* Summary stats bar */}
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
-                {[
+              {(() => {
+                // Normalize once — matches the PrinterCard normalization so
+                // summary counts stay in sync with what the cards render.
+                const normStatus = (p) => (p.status || "offline").toLowerCase();
+                const countBy = (s) => printers.filter((p) => normStatus(p) === s).length;
+                const tiles = [
                   { label: "Total", value: printers.length },
-                  { label: "Printing", value: printers.filter((p) => p.status === "printing").length },
-                  { label: "Idle", value: printers.filter((p) => p.status === "idle").length },
-                  { label: "Offline", value: printers.filter((p) => p.status === "offline").length },
-                  { label: "Errors", value: printers.filter((p) => p.status === "error").length },
-                  { label: "Maintenance", value: printers.filter((p) => p.status === "maintenance").length },
-                ].map((stat) => (
+                  { label: "Printing", value: countBy("printing") },
+                  { label: "Idle", value: countBy("idle") },
+                  { label: "Offline", value: countBy("offline") },
+                  { label: "Errors", value: countBy("error") },
+                  { label: "Maintenance", value: countBy("maintenance") },
+                ];
+                return (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+                {tiles.map((stat) => (
                   <div
                     key={stat.label}
                     className="rounded-3xl border border-slate-800 bg-slate-900/70 p-4 shadow-2xl shadow-black/20"
@@ -542,6 +566,8 @@ export default function AdminPrinters() {
                   </div>
                 ))}
               </div>
+                );
+              })()}
 
               {/* Printer cards grid */}
               <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
@@ -556,6 +582,7 @@ export default function AdminPrinters() {
                     onCommand={handleCommand}
                     onTest={handleTestConnection}
                     testing={testingConnection === printer.id}
+                    commandPending={pendingCommands.has(printer.id)}
                   />
                 ))}
               </div>

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -365,6 +365,19 @@ export default function AdminPrinters() {
   // Render
   // ============================================================================
 
+  // Summary tile counts for the PRO fleet dashboard. Normalization matches the
+  // status derivation in PrinterCard so tile counts stay in sync with cards.
+  const normStatus = (p) => (p.status || "offline").toLowerCase();
+  const countByStatus = (s) => printers.filter((p) => normStatus(p) === s).length;
+  const summaryTiles = [
+    { label: "Total", value: printers.length },
+    { label: "Printing", value: countByStatus("printing") },
+    { label: "Idle", value: countByStatus("idle") },
+    { label: "Offline", value: countByStatus("offline") },
+    { label: "Errors", value: countByStatus("error") },
+    { label: "Maintenance", value: countByStatus("maintenance") },
+  ];
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -537,22 +550,8 @@ export default function AdminPrinters() {
             // summary stats, contextual actions, and gradient accents.
             <div className="space-y-6">
               {/* Summary stats bar */}
-              {(() => {
-                // Normalize once — matches the PrinterCard normalization so
-                // summary counts stay in sync with what the cards render.
-                const normStatus = (p) => (p.status || "offline").toLowerCase();
-                const countBy = (s) => printers.filter((p) => normStatus(p) === s).length;
-                const tiles = [
-                  { label: "Total", value: printers.length },
-                  { label: "Printing", value: countBy("printing") },
-                  { label: "Idle", value: countBy("idle") },
-                  { label: "Offline", value: countBy("offline") },
-                  { label: "Errors", value: countBy("error") },
-                  { label: "Maintenance", value: countBy("maintenance") },
-                ];
-                return (
               <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
-                {tiles.map((stat) => (
+                {summaryTiles.map((stat) => (
                   <div
                     key={stat.label}
                     className="rounded-3xl border border-slate-800 bg-slate-900/70 p-4 shadow-2xl shadow-black/20"
@@ -566,8 +565,6 @@ export default function AdminPrinters() {
                   </div>
                 ))}
               </div>
-                );
-              })()}
 
               {/* Printer cards grid */}
               <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -520,13 +520,14 @@ export default function AdminPrinters() {
             // summary stats, contextual actions, and gradient accents.
             <div className="space-y-6">
               {/* Summary stats bar */}
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
                 {[
                   { label: "Total", value: printers.length },
                   { label: "Printing", value: printers.filter((p) => p.status === "printing").length },
                   { label: "Idle", value: printers.filter((p) => p.status === "idle").length },
                   { label: "Offline", value: printers.filter((p) => p.status === "offline").length },
-                  { label: "Errors", value: printers.filter((p) => p.status === "error" || p.status === "maintenance").length },
+                  { label: "Errors", value: printers.filter((p) => p.status === "error").length },
+                  { label: "Maintenance", value: printers.filter((p) => p.status === "maintenance").length },
                 ].map((stat) => (
                   <div
                     key={stat.label}

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -61,7 +61,10 @@ export default function AdminPrinters() {
   const [testingConnection, setTestingConnection] = useState(null); // printer id being tested
 
   // Per-printer fleet-command in-flight set (pause/resume/cancel).
-  // Prevents double-firing when a user double-clicks a card action.
+  // Ref-backed for synchronous check+add on the click handler (fast
+  // double-clicks race React state updates), mirrored into state for UI
+  // button-disable feedback.
+  const pendingCommandsRef = useRef(new Set());
   const [pendingCommands, setPendingCommands] = useState(() => new Set());
 
   // Active work tracking
@@ -294,13 +297,11 @@ export default function AdminPrinters() {
   };
 
   const handleCommand = async (printerId, command) => {
-    // Guard against double-firing when a user double-clicks a card action.
-    if (pendingCommands.has(printerId)) return;
-    setPendingCommands((prev) => {
-      const next = new Set(prev);
-      next.add(printerId);
-      return next;
-    });
+    // Synchronous guard via ref — React state reads are stale when two clicks
+    // land before a re-render, so state alone is a flimsy mutex.
+    if (pendingCommandsRef.current.has(printerId)) return;
+    pendingCommandsRef.current.add(printerId);
+    setPendingCommands(new Set(pendingCommandsRef.current));
     try {
       await api.post(`/api/v1/pro/filafarm/printers/${printerId}/command`, { command });
       toast.success(`${command} sent`);
@@ -309,11 +310,8 @@ export default function AdminPrinters() {
     } catch (err) {
       toast.error(err.message);
     } finally {
-      setPendingCommands((prev) => {
-        const next = new Set(prev);
-        next.delete(printerId);
-        return next;
-      });
+      pendingCommandsRef.current.delete(printerId);
+      setPendingCommands(new Set(pendingCommandsRef.current));
     }
   };
 

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -12,7 +12,7 @@ import { statusColors, brandLabels, MAINTENANCE_TYPE_CLASS } from "../../compone
 import PrinterModal from "../../components/printers/PrinterModal";
 import IPProbeSection from "../../components/printers/IPProbeSection";
 import MaintenanceModal from "../../components/printers/MaintenanceModal";
-import { PrinterCardHUD, HUD_KEYFRAMES, T as HUD_T } from "../../components/printers/hud";
+import PrinterCard from "../../components/printers/PrinterCard";
 
 export default function AdminPrinters() {
   const api = useApi();
@@ -289,6 +289,17 @@ export default function AdminPrinters() {
     }
   };
 
+  const handleCommand = async (printerId, command) => {
+    try {
+      await api.post(`/api/v1/pro/filafarm/printers/${printerId}/command`, { command });
+      toast.success(`${command} sent`);
+      // Refresh after a short delay to let the printer state update
+      setTimeout(() => fetchPrinters({ silent: true }), 1000);
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
   const handleDelete = async (printer) => {
     if (!confirm(`Delete printer "${printer.name}"? This cannot be undone.`)) {
       return;
@@ -366,7 +377,7 @@ export default function AdminPrinters() {
                 type="button"
                 onClick={() => {
                   if (!canUseHud) {
-                    toast.info("HUD view is a PRO feature. Upgrade to unlock the industrial fleet view.");
+                    toast.info("Cards view is a PRO feature. Upgrade to unlock the fleet dashboard.");
                     return;
                   }
                   setViewMode("hud");
@@ -380,7 +391,7 @@ export default function AdminPrinters() {
                 } ${!canUseHud ? "opacity-60 cursor-not-allowed" : ""}`}
                 aria-pressed={viewMode === "hud"}
               >
-                HUD
+                Cards
                 {!canUseHud && (
                   <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-400 border border-amber-700/40" aria-label="PRO feature">
                     🔒 PRO
@@ -505,39 +516,45 @@ export default function AdminPrinters() {
               </button>
             </div>
           ) : viewMode === "hud" && canUseHud ? (
-            // Industrial HUD view — PRO only. Double-gated: the useEffect
-            // above forces viewMode back to "table" when canUseHud flips
-            // false, and this render condition refuses to draw the HUD
-            // without the feature flag even if state gets out of sync.
-            // Rendered as a parallel path to the tailwind table view below.
-            // Core's `/api/v1/printers` does not
-            // populate live telemetry (nozzle_temp, bed_temp, progress,
-            // ams_slots) — PrinterCardHUD degrades gracefully when those
-            // fields are missing. PRO's live MQTT path (BambuFleetManager)
-            // populates them via /api/v1/pro/filafarm/*.
-            <div style={{ background: HUD_T.bg, borderRadius: 10, padding: 16, border: `1px solid ${HUD_T.border}` }}>
-              <style>{HUD_KEYFRAMES}</style>
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(auto-fill, minmax(420px, 1fr))",
-                  gap: 20,
-                }}
-              >
+            // PRO fleet dashboard — rich card view with live telemetry,
+            // summary stats, contextual actions, and gradient accents.
+            <div className="space-y-6">
+              {/* Summary stats bar */}
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+                {[
+                  { label: "Total", value: printers.length },
+                  { label: "Printing", value: printers.filter((p) => p.status === "printing").length },
+                  { label: "Idle", value: printers.filter((p) => p.status === "idle").length },
+                  { label: "Offline", value: printers.filter((p) => p.status === "offline").length },
+                  { label: "Errors", value: printers.filter((p) => p.status === "error" || p.status === "maintenance").length },
+                ].map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="rounded-3xl border border-slate-800 bg-slate-900/70 p-4 shadow-2xl shadow-black/20"
+                  >
+                    <div className="text-xs uppercase tracking-[0.18em] text-slate-500">
+                      {stat.label}
+                    </div>
+                    <div className="mt-3 text-2xl font-semibold text-white">
+                      {stat.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Printer cards grid */}
+              <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
                 {printers.map((printer) => (
-                  <PrinterCardHUD
+                  <PrinterCard
                     key={printer.id}
                     printer={printer}
                     onEdit={(p) => {
                       setSelectedPrinter(p);
                       setShowEditModal(true);
                     }}
-                    onRemove={handleDelete}
-                    // onCommand intentionally omitted — pause/resume/cancel
-                    // is a PRO fleet-management feature routed through
-                    // /api/v1/pro/filafarm/printers/:id/command. When the
-                    // PRO page injection arrives, that handler will be
-                    // passed here; until then, Core HUD shows status only.
+                    onCommand={handleCommand}
+                    onTest={handleTestConnection}
+                    testing={testingConnection === printer.id}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Replaces the inline-styled HUD view (SVG arc gauges, amber design tokens, dark panel wrapper) with a modern Tailwind-based fleet dashboard. Same data pipeline from #548, completely new rendering.

## Before → After

| Before (#547 HUD) | After (this PR) |
|---|---|
| SVG arc gauges (58→100px) | Metric tiles (Nozzle, Bed, Filament, Feed) |
| Inline styles via `T` token object | Native Tailwind classes |
| Flat dark panel wrapper | Gradient borders on active printers |
| Fixed Pause/Resume/Cancel strip | Contextual actions per status |
| No job details section | Current Job + ETA + progress bar |
| No heartbeat indicator | "Live now" / "Last seen X ago" |
| No summary stats | Total / Printing / Idle / Offline / Errors bar |

## What changed

**New file: `frontend/src/components/printers/PrinterCard.jsx`** (+244 lines)
- Gradient borders: emerald for printing, red for error, slate for idle/offline
- Job detail section: Current Job name, ETA (formatted from `remaining_minutes`), progress bar
- Metric tiles: Nozzle temp, Bed temp, active Filament material, AMS Feed slot
- Contextual actions: Pause (printing), Resume (paused), Cancel (active), Test (offline), Edit (always)
- Heartbeat: "Live now" when printing, connection time for idle, `last_seen` for offline
- Status pill badges with ring borders matching the mockup aesthetic
- `fmtTemp()`, `fmtEta()`, `stateLabel()`, `getActiveAmsSlot()` helpers

**Modified: `frontend/src/pages/admin/AdminPrinters.jsx`** (+61/-29)
- Import swapped: `PrinterCardHUD` → `PrinterCard`
- HUD render block replaced with summary stats bar + card grid
- New `handleCommand(printerId, command)` sends pause/resume/cancel to PRO fleet endpoint
- View toggle renamed "HUD" → "Cards" (better naming, same PRO gate)
- `onRemove` removed from card props (destructive action stays in edit flow)

## What did NOT change

The entire data pipeline from #548 is untouched:
- `fetchPrinters()` with PRO telemetry overlay
- `String(p.id)` merge for Core↔PRO ID type mismatch
- 15-second silent polling in Cards mode
- `canUseHud` feature gate (`!featureFlagsLoading && isPro && hasFeature("filafarm")`)
- `activeTab` in useEffect deps (no leaked intervals)
- `setError(null)` on success (no stuck errors)

## Design credit

Dashboard design by @Blb3D — mockup provided as `printers_dashboard_redesign.jsx`. I wired the static mockup to the live data pipeline and added dynamic actions/formatting.

## Cleanup note

The old `components/printers/hud/` directory (PrinterCardHUD.jsx, TempGauge.jsx, StatChip.jsx, tokens.js, index.js) is now dead code. Keeping it out of this PR for a clean diff — will delete in a followup commit or separate cleanup PR.

## Test plan

- [ ] PRO tier: Cards toggle visible, click → summary stats bar + card grid renders
- [ ] Printing printer: emerald gradient border, job details section, progress bar, Pause + Cancel + Edit actions
- [ ] Idle printer: blue status pill, "Ready" state, "Connected" heartbeat, Edit action
- [ ] Offline printer: slate border, "Not responding", Test + Edit actions
- [ ] Metric tiles show live temps when PRO telemetry is flowing (220°C nozzle, 55°C bed)
- [ ] Pause button sends command → toast "pause sent" → printer updates on next poll
- [ ] Core tier: Cards button shows 🔒 PRO badge, toast on click, table view unchanged
- [ ] Summary stats update dynamically as printer states change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New responsive printer cards showing name, model, location, status badge, heartbeat, AMS slot, ETA, and job progress; contextual action buttons (Pause/Resume/Cancel/Test/Edit) with disabled and testing states.
  * “Cards” PRO fleet dashboard layout with summary statistic tiles.

* **Improvements**
  * Command submission prevents duplicate commands, shows success/error toasts, and refreshes printer data after actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->