### PR TITLE
security: refuse production startup with placeholder credentials (F12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Open-source ERP for 3D print farms. Manage inventory, production, sales, purchas
 ```bash
 git clone https://github.com/Blb3D/filaops.git
 cd filaops
+cp backend/.env.example .env
+# Generate secrets (required — production startup refuses to boot without these):
+echo "SECRET_KEY=$(openssl rand -hex 32)" >> .env
+echo "DB_PASSWORD=$(openssl rand -hex 24)" >> .env
 docker compose up -d
 # Open http://localhost — create your admin account on first visit
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,16 +12,18 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=filaops
 DB_USER=postgres
-DB_PASSWORD=your-secure-password-here
+# Generate with: openssl rand -hex 32
+# Required: production startup refuses to boot with this empty or set to a placeholder.
+DB_PASSWORD=
 # Or provide a full URL (overrides DB_* settings above):
 # DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/filaops
 
 # ===========================================
 # SECURITY (Required)
 # ===========================================
-# Generate a secure key with:
-#   python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=change-this-to-a-random-secret-key-in-production
+# Generate with: openssl rand -hex 32
+# Required: production startup refuses to boot with this empty or set to a placeholder.
+SECRET_KEY=
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 # API_KEY=optional-api-key-for-integrations
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 from decimal import Decimal
+from urllib.parse import unquote, urlsplit
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -183,10 +184,28 @@ class Settings(BaseSettings):
         offenders = []
         if self.SECRET_KEY.strip().lower() in _SECRET_KEY_PLACEHOLDERS:
             offenders.append("SECRET_KEY")
-        # DB_PASSWORD is ignored when DATABASE_URL is set (see the
-        # `database_url` property), so don't gate startup on a stale default
-        # in that case.
-        if not self.DATABASE_URL and self.DB_PASSWORD.strip().lower() in _DB_PASSWORD_PLACEHOLDERS:
+
+        # The effective DB password is whatever `database_url` will hand to
+        # SQLAlchemy at runtime: the password embedded in DATABASE_URL when
+        # set, otherwise self.DB_PASSWORD. Validating only DB_PASSWORD would
+        # leave docker-compose's `DATABASE_URL: postgresql+psycopg://...:
+        # ${DB_PASSWORD:-changeme}@db:5432/...` as an open airlock.
+        #
+        # urlsplit().password returns None when the URL has no password
+        # component (peer auth, trust auth, .pgpass, IAM auth). In that
+        # case we deliberately skip the check rather than fail-closed —
+        # passwordless auth is a legitimate production setup.
+        # `unquote` decodes percent-escapes so the validator sees the same
+        # password SQLAlchemy will actually use at connect time.
+        if self.DATABASE_URL:
+            url_password = urlsplit(self.DATABASE_URL).password
+            effective_db_password = unquote(url_password) if url_password else None
+        else:
+            effective_db_password = self.DB_PASSWORD
+        if (
+            effective_db_password is not None
+            and effective_db_password.strip().lower() in _DB_PASSWORD_PLACEHOLDERS
+        ):
             offenders.append("DB_PASSWORD")
 
         if not offenders:

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -194,7 +194,7 @@ class Settings(BaseSettings):
 
         names = ", ".join(offenders)
         hint = "Generate a real value with: openssl rand -hex 32"
-        if self.ENVIRONMENT.lower() == "production":
+        if self.ENVIRONMENT.strip().lower() == "production":
             raise RuntimeError(
                 f"Refusing to start in production: placeholder credential(s) "
                 f"detected for {names}. {hint}"

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -7,6 +7,7 @@ FilaOps ERP - Configuration Management with pydantic-settings
 - Cached singleton via get_settings()
 """
 import json
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional, List, Dict, Any
@@ -15,6 +16,8 @@ from decimal import Decimal
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+logger = logging.getLogger(__name__)
+
 # Read version from VERSION file (single source of truth)
 _VERSION_FILE = Path(__file__).resolve().parent.parent.parent / "VERSION"
 _VERSION = _VERSION_FILE.read_text().strip() if _VERSION_FILE.exists() else "0.0.0"
@@ -22,6 +25,25 @@ _VERSION = _VERSION_FILE.read_text().strip() if _VERSION_FILE.exists() else "0.0
 # Calculate path to .env in backend folder (3 levels up from this file)
 # backend/app/core/settings.py -> backend/.env
 _ENV_FILE = Path(__file__).resolve().parent.parent.parent / ".env"
+
+# Placeholder credential values rejected in production (audit finding F12).
+# Covers docker-compose fallbacks (changeme, change-in-production), the
+# Settings field defaults below (postgres, change-this-...), the .env.example
+# sample text (your-secret-key-here, your-secure-password-here), and "" for
+# users who clear the value but never set a real one.
+_SECRET_KEY_PLACEHOLDERS = frozenset({
+    "",
+    "change-in-production",
+    "your-secret-key-here",
+    "change-this-to-a-random-secret-key-in-production",
+})
+_DB_PASSWORD_PLACEHOLDERS = frozenset({
+    "",
+    "changeme",
+    "password",
+    "postgres",
+    "your-secure-password-here",
+})
 
 
 class Settings(BaseSettings):
@@ -95,24 +117,10 @@ class Settings(BaseSettings):
         description="Auth token delivery: 'cookie' (httpOnly) or 'header' (bearer in body). Use 'header' to rollback.",
     )
 
-    @field_validator("SECRET_KEY")
-    @classmethod
-    def warn_default_secret(cls, v: str) -> str:
-        """Fail in prod if default secret; warn in dev."""
-        if "change-this" in v.lower():
-            import warnings
-            import os
-
-            if os.getenv("ENVIRONMENT", "development").lower() == "production":
-                raise ValueError(
-                    "Default SECRET_KEY detected in production. Set a secure SECRET_KEY."
-                )
-            warnings.warn(
-                "WARNING: Using default SECRET_KEY. Do not use this in production.",
-                UserWarning,
-                stacklevel=2,
-            )
-        return v
+    # SECRET_KEY validation lives in `validate_no_placeholder_credentials`
+    # (model_validator at the bottom of the class). Both SECRET_KEY and
+    # DB_PASSWORD share one post-init check so production startup fails
+    # for either placeholder rather than only the first one Pydantic sees.
 
     # ===================
     # CORS Settings
@@ -160,6 +168,43 @@ class Settings(BaseSettings):
         if self.FRONTEND_URL and self.FRONTEND_URL not in self.ALLOWED_ORIGINS:
             # Append to the raw string since ALLOWED_ORIGINS is a property
             self.ALLOWED_ORIGINS_STR = f"{self.ALLOWED_ORIGINS_STR},{self.FRONTEND_URL}"
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_placeholder_credentials(self):
+        """Reject placeholder SECRET_KEY/DB_PASSWORD in production; warn in dev.
+
+        Audit finding F12 (Portainer compatibility review): docker-compose has
+        :-defaults of `changeme` / `change-in-production`, so a fresh
+        `git clone && docker compose up -d` previously produced a "running"
+        stack with insecure credentials. This validator turns that footgun
+        into a fail-fast at config load.
+        """
+        offenders = []
+        if self.SECRET_KEY.strip().lower() in _SECRET_KEY_PLACEHOLDERS:
+            offenders.append("SECRET_KEY")
+        # DB_PASSWORD is ignored when DATABASE_URL is set (see the
+        # `database_url` property), so don't gate startup on a stale default
+        # in that case.
+        if not self.DATABASE_URL and self.DB_PASSWORD.strip().lower() in _DB_PASSWORD_PLACEHOLDERS:
+            offenders.append("DB_PASSWORD")
+
+        if not offenders:
+            return self
+
+        names = ", ".join(offenders)
+        hint = "Generate a real value with: openssl rand -hex 32"
+        if self.ENVIRONMENT.lower() == "production":
+            raise RuntimeError(
+                f"Refusing to start in production: placeholder credential(s) "
+                f"detected for {names}. {hint}"
+            )
+        logger.warning(
+            "Insecure placeholder credential(s) detected for %s. "
+            "This is allowed in development but will block production startup. %s",
+            names,
+            hint,
+        )
         return self
 
     # ===================

--- a/backend/tests/unit/test_settings_validation.py
+++ b/backend/tests/unit/test_settings_validation.py
@@ -58,6 +58,12 @@ class TestProductionPlaceholderCredentials:
         with pytest.raises(RuntimeError, match="SECRET_KEY"):
             _build("production", secret_key="  change-in-production  ")
 
+    def test_whitespace_padded_environment_still_triggers_gate(self):
+        # ENVIRONMENT="production " (trailing space) must not silently fall
+        # into the warning path — that turns the safeguard into mood lighting.
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            _build("production ", secret_key="change-in-production")
+
     def test_database_url_set_skips_db_password_check(self):
         # When DATABASE_URL overrides DB_PASSWORD, the placeholder default is
         # irrelevant — startup must not block on it.

--- a/backend/tests/unit/test_settings_validation.py
+++ b/backend/tests/unit/test_settings_validation.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for app.core.settings credential validation.
+
+Audit finding F12 (Portainer compatibility review) — production startup
+must refuse to boot with placeholder SECRET_KEY/DB_PASSWORD; development
+should warn but proceed.
+"""
+import logging
+
+import pytest
+
+from app.core.settings import Settings
+
+
+def _build(environment: str, *, secret_key: str = "f" * 64, db_password: str = "real-db-pass-not-a-placeholder"):
+    """Construct a Settings instance bypassing the on-disk .env file."""
+    return Settings(
+        _env_file=None,
+        ENVIRONMENT=environment,
+        SECRET_KEY=secret_key,
+        DB_PASSWORD=db_password,
+    )
+
+
+class TestProductionPlaceholderCredentials:
+    def test_placeholder_secret_key_raises(self):
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            _build("production", secret_key="change-in-production")
+
+    def test_placeholder_db_password_raises(self):
+        with pytest.raises(RuntimeError, match="DB_PASSWORD"):
+            _build("production", db_password="changeme")
+
+    def test_empty_secret_key_raises(self):
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            _build("production", secret_key="")
+
+    def test_compose_default_secret_key_raises(self):
+        # Settings field default value
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            _build("production", secret_key="change-this-to-a-random-secret-key-in-production")
+
+    def test_error_message_includes_openssl_hint(self):
+        with pytest.raises(RuntimeError, match=r"openssl rand"):
+            _build("production", secret_key="change-in-production")
+
+    def test_real_credentials_pass(self):
+        s = _build("production")
+        assert s.is_production
+        assert s.SECRET_KEY
+
+    def test_uppercase_placeholder_still_rejected(self):
+        # Case-insensitive comparison so CHANGEME / Password don't slip through.
+        with pytest.raises(RuntimeError, match="DB_PASSWORD"):
+            _build("production", db_password="CHANGEME")
+
+    def test_whitespace_padded_placeholder_still_rejected(self):
+        with pytest.raises(RuntimeError, match="SECRET_KEY"):
+            _build("production", secret_key="  change-in-production  ")
+
+    def test_database_url_set_skips_db_password_check(self):
+        # When DATABASE_URL overrides DB_PASSWORD, the placeholder default is
+        # irrelevant — startup must not block on it.
+        s = Settings(
+            _env_file=None,
+            ENVIRONMENT="production",
+            SECRET_KEY="f" * 64,
+            DB_PASSWORD="changeme",
+            DATABASE_URL="postgresql+psycopg://realuser:realpass@db:5432/filaops",
+        )
+        assert s.is_production
+
+
+class TestDevelopmentPlaceholderCredentials:
+    def test_placeholder_secret_key_logs_warning(self, caplog):
+        caplog.set_level(logging.WARNING, logger="app.core.settings")
+        _build("development", secret_key="change-in-production")
+        assert any(
+            "SECRET_KEY" in record.getMessage() for record in caplog.records
+        ), "expected a warning naming SECRET_KEY"
+
+    def test_placeholder_db_password_logs_warning(self, caplog):
+        caplog.set_level(logging.WARNING, logger="app.core.settings")
+        _build("development", db_password="changeme")
+        assert any(
+            "DB_PASSWORD" in record.getMessage() for record in caplog.records
+        ), "expected a warning naming DB_PASSWORD"
+
+    def test_placeholder_does_not_raise_in_development(self):
+        # Must not raise — kick-the-tires UX is preserved.
+        s = _build("development", secret_key="change-in-production", db_password="changeme")
+        assert s.is_development
+
+    def test_real_credentials_no_warning(self, caplog):
+        caplog.set_level(logging.WARNING, logger="app.core.settings")
+        _build("development")
+        placeholder_warnings = [
+            r for r in caplog.records if "placeholder credential" in r.getMessage()
+        ]
+        assert not placeholder_warnings

--- a/backend/tests/unit/test_settings_validation.py
+++ b/backend/tests/unit/test_settings_validation.py
@@ -6,19 +6,34 @@ must refuse to boot with placeholder SECRET_KEY/DB_PASSWORD; development
 should warn but proceed.
 """
 import logging
+from typing import Optional
 
 import pytest
 
 from app.core.settings import Settings
 
 
-def _build(environment: str, *, secret_key: str = "f" * 64, db_password: str = "real-db-pass-not-a-placeholder"):
-    """Construct a Settings instance bypassing the on-disk .env file."""
+def _build(
+    environment: str,
+    *,
+    secret_key: str = "f" * 64,
+    db_password: str = "real-db-pass-not-a-placeholder",
+    database_url: Optional[str] = None,
+):
+    """Construct a Settings instance with hermetic config.
+
+    `_env_file=None` disables the on-disk .env, but pydantic-settings still
+    reads OS environment variables. CI exports DATABASE_URL, which would
+    silently route around the DB_PASSWORD branch of the validator. Passing
+    `DATABASE_URL=database_url` (default None) explicitly overrides any
+    inherited env var so each test exercises the branch it claims to.
+    """
     return Settings(
         _env_file=None,
         ENVIRONMENT=environment,
         SECRET_KEY=secret_key,
         DB_PASSWORD=db_password,
+        DATABASE_URL=database_url,
     )
 
 
@@ -64,17 +79,49 @@ class TestProductionPlaceholderCredentials:
         with pytest.raises(RuntimeError, match="SECRET_KEY"):
             _build("production ", secret_key="change-in-production")
 
-    def test_database_url_set_skips_db_password_check(self):
-        # When DATABASE_URL overrides DB_PASSWORD, the placeholder default is
-        # irrelevant — startup must not block on it.
-        s = Settings(
-            _env_file=None,
-            ENVIRONMENT="production",
-            SECRET_KEY="f" * 64,
-            DB_PASSWORD="changeme",
-            DATABASE_URL="postgresql+psycopg://realuser:realpass@db:5432/filaops",
+
+class TestDatabaseUrlPasswordValidation:
+    """The effective DB password is whatever `database_url` hands to
+    SQLAlchemy — the URL's password when DATABASE_URL is set, else
+    DB_PASSWORD. Validating only DB_PASSWORD would leave docker-compose's
+    `DATABASE_URL: ...:${DB_PASSWORD:-changeme}@db/...` as an open airlock.
+    """
+
+    def test_url_with_placeholder_password_raises(self):
+        with pytest.raises(RuntimeError, match="DB_PASSWORD"):
+            _build(
+                "production",
+                db_password="real-not-checked-because-url-overrides",
+                database_url="postgresql+psycopg://user:changeme@db:5432/filaops",
+            )
+
+    def test_url_with_real_password_passes(self):
+        s = _build(
+            "production",
+            db_password="changeme",  # ignored — URL takes precedence
+            database_url="postgresql+psycopg://user:strongpw-actually-set@db:5432/filaops",
         )
         assert s.is_production
+
+    def test_url_without_password_skips_check(self):
+        # No password in the URL = peer auth, trust auth, .pgpass, or IAM
+        # auth. These are legitimate production configs; do NOT fail-closed.
+        s = _build(
+            "production",
+            db_password="changeme",  # not used at runtime when URL is set
+            database_url="postgresql+psycopg://user@db:5432/filaops",
+        )
+        assert s.is_production
+
+    def test_url_with_url_encoded_placeholder_password_raises(self):
+        # %63%68%61%6e%67%65%6d%65 decodes to "changeme". This proves
+        # urllib.parse end-to-end decoding works and prevents a future
+        # refactor from accidentally comparing the encoded form.
+        with pytest.raises(RuntimeError, match="DB_PASSWORD"):
+            _build(
+                "production",
+                database_url="postgresql+psycopg://user:%63%68%61%6e%67%65%6d%65@db:5432/filaops",
+            )
 
 
 class TestDevelopmentPlaceholderCredentials:


### PR DESCRIPTION
Closes audit finding F12 from Portainer compatibility review.
- SECRET_KEY/DB_PASSWORD validated at config load
- Production: hard-fail with openssl rand -hex 32 hint
- Development: warning only, preserves kick-the-tires UX
- README updated with secure initialization sequence


Agent-Session: 4d49f2b7-4fde-46ea-baba-91122eb32b31

## Summary
<!-- What does this PR do? 1-3 bullet points. -->

## Related Issues
<!-- Closes #XX, Fixes #XX -->

## Changes
<!-- List key file changes -->

## Testing
- [ ] Manual browser validation (eyes and mouse)
- [ ] API endpoint tested
- [ ] Fresh database tested

## Checklist
- [ ] No secrets or business data committed
- [ ] No PRO code in core changes
- [ ] Tested on Windows (if backend/seed changes)

This is in reference to discussion (https://github.com/Blb3D/filaops/discussions/575)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment setup instructions to require generating secure secret values.

* **Chores**
  * Environment configuration now enforces production credential validation, preventing deployment with placeholder secrets.

* **Tests**
  * Added validation tests for credential security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->