### PR TITLE
feat(production-orders): variant swap on PO operation materials (B0)

### DIFF
--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -173,6 +173,7 @@ def get_operations(
                 component_id=mat.component_id,
                 component_sku=mat.component.sku if mat.component else None,
                 component_name=mat.component.name if mat.component else None,
+                component_is_template=bool(mat.component.is_template) if mat.component else False,
                 quantity_required=mat.quantity_required,
                 quantity_consumed=mat.quantity_consumed,
                 unit=mat.unit,

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -16,7 +16,11 @@ from app.api.v1.endpoints.auth import get_current_user
 from app.api.v1.deps import get_pagination_params
 from app.schemas.common import MessageResponse, PaginationParams
 from app.models import User, Product, SalesOrder
-from app.models.production_order import ProductionOrder, ProductionOrderOperation
+from app.models.production_order import (
+    ProductionOrder,
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
 from app.models.work_center import WorkCenter
 from app.models.manufacturing import Resource
 from app.schemas.production_order import (
@@ -75,6 +79,30 @@ router = APIRouter()
 # Response Builders
 # =============================================================================
 
+def _build_operation_material_response(
+    mat: ProductionOrderOperationMaterial, db: Session
+) -> OperationMaterialResponse:
+    """Build the wire-format OperationMaterialResponse for one PO operation material.
+
+    Single source of truth for material serialization — every new field (e.g.
+    component_is_template added in Workstream B0) only needs to be wired here
+    rather than in each call site.
+    """
+    component = db.query(Product).filter(Product.id == mat.component_id).first()
+    return OperationMaterialResponse(
+        id=mat.id,
+        component_id=mat.component_id,
+        component_sku=component.sku if component else None,
+        component_name=component.name if component else None,
+        component_is_template=bool(component.is_template) if component else False,
+        quantity_required=mat.quantity_required,
+        quantity_allocated=mat.quantity_allocated or Decimal(0),
+        quantity_consumed=mat.quantity_consumed or Decimal(0),
+        unit=mat.unit,
+        status=mat.status or "pending",
+    )
+
+
 def build_production_order_response(order: ProductionOrder, db: Session) -> ProductionOrderResponse:
     """Build full response with related data."""
     from app.models import BOM
@@ -104,23 +132,9 @@ def build_production_order_response(order: ProductionOrder, db: Session) -> Prod
             wc = db.query(WorkCenter).filter(WorkCenter.id == op.work_center_id).first()
             res = db.query(Resource).filter(Resource.id == op.resource_id).first() if op.resource_id else None
 
-            materials_response = []
-            for mat in op.materials:
-                component = db.query(Product).filter(Product.id == mat.component_id).first()
-                materials_response.append(
-                    OperationMaterialResponse(
-                        id=mat.id,
-                        component_id=mat.component_id,
-                        component_sku=component.sku if component else None,
-                        component_name=component.name if component else None,
-                        component_is_template=bool(component.is_template) if component else False,
-                        quantity_required=mat.quantity_required,
-                        quantity_allocated=mat.quantity_allocated or Decimal(0),
-                        quantity_consumed=mat.quantity_consumed or Decimal(0),
-                        unit=mat.unit,
-                        status=mat.status or "pending",
-                    )
-                )
+            materials_response = [
+                _build_operation_material_response(mat, db) for mat in op.materials
+            ]
 
             operations_response.append(
                 ProductionOrderOperationResponse(
@@ -941,23 +955,9 @@ async def update_operation(
     wc = db.query(WorkCenter).filter(WorkCenter.id == op.work_center_id).first()
     res = db.query(Resource).filter(Resource.id == op.resource_id).first() if op.resource_id else None
 
-    materials_response = []
-    for mat in op.materials:
-        component = db.query(Product).filter(Product.id == mat.component_id).first()
-        materials_response.append(
-            OperationMaterialResponse(
-                id=mat.id,
-                component_id=mat.component_id,
-                component_sku=component.sku if component else None,
-                component_name=component.name if component else None,
-                component_is_template=bool(component.is_template) if component else False,
-                quantity_required=mat.quantity_required,
-                quantity_allocated=mat.quantity_allocated or Decimal(0),
-                quantity_consumed=mat.quantity_consumed or Decimal(0),
-                unit=mat.unit,
-                status=mat.status or "pending",
-            )
-        )
+    materials_response = [
+        _build_operation_material_response(mat, db) for mat in op.materials
+    ]
 
     return ProductionOrderOperationResponse(
         id=op.id,
@@ -1090,7 +1090,6 @@ async def check_compatibility(
     """
     from app.services.compatibility_service import check_order_compatibility
     from sqlalchemy.orm import selectinload
-    from app.models.production_order import ProductionOrderOperationMaterial
     from app.models.product import Product
 
     order = (
@@ -1238,17 +1237,4 @@ async def swap_material_variant_endpoint(
     )
     db.commit()
     db.refresh(mat)
-
-    component = db.query(Product).filter(Product.id == mat.component_id).first()
-    return OperationMaterialResponse(
-        id=mat.id,
-        component_id=mat.component_id,
-        component_sku=component.sku if component else None,
-        component_name=component.name if component else None,
-        component_is_template=bool(component.is_template) if component else False,
-        quantity_required=mat.quantity_required,
-        quantity_allocated=mat.quantity_allocated or Decimal(0),
-        quantity_consumed=mat.quantity_consumed or Decimal(0),
-        unit=mat.unit,
-        status=mat.status or "pending",
-    )
+    return _build_operation_material_response(mat, db)

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -40,6 +40,7 @@ from app.schemas.production_order import (
     QCInspectionRequest,
     QCInspectionResponse,
     OperationMaterialResponse,
+    SwapMaterialVariantRequest,
     OperationScrapRequest,
     StatusTransitionsResponse,
     QCStatusesResponse,
@@ -112,6 +113,7 @@ def build_production_order_response(order: ProductionOrder, db: Session) -> Prod
                         component_id=mat.component_id,
                         component_sku=component.sku if component else None,
                         component_name=component.name if component else None,
+                        component_is_template=bool(component.is_template) if component else False,
                         quantity_required=mat.quantity_required,
                         quantity_allocated=mat.quantity_allocated or Decimal(0),
                         quantity_consumed=mat.quantity_consumed or Decimal(0),
@@ -948,6 +950,7 @@ async def update_operation(
                 component_id=mat.component_id,
                 component_sku=component.sku if component else None,
                 component_name=component.name if component else None,
+                component_is_template=bool(component.is_template) if component else False,
                 quantity_required=mat.quantity_required,
                 quantity_allocated=mat.quantity_allocated or Decimal(0),
                 quantity_consumed=mat.quantity_consumed or Decimal(0),
@@ -1211,3 +1214,41 @@ async def assign_spool_to_order(
     db.commit()
 
     return result
+
+
+@router.patch(
+    "/{order_id}/materials/{material_id}/component",
+    response_model=OperationMaterialResponse,
+)
+async def swap_material_variant_endpoint(
+    order_id: int,
+    material_id: int,
+    request: SwapMaterialVariantRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OperationMaterialResponse:
+    """Workstream B0: swap a PO operation material's component to a variant.
+
+    Tactical override for the case where a PO's BOM specifies a template that has
+    0 own-stock but variants have stock. Operator picks the variant they want to
+    consume from instead of the template.
+    """
+    mat = production_order_service.swap_material_variant(
+        db, order_id, material_id, request.new_component_id, request.reason,
+    )
+    db.commit()
+    db.refresh(mat)
+
+    component = db.query(Product).filter(Product.id == mat.component_id).first()
+    return OperationMaterialResponse(
+        id=mat.id,
+        component_id=mat.component_id,
+        component_sku=component.sku if component else None,
+        component_name=component.name if component else None,
+        component_is_template=bool(component.is_template) if component else False,
+        quantity_required=mat.quantity_required,
+        quantity_allocated=mat.quantity_allocated or Decimal(0),
+        quantity_consumed=mat.quantity_consumed or Decimal(0),
+        unit=mat.unit,
+        status=mat.status or "pending",
+    )

--- a/backend/app/schemas/operation_status.py
+++ b/backend/app/schemas/operation_status.py
@@ -123,6 +123,7 @@ class OperationMaterial(BaseModel):
     component_id: int
     component_sku: Optional[str] = None
     component_name: Optional[str] = None
+    component_is_template: bool = False  # Workstream B0: gates the variant-swap UI
     quantity_required: Decimal
     quantity_consumed: Decimal = Decimal("0")
     unit: Optional[str] = None

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -155,6 +155,7 @@ class OperationMaterialResponse(BaseModel):
     component_id: int
     component_sku: Optional[str] = None
     component_name: Optional[str] = None
+    component_is_template: bool = False  # Workstream B0: gates the variant-swap UI
     quantity_required: Decimal
     quantity_allocated: Decimal = Decimal("0")
     quantity_consumed: Decimal = Decimal("0")
@@ -163,6 +164,14 @@ class OperationMaterialResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class SwapMaterialVariantRequest(BaseModel):
+    """Workstream B0: swap a PO operation material's component to a variant
+    of the current component. Used as a tactical override when the BOM specifies
+    a template that has 0 own-stock but variants have stock."""
+    new_component_id: int
+    reason: Optional[str] = None
 
 
 # ============================================================================

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -1630,6 +1630,97 @@ def get_cost_breakdown(db: Session, order_id: int) -> dict:
 
 
 # =============================================================================
+# Workstream B0: variant swap on PO operation materials
+# =============================================================================
+
+def swap_material_variant(
+    db: Session,
+    order_id: int,
+    material_id: int,
+    new_component_id: int,
+    reason: str | None = None,
+) -> ProductionOrderOperationMaterial:
+    """
+    Swap a PO operation material's component to a variant of the current component.
+
+    Tactical override (Workstream B0): when a PO's BOM specifies a template product
+    that has 0 own-stock but variants have stock, the operator can pick a variant
+    to consume from instead. The swap is permitted only while the material is still
+    pending (no allocation or consumption yet).
+
+    Validation rules:
+      - Order must exist
+      - Material must exist AND belong to the given order
+      - Material status must be 'pending'
+      - new_component_id must reference an active product that is either:
+          (a) equal to the current component_id (no-op, allowed for cancel/reset)
+          (b) a variant of the current component (parent_product_id == current_component_id)
+
+    Returns the updated material row.
+    """
+    get_production_order(db, order_id)  # Validates order exists; raises 404
+
+    mat = (
+        db.query(ProductionOrderOperationMaterial)
+        .join(
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial.production_order_operation_id
+            == ProductionOrderOperation.id,
+        )
+        .filter(
+            ProductionOrderOperationMaterial.id == material_id,
+            ProductionOrderOperation.production_order_id == order_id,
+        )
+        .first()
+    )
+    if not mat:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Material {material_id} not found on production order {order_id}",
+        )
+
+    if mat.status != "pending":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot swap variant: material status is '{mat.status}', "
+                "must be 'pending' (release allocation first if applicable)"
+            ),
+        )
+
+    new_component = db.query(Product).filter(Product.id == new_component_id).first()
+    if not new_component:
+        raise HTTPException(status_code=404, detail=f"Product {new_component_id} not found")
+    if not new_component.active:
+        raise HTTPException(status_code=400, detail="Target component is not active")
+
+    # Same component → no-op (still valid, lets UI use this for cancel/reset)
+    if new_component_id == mat.component_id:
+        return mat
+
+    if new_component.parent_product_id != mat.component_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Target {new_component.sku} is not a variant of current component "
+                f"{mat.component_id} (expected parent_product_id={mat.component_id}, "
+                f"got {new_component.parent_product_id})"
+            ),
+        )
+
+    old_component_id = mat.component_id
+    mat.component_id = new_component_id
+    db.flush()
+
+    logger.info(
+        "PO %s op-material %s variant swap: component_id %s -> %s (reason: %s)",
+        order_id, material_id, old_component_id, new_component_id, reason or "(none)",
+    )
+
+    return mat
+
+
+# =============================================================================
 # Spool Management
 # =============================================================================
 

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -1652,9 +1652,16 @@ def swap_material_variant(
       - Order must exist
       - Material must exist AND belong to the given order
       - Material status must be 'pending'
+      - Material must have zero allocation/consumption (defensive integrity guard
+        against stale 'pending' rows whose state has drifted)
       - new_component_id must reference an active product that is either:
-          (a) equal to the current component_id (no-op, allowed for cancel/reset)
+          (a) equal to the current component_id (no-op, logged for audit)
           (b) a variant of the current component (parent_product_id == current_component_id)
+
+    Concurrency: the material row is selected with FOR UPDATE so concurrent
+    swaps or allocate/consume operations against the same row block until this
+    transaction commits. Prevents lost-update races between two operators
+    (and between a swap and an allocation in flight).
 
     Returns the updated material row.
     """
@@ -1671,6 +1678,7 @@ def swap_material_variant(
             ProductionOrderOperationMaterial.id == material_id,
             ProductionOrderOperation.production_order_id == order_id,
         )
+        .with_for_update()  # Row lock — prevents concurrent swap or allocate from clobbering
         .first()
     )
     if not mat:
@@ -1688,17 +1696,32 @@ def swap_material_variant(
             ),
         )
 
+    # Defensive integrity guard: status='pending' should imply zero qty_allocated
+    # and zero qty_consumed, but if either is non-zero the row's status has
+    # drifted. Refuse the swap rather than silently retargeting a row whose
+    # allocation/consumption was tracked against the previous component.
+    if (mat.quantity_allocated and float(mat.quantity_allocated) > 0) or (
+        mat.quantity_consumed and float(mat.quantity_consumed) > 0
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot swap variant: material status is 'pending' but "
+                f"quantity_allocated={mat.quantity_allocated} / "
+                f"quantity_consumed={mat.quantity_consumed} indicate the row's "
+                "state has drifted; reset the material before swapping"
+            ),
+        )
+
     new_component = db.query(Product).filter(Product.id == new_component_id).first()
     if not new_component:
         raise HTTPException(status_code=404, detail=f"Product {new_component_id} not found")
     if not new_component.active:
         raise HTTPException(status_code=400, detail="Target component is not active")
 
-    # Same component → no-op (still valid, lets UI use this for cancel/reset)
-    if new_component_id == mat.component_id:
-        return mat
+    is_no_op = new_component_id == mat.component_id
 
-    if new_component.parent_product_id != mat.component_id:
+    if not is_no_op and new_component.parent_product_id != mat.component_id:
         raise HTTPException(
             status_code=400,
             detail=(
@@ -1709,12 +1732,17 @@ def swap_material_variant(
         )
 
     old_component_id = mat.component_id
-    mat.component_id = new_component_id
-    db.flush()
+    if not is_no_op:
+        mat.component_id = new_component_id
+        db.flush()
 
+    # Always log — including the no-op case. A 'cancel/reset' click that resolves
+    # to no-op still leaves an audit breadcrumb of "operator considered swap, kept original".
     logger.info(
-        "PO %s op-material %s variant swap: component_id %s -> %s (reason: %s)",
-        order_id, material_id, old_component_id, new_component_id, reason or "(none)",
+        "PO %s op-material %s variant swap: component_id %s -> %s%s (reason: %s)",
+        order_id, material_id, old_component_id, new_component_id,
+        " [no-op]" if is_no_op else "",
+        reason or "(none)",
     )
 
     return mat

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2570,3 +2570,157 @@ class TestProductionOrderLifecycle:
                 notes=f"Cancelled from {status}",
             )
             assert cancelled.status == "cancelled"
+
+
+# =============================================================================
+# Workstream B0: variant swap on PO operation materials
+# =============================================================================
+
+def _make_template_with_variant(db, make_product, variant_qty=20):
+    """Build a template product + one variant with on_hand inventory."""
+    template = make_product(
+        sku=f"TMPL-{datetime.now(timezone.utc).timestamp()}",
+        item_type="component",
+        is_template=True,
+    )
+    variant = make_product(
+        sku=f"{template.sku}-V1",
+        item_type="component",
+        parent_product_id=template.id,
+    )
+    inv = Inventory(
+        product_id=variant.id,
+        location_id=1,
+        on_hand_quantity=Decimal(variant_qty),
+    )
+    db.add(inv)
+    db.flush()
+    return template, variant
+
+
+def _make_po_with_pending_material(db, make_product, finished_good, component, *, status="draft"):
+    """Build a PO with a single pending operation material consuming `component`."""
+    order = _make_production_order(db, finished_good, status=status)
+    routing, rop = _make_routing_with_operation(db, finished_good)
+    op = ProductionOrderOperation(
+        production_order_id=order.id,
+        routing_operation_id=rop.id,
+        work_center_id=1,
+        sequence=10,
+        operation_code="PRINT",
+        operation_name="Print",
+        status="pending",
+        planned_setup_minutes=Decimal("5"),
+        planned_run_minutes=Decimal("10"),
+    )
+    db.add(op)
+    db.flush()
+
+    mat = ProductionOrderOperationMaterial(
+        production_order_operation_id=op.id,
+        component_id=component.id,
+        quantity_required=Decimal("2"),
+        unit="EA",
+        status="pending",
+    )
+    db.add(mat)
+    db.flush()
+    return order, mat
+
+
+class TestSwapMaterialVariant:
+    """B0 — operator swaps a PO operation material's component to a variant.
+
+    Unblocks the case where a BOM specifies a template (e.g. FG-003 with 0 own-stock)
+    but variants have stock (e.g. FG-003-PLA_BASIC-BLK with 20 EA). Without this swap,
+    the PO is permanently blocked by 'material shortage' even though stock exists.
+    """
+
+    def test_happy_path_pending_material_to_variant(
+        self, db, make_product, finished_good
+    ):
+        template, variant = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+
+        result = svc.swap_material_variant(
+            db, order.id, mat.id, variant.id, reason="BLK in stock"
+        )
+
+        assert result.component_id == variant.id
+        assert result.quantity_required == Decimal("2")  # qty unchanged
+        assert result.unit == "EA"
+        assert result.status == "pending"
+
+    def test_swap_to_self_is_noop_no_op(self, db, make_product, finished_good):
+        """Swapping to the current component (e.g. cancel/reset) returns successfully."""
+        template, _ = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+
+        result = svc.swap_material_variant(
+            db, order.id, mat.id, template.id, reason="reset"
+        )
+        assert result.component_id == template.id
+
+    def test_rejects_non_variant_target(self, db, make_product, finished_good):
+        """Cannot swap to a product that is not a variant of the current component."""
+        template, _ = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        unrelated = make_product(sku="UNRELATED-001", item_type="component")
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, unrelated.id, reason="bad")
+        assert exc.value.status_code == 400
+        assert "variant" in exc.value.detail.lower()
+
+    def test_rejects_inactive_target(self, db, make_product, finished_good):
+        template, variant = _make_template_with_variant(db, make_product)
+        variant.active = False
+        db.flush()
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 400
+        assert "active" in exc.value.detail.lower()
+
+    def test_rejects_allocated_status(self, db, make_product, finished_good):
+        """Allocated materials cannot be swapped — release allocation first."""
+        template, variant = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        mat.status = "allocated"
+        mat.quantity_allocated = Decimal("2")
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 400
+        assert "pending" in exc.value.detail.lower()
+
+    def test_rejects_consumed_status(self, db, make_product, finished_good):
+        """Consumed materials cannot be swapped — already inventory transactions exist."""
+        template, variant = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        mat.status = "consumed"
+        mat.quantity_consumed = Decimal("2")
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 400
+
+    def test_rejects_material_belonging_to_different_order(
+        self, db, make_product, finished_good
+    ):
+        template, variant = _make_template_with_variant(db, make_product)
+        order_a, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        order_b = _make_production_order(db, finished_good)
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order_b.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 404
+
+    def test_rejects_unknown_material(self, db, finished_good):
+        order = _make_production_order(db, finished_good)
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, 999_999, 1, reason="bad")
+        assert exc.value.status_code == 404

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2708,6 +2708,40 @@ class TestSwapMaterialVariant:
             svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
         assert exc.value.status_code == 400
 
+    def test_rejects_pending_material_with_drifted_allocated_quantity(
+        self, db, make_product, finished_good
+    ):
+        """Defensive integrity guard: status='pending' but quantity_allocated > 0
+        indicates the row's state has drifted (allocator updated qty without
+        flipping status, or status was hand-edited). Refuse the swap rather
+        than silently retargeting a row whose allocation was tracked against
+        the previous component.
+        """
+        template, variant = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        # Status stays 'pending', but quantity_allocated drifts to non-zero.
+        mat.quantity_allocated = Decimal("1")
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 400
+        assert "quantity_allocated" in exc.value.detail.lower() or "drift" in exc.value.detail.lower()
+
+    def test_rejects_pending_material_with_drifted_consumed_quantity(
+        self, db, make_product, finished_good
+    ):
+        """Same defensive guard as above, but for quantity_consumed > 0."""
+        template, variant = _make_template_with_variant(db, make_product)
+        order, mat = _make_po_with_pending_material(db, make_product, finished_good, template)
+        mat.quantity_consumed = Decimal("1")
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            svc.swap_material_variant(db, order.id, mat.id, variant.id, reason="bad")
+        assert exc.value.status_code == 400
+        assert "quantity_consumed" in exc.value.detail.lower() or "drift" in exc.value.detail.lower()
+
     def test_rejects_material_belonging_to_different_order(
         self, db, make_product, finished_good
     ):

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -79,6 +79,15 @@ export default function ProductionOrderModal({
   const [availableSpools, setAvailableSpools] = useState([]);
   const [spoolLoading, setSpoolLoading] = useState(false);
 
+  // Workstream B0: variant swap state. variantPickerFor = { materialId, templateId }
+  // when the operator is choosing a variant to substitute for a template-component
+  // material. Tactical override for templates whose own-stock is 0 but variants
+  // have stock — does not change BOM, only mutates this PO's material row.
+  const [variantPickerFor, setVariantPickerFor] = useState(null);
+  const [availableVariants, setAvailableVariants] = useState([]);
+  const [variantLoading, setVariantLoading] = useState(false);
+  const [variantSwapReason, setVariantSwapReason] = useState("");
+
   // Schedule modal state (for pending ops)
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [operationToSchedule, setOperationToSchedule] = useState(null);
@@ -155,6 +164,55 @@ export default function ProductionOrderModal({
       }
     } catch { /* ignore */ }
     setSpoolLoading(false);
+  };
+
+  const openVariantPicker = async (materialId, templateId) => {
+    setVariantPickerFor({ materialId, templateId });
+    setAvailableVariants([]);
+    setVariantSwapReason("");
+    setVariantLoading(true);
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/items/${templateId}/variants`,
+        { credentials: "include" }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setAvailableVariants(Array.isArray(data) ? data : data.items || []);
+      }
+    } catch { /* ignore */ }
+    setVariantLoading(false);
+  };
+
+  const swapVariant = async (newComponentId) => {
+    if (!variantPickerFor || variantLoading) return;
+    try {
+      setVariantLoading(true);
+      const res = await fetch(
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/materials/${variantPickerFor.materialId}/component`,
+        {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            new_component_id: newComponentId,
+            reason: variantSwapReason || null,
+          }),
+        }
+      );
+      if (res.ok) {
+        setVariantPickerFor(null);
+        setVariantSwapReason("");
+        await fetchOperations();
+        if (onUpdated) onUpdated();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setError(err.detail || "Failed to swap variant");
+      }
+    } catch (e) {
+      setError(e.message || "Failed to swap variant");
+    }
+    setVariantLoading(false);
   };
 
   const fetchOperations = async () => {
@@ -778,6 +836,16 @@ export default function ProductionOrderModal({
                           >
                             {mat.status}
                           </span>
+                          {mat.component_id && mat.component_is_template && mat.status === "pending" && (
+                            <button
+                              onClick={() => openVariantPicker(mat.id, mat.component_id)}
+                              className="text-xs px-2 py-0.5 rounded bg-blue-700/50 hover:bg-blue-700 text-blue-200 transition-colors"
+                              title={`${mat.component_sku || 'Component'} is a template — pick a variant to consume from instead`}
+                              aria-label={`Swap ${mat.component_sku || 'component'} to a variant`}
+                            >
+                              ↘ Swap Variant
+                            </button>
+                          )}
                           {mat.component_id && (
                             <button
                               onClick={() => openSpoolPicker(mat.component_id)}
@@ -832,6 +900,60 @@ export default function ProductionOrderModal({
                         {spool.supplier_lot_number && (
                           <span className="ml-2 text-gray-500">Lot: {spool.supplier_lot_number}</span>
                         )}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Variant Picker (Workstream B0) */}
+          {variantPickerFor && (
+            <div className="bg-gray-800 border border-blue-700/40 rounded-lg p-4">
+              <div className="flex justify-between items-center mb-3">
+                <h4 className="text-sm font-medium text-white">
+                  Pick variant to consume
+                  <span className="ml-2 text-xs text-gray-400 font-normal">
+                    (overrides the BOM template for this PO only)
+                  </span>
+                </h4>
+                <button
+                  onClick={() => { setVariantPickerFor(null); setVariantSwapReason(""); }}
+                  className="text-gray-400 hover:text-white text-sm"
+                  aria-label="Cancel variant swap"
+                >
+                  ✕
+                </button>
+              </div>
+              <input
+                type="text"
+                value={variantSwapReason}
+                onChange={(e) => setVariantSwapReason(e.target.value)}
+                placeholder="Reason (optional, logged for audit)"
+                className="w-full mb-3 px-3 py-1.5 text-sm rounded bg-gray-900 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+              />
+              {variantLoading ? (
+                <div className="text-gray-400 text-sm">Loading variants…</div>
+              ) : availableVariants.length === 0 ? (
+                <div className="text-gray-500 text-sm">
+                  This template has no variants yet. Create some via the items page first.
+                </div>
+              ) : (
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {availableVariants.map((v) => (
+                    <button
+                      key={v.id}
+                      onClick={() => swapVariant(v.id)}
+                      disabled={variantLoading || !v.active}
+                      className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-gray-700 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <span className="text-white text-left">
+                        {v.sku}
+                        <span className="text-gray-500 ml-2">{v.name}</span>
+                      </span>
+                      <span className={(v.on_hand_qty ?? 0) > 0 ? "text-green-400" : "text-red-400"}>
+                        {(v.on_hand_qty ?? 0).toFixed(0)} on hand
                       </span>
                     </button>
                   ))}

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -136,6 +136,17 @@ export default function ProductionOrderModal({
     fetchWorkCenters();
   }, []);
 
+  // Workstream B0: abort any in-flight variant-list fetch on unmount so the
+  // response can't write into state after the component is gone.
+  useEffect(() => {
+    return () => {
+      if (variantFetchControllerRef.current) {
+        variantFetchControllerRef.current.abort();
+        variantFetchControllerRef.current = null;
+      }
+    };
+  }, []);
+
   // Fetch resources when work center changes
   useEffect(() => {
     if (selectedWorkCenter) {
@@ -213,9 +224,17 @@ export default function ProductionOrderModal({
       if (res.ok) {
         const data = await res.json();
         setAvailableVariants(Array.isArray(data) ? data : data.items || []);
+      } else {
+        // Surface real failures instead of silently rendering "no variants".
+        const err = await res.json().catch(() => ({}));
+        setError(normalizeErrorDetail(err.detail, "Failed to load variants"));
       }
     } catch (e) {
-      if (e.name === "AbortError") return;  // expected on supersession
+      if (e.name === "AbortError") return;  // expected on supersession or unmount
+      // Genuine network/parse error on the latest request — show it.
+      if (variantFetchControllerRef.current === controller) {
+        setError(normalizeErrorDetail(e?.message, "Failed to load variants"));
+      }
     } finally {
       // Only clear loading if this is still the latest request.
       if (variantFetchControllerRef.current === controller) {
@@ -237,7 +256,7 @@ export default function ProductionOrderModal({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             new_component_id: newComponentId,
-            reason: variantSwapReason || null,
+            reason: variantSwapReason.trim() || null,
           }),
         }
       );
@@ -643,19 +662,7 @@ export default function ProductionOrderModal({
       );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        const detail = data?.detail;
-        const message =
-          typeof detail === "string"
-            ? detail
-            : Array.isArray(detail)
-              ? detail
-                  .map((d) => (typeof d === "string" ? d : d?.msg))
-                  .filter(Boolean)
-                  .join("; ")
-              : detail
-                ? JSON.stringify(detail)
-                : "Failed to refresh routing";
-        throw new Error(message);
+        throw new Error(normalizeErrorDetail(data?.detail, "Failed to refresh routing"));
       }
       await fetchOperations();
       onUpdated?.();
@@ -960,7 +967,16 @@ export default function ProductionOrderModal({
                   </span>
                 </h4>
                 <button
-                  onClick={() => { setVariantPickerFor(null); setVariantSwapReason(""); }}
+                  onClick={() => {
+                    // Abort the in-flight variant fetch so the response
+                    // can't write into a closed picker's state.
+                    if (variantFetchControllerRef.current) {
+                      variantFetchControllerRef.current.abort();
+                      variantFetchControllerRef.current = null;
+                    }
+                    setVariantPickerFor(null);
+                    setVariantSwapReason("");
+                  }}
                   className="text-gray-400 hover:text-white text-sm"
                   aria-label="Cancel variant swap"
                 >
@@ -971,6 +987,7 @@ export default function ProductionOrderModal({
                 type="text"
                 value={variantSwapReason}
                 onChange={(e) => setVariantSwapReason(e.target.value)}
+                maxLength={500}
                 placeholder="Reason (optional, logged for audit)"
                 className="w-full mb-3 px-3 py-1.5 text-sm rounded bg-gray-900 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
               />

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { API_URL } from "../../config/api";
 import { formatDuration, formatDate } from "../../utils/formatting";
 import { PRODUCTION_ORDER_BADGE_CONFIGS } from "../../lib/statusColors.js";
@@ -6,6 +6,26 @@ import Modal from "../Modal";
 import OperationCard from "./OperationCard";
 import SkipOperationModal from "./SkipOperationModal";
 import ShortageModal from "./ShortageModal";
+
+/**
+ * Normalize a FastAPI error detail into a renderable string.
+ * `detail` can be a string, an array (pydantic validation errors), or an
+ * arbitrary object. Calling setError(detail) directly with the latter two
+ * shapes produces "[object Object]" on screen.
+ */
+function normalizeErrorDetail(detail, fallback) {
+  if (detail == null) return fallback;
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    return detail
+      .map((d) => (typeof d === "string" ? d : d?.msg || JSON.stringify(d)))
+      .join("; ");
+  }
+  if (typeof detail === "object") {
+    return detail.msg || detail.message || JSON.stringify(detail);
+  }
+  return String(detail);
+}
 
 /**
  * Status badge component
@@ -87,6 +107,10 @@ export default function ProductionOrderModal({
   const [availableVariants, setAvailableVariants] = useState([]);
   const [variantLoading, setVariantLoading] = useState(false);
   const [variantSwapReason, setVariantSwapReason] = useState("");
+  // Tracks the in-flight variant-list AbortController so a quick second click
+  // on a different material aborts the older request and prevents a slow
+  // earlier response from clobbering a faster later one.
+  const variantFetchControllerRef = useRef(null);
 
   // Schedule modal state (for pending ops)
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
@@ -167,6 +191,14 @@ export default function ProductionOrderModal({
   };
 
   const openVariantPicker = async (materialId, templateId) => {
+    // Abort any in-flight variant-list fetch from a prior click — guards
+    // against the slow-response-clobbers-fast-response race.
+    if (variantFetchControllerRef.current) {
+      variantFetchControllerRef.current.abort();
+    }
+    const controller = new AbortController();
+    variantFetchControllerRef.current = controller;
+
     setVariantPickerFor({ materialId, templateId });
     setAvailableVariants([]);
     setVariantSwapReason("");
@@ -174,14 +206,23 @@ export default function ProductionOrderModal({
     try {
       const res = await fetch(
         `${API_URL}/api/v1/items/${templateId}/variants`,
-        { credentials: "include" }
+        { credentials: "include", signal: controller.signal }
       );
+      // If a newer request started, this response is stale — silently drop it.
+      if (variantFetchControllerRef.current !== controller) return;
       if (res.ok) {
         const data = await res.json();
         setAvailableVariants(Array.isArray(data) ? data : data.items || []);
       }
-    } catch { /* ignore */ }
-    setVariantLoading(false);
+    } catch (e) {
+      if (e.name === "AbortError") return;  // expected on supersession
+    } finally {
+      // Only clear loading if this is still the latest request.
+      if (variantFetchControllerRef.current === controller) {
+        setVariantLoading(false);
+        variantFetchControllerRef.current = null;
+      }
+    }
   };
 
   const swapVariant = async (newComponentId) => {
@@ -207,10 +248,10 @@ export default function ProductionOrderModal({
         if (onUpdated) onUpdated();
       } else {
         const err = await res.json().catch(() => ({}));
-        setError(err.detail || "Failed to swap variant");
+        setError(normalizeErrorDetail(err.detail, "Failed to swap variant"));
       }
     } catch (e) {
-      setError(e.message || "Failed to swap variant");
+      setError(normalizeErrorDetail(e.message, "Failed to swap variant"));
     }
     setVariantLoading(false);
   };


### PR DESCRIPTION
## Summary

Workstream **B0** — tactical override unblocking POs whose BOM specifies a template product (e.g. `FG-003`) that has 0 own-stock when variants do have stock (e.g. `FG-003-PLA_BASIC-BLK` with 20 EA). Operator clicks **Swap Variant** on the template-component material row, picks a variant from the dropdown, the PO's `ProductionOrderOperationMaterial.component_id` updates, and subsequent allocate/consume runs against the variant's inventory.

This is the documented **manual workaround** from `project_variant_consumption_rollup.md`, made into a one-click button. Unblocks PO-2026-0021 (`FG-003_test_assy × 5`, blocked by "material shortage: FG-003" despite 40 EA on variants) **today** without waiting for the formal Workstreams B (generalize variant axis) or C (CTO at sales-order time) to ship.

## Backend

- **Service** (`production_order_service.swap_material_variant`): validates order existence, material belongs to order, `status='pending'`, target product is active and either (a) equal to current component (no-op for cancel/reset) or (b) a variant of the current component (`parent_product_id == current_component_id`). Logs the swap with reason for audit.
- **Endpoint**: `PATCH /production-orders/{order_id}/materials/{material_id}/component`
- **Schema**: new `SwapMaterialVariantRequest`; new `component_is_template: bool` field on `OperationMaterialResponse` so the frontend can gate the swap UI without re-querying.
- **8 new backend tests** (`TestSwapMaterialVariant`): happy path, no-op self-swap, reject non-variant target, reject inactive target, reject allocated/consumed material, reject cross-order material, reject unknown material.

## Frontend

- **Swap Variant button** added next to the existing "Assign Spool" button on each material row in `ProductionOrderModal`. Only renders when `mat.component_is_template && mat.status === "pending"`.
- **Variant picker panel** matching the existing spool-picker style: lists variants with `on_hand_qty` color-coded (green if >0, red if 0), reason input (logged for audit), refreshes operations + parent on success.
- `aria-label="Swap {sku} to a variant"` for screen readers.

## What's deliberately NOT in this PR

- No formal Workstream B work (variant_service.py axis generalization)
- No CTO config payload on SalesOrderLine
- No MRP variant rollup
- No allocated/consumed material swap (release allocation first if needed)

These are tracked in `project_variant_consumption_rollup.md` as the formal B / C scope. B0 is the tactical exception path; it stays useful long-term even after B/C ship.

## Verification results

- `pytest tests/services/test_production_order_service.py::TestSwapMaterialVariant` — **8/8** new
- `pytest tests/services/test_production_order_service.py tests/services/test_production_order_accept_short.py tests/test_variant_service.py tests/services/test_inventory_service.py` — **257/257**, no regressions
- `vitest run src/components/production/ src/components/items/` — **12/12**, no regressions (no new frontend tests; existing modal had no test scaffolding — flagged for future hardening)
- `ruff check` — clean on all 3 changed app files; pre-existing F401 in test file's unused imports reported via `cortex_observe`

## Test plan

- [x] Unit tests cover all validation branches
- [ ] CI green
- [ ] Manual: open PO-2026-0021 in the dev server (worktree branch `feat/po-variant-swap`), click "Swap Variant" on the FG-003 row, pick `FG-003-PLA_BASIC-BLK`, release the PO and confirm it allocates from BLK's stock instead of failing on FG-003 shortage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators can swap template components for pending production-order materials using a “Swap Variant” action and optional reason for audit logging.
  * Material rows now indicate whether a component is a template.
  * Variant picker loads template variants, disables inactive variants, and performs the swap via a PATCH request (no-op allowed when choosing the same component).
  * Improved error messages for swap failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->