### PR TITLE
PR-01: SystemSetting backend + CORS middleware refactor

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -39,6 +39,7 @@ from app.api.v1.endpoints import (
     invoices,
     notifications,
     price_levels,
+    system_settings,
 )
 from app.api.v1.endpoints.admin import router as admin_router
 
@@ -213,6 +214,9 @@ router.include_router(
 
 # System (version, updates, health)
 router.include_router(system.router)
+
+# System Settings (admin-editable key/value config; PR-01)
+router.include_router(system_settings.router)
 
 # Security Audit
 router.include_router(security.router)

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -45,7 +45,9 @@ def is_valid_origin(value: object) -> bool:
 
     - Non-string values
     - Schemes other than ``http``/``https``
-    - Empty hostnames
+    - Empty hostnames (incl. authorities like ``http://:80`` where only a port
+      is given — ``parsed.netloc`` is truthy but ``parsed.hostname`` is None)
+    - Out-of-range or non-numeric ports (``parsed.port`` raises ``ValueError``)
     - Non-empty path (including a trailing ``/``)
     - Query strings (``?...``) or fragments (``#...``)
     - Userinfo in netloc (``user@host``)
@@ -56,9 +58,15 @@ def is_valid_origin(value: object) -> bool:
     if not isinstance(value, str):
         return False
     parsed = urlsplit(value.strip())
+    try:
+        # Accessing .port forces stdlib to parse and validate the port number.
+        # Out-of-range (>65535) or non-numeric ports raise ValueError here.
+        _ = parsed.port
+    except ValueError:
+        return False
     return (
         parsed.scheme in ("http", "https")
-        and bool(parsed.netloc)
+        and bool(parsed.hostname)  # hostname (not just netloc) must be present
         and parsed.path == ""
         and parsed.query == ""
         and parsed.fragment == ""

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -67,24 +67,32 @@ def is_valid_origin(value: object) -> bool:
 
 
 def _validate_origin_list(value: Any) -> list[str]:
-    """Validate a list of CORS origin strings.
+    """Validate and normalize a list of CORS origin strings.
 
     Each origin must be ``scheme://host[:port]`` — see ``is_valid_origin``.
-    Returns the validated list (empty list is acceptable — means "no origins").
+    Surrounding whitespace is stripped (browsers never send padding in
+    ``Origin`` headers, so unstripped values would never match), and the
+    normalized list is what gets persisted.
+
+    Returns the validated, normalized list (empty list is acceptable —
+    means "no origins").
     """
     if not isinstance(value, list):
         raise ValueError("must be a list of origin strings")
+    normalized: list[str] = []
     for origin in value:
         if not isinstance(origin, str):
             raise ValueError(
                 f"origin must be a string, got {type(origin).__name__}"
             )
-        if not is_valid_origin(origin):
+        candidate = origin.strip()
+        if not is_valid_origin(candidate):
             raise ValueError(
                 f"invalid origin {origin!r}: must be scheme + host with no path, "
                 "trailing slash, query string, fragment, or userinfo"
             )
-    return value
+        normalized.append(candidate)
+    return normalized
 
 
 SETTING_VALIDATORS: dict[str, Callable[[Any], Any]] = {

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -13,11 +13,11 @@ All endpoints require admin authentication.
 """
 from datetime import datetime
 from typing import Annotated, Any, Callable
-
-import re
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.v1.deps import get_current_admin_user
@@ -32,17 +32,45 @@ router = APIRouter(prefix="/system/settings", tags=["System Settings"])
 
 
 # ============================================================================
-# Validator registry
+# Origin validation (shared with main.py CORS loader)
 # ============================================================================
 
-_ORIGIN_REGEX = re.compile(r"^https?://[^/\s]+$")
+
+def is_valid_origin(value: object) -> bool:
+    """Strict CORS-Origin shape check.
+
+    A browser ``Origin`` header is always exactly ``scheme://host[:port]`` — no
+    path, query, fragment, or userinfo. Anything else stored in our allowlist
+    can never match a real browser origin, so this function rejects:
+
+    - Non-string values
+    - Schemes other than ``http``/``https``
+    - Empty hostnames
+    - Non-empty path (including a trailing ``/``)
+    - Query strings (``?...``) or fragments (``#...``)
+    - Userinfo in netloc (``user@host``)
+
+    Used by both ``_validate_origin_list`` (PUT body validation) and
+    ``app.main._load_pro_cors_origins`` (defensive runtime filtering).
+    """
+    if not isinstance(value, str):
+        return False
+    parsed = urlsplit(value.strip())
+    return (
+        parsed.scheme in ("http", "https")
+        and bool(parsed.netloc)
+        and parsed.path == ""
+        and parsed.query == ""
+        and parsed.fragment == ""
+        and "@" not in parsed.netloc
+    )
 
 
 def _validate_origin_list(value: Any) -> list[str]:
     """Validate a list of CORS origin strings.
 
-    Each origin must be `scheme://host[:port]` — no path, no trailing slash,
-    no whitespace. Returns the validated list.
+    Each origin must be ``scheme://host[:port]`` — see ``is_valid_origin``.
+    Returns the validated list (empty list is acceptable — means "no origins").
     """
     if not isinstance(value, list):
         raise ValueError("must be a list of origin strings")
@@ -51,10 +79,10 @@ def _validate_origin_list(value: Any) -> list[str]:
             raise ValueError(
                 f"origin must be a string, got {type(origin).__name__}"
             )
-        if not _ORIGIN_REGEX.match(origin):
+        if not is_valid_origin(origin):
             raise ValueError(
-                f"invalid origin {origin!r}: must be scheme + host with no path "
-                "or trailing slash"
+                f"invalid origin {origin!r}: must be scheme + host with no path, "
+                "trailing slash, query string, fragment, or userinfo"
             )
     return value
 
@@ -95,8 +123,22 @@ async def list_settings(
     current_user: Annotated[User, Depends(get_current_admin_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[SystemSetting]:
-    """List all registered system settings (admin overview)."""
-    return db.query(SystemSetting).order_by(SystemSetting.key).all()
+    """List all registered system settings.
+
+    Filtered to keys present in ``SETTING_VALIDATORS`` so this endpoint surfaces
+    only the contracted-and-supported configuration. Unregistered rows that may
+    exist from manual DB edits or stale data are intentionally hidden from the
+    admin UI.
+    """
+    registered_keys = list(SETTING_VALIDATORS.keys())
+    if not registered_keys:
+        return []
+    return (
+        db.query(SystemSetting)
+        .filter(SystemSetting.key.in_(registered_keys))
+        .order_by(SystemSetting.key)
+        .all()
+    )
 
 
 @router.get("/{key}", response_model=SystemSettingResponse)
@@ -127,7 +169,13 @@ async def update_setting(
     current_user: Annotated[User, Depends(get_current_admin_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> SystemSetting:
-    """Update a setting's value. Validates against the registered validator."""
+    """Update a setting's value. Validates against the registered validator.
+
+    Concurrency-safe: if the row is missing (manually deleted, never seeded)
+    we attempt to insert it; on ``IntegrityError`` (another admin won the race)
+    we rollback, re-fetch, and update. Mirrors the pattern used by
+    ``get_or_create_settings`` in ``endpoints/settings.py``.
+    """
     validator = SETTING_VALIDATORS.get(key)
     if validator is None:
         raise HTTPException(
@@ -144,16 +192,34 @@ async def update_setting(
 
     setting = db.query(SystemSetting).filter(SystemSetting.key == key).first()
     if setting is None:
-        # Seeded by migration, but if the row was somehow removed, re-create it.
-        setting = SystemSetting(key=key, value=validated_value)
+        # Row missing (manually deleted or never seeded) — try to insert,
+        # fall back to updating the row another concurrent request just created.
+        setting = SystemSetting(
+            key=key, value=validated_value, updated_by=current_user.email,
+        )
         db.add(setting)
+        try:
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            setting = (
+                db.query(SystemSetting).filter(SystemSetting.key == key).first()
+            )
+            if setting is None:
+                # Truly impossible state — surface an error rather than guessing.
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"could not persist setting {key!r}",
+                )
+            setting.value = validated_value
+            setting.updated_by = current_user.email
+            db.commit()
     else:
         setting.value = validated_value
-    setting.updated_by = current_user.email
+        setting.updated_by = current_user.email
+        db.commit()
 
-    db.commit()
     db.refresh(setting)
-
     logger.info(
         "system setting updated: %s by %s", key, current_user.email,
         extra={"setting_key": key, "updated_by": current_user.email},

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -1,0 +1,161 @@
+"""
+System Settings API Endpoints
+
+Generic admin-editable key/value configuration store. First launch use is PRO
+CORS origins (`pro_portal_origins`, `pro_quoter_origins`). Subsequent PRs may
+add their own keys, each requiring a validator entry in
+``SETTING_VALIDATORS``.
+
+Unknown keys are rejected at the endpoint with 404, so this is not a generic
+JSON dump — every key must be registered in the validator table.
+
+All endpoints require admin authentication.
+"""
+from datetime import datetime
+from typing import Annotated, Any, Callable
+
+import re
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.v1.deps import get_current_admin_user
+from app.db.session import get_db
+from app.logging_config import get_logger
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/system/settings", tags=["System Settings"])
+
+
+# ============================================================================
+# Validator registry
+# ============================================================================
+
+_ORIGIN_REGEX = re.compile(r"^https?://[^/\s]+$")
+
+
+def _validate_origin_list(value: Any) -> list[str]:
+    """Validate a list of CORS origin strings.
+
+    Each origin must be `scheme://host[:port]` — no path, no trailing slash,
+    no whitespace. Returns the validated list.
+    """
+    if not isinstance(value, list):
+        raise ValueError("must be a list of origin strings")
+    for origin in value:
+        if not isinstance(origin, str):
+            raise ValueError(
+                f"origin must be a string, got {type(origin).__name__}"
+            )
+        if not _ORIGIN_REGEX.match(origin):
+            raise ValueError(
+                f"invalid origin {origin!r}: must be scheme + host with no path "
+                "or trailing slash"
+            )
+    return value
+
+
+SETTING_VALIDATORS: dict[str, Callable[[Any], Any]] = {
+    "pro_portal_origins": _validate_origin_list,
+    "pro_quoter_origins": _validate_origin_list,
+}
+
+
+# ============================================================================
+# Schemas
+# ============================================================================
+
+
+class SystemSettingResponse(BaseModel):
+    """Response shape for a single setting."""
+    key: str
+    value: Any
+    updated_at: datetime
+    updated_by: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class SystemSettingUpdate(BaseModel):
+    """PUT body for a setting update."""
+    value: Any
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.get("", response_model=list[SystemSettingResponse])
+async def list_settings(
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[SystemSetting]:
+    """List all registered system settings (admin overview)."""
+    return db.query(SystemSetting).order_by(SystemSetting.key).all()
+
+
+@router.get("/{key}", response_model=SystemSettingResponse)
+async def get_setting(
+    key: str,
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> SystemSetting:
+    """Get a single setting by key. 404 if the key is not registered or has no row."""
+    if key not in SETTING_VALIDATORS:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"unknown setting key {key!r}",
+        )
+    setting = db.query(SystemSetting).filter(SystemSetting.key == key).first()
+    if setting is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"setting {key!r} has no row (was it seeded by migration?)",
+        )
+    return setting
+
+
+@router.put("/{key}", response_model=SystemSettingResponse)
+async def update_setting(
+    key: str,
+    body: SystemSettingUpdate,
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> SystemSetting:
+    """Update a setting's value. Validates against the registered validator."""
+    validator = SETTING_VALIDATORS.get(key)
+    if validator is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"unknown setting key {key!r}",
+        )
+    try:
+        validated_value = validator(body.value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+    setting = db.query(SystemSetting).filter(SystemSetting.key == key).first()
+    if setting is None:
+        # Seeded by migration, but if the row was somehow removed, re-create it.
+        setting = SystemSetting(key=key, value=validated_value)
+        db.add(setting)
+    else:
+        setting.value = validated_value
+    setting.updated_by = current_user.email
+
+    db.commit()
+    db.refresh(setting)
+
+    logger.info(
+        "system setting updated: %s by %s", key, current_user.email,
+        extra={"setting_key": key, "updated_by": current_user.email},
+    )
+    return setting

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -195,10 +195,60 @@ app.add_middleware(CorrelationIdMiddleware)
 # Security headers middleware
 app.add_middleware(SecurityHeadersMiddleware)
 
-# CORS middleware — uses settings.ALLOWED_ORIGINS directly (no wildcard fallback)
+def _load_pro_cors_origins() -> list[str]:
+    """Load PRO CORS origins from the system_settings table.
+
+    Reads `pro_portal_origins` and `pro_quoter_origins` (seeded by migration 080)
+    and returns their merged contents. Customer-facing portal/quoter SPAs hosted
+    on external domains (e.g. shop.example.com) need their origins listed here.
+
+    Falls back to the `PRO_CORS_ORIGINS` env var (comma-separated) if the DB
+    read fails or returns empty. The env fallback is a documented escape hatch
+    (v3 plan): used when PRO is uninstalled (admin UI gone), the DB is
+    unreachable at boot, or the operator wants config-as-code.
+
+    Returns an empty list if neither source provides values — Core still serves
+    same-origin portal/quoter requests fine.
+    """
+    try:
+        from app.db.session import SessionLocal
+        from app.models.system_setting import SystemSetting
+
+        with SessionLocal() as db:
+            rows = db.query(SystemSetting).filter(
+                SystemSetting.key.in_(["pro_portal_origins", "pro_quoter_origins"])
+            ).all()
+            origins: list[str] = []
+            for row in rows:
+                if isinstance(row.value, list):
+                    origins.extend(o for o in row.value if isinstance(o, str))
+            if origins:
+                return origins
+    except Exception as exc:
+        logger.warning("Could not load PRO CORS origins from DB: %s", exc)
+
+    # Escape hatch: env var fallback
+    raw = os.environ.get("PRO_CORS_ORIGINS", "")
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+# CORS middleware — base origins from settings.ALLOWED_ORIGINS plus PRO origins
+# loaded from the system_settings table (or PRO_CORS_ORIGINS env fallback).
+# PRO origins are merged at boot; updates require a Core restart to apply.
+_pro_origins = _load_pro_cors_origins()
+_base_origins = list(settings.ALLOWED_ORIGINS)
+# dict.fromkeys preserves order while deduplicating
+_all_cors_origins = list(dict.fromkeys(_base_origins + _pro_origins))
+
+if _pro_origins:
+    logger.info(
+        "Loaded %d PRO CORS origin(s) merged with %d base origin(s)",
+        len(_pro_origins), len(_base_origins),
+    )
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.ALLOWED_ORIGINS,
+    allow_origins=_all_cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With", "X-API-Key"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -202,15 +202,24 @@ def _load_pro_cors_origins() -> list[str]:
     and returns their merged contents. Customer-facing portal/quoter SPAs hosted
     on external domains (e.g. shop.example.com) need their origins listed here.
 
-    Falls back to the `PRO_CORS_ORIGINS` env var (comma-separated) if the DB
-    read fails or returns empty. The env fallback is a documented escape hatch
-    (v3 plan): used when PRO is uninstalled (admin UI gone), the DB is
-    unreachable at boot, or the operator wants config-as-code.
+    Falls back to the `PRO_CORS_ORIGINS` env var (comma-separated) when the DB
+    rows are empty/missing — for example before migration runs, when PRO is
+    uninstalled (so the admin UI to populate the rows is gone), or when the
+    operator prefers config-as-code. Note: a fully unreachable database raises
+    earlier in the lifespan handler (`init_database()`); this function never
+    sees that case.
+
+    Every origin is re-validated through ``is_valid_origin`` before being
+    returned, so any malformed entry that bypassed PUT validation (or arrived
+    via the env fallback, which has no validation gate of its own) is silently
+    dropped with a warning rather than handed to the CORS middleware.
 
     Returns an empty list if neither source provides values — Core still serves
     same-origin portal/quoter requests fine.
     """
     try:
+        # Lazy imports so module-load doesn't depend on DB or endpoint module.
+        from app.api.v1.endpoints.system_settings import is_valid_origin
         from app.db.session import SessionLocal
         from app.models.system_setting import SystemSetting
 
@@ -220,16 +229,48 @@ def _load_pro_cors_origins() -> list[str]:
             ).all()
             origins: list[str] = []
             for row in rows:
-                if isinstance(row.value, list):
-                    origins.extend(o for o in row.value if isinstance(o, str))
+                if not isinstance(row.value, list):
+                    continue
+                for raw in row.value:
+                    if not isinstance(raw, str):
+                        continue
+                    candidate = raw.strip()
+                    if is_valid_origin(candidate):
+                        origins.append(candidate)
+                    else:
+                        logger.warning(
+                            "Dropping malformed PRO CORS origin from DB row %s: %r",
+                            row.key, raw,
+                        )
             if origins:
                 return origins
     except Exception as exc:
         logger.warning("Could not load PRO CORS origins from DB: %s", exc)
 
-    # Escape hatch: env var fallback
+    # Escape hatch: env var fallback. Re-validate each entry — env input has no
+    # gate equivalent to the PUT endpoint, so bad values would otherwise reach
+    # CORSMiddleware and get treated as legitimate allowlist entries.
+    try:
+        from app.api.v1.endpoints.system_settings import is_valid_origin
+    except Exception:
+        # If the endpoint module can't be imported (Core boot before that side
+        # is ready), accept entries verbatim so we don't lock the operator out.
+        return [o.strip() for o in os.environ.get("PRO_CORS_ORIGINS", "").split(",") if o.strip()]
+
     raw = os.environ.get("PRO_CORS_ORIGINS", "")
-    return [o.strip() for o in raw.split(",") if o.strip()]
+    out: list[str] = []
+    for entry in raw.split(","):
+        candidate = entry.strip()
+        if not candidate:
+            continue
+        if is_valid_origin(candidate):
+            out.append(candidate)
+        else:
+            logger.warning(
+                "Dropping malformed PRO CORS origin from PRO_CORS_ORIGINS env: %r",
+                entry,
+            )
+    return out
 
 
 # CORS middleware — base origins from settings.ALLOWED_ORIGINS plus PRO origins

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -50,6 +50,9 @@ from app.models.price_level import PriceLevel
 # i18n / Tax Rates
 from app.models.tax_rate import TaxRate
 
+# System Settings (generic key/value store for admin-editable config; PR-01)
+from app.models.system_setting import SystemSetting
+
 __all__ = [
     # Item management
     "ItemCategory",
@@ -141,4 +144,6 @@ __all__ = [
     "CloseShortRecord",
     # Price Levels
     "PriceLevel",
+    # System Settings
+    "SystemSetting",
 ]

--- a/backend/app/models/system_setting.py
+++ b/backend/app/models/system_setting.py
@@ -1,0 +1,36 @@
+"""
+SystemSetting model
+
+Generic key-value store for system-level configuration that needs to be editable
+from an admin UI rather than from `.env` files. The first launch use is PRO CORS
+origins (`pro_portal_origins`, `pro_quoter_origins`); the table is intentionally
+generic so subsequent PRs can add their own keys without schema changes.
+
+Each setting key has a server-side validator registered in
+``app.api.v1.endpoints.system_settings.SETTING_VALIDATORS``. Unknown keys are
+rejected at the endpoint, so this table cannot be used as a generic JSON dump.
+
+The endpoint and middleware that read these values live elsewhere; this module
+defines storage only.
+"""
+from sqlalchemy import Column, DateTime, JSON, String, func
+
+from app.db.base import Base
+
+
+class SystemSetting(Base):
+    """One row per registered setting key. Value is JSON for flexibility."""
+    __tablename__ = "system_settings"
+
+    key = Column(String, primary_key=True)
+    value = Column(JSON, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    updated_by = Column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SystemSetting(key={self.key!r})>"

--- a/backend/migrations/versions/080_add_system_settings.py
+++ b/backend/migrations/versions/080_add_system_settings.py
@@ -1,0 +1,49 @@
+"""Add system_settings table
+
+Generic key/value store for admin-editable configuration. First launch use is
+PRO CORS origins; subsequent PRs may add their own keys (each requiring a
+server-side validator registered in the endpoint module).
+
+This migration seeds the two PRO CORS origin keys with empty lists so the
+GET endpoint succeeds immediately after the migration runs, before any
+operator has saved values via the admin UI.
+
+Revision ID: 080
+Revises: 079
+Create Date: 2026-04-30
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "080"
+down_revision = "079"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(), primary_key=True),
+        sa.Column("value", sa.JSON(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("updated_by", sa.String(), nullable=True),
+    )
+    # Seed the two PRO CORS origin keys with empty lists. This makes
+    # `GET /api/v1/system/settings/pro_portal_origins` return immediately after
+    # migration, before any operator has saved values via the admin UI.
+    op.execute(
+        "INSERT INTO system_settings (key, value) VALUES "
+        "('pro_portal_origins', '[]'::json), "
+        "('pro_quoter_origins', '[]'::json)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("system_settings")

--- a/backend/tests/endpoints/test_system_settings.py
+++ b/backend/tests/endpoints/test_system_settings.py
@@ -138,11 +138,15 @@ def test_is_valid_origin_accepts_real_origins(value):
         "ftp://shop.example.com",               # wrong scheme
         "https://",                             # no host
         "http://",                              # no host
+        "http://:80",                           # port-only authority, no host
+        "https://example.com:99999",            # out-of-range port
+        "https://example.com:abc",              # non-numeric port
         "https://shop.example.com/",            # trailing slash
         "https://shop.example.com/path",        # has path
         "https://shop.example.com?x=1",         # query string
         "https://shop.example.com#frag",        # fragment
         "https://user@shop.example.com",        # userinfo
+        "https://user:pass@shop.example.com",   # userinfo with password
         "",                                     # empty
         "   ",                                  # whitespace-only
         None,                                   # not a string
@@ -347,10 +351,13 @@ def test_put_updates_existing_row(client, seeded_settings, db):
     )
     assert pre_count == 1
 
-    client.put(
+    resp = client.put(
         f"{SETTINGS_URL}/{PORTAL_KEY}",
         json={"value": ["https://shop.example.com"]},
     )
+    # Without this assert, a silent PUT failure would leave count at 1 and
+    # this test would falsely pass.
+    assert resp.status_code == 200
 
     post_count = (
         db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).count()

--- a/backend/tests/endpoints/test_system_settings.py
+++ b/backend/tests/endpoints/test_system_settings.py
@@ -1,0 +1,328 @@
+"""
+Tests for the system_settings admin endpoints (PR-01).
+
+Covers:
+- GET /system/settings/{key} — happy path, unknown key, missing row, auth/permission
+- GET /system/settings (list) — filtered to registered keys only
+- PUT /system/settings/{key} — validation matrix, unknown key, auth/permission,
+  row-missing -> create path, IntegrityError race fallback
+- is_valid_origin — boundary cases for the strict origin shape check
+"""
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.api.v1.endpoints.system_settings import is_valid_origin
+from app.models.system_setting import SystemSetting
+from app.models.user import User
+
+
+SETTINGS_URL = "/api/v1/system/settings"
+PORTAL_KEY = "pro_portal_origins"
+QUOTER_KEY = "pro_quoter_origins"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limits():
+    """Disable slowapi rate limiting for all tests in this module."""
+    from app.core.limiter import limiter
+
+    original_enabled = getattr(limiter, "_enabled", True)
+    limiter.enabled = False
+    yield
+    limiter.enabled = original_enabled
+
+
+@pytest.fixture
+def seeded_settings(db):
+    """Seed the two PRO origin rows so GET endpoints have something to read."""
+    db.execute(
+        text(
+            "INSERT INTO system_settings (key, value, updated_at) VALUES "
+            "(:k1, '[]'::json, now()), (:k2, '[]'::json, now()) "
+            "ON CONFLICT (key) DO NOTHING"
+        ),
+        {"k1": PORTAL_KEY, "k2": QUOTER_KEY},
+    )
+    db.flush()
+    yield
+
+
+@pytest.fixture
+def non_admin_user(db):
+    """Create a non-admin user for 403 tests."""
+    from app.core.security import hash_password
+
+    uid = uuid.uuid4().hex[:8]
+    user = User(
+        email=f"nonadmin-{uid}@filaops.dev",
+        password_hash=hash_password("TestPass123!"),
+        first_name="NonAdmin",
+        last_name="User",
+        account_type="customer",
+        status="active",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def non_admin_client(db, non_admin_user):
+    """TestClient authenticated as a non-admin user."""
+    from fastapi.testclient import TestClient
+    from app.core.security import create_access_token
+    from app.db.session import get_db
+    from app.main import app
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    token = create_access_token(user_id=non_admin_user.id)
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        yield c
+    app.dependency_overrides.clear()
+
+
+# =============================================================================
+# is_valid_origin (strict shape check)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://shop.example.com",
+        "http://localhost:3000",
+        "https://192.168.1.50",
+        "https://example.com:8080",
+        "http://erp",  # single-word intranet hostname is a valid origin
+    ],
+)
+def test_is_valid_origin_accepts_real_origins(value):
+    assert is_valid_origin(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "shop.example.com",                     # no scheme
+        "ftp://shop.example.com",               # wrong scheme
+        "https://",                             # no host
+        "http://",                              # no host
+        "https://shop.example.com/",            # trailing slash
+        "https://shop.example.com/path",        # has path
+        "https://shop.example.com?x=1",         # query string
+        "https://shop.example.com#frag",        # fragment
+        "https://user@shop.example.com",        # userinfo
+        "",                                     # empty
+        "   ",                                  # whitespace-only
+        None,                                   # not a string
+        123,                                    # not a string
+        ["https://shop.example.com"],           # not a string
+    ],
+)
+def test_is_valid_origin_rejects_malformed(value):
+    assert is_valid_origin(value) is False
+
+
+# =============================================================================
+# GET /{key}
+# =============================================================================
+
+
+def test_get_setting_happy_path(client, seeded_settings):
+    resp = client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["key"] == PORTAL_KEY
+    assert body["value"] == []
+    assert body["updated_at"] is not None
+
+
+def test_get_setting_unknown_key_returns_404(client, seeded_settings):
+    resp = client.get(f"{SETTINGS_URL}/foo_bar")
+    assert resp.status_code == 404
+    assert "unknown setting key" in resp.json()["detail"]
+
+
+def test_get_setting_registered_but_unseeded_returns_404(client, db):
+    # Don't seed any rows. Endpoint should distinguish "unknown key" from
+    # "registered key with no row" — the latter is the migration-not-run case.
+    resp = client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
+    assert resp.status_code == 404
+    assert "has no row" in resp.json()["detail"]
+
+
+def test_get_setting_no_auth_returns_401(unauthed_client, seeded_settings):
+    resp = unauthed_client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
+    assert resp.status_code == 401
+
+
+def test_get_setting_non_admin_returns_403(non_admin_client, seeded_settings):
+    resp = non_admin_client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
+    assert resp.status_code == 403
+
+
+# =============================================================================
+# GET / (list)
+# =============================================================================
+
+
+def test_list_settings_returns_only_registered_keys(client, seeded_settings, db):
+    # Inject an unregistered row to confirm the filter excludes it.
+    db.execute(
+        text(
+            "INSERT INTO system_settings (key, value, updated_at) "
+            "VALUES ('legacy_orphan', '\"junk\"'::json, now())"
+        ),
+    )
+    db.flush()
+
+    resp = client.get(SETTINGS_URL)
+    assert resp.status_code == 200
+    keys = [row["key"] for row in resp.json()]
+    assert PORTAL_KEY in keys
+    assert QUOTER_KEY in keys
+    assert "legacy_orphan" not in keys
+
+
+def test_list_settings_orders_by_key(client, seeded_settings):
+    resp = client.get(SETTINGS_URL)
+    assert resp.status_code == 200
+    keys = [row["key"] for row in resp.json()]
+    assert keys == sorted(keys)
+
+
+def test_list_settings_no_auth_returns_401(unauthed_client, seeded_settings):
+    resp = unauthed_client.get(SETTINGS_URL)
+    assert resp.status_code == 401
+
+
+def test_list_settings_non_admin_returns_403(non_admin_client, seeded_settings):
+    resp = non_admin_client.get(SETTINGS_URL)
+    assert resp.status_code == 403
+
+
+# =============================================================================
+# PUT /{key}
+# =============================================================================
+
+
+def test_put_valid_origins_persists(client, seeded_settings):
+    payload = {"value": ["https://shop.example.com", "http://localhost:3000"]}
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["value"] == payload["value"]
+    assert body["updated_by"] is not None  # captures admin email
+
+    # Round-trip: GET should now return the persisted value
+    resp = client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
+    assert resp.status_code == 200
+    assert resp.json()["value"] == payload["value"]
+
+
+def test_put_empty_list_is_valid(client, seeded_settings):
+    """Empty list = 'no origins listed' is a legitimate config."""
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": []})
+    assert resp.status_code == 200
+    assert resp.json()["value"] == []
+
+
+@pytest.mark.parametrize(
+    "bad_origin",
+    [
+        "shop.example.com",                     # no scheme
+        "ftp://shop.example.com",
+        "https://shop.example.com/",            # trailing slash
+        "https://shop.example.com/path",
+        "https://shop.example.com?x=1",         # query string
+        "https://shop.example.com#frag",        # fragment
+        "https://user@shop.example.com",        # userinfo
+    ],
+)
+def test_put_rejects_malformed_origin_with_400(client, seeded_settings, bad_origin):
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": [bad_origin]})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "invalid origin" in detail
+    assert bad_origin in detail
+
+
+def test_put_rejects_non_list_with_400(client, seeded_settings):
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": "not-a-list"})
+    assert resp.status_code == 400
+    assert "must be a list of origin strings" in resp.json()["detail"]
+
+
+def test_put_rejects_non_string_in_list_with_400(client, seeded_settings):
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": [123]})
+    assert resp.status_code == 400
+    assert "must be a string" in resp.json()["detail"]
+
+
+def test_put_unknown_key_returns_404(client, seeded_settings):
+    resp = client.put(f"{SETTINGS_URL}/foo_bar", json={"value": []})
+    assert resp.status_code == 404
+    assert "unknown setting key" in resp.json()["detail"]
+
+
+def test_put_no_auth_returns_401(unauthed_client, seeded_settings):
+    resp = unauthed_client.put(
+        f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": []}
+    )
+    assert resp.status_code == 401
+
+
+def test_put_non_admin_returns_403(non_admin_client, seeded_settings):
+    resp = non_admin_client.put(
+        f"{SETTINGS_URL}/{PORTAL_KEY}", json={"value": []}
+    )
+    assert resp.status_code == 403
+
+
+def test_put_creates_row_when_missing(client, db):
+    """Spec: if the seeded row is missing (manually deleted, never seeded),
+    PUT recreates it instead of 404ing. Mirrors get_or_create_settings."""
+    # No seeded_settings fixture here — table is empty for this key.
+    existing = (
+        db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).first()
+    )
+    assert existing is None  # precondition
+
+    resp = client.put(
+        f"{SETTINGS_URL}/{PORTAL_KEY}",
+        json={"value": ["https://shop.example.com"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["value"] == ["https://shop.example.com"]
+
+
+def test_put_updates_existing_row(client, seeded_settings, db):
+    """Sanity: existing row gets updated, not duplicated."""
+    pre_count = (
+        db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).count()
+    )
+    assert pre_count == 1
+
+    client.put(
+        f"{SETTINGS_URL}/{PORTAL_KEY}",
+        json={"value": ["https://shop.example.com"]},
+    )
+
+    post_count = (
+        db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).count()
+    )
+    assert post_count == 1

--- a/backend/tests/endpoints/test_system_settings.py
+++ b/backend/tests/endpoints/test_system_settings.py
@@ -259,6 +259,18 @@ def test_put_empty_list_is_valid(client, seeded_settings):
     assert resp.json()["value"] == []
 
 
+def test_put_strips_surrounding_whitespace(client, seeded_settings):
+    """Whitespace padding is normalized away — browsers never send it in
+    Origin headers, so persisting it would guarantee a CORS mismatch."""
+    payload = {"value": ["  https://shop.example.com  ", "\thttp://localhost:3000\n"]}
+    resp = client.put(f"{SETTINGS_URL}/{PORTAL_KEY}", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["value"] == [
+        "https://shop.example.com",
+        "http://localhost:3000",
+    ]
+
+
 @pytest.mark.parametrize(
     "bad_origin",
     [

--- a/backend/tests/endpoints/test_system_settings.py
+++ b/backend/tests/endpoints/test_system_settings.py
@@ -41,13 +41,30 @@ def _disable_rate_limits():
 
 @pytest.fixture
 def seeded_settings(db):
-    """Seed the two PRO origin rows so GET endpoints have something to read."""
+    """Ensure the two PRO origin rows exist (idempotent ON CONFLICT)."""
     db.execute(
         text(
             "INSERT INTO system_settings (key, value, updated_at) VALUES "
             "(:k1, '[]'::json, now()), (:k2, '[]'::json, now()) "
             "ON CONFLICT (key) DO NOTHING"
         ),
+        {"k1": PORTAL_KEY, "k2": QUOTER_KEY},
+    )
+    db.flush()
+    yield
+
+
+@pytest.fixture
+def unseeded_settings(db):
+    """Force the two PRO origin rows to be ABSENT for tests that need empty DB.
+
+    Necessary because the CI test DB is migrated (alembic upgrade head) before
+    pytest runs, which seeds these rows via migration 080's INSERT. The
+    transaction-isolated ``db`` fixture rolls back the DELETE at test end,
+    restoring the migration-seeded state for subsequent tests.
+    """
+    db.execute(
+        text("DELETE FROM system_settings WHERE key IN (:k1, :k2)"),
         {"k1": PORTAL_KEY, "k2": QUOTER_KEY},
     )
     db.flush()
@@ -157,9 +174,10 @@ def test_get_setting_unknown_key_returns_404(client, seeded_settings):
     assert "unknown setting key" in resp.json()["detail"]
 
 
-def test_get_setting_registered_but_unseeded_returns_404(client, db):
-    # Don't seed any rows. Endpoint should distinguish "unknown key" from
-    # "registered key with no row" — the latter is the migration-not-run case.
+def test_get_setting_registered_but_unseeded_returns_404(client, unseeded_settings):
+    # Endpoint should distinguish "unknown key" (key not in SETTING_VALIDATORS)
+    # from "registered key with no row" — the latter is the migration-not-run
+    # or row-manually-deleted case.
     resp = client.get(f"{SETTINGS_URL}/{PORTAL_KEY}")
     assert resp.status_code == 404
     assert "has no row" in resp.json()["detail"]
@@ -293,10 +311,10 @@ def test_put_non_admin_returns_403(non_admin_client, seeded_settings):
     assert resp.status_code == 403
 
 
-def test_put_creates_row_when_missing(client, db):
+def test_put_creates_row_when_missing(client, unseeded_settings, db):
     """Spec: if the seeded row is missing (manually deleted, never seeded),
     PUT recreates it instead of 404ing. Mirrors get_or_create_settings."""
-    # No seeded_settings fixture here — table is empty for this key.
+    # unseeded_settings fixture deleted both PRO rows for this test.
     existing = (
         db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).first()
     )

--- a/backend/tests/endpoints/test_system_settings.py
+++ b/backend/tests/endpoints/test_system_settings.py
@@ -343,6 +343,15 @@ def test_put_creates_row_when_missing(client, unseeded_settings, db):
     assert resp.status_code == 200
     assert resp.json()["value"] == ["https://shop.example.com"]
 
+    # Verify the row was actually persisted (not just returned in the response).
+    # An endpoint that builds a response object but fails to commit would still
+    # produce a passing 200 + payload check; this query catches that path.
+    persisted = (
+        db.query(SystemSetting).filter(SystemSetting.key == PORTAL_KEY).first()
+    )
+    assert persisted is not None
+    assert persisted.value == ["https://shop.example.com"]
+
 
 def test_put_updates_existing_row(client, seeded_settings, db):
     """Sanity: existing row gets updated, not duplicated."""


### PR DESCRIPTION
## Summary

Establishes the foundational pattern for admin-editable settings (DB-backed key/value store) and pivots the CORS middleware to read PRO origins from that store instead of being env-only. Part of the PRO launch v3 plan — first of nine PRs that ship before charge.

This is the **backend half** of PR-01. The portal SPA half (AdminCORSSettings page) lives in [filaops-ecosystem PR-01](https://github.com/Blb3D/filaops-ecosystem/pull/new/feature/pr01-system-settings).

## Sacred Rule

**Yes, applies.** Every file in this PR was diff-reviewed in chat before commit. No file imports from `filaops_pro` — Core stays Community-functional even if PRO is never installed.

## What changed (5 commits)

| Commit | Purpose |
|---|---|
| `2dc061f` | `SystemSetting` SQLAlchemy model — generic key/value store, registered on `Base.metadata` |
| `53647ca` | Alembic migration `080` — creates `system_settings` table, seeds `pro_portal_origins=[]` and `pro_quoter_origins=[]` |
| `dd8dd28` | `/api/v1/system/settings` endpoints — GET (single + list) + PUT, all admin-auth gated, validator registry rejects unknown keys with 404 |
| `cce91cb` | Router registration in `app/api/v1/__init__.py` |
| `6c99ac0` | CORS middleware refactor — reads PRO origins from DB at boot, falls back to `PRO_CORS_ORIGINS` env var (escape hatch per v3 plan) |

## Architecture notes

- **Generic table.** `system_settings` ships with two PRO CORS keys at launch but is intentionally generic so future PRs (license entry, integration config, etc.) can add their own keys without schema changes.
- **Validator registry.** Every key must be registered in `SETTING_VALIDATORS` in the endpoint module. Unknown keys → 404. This is not a generic JSON dump.
- **Escape hatch.** If PRO is uninstalled or the DB is unreachable at boot, the CORS middleware falls back to the `PRO_CORS_ORIGINS` env var (comma-separated). v3 plan documents this as the always-available recovery path.
- **Lazy DB import.** `_load_pro_cors_origins()` imports `SessionLocal` and `SystemSetting` inside the function so module-load doesn't depend on DB. Catches all exceptions; failure → empty fallback. Core boots cleanly even if `system_settings` table doesn't exist.
- **Restart to apply.** No hot-reload of CORS — saving via the admin UI requires a Core restart (banner copy says so).

## Verification (live dogfood, all PASS)

Ran a full isolated docker-compose stack on host ports 15432/18000 (no production data touched), executed every backend acceptance criterion from the PR-01 spec:

- ✅ `alembic upgrade head` clean — table created, both seed rows present (`pro_portal_origins=[]`, `pro_quoter_origins=[]`)
- ✅ `alembic downgrade -1` reversible — table dropped cleanly
- ✅ `alembic upgrade head` re-applies after downgrade — seeds back
- ✅ `GET /api/v1/system/settings/pro_portal_origins` (admin-auth) → 200 with seeded `[]`
- ✅ `GET /api/v1/system/settings` (list) → both rows
- ✅ `GET unknown_key` → 404 `"unknown setting key 'foo_bar'"`
- ✅ `GET` without auth → 401
- ✅ `PUT` valid `["https://shop.example.com", "http://localhost:3000"]` → 200, persisted, `updated_by` captured
- ✅ `PUT` no-scheme (`"shop.example.com"`) → 400 `"invalid origin 'shop.example.com': must be scheme + host with no path or trailing slash"`
- ✅ `PUT` trailing-slash → 400
- ✅ `PUT` with path → 400
- ✅ `PUT` non-list (`"not-a-list"`) → 400 `"must be a list of origin strings"`
- ✅ `PUT` unknown key → 404
- ✅ Restart Core: middleware boot log says `"Loaded 2 PRO CORS origin(s) merged with 1 base origin(s)"`; preflight from listed origin returns 200 with `Access-Control-Allow-Origin` echo; non-listed origin returns 400
- ✅ Restart Core with empty DB rows + `PRO_CORS_ORIGINS=https://envfallback.example.com,https://second.example.com` env var → middleware uses env fallback; both env-listed origins pass preflight; non-listed blocked

## Test plan (post-merge)

- [ ] CI green
- [ ] Migration runs cleanly in any deployed Core that pulls this branch
- [ ] No regression on existing CORS behavior for Core's own frontend

## Plan references

- v3 launch plan: [`docs/plans/PRO_LAUNCH_PIVOT_v3.md`](https://github.com/Blb3D/filaops-ecosystem/blob/main/docs/plans/PRO_LAUNCH_PIVOT_v3.md) (in ecosystem repo)
- PR-01 spec: [`docs/plans/PR-01-cors-settings-v3.md`](https://github.com/Blb3D/filaops-ecosystem/blob/main/docs/plans/PR-01-cors-settings-v3.md) (in ecosystem repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only System Settings API to list, retrieve, and update keyed configuration values.
  * CORS now can load and validate origins from system settings with a validated fallback to environment variables.
* **Database**
  * Migration adding a persistent system_settings table and seeding initial origin entries.
* **Tests**
  * End-to-end tests for settings endpoints and origin validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->