### PR TITLE
feat(items): roll up variant on-hand + available qty onto template rows

### DIFF
--- a/backend/app/api/v1/endpoints/items.py
+++ b/backend/app/api/v1/endpoints/items.py
@@ -256,6 +256,8 @@ async def list_items(
             parent_product_id=item.get("parent_product_id"),
             is_template=item.get("is_template", False),
             variant_count=item.get("variant_count", 0),
+            variants_on_hand_qty=item.get("variants_on_hand_qty"),
+            variants_available_qty=item.get("variants_available_qty"),
         )
         for item in items_data
     ]

--- a/backend/app/schemas/item.py
+++ b/backend/app/schemas/item.py
@@ -264,6 +264,11 @@ class ItemListResponse(BaseModel):
     parent_product_id: Optional[int] = None
     is_template: bool = False
     variant_count: int = 0
+    # Variant inventory rollup — populated for templates only (None otherwise).
+    # SUM across child variants linked by parent_product_id. Pure presentation;
+    # consumption/MRP/PO logic still operates on individual variant rows.
+    variants_on_hand_qty: Optional[Decimal] = None
+    variants_available_qty: Optional[Decimal] = None
 
     class Config:
         from_attributes = True

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -449,6 +449,68 @@ def list_items(
         )
         variant_count_map = {r.parent_product_id: r.cnt for r in vc_rows}
 
+    # Variant inventory rollup for templates (Workstream A — display only).
+    # Templates carry no inventory of their own today; surface child variants'
+    # combined stock so the template row reflects what's actually available.
+    # Maps are keyed by template_id; absence = "no rollup eligible" (None to UI).
+    variants_on_hand_map: dict[int, float] = {}
+    variants_available_map: dict[int, float] = {}
+    if template_ids:
+        # Sum on-hand grouped by parent (outerjoin so variants without
+        # Inventory rows still anchor the template at 0, not None).
+        v_inv_rows = (
+            db.query(
+                Product.parent_product_id.label("parent_id"),
+                func.coalesce(func.sum(Inventory.on_hand_quantity), 0).label("on_hand"),
+            )
+            .select_from(Product)
+            .outerjoin(Inventory, Inventory.product_id == Product.id)
+            .filter(Product.parent_product_id.in_(template_ids))
+            .group_by(Product.parent_product_id)
+            .all()
+        )
+        variants_on_hand_map = {r.parent_id: float(r.on_hand) for r in v_inv_rows}
+
+        # Sum allocations attributed to variant components grouped by their
+        # parent template. Mirrors the per-item alloc query above, but the
+        # outer GROUP BY is the variant's parent rather than the variant itself.
+        from app.models.production_order import ProductionOrder
+
+        v_alloc_rows = (
+            db.query(
+                Product.parent_product_id.label("parent_id"),
+                func.coalesce(
+                    func.sum(
+                        (
+                            ProductionOrder.quantity_ordered
+                            - func.coalesce(ProductionOrder.quantity_completed, 0)
+                            - func.coalesce(ProductionOrder.quantity_scrapped, 0)
+                        )
+                        * BOMLine.quantity
+                    ),
+                    0,
+                ).label("allocated"),
+            )
+            .select_from(ProductionOrder)
+            .join(BOM, ProductionOrder.product_id == BOM.product_id)
+            .join(BOMLine, BOM.id == BOMLine.bom_id)
+            .join(Product, Product.id == BOMLine.component_id)
+            .filter(
+                BOM.active.is_(True),
+                Product.parent_product_id.in_(template_ids),
+                ProductionOrder.status.in_(
+                    ["draft", "released", "scheduled", "in_progress"]
+                ),
+            )
+            .group_by(Product.parent_product_id)
+            .all()
+        )
+        v_alloc_map = {r.parent_id: float(r.allocated) for r in v_alloc_rows}
+
+        # available = on_hand - allocated, only for templates with rollup data
+        for parent_id, on_hand in variants_on_hand_map.items():
+            variants_available_map[parent_id] = on_hand - v_alloc_map.get(parent_id, 0.0)
+
     result = []
     for item in items:
         on_hand = on_hand_map.get(item.id, 0.0)
@@ -494,6 +556,8 @@ def list_items(
                 "parent_product_id": item.parent_product_id,
                 "is_template": item.is_template,
                 "variant_count": variant_count_map.get(item.id, 0),
+                "variants_on_hand_qty": variants_on_hand_map.get(item.id) if item.is_template else None,
+                "variants_available_qty": variants_available_map.get(item.id) if item.is_template else None,
             }
         )
 

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -434,7 +434,8 @@ def list_items(
         )
         routing_ids = {r.product_id for r in routing_rows}
 
-    # Batch variant count query for templates
+    # Batch variant count query for templates — active variants only, so
+    # soft-deleted variants don't inflate the count or roll up to live templates.
     variant_count_map: dict[int, int] = {}
     template_ids = [item.id for item in items if item.is_template]
     if template_ids:
@@ -443,7 +444,10 @@ def list_items(
                 Product.parent_product_id,
                 func.count(Product.id).label("cnt"),
             )
-            .filter(Product.parent_product_id.in_(template_ids))
+            .filter(
+                Product.parent_product_id.in_(template_ids),
+                Product.active.is_(True),
+            )
             .group_by(Product.parent_product_id)
             .all()
         )
@@ -453,28 +457,70 @@ def list_items(
     # Templates carry no inventory of their own today; surface child variants'
     # combined stock so the template row reflects what's actually available.
     # Maps are keyed by template_id; absence = "no rollup eligible" (None to UI).
+    # Symmetry with variant_count_map: only active variants contribute.
     variants_on_hand_map: dict[int, float] = {}
     variants_available_map: dict[int, float] = {}
     if template_ids:
-        # Sum on-hand grouped by parent (outerjoin so variants without
+        # Pre-filter subquery: only active variants under our templates.
+        # Reused as the join target for both inventory and allocation rollups,
+        # mirroring the alloc_map shape (component pre-filter before BOM/PO joins).
+        active_variants_sub = (
+            db.query(
+                Product.id.label("variant_id"),
+                Product.parent_product_id.label("parent_id"),
+            )
+            .filter(
+                Product.parent_product_id.in_(template_ids),
+                Product.active.is_(True),
+            )
+            .subquery()
+        )
+
+        # Sum on-hand grouped by parent (outerjoin so active variants without
         # Inventory rows still anchor the template at 0, not None).
         v_inv_rows = (
             db.query(
-                Product.parent_product_id.label("parent_id"),
+                active_variants_sub.c.parent_id,
                 func.coalesce(func.sum(Inventory.on_hand_quantity), 0).label("on_hand"),
             )
-            .select_from(Product)
-            .outerjoin(Inventory, Inventory.product_id == Product.id)
-            .filter(Product.parent_product_id.in_(template_ids))
-            .group_by(Product.parent_product_id)
+            .select_from(active_variants_sub)
+            .outerjoin(
+                Inventory, Inventory.product_id == active_variants_sub.c.variant_id
+            )
+            .group_by(active_variants_sub.c.parent_id)
             .all()
         )
         variants_on_hand_map = {r.parent_id: float(r.on_hand) for r in v_inv_rows}
 
-        # Sum allocations attributed to variant components grouped by their
-        # parent template. Mirrors the per-item alloc query above, but the
-        # outer GROUP BY is the variant's parent rather than the variant itself.
-        from app.models.production_order import ProductionOrder
+        # Allocations: pre-filter BOMLine to active-variant component_ids first,
+        # then join PO/BOM. Mirrors the per-item alloc_map shape — narrows the
+        # cross-join surface before the aggregate.
+        # ProductionOrder is already imported above (line 365); list_items() always
+        # exits early if items is empty, and item_ids is non-empty whenever
+        # template_ids is non-empty, so the earlier import has already executed.
+        v_bom_lines_sub = (
+            db.query(
+                BOMLine.component_id,
+                BOMLine.bom_id,
+                BOMLine.quantity,
+            )
+            .join(
+                active_variants_sub,
+                BOMLine.component_id == active_variants_sub.c.variant_id,
+            )
+            .subquery()
+        )
+
+        v_boms_sub = (
+            db.query(
+                BOM.product_id,
+                v_bom_lines_sub.c.component_id,
+                v_bom_lines_sub.c.quantity,
+            )
+            .join(v_bom_lines_sub, BOM.id == v_bom_lines_sub.c.bom_id)
+            .filter(BOM.active.is_(True))
+            .subquery()
+        )
 
         v_alloc_rows = (
             db.query(
@@ -486,21 +532,18 @@ def list_items(
                             - func.coalesce(ProductionOrder.quantity_completed, 0)
                             - func.coalesce(ProductionOrder.quantity_scrapped, 0)
                         )
-                        * BOMLine.quantity
+                        * v_boms_sub.c.quantity
                     ),
                     0,
                 ).label("allocated"),
             )
             .select_from(ProductionOrder)
-            .join(BOM, ProductionOrder.product_id == BOM.product_id)
-            .join(BOMLine, BOM.id == BOMLine.bom_id)
-            .join(Product, Product.id == BOMLine.component_id)
+            .join(v_boms_sub, ProductionOrder.product_id == v_boms_sub.c.product_id)
+            .join(Product, Product.id == v_boms_sub.c.component_id)
             .filter(
-                BOM.active.is_(True),
-                Product.parent_product_id.in_(template_ids),
                 ProductionOrder.status.in_(
                     ["draft", "released", "scheduled", "in_progress"]
-                ),
+                )
             )
             .group_by(Product.parent_product_id)
             .all()

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -643,6 +643,112 @@ class TestListItems:
 
 
 # =============================================================================
+# list_items — variant inventory rollup (Workstream A)
+# =============================================================================
+
+class TestListItemsVariantsRollup:
+    """When a row is is_template=True, list_items() returns SUM of child variants'
+    on-hand and available quantities under variants_on_hand_qty / variants_available_qty.
+
+    Pure presentation rollup — does not affect consumption, MRP, or production orders.
+    Templates carry no inventory of their own today (always 0), so this surfaces the
+    stock that would otherwise be invisible on the template row.
+    """
+
+    def test_template_with_variants_rolls_up_on_hand(
+        self, db, make_product
+    ):
+        template = make_product(sku="ROLLUP-TMPL-A", is_template=True)
+        v1 = make_product(sku="ROLLUP-TMPL-A-V1", parent_product_id=template.id)
+        v2 = make_product(sku="ROLLUP-TMPL-A-V2", parent_product_id=template.id)
+        _make_inventory(db, v1.id, on_hand=Decimal("5"))
+        _make_inventory(db, v2.id, on_hand=Decimal("7"))
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-TMPL-A")
+        row = next(i for i in items if i["sku"] == "ROLLUP-TMPL-A")
+
+        assert row["is_template"] is True
+        assert row["on_hand_qty"] == 0  # template carries no inventory of its own
+        assert row["variants_on_hand_qty"] == 12
+
+    def test_template_with_variants_rolls_up_available(
+        self, db, make_product
+    ):
+        """Without any open POs allocating against children, available equals on_hand."""
+        template = make_product(sku="ROLLUP-TMPL-B", is_template=True)
+        v1 = make_product(sku="ROLLUP-TMPL-B-V1", parent_product_id=template.id)
+        v2 = make_product(sku="ROLLUP-TMPL-B-V2", parent_product_id=template.id)
+        _make_inventory(db, v1.id, on_hand=Decimal("4"))
+        _make_inventory(db, v2.id, on_hand=Decimal("6"))
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-TMPL-B")
+        row = next(i for i in items if i["sku"] == "ROLLUP-TMPL-B")
+
+        assert row["variants_on_hand_qty"] == 10
+        assert row["variants_available_qty"] == 10
+
+    def test_template_with_no_variants_yields_none(self, db, make_product):
+        make_product(sku="ROLLUP-EMPTY-TMPL", is_template=True)
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-EMPTY-TMPL")
+        row = next(i for i in items if i["sku"] == "ROLLUP-EMPTY-TMPL")
+
+        assert row["is_template"] is True
+        assert row["variants_on_hand_qty"] is None
+        assert row["variants_available_qty"] is None
+
+    def test_non_template_yields_none(self, db, make_product):
+        make_product(sku="ROLLUP-STANDALONE")
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-STANDALONE")
+        row = next(i for i in items if i["sku"] == "ROLLUP-STANDALONE")
+
+        assert row["is_template"] is False
+        assert row["variants_on_hand_qty"] is None
+        assert row["variants_available_qty"] is None
+
+    def test_template_with_variants_but_no_inventory_rolls_up_zero(
+        self, db, make_product
+    ):
+        """Variants exist but none have Inventory rows — rollup is 0, not None.
+        The semantic distinction: 0 means 'rollup computed, sum is zero'.
+        None means 'not eligible for rollup' (non-template or no children).
+        """
+        template = make_product(sku="ROLLUP-TMPL-NOSTOCK", is_template=True)
+        make_product(
+            sku="ROLLUP-TMPL-NOSTOCK-V1", parent_product_id=template.id
+        )
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-TMPL-NOSTOCK")
+        row = next(i for i in items if i["sku"] == "ROLLUP-TMPL-NOSTOCK")
+
+        assert row["variants_on_hand_qty"] == 0
+        assert row["variants_available_qty"] == 0
+
+    def test_rollup_isolated_per_template(self, db, make_product):
+        """Two templates listed in the same response don't cross-pollinate."""
+        t_a = make_product(sku="ROLLUP-ISO-A", is_template=True)
+        t_b = make_product(sku="ROLLUP-ISO-B", is_template=True)
+        a_v = make_product(sku="ROLLUP-ISO-A-V1", parent_product_id=t_a.id)
+        b_v = make_product(sku="ROLLUP-ISO-B-V1", parent_product_id=t_b.id)
+        _make_inventory(db, a_v.id, on_hand=Decimal("3"))
+        _make_inventory(db, b_v.id, on_hand=Decimal("9"))
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-ISO")
+        a_row = next(i for i in items if i["sku"] == "ROLLUP-ISO-A")
+        b_row = next(i for i in items if i["sku"] == "ROLLUP-ISO-B")
+
+        assert a_row["variants_on_hand_qty"] == 3
+        assert b_row["variants_on_hand_qty"] == 9
+
+
+# =============================================================================
 # bulk_update_items
 # =============================================================================
 

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -747,6 +747,81 @@ class TestListItemsVariantsRollup:
         assert a_row["variants_on_hand_qty"] == 3
         assert b_row["variants_on_hand_qty"] == 9
 
+    def test_inactive_variant_inventory_excluded_from_rollup(
+        self, db, make_product
+    ):
+        """Soft-deleted variants must not contribute on-hand stock to the active template.
+        Without the active filter, a deleted FG-003-RED with leftover inventory
+        would falsely inflate FG-003's rollup."""
+        template = make_product(sku="ROLLUP-INACTIVE-TMPL", is_template=True)
+        live_variant = make_product(
+            sku="ROLLUP-INACTIVE-TMPL-V1", parent_product_id=template.id
+        )
+        dead_variant = make_product(
+            sku="ROLLUP-INACTIVE-TMPL-DEAD",
+            parent_product_id=template.id,
+            active=False,
+        )
+        _make_inventory(db, live_variant.id, on_hand=Decimal("4"))
+        _make_inventory(db, dead_variant.id, on_hand=Decimal("100"))
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-INACTIVE-TMPL")
+        row = next(i for i in items if i["sku"] == "ROLLUP-INACTIVE-TMPL")
+
+        assert row["variants_on_hand_qty"] == 4  # only the live variant
+        assert row["variant_count"] == 1  # dead variant excluded from count too
+
+    def test_inactive_variant_allocation_excluded_from_rollup(
+        self, db, make_product, make_bom
+    ):
+        """Soft-deleted variants with allocations against open POs must not
+        depress the live template's variants_available_qty.
+        Active variant has 10 on hand, dead variant has 50 on hand AND a 50-qty
+        allocation; if the inactive filter leaks, available would compute wrong."""
+        from app.models.production_order import ProductionOrder
+
+        template = make_product(sku="ROLLUP-INACT-ALLOC-TMPL", is_template=True)
+        live_variant = make_product(
+            sku="ROLLUP-INACT-ALLOC-TMPL-LIVE", parent_product_id=template.id
+        )
+        dead_variant = make_product(
+            sku="ROLLUP-INACT-ALLOC-TMPL-DEAD",
+            parent_product_id=template.id,
+            active=False,
+        )
+        _make_inventory(db, live_variant.id, on_hand=Decimal("10"))
+        _make_inventory(db, dead_variant.id, on_hand=Decimal("50"))
+
+        # Create a parent FG and a BOM consuming the dead variant
+        consumer = make_product(sku="ROLLUP-INACT-CONSUMER")
+        make_bom(
+            consumer.id,
+            lines=[
+                {"component_id": dead_variant.id, "quantity": Decimal("1")},
+            ],
+        )
+        po = ProductionOrder(
+            code="PO-INACT-TEST-0001",
+            product_id=consumer.id,
+            quantity_ordered=Decimal("50"),
+            quantity_completed=Decimal("0"),
+            quantity_scrapped=Decimal("0"),
+            source="manual",
+            status="released",
+            priority=3,
+            created_by="test@filaops.dev",
+        )
+        db.add(po)
+        db.commit()
+
+        items, _ = item_service.list_items(db, search="ROLLUP-INACT-ALLOC-TMPL")
+        row = next(i for i in items if i["sku"] == "ROLLUP-INACT-ALLOC-TMPL")
+
+        # Only live variant counts: 10 on hand, 0 allocated → 10 available
+        assert row["variants_on_hand_qty"] == 10
+        assert row["variants_available_qty"] == 10
+
 
 # =============================================================================
 # bulk_update_items

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -777,8 +777,11 @@ class TestListItemsVariantsRollup:
     ):
         """Soft-deleted variants with allocations against open POs must not
         depress the live template's variants_available_qty.
-        Active variant has 10 on hand, dead variant has 50 on hand AND a 50-qty
-        allocation; if the inactive filter leaks, available would compute wrong."""
+        Dead variant intentionally carries 0 on-hand here so any leak via the
+        allocation join makes available go negative (10 - 50 = -40), surfacing
+        the bug. The companion test_inactive_variant_inventory_excluded_from_rollup
+        covers the on-hand filter independently — separating the two prevents
+        symmetric-leak masking (where +50 on-hand and +50 alloc cancel)."""
         from app.models.production_order import ProductionOrder
 
         template = make_product(sku="ROLLUP-INACT-ALLOC-TMPL", is_template=True)
@@ -791,7 +794,7 @@ class TestListItemsVariantsRollup:
             active=False,
         )
         _make_inventory(db, live_variant.id, on_hand=Decimal("10"))
-        _make_inventory(db, dead_variant.id, on_hand=Decimal("50"))
+        _make_inventory(db, dead_variant.id, on_hand=Decimal("0"))
 
         # Create a parent FG and a BOM consuming the dead variant
         consumer = make_product(sku="ROLLUP-INACT-CONSUMER")

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -281,6 +281,26 @@ export default function ItemsTable({
                       ✕
                     </button>
                   </div>
+                ) : item.is_template && item.variants_on_hand_qty != null ? (
+                  // Variant inventory rollup (Workstream A): templates currently can't
+                  // carry their own inventory, so we replace the always-zero own-qty
+                  // cell with the SUM across child variants. If templates ever gain
+                  // their own stock, revisit this — we may need to show both values.
+                  <span
+                    className="text-right px-2 py-1 text-gray-300"
+                    title={`Sum across ${item.variant_count ?? 0} variants`}
+                  >
+                    {parseFloat(item.variants_on_hand_qty).toFixed(0)}
+                    <span className="text-gray-500 text-xs ml-1">
+                      {item.unit || "EA"}
+                    </span>
+                    <span
+                      className="text-blue-400 text-xs ml-1"
+                      aria-label={`On-hand rolled up from ${item.variant_count ?? 0} variants`}
+                    >
+                      ↘
+                    </span>
+                  </span>
                 ) : (
                   <button
                     onClick={() => onStartEditQty(item)}
@@ -320,6 +340,27 @@ export default function ItemsTable({
                 )}
               </td>
               <td className="py-3 px-4 text-right">
+                {item.is_template && item.variants_available_qty != null ? (
+                  <span
+                    className={
+                      parseFloat(item.variants_available_qty) <= 0
+                        ? "text-red-400"
+                        : "text-green-400"
+                    }
+                    title={`Sum across ${item.variant_count ?? 0} variants`}
+                  >
+                    {parseFloat(item.variants_available_qty).toFixed(0)}
+                    <span className="text-gray-500 text-xs ml-1">
+                      {item.unit || "EA"}
+                    </span>
+                    <span
+                      className="text-blue-400 text-xs ml-1"
+                      aria-label={`Available rolled up from ${item.variant_count ?? 0} variants`}
+                    >
+                      ↘
+                    </span>
+                  </span>
+                ) : (
                 <span
                   className={
                     item.available_qty != null &&
@@ -343,6 +384,7 @@ export default function ItemsTable({
                     "-"
                   )}
                 </span>
+                )}
               </td>
               <td className="py-3 px-4 text-center">
                 <span

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -28,6 +28,35 @@ const getItemTypeStyle = (type, hasFilament = false) => {
   }[found.color];
 };
 
+/**
+ * Format a quantity value with the right unit for an item.
+ * Materials display in grams; non-materials use item.unit (default "EA").
+ *
+ * `scaleMaterial` exists because on_hand_qty is stored in grams already
+ * (raw inventory), while available_qty / allocated_qty come back in the
+ * item's purchase_uom (KG for materials) and need ×1000 to render in grams.
+ * If that backend convention ever unifies, drop the flag and the call sites
+ * become symmetric.
+ */
+function formatQtyWithUnit(item, qty, { scaleMaterial = false } = {}) {
+  if (qty == null) return null;
+  const isMaterial = !!item?.material_type_id;
+  const num = parseFloat(qty);
+  const value = isMaterial && scaleMaterial ? num * 1000 : num;
+  const unit = isMaterial ? "g" : (item?.unit || "EA");
+  return { display: value.toFixed(0), unit };
+}
+
+function QtyCell({ formatted, fallback = "-" }) {
+  if (!formatted) return <>{fallback}</>;
+  return (
+    <>
+      {formatted.display}
+      <span className="text-gray-500 text-xs ml-1">{formatted.unit}</span>
+    </>
+  );
+}
+
 function SortIndicator({ columnKey, sortConfig }) {
   if (sortConfig.key !== columnKey && !(sortConfig.key === "stock_status" && columnKey === "available_qty")) {
     return <span className="text-gray-600 ml-1">↕</span>;
@@ -290,10 +319,9 @@ export default function ItemsTable({
                     className="text-right px-2 py-1 text-gray-300"
                     title={`Sum across ${item.variant_count ?? 0} variants`}
                   >
-                    {parseFloat(item.variants_on_hand_qty).toFixed(0)}
-                    <span className="text-gray-500 text-xs ml-1">
-                      {item.unit || "EA"}
-                    </span>
+                    <QtyCell
+                      formatted={formatQtyWithUnit(item, item.variants_on_hand_qty)}
+                    />
                     <span
                       className="text-blue-400 text-xs ml-1"
                       aria-label={`On-hand rolled up from ${item.variant_count ?? 0} variants`}
@@ -309,32 +337,18 @@ export default function ItemsTable({
                     } hover:text-white`}
                     title="Click to edit on-hand quantity"
                   >
-                    {item.on_hand_qty != null ? (
-                      <>
-                        {item.material_type_id
-                          ? parseFloat(item.on_hand_qty).toFixed(0)
-                          : parseFloat(item.on_hand_qty).toFixed(0)}
-                        <span className="text-gray-500 text-xs ml-1">
-                          {item.material_type_id ? "g" : (item.unit || "EA")}
-                        </span>
-                      </>
-                    ) : (
-                      "-"
-                    )}
+                    <QtyCell
+                      formatted={formatQtyWithUnit(item, item.on_hand_qty)}
+                    />
                   </button>
                 )}
               </td>
               <td className="py-3 px-4 text-right text-yellow-400">
                 {item.allocated_qty != null &&
                 parseFloat(item.allocated_qty) > 0 ? (
-                  <>
-                    {item.material_type_id
-                      ? (parseFloat(item.allocated_qty) * 1000).toFixed(0)
-                      : parseFloat(item.allocated_qty).toFixed(0)}
-                    <span className="text-gray-500 text-xs ml-1">
-                      {item.material_type_id ? "g" : (item.unit || "EA")}
-                    </span>
-                  </>
+                  <QtyCell
+                    formatted={formatQtyWithUnit(item, item.allocated_qty, { scaleMaterial: true })}
+                  />
                 ) : (
                   "-"
                 )}
@@ -349,10 +363,9 @@ export default function ItemsTable({
                     }
                     title={`Sum across ${item.variant_count ?? 0} variants`}
                   >
-                    {parseFloat(item.variants_available_qty).toFixed(0)}
-                    <span className="text-gray-500 text-xs ml-1">
-                      {item.unit || "EA"}
-                    </span>
+                    <QtyCell
+                      formatted={formatQtyWithUnit(item, item.variants_available_qty, { scaleMaterial: true })}
+                    />
                     <span
                       className="text-blue-400 text-xs ml-1"
                       aria-label={`Available rolled up from ${item.variant_count ?? 0} variants`}
@@ -371,18 +384,9 @@ export default function ItemsTable({
                       : "text-green-400"
                   }
                 >
-                  {item.available_qty != null ? (
-                    <>
-                      {item.material_type_id
-                        ? (parseFloat(item.available_qty) * 1000).toFixed(0)
-                        : parseFloat(item.available_qty).toFixed(0)}
-                      <span className="text-gray-500 text-xs ml-1">
-                        {item.material_type_id ? "g" : (item.unit || "EA")}
-                      </span>
-                    </>
-                  ) : (
-                    "-"
-                  )}
+                  <QtyCell
+                    formatted={formatQtyWithUnit(item, item.available_qty, { scaleMaterial: true })}
+                  />
                 </span>
                 )}
               </td>

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -30,7 +30,8 @@ const getItemTypeStyle = (type, hasFilament = false) => {
 
 /**
  * Format a quantity value with the right unit for an item.
- * Materials display in grams; non-materials use item.unit (default "EA").
+ * Materials display in grams (integer); non-materials use item.unit (default
+ * "EA") and preserve fractional precision via toLocaleString.
  *
  * `scaleMaterial` exists because on_hand_qty is stored in grams already
  * (raw inventory), while available_qty / allocated_qty come back in the
@@ -43,8 +44,11 @@ function formatQtyWithUnit(item, qty, { scaleMaterial = false } = {}) {
   const isMaterial = !!item?.material_type_id;
   const num = parseFloat(qty);
   const value = isMaterial && scaleMaterial ? num * 1000 : num;
+  // Materials are always whole grams in display. Non-materials preserve any
+  // fractional EA / piece quantities entered by the user (e.g. 2.5 EA stays "2.5").
+  const display = isMaterial ? value.toFixed(0) : value.toLocaleString();
   const unit = isMaterial ? "g" : (item?.unit || "EA");
-  return { display: value.toFixed(0), unit };
+  return { display, unit };
 }
 
 function QtyCell({ formatted, fallback = "-" }) {
@@ -55,6 +59,27 @@ function QtyCell({ formatted, fallback = "-" }) {
       <span className="text-gray-500 text-xs ml-1">{formatted.unit}</span>
     </>
   );
+}
+
+/**
+ * Build tooltip + aria-label copy for a variant rollup cell.
+ * `kind` is "On-hand" or "Available". Defensive: when `count` is somehow 0
+ * (shouldn't happen since the rollup cell only renders when at least one
+ * active variant exists), we fall back to neutral copy rather than the
+ * awkward "Sum across 0 variants".
+ */
+function rollupCopy(kind, count) {
+  const c = count ?? 0;
+  if (c <= 0) {
+    return {
+      title: `${kind} variant rollup`,
+      ariaLabel: `${kind} variant rollup`,
+    };
+  }
+  return {
+    title: `Sum across ${c} variants`,
+    ariaLabel: `${kind} rolled up from ${c} variants`,
+  };
 }
 
 function SortIndicator({ columnKey, sortConfig }) {
@@ -315,20 +340,22 @@ export default function ItemsTable({
                   // carry their own inventory, so we replace the always-zero own-qty
                   // cell with the SUM across child variants. If templates ever gain
                   // their own stock, revisit this — we may need to show both values.
-                  <span
-                    className="text-right px-2 py-1 text-gray-300"
-                    title={`Sum across ${item.variant_count ?? 0} variants`}
-                  >
-                    <QtyCell
-                      formatted={formatQtyWithUnit(item, item.variants_on_hand_qty)}
-                    />
-                    <span
-                      className="text-blue-400 text-xs ml-1"
-                      aria-label={`On-hand rolled up from ${item.variant_count ?? 0} variants`}
-                    >
-                      ↘
-                    </span>
-                  </span>
+                  (() => {
+                    const copy = rollupCopy("On-hand", item.variant_count);
+                    return (
+                      <span className="px-2 py-1 text-gray-300" title={copy.title}>
+                        <QtyCell
+                          formatted={formatQtyWithUnit(item, item.variants_on_hand_qty)}
+                        />
+                        <span
+                          className="text-blue-400 text-xs ml-1"
+                          aria-label={copy.ariaLabel}
+                        >
+                          ↘
+                        </span>
+                      </span>
+                    );
+                  })()
                 ) : (
                   <button
                     onClick={() => onStartEditQty(item)}
@@ -355,24 +382,29 @@ export default function ItemsTable({
               </td>
               <td className="py-3 px-4 text-right">
                 {item.is_template && item.variants_available_qty != null ? (
-                  <span
-                    className={
-                      parseFloat(item.variants_available_qty) <= 0
-                        ? "text-red-400"
-                        : "text-green-400"
-                    }
-                    title={`Sum across ${item.variant_count ?? 0} variants`}
-                  >
-                    <QtyCell
-                      formatted={formatQtyWithUnit(item, item.variants_available_qty, { scaleMaterial: true })}
-                    />
-                    <span
-                      className="text-blue-400 text-xs ml-1"
-                      aria-label={`Available rolled up from ${item.variant_count ?? 0} variants`}
-                    >
-                      ↘
-                    </span>
-                  </span>
+                  (() => {
+                    const copy = rollupCopy("Available", item.variant_count);
+                    return (
+                      <span
+                        className={
+                          parseFloat(item.variants_available_qty) <= 0
+                            ? "text-red-400"
+                            : "text-green-400"
+                        }
+                        title={copy.title}
+                      >
+                        <QtyCell
+                          formatted={formatQtyWithUnit(item, item.variants_available_qty, { scaleMaterial: true })}
+                        />
+                        <span
+                          className="text-blue-400 text-xs ml-1"
+                          aria-label={copy.ariaLabel}
+                        >
+                          ↘
+                        </span>
+                      </span>
+                    );
+                  })()
                 ) : (
                 <span
                   className={

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -371,8 +371,32 @@ export default function ItemsTable({
                 )}
               </td>
               <td className="py-3 px-4 text-right text-yellow-400">
-                {item.allocated_qty != null &&
-                parseFloat(item.allocated_qty) > 0 ? (
+                {item.is_template &&
+                item.variants_on_hand_qty != null &&
+                item.variants_available_qty != null ? (
+                  // Reserved rollup: derived from on_hand − available so the row
+                  // math reconciles. variants_*_qty come back in matching units
+                  // (both already in grams for materials, no scaling), so the
+                  // subtraction preserves the convention.
+                  (() => {
+                    const reserved =
+                      parseFloat(item.variants_on_hand_qty) -
+                      parseFloat(item.variants_available_qty);
+                    const copy = rollupCopy("Reserved", item.variant_count);
+                    return (
+                      <span title={copy.title}>
+                        <QtyCell formatted={formatQtyWithUnit(item, reserved)} />
+                        <span
+                          className="text-blue-400 text-xs ml-1"
+                          aria-label={copy.ariaLabel}
+                        >
+                          ↘
+                        </span>
+                      </span>
+                    );
+                  })()
+                ) : item.allocated_qty != null &&
+                  parseFloat(item.allocated_qty) > 0 ? (
                   <QtyCell
                     formatted={formatQtyWithUnit(item, item.allocated_qty, { scaleMaterial: true })}
                   />
@@ -394,7 +418,7 @@ export default function ItemsTable({
                         title={copy.title}
                       >
                         <QtyCell
-                          formatted={formatQtyWithUnit(item, item.variants_available_qty, { scaleMaterial: true })}
+                          formatted={formatQtyWithUnit(item, item.variants_available_qty)}
                         />
                         <span
                           className="text-blue-400 text-xs ml-1"

--- a/frontend/src/components/items/__tests__/ItemsTable.test.jsx
+++ b/frontend/src/components/items/__tests__/ItemsTable.test.jsx
@@ -90,3 +90,61 @@ describe('ItemsTable — currency display', () => {
     expect(screen.queryByText('$35.00')).not.toBeInTheDocument()
   })
 })
+
+describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
+  const templateRow = {
+    ...item,
+    id: 99,
+    sku: 'FG-TMPL-X',
+    name: 'Zorble Template',
+    item_type: 'finished_good',
+    material_type_id: null,
+    unit: 'EA',
+    on_hand_qty: 0,
+    available_qty: 0,
+    is_template: true,
+    variant_count: 3,
+    variants_on_hand_qty: 12,
+    variants_available_qty: 9,
+  }
+
+  const renderTemplate = () =>
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} items={[templateRow]} />
+      </MockLocaleProvider>
+    )
+
+  it('renders the rollup on-hand value (12) instead of the templates own 0', () => {
+    renderTemplate()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    // Template own-qty is always 0, but the cell should now show the rollup
+    expect(screen.queryByText('0', { selector: 'button' })).not.toBeInTheDocument()
+  })
+
+  it('renders the rollup available value (9)', () => {
+    renderTemplate()
+    expect(screen.getByText('9')).toBeInTheDocument()
+  })
+
+  it('exposes an accessible aria-label that names the variant count', () => {
+    renderTemplate()
+    // On-hand rollup indicator
+    expect(
+      screen.getByLabelText(/on-hand rolled up from 3 variants/i),
+    ).toBeInTheDocument()
+    // Available rollup indicator
+    expect(
+      screen.getByLabelText(/available rolled up from 3 variants/i),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render rollup indicator for non-template rows', () => {
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} />
+      </MockLocaleProvider>
+    )
+    expect(screen.queryByLabelText(/rolled up from/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/items/__tests__/ItemsTable.test.jsx
+++ b/frontend/src/components/items/__tests__/ItemsTable.test.jsx
@@ -147,4 +147,35 @@ describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
     )
     expect(screen.queryByLabelText(/rolled up from/i)).not.toBeInTheDocument()
   })
+
+  it('renders material template rollup with "g" unit and ×1000 scaling on AVAILABLE only', () => {
+    // Material template: on_hand stays in grams (raw), available is in KG (scaled ×1000).
+    // The variants_on_hand_qty is the on-hand sum (already grams), variants_available_qty
+    // is the available sum (KG-equivalent) — same convention as the per-item fields.
+    const materialTemplate = {
+      ...templateRow,
+      id: 100,
+      sku: 'FIL-PLA-TMPL',
+      name: 'PLA Filament Template',
+      item_type: 'material',
+      material_type_id: 5,
+      unit: 'G',
+      variants_on_hand_qty: 800, // grams, render as-is
+      variants_available_qty: 0.7, // KG, render as 700 g
+    }
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} items={[materialTemplate]} />
+      </MockLocaleProvider>
+    )
+    // ON-HAND: 800 (no scaling) with 'g' unit
+    expect(screen.getByText('800')).toBeInTheDocument()
+    // AVAILABLE: 700 (0.7 × 1000) with 'g' unit
+    expect(screen.getByText('700')).toBeInTheDocument()
+    // 'g' unit appears at least twice (on-hand + available + allocated cells if any)
+    const gUnits = screen.getAllByText('g')
+    expect(gUnits.length).toBeGreaterThanOrEqual(2)
+    // 'EA' should NOT appear for this material template
+    expect(screen.queryByText('EA')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/items/__tests__/ItemsTable.test.jsx
+++ b/frontend/src/components/items/__tests__/ItemsTable.test.jsx
@@ -173,10 +173,11 @@ describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
     expect(fractional.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders material template rollup with "g" unit and ×1000 scaling on AVAILABLE only', () => {
-    // Material template: on_hand stays in grams (raw), available is in KG (scaled ×1000).
-    // The variants_on_hand_qty is the on-hand sum (already grams), variants_available_qty
-    // is the available sum (KG-equivalent) — same convention as the per-item fields.
+  it('renders material template rollup with "g" unit and no scaling on either column', () => {
+    // Both variants_on_hand_qty AND variants_available_qty come back from the
+    // backend already in grams (computed as raw Inventory.on_hand_quantity sums
+    // and BOMLine.quantity allocations — no KG conversion). Rollup display must
+    // not multiply by 1000 on either column.
     const materialTemplate = {
       ...templateRow,
       id: 100,
@@ -185,22 +186,66 @@ describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
       item_type: 'material',
       material_type_id: 5,
       unit: 'G',
-      variants_on_hand_qty: 800, // grams, render as-is
-      variants_available_qty: 0.7, // KG, render as 700 g
+      variants_on_hand_qty: 800,        // grams — render "800"
+      variants_available_qty: 700,      // grams — render "700" (NOT 700,000)
     }
     render(
       <MockLocaleProvider currency="USD" locale="en-US">
         <ItemsTable {...baseProps} items={[materialTemplate]} />
       </MockLocaleProvider>
     )
-    // ON-HAND: 800 (no scaling) with 'g' unit
     expect(screen.getByText('800')).toBeInTheDocument()
-    // AVAILABLE: 700 (0.7 × 1000) with 'g' unit
     expect(screen.getByText('700')).toBeInTheDocument()
-    // 'g' unit appears at least twice (on-hand + available + allocated cells if any)
+    // Rollup must not scale: 700,000 would be the buggy ×1000 output
+    expect(screen.queryByText('700,000')).not.toBeInTheDocument()
+    // 'g' unit appears for ON-HAND, RESERVED, AVAILABLE rollup cells
     const gUnits = screen.getAllByText('g')
     expect(gUnits.length).toBeGreaterThanOrEqual(2)
-    // 'EA' should NOT appear for this material template
     expect(screen.queryByText('EA')).not.toBeInTheDocument()
+  })
+
+  it('renders Reserved rollup as on_hand − available for templates instead of "-"', () => {
+    // Without this, a template with stock and allocations shows the math gap:
+    // On Hand 40, Available 30, Reserved should be 10 (but used to render "-").
+    const reservedRow = {
+      ...templateRow,
+      id: 101,
+      sku: 'FG-RESERVED-TMPL',
+      variant_count: 4,
+      variants_on_hand_qty: 40,
+      variants_available_qty: 30,  // 10 reserved across variants
+    }
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} items={[reservedRow]} />
+      </MockLocaleProvider>
+    )
+    expect(screen.getByText('40')).toBeInTheDocument()  // on-hand rollup
+    expect(screen.getByText('30')).toBeInTheDocument()  // available rollup
+    expect(screen.getByText('10')).toBeInTheDocument()  // reserved derived
+    expect(
+      screen.getByLabelText(/reserved rolled up from 4 variants/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders Reserved as 0 for templates with stock but no allocations', () => {
+    const noAllocRow = {
+      ...templateRow,
+      id: 102,
+      sku: 'FG-NOALLOC-TMPL',
+      variant_count: 2,
+      variants_on_hand_qty: 12,
+      variants_available_qty: 12,
+    }
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} items={[noAllocRow]} />
+      </MockLocaleProvider>
+    )
+    // Reserved = 12 - 12 = 0 → renders "0", not "-"
+    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(/reserved rolled up from 2 variants/i),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/items/__tests__/ItemsTable.test.jsx
+++ b/frontend/src/components/items/__tests__/ItemsTable.test.jsx
@@ -148,6 +148,31 @@ describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
     expect(screen.queryByLabelText(/rolled up from/i)).not.toBeInTheDocument()
   })
 
+  it('preserves fractional non-material quantities (e.g. 2.5 EA) instead of rounding to 3', () => {
+    // Regression for the toFixed(0)-everywhere bug: non-material units must keep decimals.
+    const fractionalRow = {
+      ...item,
+      id: 200,
+      sku: 'COMP-FRAC-001',
+      name: 'Fractional Component',
+      item_type: 'component',
+      material_type_id: null, // explicitly non-material
+      unit: 'EA',
+      on_hand_qty: 2.5,
+      available_qty: 2.5,
+    }
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable {...baseProps} items={[fractionalRow]} />
+      </MockLocaleProvider>
+    )
+    // 2.5 EA must NOT round to "3"
+    expect(screen.queryByText('3')).not.toBeInTheDocument()
+    // Both ON-HAND and AVAILABLE cells render the fractional value (toLocaleString)
+    const fractional = screen.getAllByText('2.5')
+    expect(fractional.length).toBeGreaterThanOrEqual(2)
+  })
+
   it('renders material template rollup with "g" unit and ×1000 scaling on AVAILABLE only', () => {
     // Material template: on_hand stays in grams (raw), available is in KG (scaled ×1000).
     // The variants_on_hand_qty is the on-hand sum (already grams), variants_available_qty


### PR DESCRIPTION
## Summary

Templates carry no inventory of their own — the items list previously showed `0 EA` on template rows even when child variants had stock. This PR adds `variants_on_hand_qty` + `variants_available_qty` as `Optional[Decimal]` fields on `ItemListResponse`, computed via two batched grouped queries on `Product.parent_product_id`. **Pure presentation** — consumption, MRP, and production order logic untouched.

This is **Workstream A** from `project_variant_consumption_rollup.md` (memory). It is *distinct* from `project_variant_matrix.md`'s Phase 3, which is the matrix grid UX text-input work.

### What you'll see in the UI
- Template row's ON HAND cell: `12 EA ↘` (with tooltip "Sum across N variants" and `aria-label="On-hand rolled up from N variants"`)
- Template row's AVAILABLE cell: same treatment (sum minus open PO allocations against children)
- Variant rows and standalone products: unchanged
- Verified live in this repo: FG-003 with 20 EA on BLK + 20 EA on BLU now correctly shows **40 EA ↘** on the template row

### What's deliberately NOT in this PR
- No schema migration
- No changes to `production_order_service.py`, `mrp.py`, `variant_service.py`
- The demand-side gap (PO release sees template's own 0, not the rollup) is the documented Workstream B/C scope and is unchanged

### Implementation
- **Service** (`item_service.list_items`): `variants_on_hand_map` + `variants_available_map` built alongside the existing `variant_count_map` block. Two extra round-trips, both grouped by the indexed `parent_product_id` FK.
- **Schema** (`ItemListResponse`): two new `Optional[Decimal]` fields (`None` for non-templates, `0` for templates whose variants have no inventory rows).
- **Endpoint** (`items.list_items`): propagates both fields in the response builder.
- **Frontend** (`ItemsTable.jsx`): on-hand and available cells branch on `is_template && variants_*_qty != null`, render the rollup with `↘` indicator + `aria-label` for screen readers, plus a defensive comment noting that if templates ever gain their own inventory, this display logic will need to show both values.

### Coverage caveat
The "available equals on-hand when no allocations exist" test passes because no open POs are in the fixtures (`x − 0 = x`). The query shape is mechanically derived from the existing per-item `alloc_map` query (just grouped by parent rather than by component), so the math is structurally identical. A future test creating an active PO consuming a variant would harden this — flagged as a follow-up rather than scoped in.

## Test plan

- [x] `pytest backend/tests/services/test_item_service.py::TestListItemsVariantsRollup` — 6/6 new tests pass (rollup math, no-variants → None, non-template → None, no-inventory variants → 0, isolation across templates)
- [x] `pytest backend/tests/services/test_item_service.py backend/tests/services/test_inventory_service.py backend/tests/services/test_inventory_extra.py backend/tests/test_variant_service.py` — 215/215, no regressions
- [x] `vitest run --config vitest.unit.config.js src/components/items/` — 16/16 (4 new in `ItemsTable.test.jsx`, including aria-label assertion)
- [x] `ruff check` — clean on all 3 changed app files
- [x] Manual UI verification: FG-003 template with 20 EA on BLK + 20 EA on BLU correctly shows `40 EA ↘` for both ON HAND and AVAILABLE
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API and UI now surface aggregated variant totals for template items as "On Hand" and "Available".
  * UI shows rollup indicator with tooltip/aria text; quantity formatting/refactoring added for consistent unit handling and material scaling.

* **Tests**
  * Added tests covering rollup computation, rendering, accessibility labels, unit formatting, and exclusion of inactive variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->