### PR TITLE
fix(printers): send work_center_id as null, not empty string (#577)

### DIFF
--- a/frontend/src/components/printers/PrinterModal.jsx
+++ b/frontend/src/components/printers/PrinterModal.jsx
@@ -28,7 +28,7 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo = [] 
     ip_address: printer?.ip_address || "",
     access_code: printer?.connection_config?.access_code || "",
     location: printer?.location || "",
-    work_center_id: printer?.work_center_id || "",
+    work_center_id: printer?.work_center_id ?? null,
     notes: printer?.notes || "",
     active: printer?.active !== false,
     filament_diameters: printer?.capabilities?.filament_diameters || [],
@@ -317,8 +317,8 @@ export default function PrinterModal({ printer, onClose, onSave, brandInfo = [] 
           <div>
             <label className="block text-sm text-gray-300 mb-1">Machine Pool</label>
             <select
-              value={form.work_center_id}
-              onChange={(e) => setForm({ ...form, work_center_id: e.target.value ? parseInt(e.target.value) : "" })}
+              value={form.work_center_id ?? ""}
+              onChange={(e) => setForm({ ...form, work_center_id: e.target.value ? parseInt(e.target.value, 10) : null })}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">None</option>

--- a/frontend/src/components/printers/__tests__/PrinterModal.test.jsx
+++ b/frontend/src/components/printers/__tests__/PrinterModal.test.jsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+  },
+}))
+
+vi.mock('../../Toast', () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ isPro: false, hasFeature: () => false }),
+}))
+
+vi.mock('../../Modal', () => ({
+  default: ({ children }) => <div role="dialog">{children}</div>,
+}))
+
+import PrinterModal from '../PrinterModal'
+
+const brandInfo = [
+  { code: 'generic', name: 'Generic', models: [] },
+  { code: 'bambulab', name: 'Bambu Lab', models: [{ value: 'X1C', label: 'X1 Carbon' }] },
+]
+
+const editablePrinter = {
+  id: 1,
+  code: 'PRT-001',
+  name: 'X1C Bay 1',
+  brand: 'bambulab',
+  model: 'X1C',
+  serial_number: 'SN123',
+  ip_address: '192.168.1.100',
+  location: 'Farm A',
+  work_center_id: null,
+  notes: '',
+  active: true,
+  connection_config: { access_code: '12345678' },
+  capabilities: { filament_diameters: [1.75] },
+}
+
+const fetchOk = (body = []) => ({
+  ok: true,
+  json: async () => body,
+})
+
+const lastPrinterPutBody = () => {
+  const calls = global.fetch.mock.calls
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const [url, opts] = calls[i]
+    if (typeof url === 'string' && /\/api\/v1\/printers\/\d+/.test(url) && opts?.method === 'PUT') {
+      return JSON.parse(opts.body)
+    }
+  }
+  throw new Error('No PUT to /api/v1/printers/:id was made')
+}
+
+beforeEach(() => {
+  mocks.toastError.mockReset()
+  mocks.toastSuccess.mockReset()
+  global.fetch = vi.fn((url) => {
+    if (typeof url === 'string' && url.includes('/work-centers')) {
+      return Promise.resolve(fetchOk([{ id: 5, name: 'Print Farm A' }]))
+    }
+    return Promise.resolve(fetchOk({}))
+  })
+})
+
+describe('PrinterModal — work_center_id payload (issue #577)', () => {
+  it('sends work_center_id as null (not empty string) when editing a printer with no work center', async () => {
+    const onSave = vi.fn()
+    render(
+      <PrinterModal
+        printer={editablePrinter}
+        onClose={vi.fn()}
+        onSave={onSave}
+        brandInfo={brandInfo}
+      />
+    )
+
+    const form = screen.getByRole('dialog').querySelector('form')
+    fireEvent.submit(form)
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+
+    const body = lastPrinterPutBody()
+    expect(body.work_center_id).toBeNull()
+    expect(body.work_center_id).not.toBe('')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('sends work_center_id as null when user selects "None" in the dropdown', async () => {
+    const onSave = vi.fn()
+    render(
+      <PrinterModal
+        printer={{ ...editablePrinter, work_center_id: 5 }}
+        onClose={vi.fn()}
+        onSave={onSave}
+        brandInfo={brandInfo}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Print Farm A')).toBeInTheDocument()
+    })
+
+    const select = screen.getByRole('dialog').querySelector('select[name="work_center_id"], select:has(option[value=""])')
+    const wcSelect = Array.from(screen.getByRole('dialog').querySelectorAll('select')).find(
+      (s) => Array.from(s.options).some((o) => o.textContent === 'None')
+    )
+    fireEvent.change(wcSelect, { target: { value: '' } })
+
+    const form = screen.getByRole('dialog').querySelector('form')
+    fireEvent.submit(form)
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+
+    const body = lastPrinterPutBody()
+    expect(body.work_center_id).toBeNull()
+  })
+
+  it('sends work_center_id as integer when a work center is selected', async () => {
+    const onSave = vi.fn()
+    render(
+      <PrinterModal
+        printer={editablePrinter}
+        onClose={vi.fn()}
+        onSave={onSave}
+        brandInfo={brandInfo}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Print Farm A')).toBeInTheDocument()
+    })
+
+    const wcSelect = Array.from(screen.getByRole('dialog').querySelectorAll('select')).find(
+      (s) => Array.from(s.options).some((o) => o.textContent === 'None')
+    )
+    fireEvent.change(wcSelect, { target: { value: '5' } })
+
+    const form = screen.getByRole('dialog').querySelector('form')
+    fireEvent.submit(form)
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+
+    const body = lastPrinterPutBody()
+    expect(body.work_center_id).toBe(5)
+    expect(typeof body.work_center_id).toBe('number')
+  })
+})

--- a/frontend/src/components/printers/__tests__/PrinterModal.test.jsx
+++ b/frontend/src/components/printers/__tests__/PrinterModal.test.jsx
@@ -54,7 +54,7 @@ const fetchOk = (body = []) => ({
 })
 
 const lastPrinterPutBody = () => {
-  const calls = global.fetch.mock.calls
+  const calls = globalThis.fetch.mock.calls
   for (let i = calls.length - 1; i >= 0; i--) {
     const [url, opts] = calls[i]
     if (typeof url === 'string' && /\/api\/v1\/printers\/\d+/.test(url) && opts?.method === 'PUT') {
@@ -67,7 +67,7 @@ const lastPrinterPutBody = () => {
 beforeEach(() => {
   mocks.toastError.mockReset()
   mocks.toastSuccess.mockReset()
-  global.fetch = vi.fn((url) => {
+  globalThis.fetch = vi.fn((url) => {
     if (typeof url === 'string' && url.includes('/work-centers')) {
       return Promise.resolve(fetchOk([{ id: 5, name: 'Print Farm A' }]))
     }
@@ -113,7 +113,6 @@ describe('PrinterModal — work_center_id payload (issue #577)', () => {
       expect(screen.getByText('Print Farm A')).toBeInTheDocument()
     })
 
-    const select = screen.getByRole('dialog').querySelector('select[name="work_center_id"], select:has(option[value=""])')
     const wcSelect = Array.from(screen.getByRole('dialog').querySelectorAll('select')).find(
       (s) => Array.from(s.options).some((o) => o.textContent === 'None')
     )


### PR DESCRIPTION
## Summary
Fixes #577 — editing a printer that has no `work_center_id` assigned (or selecting **None** in the Machine Pool dropdown) returns a 422 because the frontend ships `work_center_id: ""` and Pydantic v2's `Optional[int]` rejects empty strings.

Two-line fix in `PrinterModal.jsx` so the form state holds `null` (not `""`) when there is no work center:

```diff
- work_center_id: printer?.work_center_id || "",
+ work_center_id: printer?.work_center_id ?? null,

- value={form.work_center_id}
- onChange={(e) => setForm({ ...form, work_center_id: e.target.value ? parseInt(e.target.value) : "" })}
+ value={form.work_center_id ?? ""}
+ onChange={(e) => setForm({ ...form, work_center_id: e.target.value ? parseInt(e.target.value, 10) : null })}
```

## Why this fix and not the one in the issue
The reporter suggested `parseInt(formData.work_center_id, 10)` in the save handler. That would silently produce `NaN` when no work center is assigned (`parseInt("", 10) === NaN`), which `JSON.stringify` then converts to `null` — accidentally correct for this field, but a footgun for any other numeric FK. Normalizing the form state at source avoids the empty-string-to-NaN dance entirely.

Also: the existing onChange already calls `parseInt`, so the issue's diagnosis ("select sends string") wasn't quite right — the actual culprit was the `|| ""` fallback when the FK is unset.

## Test plan
- [x] Added `frontend/src/components/printers/__tests__/PrinterModal.test.jsx` with three cases:
  - Edit a printer where `work_center_id: null` → PUT body has `work_center_id: null`
  - Edit a printer assigned to WC=5, change dropdown to None → PUT body has `work_center_id: null`
  - Edit a printer where None is currently selected, pick WC=5 → PUT body has `work_center_id: 5` (integer)
- [x] All 3 new tests pass; full unit suite (206 tests) still green
- [ ] Manual verification: open Admin → Printers → edit a printer with no Machine Pool → click Save (should succeed instead of 422)

## Follow-up (out of scope, flag for triage)
Same `_id || ""` pattern exists on numeric FKs in three other admin modals — likely the same shape of bug, just hasn't been reported yet:
- `frontend/src/components/manufacturing/ResourceModal.jsx:14` — `bambu_device_id`
- `frontend/src/components/purchasing/POCreateModal.jsx:73` — `vendor_id`
- `frontend/src/pages/admin/AdminSpools.jsx:263, 267` — `product_id`, `location_id`

Worth a separate sweep PR; behavior depends on whether those backends accept empty strings (POCreateModal's vendor_id is required so probably caught earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-authored-by: Claude <claude@anthropic.com>
Agent-Session: 5adcfdaa-e1c2-43b8-ab9b-d4481fd52678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Machine Pool selection in the printer form to correctly save when no pool is assigned or when a specific pool is chosen.

* **Tests**
  * Added test coverage for printer form's Machine Pool selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->