### PR TITLE
fix: auto-sync standard_cost on PO receive for purchased items

### DIFF
--- a/backend/app/services/purchase_order_service.py
+++ b/backend/app/services/purchase_order_service.py
@@ -23,6 +23,8 @@ from app.models.company_settings import CompanySettings
 from app.models.inventory import Inventory, InventoryLocation
 from app.models.material_spool import MaterialSpool
 from app.models.traceability import MaterialLot
+from app.models.bom import BOM
+from app.models.manufacturing import Routing
 from app.services.uom_service import convert_quantity_safe, get_conversion_factor
 from app.services.inventory_helpers import is_material
 from app.services.transaction_service import TransactionService, ReceiptItem
@@ -909,6 +911,34 @@ def receive_purchase_order(
                 logger.info(
                     f"Created spool {spool_number} for {product.sku}: {spool_data['weight_g']}g "
                     f"(lot: {spool.supplier_lot_number or 'N/A'})"
+                )
+
+    # Auto-sync standard_cost ← average_cost for purchased items.
+    # Manufactured items (active BOM or active routing of their own) own
+    # standard_cost via cost rollup, so leaving them alone preserves the
+    # variance signal and lets recost handle them. Skipped products
+    # (effective_unit != product_unit) are absent from product_receipt_accum.
+    if product_receipt_accum:
+        synced_pids = list(product_receipt_accum.keys())
+        bom_pids = {
+            row[0] for row in db.query(BOM.product_id).filter(
+                BOM.product_id.in_(synced_pids), BOM.active.is_(True)
+            ).all()
+        }
+        routing_pids = {
+            row[0] for row in db.query(Routing.product_id).filter(
+                Routing.product_id.in_(synced_pids), Routing.is_active.is_(True)
+            ).all()
+        }
+        for pid in synced_pids:
+            if pid in bom_pids or pid in routing_pids:
+                continue
+            product_to_sync = db.query(Product).filter(Product.id == pid).first()
+            if product_to_sync and product_to_sync.average_cost is not None:
+                product_to_sync.standard_cost = product_to_sync.average_cost
+                logger.debug(
+                    f"Auto-synced standard_cost for purchased item {product_to_sync.sku}: "
+                    f"${product_to_sync.standard_cost} (= average_cost)"
                 )
 
     # PO receipt via TransactionService

--- a/backend/tests/services/test_purchase_order_service.py
+++ b/backend/tests/services/test_purchase_order_service.py
@@ -1636,6 +1636,88 @@ class TestReceivePurchaseOrder:
         assert float(product.average_cost) > 0
         assert float(product.last_cost) == pytest.approx(25.0, rel=1e-2)
 
+    def test_purchased_item_standard_cost_auto_synced(
+        self, db, make_vendor, make_purchase_order, make_product
+    ):
+        """For purchased items (no BOM, no routing), receiving a PO sets
+        standard_cost = average_cost so downstream rollups (routing material
+        unit_cost, MRP suggestions, item grid) reflect the new cost basis
+        without requiring a manual Recost All.
+
+        Regression test for COMP-007 incident (2026-04-25): elastics received
+        on PO-2026-008 left standard_cost at 0, so the routing material on
+        the assembly operation showed no /unit price.
+        """
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        product = make_product(
+            item_type="component",
+            unit="EA",
+            purchase_uom="EA",
+            standard_cost=None,
+            average_cost=None,
+        )
+        line = _add_po_line(
+            db, po, product, Decimal("200"), Decimal("0.0575"), purchase_unit="EA"
+        )
+        db.commit()
+
+        receive_purchase_order(
+            db, po.id,
+            lines=[{"line_id": line.id, "quantity_received": Decimal("200")}],
+            user_id=1,
+            user_email="test@filaops.dev",
+        )
+
+        db.refresh(product)
+        assert product.average_cost is not None
+        assert float(product.average_cost) == pytest.approx(0.0575, rel=1e-3)
+        assert product.standard_cost is not None, "standard_cost should auto-sync from average_cost"
+        assert float(product.standard_cost) == pytest.approx(float(product.average_cost), rel=1e-6)
+        assert float(product.last_cost) == pytest.approx(0.0575, rel=1e-3)
+
+    def test_manufactured_item_standard_cost_not_auto_synced(
+        self, db, make_vendor, make_purchase_order, make_product
+    ):
+        """For manufactured items (active BOM or routing), standard_cost is
+        owned by the cost rollup (BOM + routing). Receiving a PO must NOT
+        overwrite it with the purchase price — that would erase the rollup
+        and make standard_cost reflect raw-material cost instead of finished
+        cost. Recost All is the path that recalculates these.
+        """
+        from app.models.bom import BOM
+
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        # Manufactured item that we somehow also purchase (e.g., outsourced backup).
+        product = make_product(
+            item_type="finished_good",
+            unit="EA",
+            purchase_uom="EA",
+            standard_cost=Decimal("12.34"),  # rollup-derived cost
+        )
+        bom = BOM(product_id=product.id, version=1, active=True)
+        db.add(bom)
+        db.flush()
+
+        line = _add_po_line(
+            db, po, product, Decimal("5"), Decimal("9.99"), purchase_unit="EA"
+        )
+        db.commit()
+
+        receive_purchase_order(
+            db, po.id,
+            lines=[{"line_id": line.id, "quantity_received": Decimal("5")}],
+            user_id=1,
+            user_email="test@filaops.dev",
+        )
+
+        db.refresh(product)
+        # average_cost still updates from receipt — it's a real number we paid
+        assert product.average_cost is not None
+        # but standard_cost stays at the rollup value, NOT the purchase price
+        assert float(product.standard_cost) == pytest.approx(12.34, rel=1e-6)
+
     def test_creates_material_lot(self, db, make_vendor, make_purchase_order, make_product):
         """Receiving a supply product creates a MaterialLot for traceability."""
         vendor = make_vendor()


### PR DESCRIPTION
## Summary

- Receiving a PO now sets `product.standard_cost = product.average_cost` for purchased items (no active BOM, no active routing of their own), so downstream rollups (routing material `unit_cost`, BOM cost rollup, item grid, MRP) reflect the new cost basis without requiring a manual **Recost All**.
- Manufactured items (with active BOM or routing) are deliberately left alone — `standard_cost` for those is owned by the cost-rollup calculation, and overwriting it with the purchase price would erase the BOM/routing contribution.

## The bug this fixes

Reproduced live on 2026-04-25 with **COMP-007 (Gumi Clear Elastics)**:

1. Component had no `standard_cost` / `average_cost` / `last_cost` (newly entered, never received).
2. Routing operation on an assembly had COMP-007 attached as material → routing row showed `2.000000 EA /unit` with **no `$` price**, because `RoutingOperationMaterial.unit_cost` returned `Decimal(0)`.
3. User created and received `PO-2026-008` (200 EA @ $0.0575). Inventory transaction landed correctly with `$0.0575/EA`.
4. **But `standard_cost` stayed at 0** because `receive_purchase_order` only updates `last_cost` and `average_cost`. The Edit Item modal on the items page only exposes `Standard Cost`, so the user saw "$0.00" and the routing rollup still showed nothing for the elastics line.

The recost flow *would* have fixed this on the next "Recost All", but that's a manual step the user shouldn't have to remember after every PO receipt.

## Logic

For purchased items, `standard_cost` is just a cached projection of the weighted moving average. So:

- After the existing per-line cost loop in `receive_purchase_order`, walk the unique products in `product_receipt_accum` (the cost-update set — already excludes UOM-mismatch lines).
- One batch query each for active BOM and active Routing membership (no N+1).
- For products that have neither, `product.standard_cost = product.average_cost`.
- Products with BOM/routing skip the assignment.

## Tests

- `test_purchased_item_standard_cost_auto_synced` — regression for the COMP-007 incident: receives 200 EA @ \$0.0575 and asserts `standard_cost == average_cost == 0.0575`.
- `test_manufactured_item_standard_cost_not_auto_synced` — purchases an item with an active BOM and asserts `standard_cost` is **not** overwritten.

All 18 tests in `TestReceivePurchaseOrder` pass, plus the broader 438-test surface (PO service unit + endpoint, item service, routing service + API).

## Out of scope (follow-ups)

- **Cascading recost for manufactured parents** when a component cost changes. Today users still need "Recost All" for that. Tracked as a separate concern — bigger, recursive, and needs careful test design for cycles.
- **Pre-existing F401 ruff violations** in `tests/services/test_purchase_order_service.py` (introduced 2026-02-06, commit `5530c15b`). Reported via `cortex_observe`. CI evidently doesn't lint tests; cleanup belongs in a separate PR.

## Test plan

- [ ] CI green on `fix/po-receive-update-standard-cost`
- [ ] On VM: receive a fresh PO for COMP-007 (or any purchased component without prior cost), confirm `Standard Cost` populates on the items page immediately, and confirm the routing material row shows `/unit \$X.XX` without re-running Recost All
- [ ] Receive a PO for a manufactured item with an active BOM and confirm its `standard_cost` does **not** change to the purchase price

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase orders now automatically synchronize standard costs from actual purchase costs for items not part of active manufacturing configurations.

* **Tests**
  * Added regression tests to verify standard cost behavior for both purchased and manufactured items during purchase order receipt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->