### PR TITLE
feat(pr-02): license activation flow on Core (frontend + backend + cache)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -40,6 +40,7 @@ from app.api.v1.endpoints import (
     notifications,
     price_levels,
     system_settings,
+    system_license,
 )
 from app.api.v1.endpoints.admin import router as admin_router
 
@@ -217,6 +218,9 @@ router.include_router(system.router)
 
 # System Settings (admin-editable key/value config; PR-01)
 router.include_router(system_settings.router)
+
+# System License (PRO activation + info; PR-02 — Core-only, no PRO imports)
+router.include_router(system_license.router)
 
 # Security Audit
 router.include_router(security.router)

--- a/backend/app/api/v1/endpoints/system_license.py
+++ b/backend/app/api/v1/endpoints/system_license.py
@@ -24,7 +24,6 @@ from typing import Annotated, Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
 
 from app.api.v1.deps import get_current_admin_user
 from app.core.config import settings
@@ -36,7 +35,6 @@ from app.core.license_cache import (
     save_license_cache,
     utc_now_iso,
 )
-from app.db.session import get_db
 from app.logging_config import get_logger
 from app.models.user import User
 
@@ -142,7 +140,6 @@ def _build_info_response(
 @router.get("/info", response_model=LicenseInfoResponse)
 async def get_license_info(
     current_user: Annotated[User, Depends(get_current_admin_user)],
-    db: Annotated[Session, Depends(get_db)],
 ) -> LicenseInfoResponse:
     """Read the persisted license state. Returns Community defaults if no license."""
     install_uuid = get_install_uuid()
@@ -154,7 +151,6 @@ async def get_license_info(
 async def activate_license(
     body: LicenseActivationRequest,
     current_user: Annotated[User, Depends(get_current_admin_user)],
-    db: Annotated[Session, Depends(get_db)],
 ) -> LicenseInfoResponse:
     """Validate a license key against the license server and persist the result.
 
@@ -253,7 +249,7 @@ async def activate_license(
             detail="License server returned an unexpected response.",
         )
 
-    valid = bool(data.get("valid"))
+    valid = data.get("valid") is True
     server_message = data.get("message")
     if not valid:
         # Server-rejected — most often "invalid key" or "expired". 400 because
@@ -295,7 +291,6 @@ async def activate_license(
 @router.delete("/", status_code=status.HTTP_204_NO_CONTENT)
 async def deactivate_license(
     current_user: Annotated[User, Depends(get_current_admin_user)],
-    db: Annotated[Session, Depends(get_db)],
 ) -> None:
     """Remove the persisted license cache.
 

--- a/backend/app/api/v1/endpoints/system_license.py
+++ b/backend/app/api/v1/endpoints/system_license.py
@@ -1,0 +1,311 @@
+"""
+License Activation API Endpoints (PR-02)
+
+Owns the Core-side bootstrap of PRO licensing: takes a license key from the
+admin UI, validates it against the license server via plain ``httpx``, and
+persists the result to ``<config_dir>/license.json`` for PRO to pick up on
+its next boot.
+
+Sacred Rule: this module MUST NOT import from ``filaops_pro``. Core must
+remain Community-functional whether or not PRO is installed, so the
+activation flow re-implements the small subset of license-server
+communication it needs (rather than reusing PRO's ``LicenseClient``).
+PR-03 will extend this with a heartbeat scheduler that lives PRO-side.
+
+The license-server's ``POST /api/v1/validate`` endpoint contract is
+documented in ``license-server/CLAUDE.md`` and the request/response
+shapes in ``license-server/app/schemas/license.py``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.api.v1.deps import get_current_admin_user
+from app.core.config import settings
+from app.core.license_cache import (
+    LicenseCache,
+    clear_license_cache,
+    get_install_uuid,
+    load_license_cache,
+    save_license_cache,
+    utc_now_iso,
+)
+from app.db.session import get_db
+from app.logging_config import get_logger
+from app.models.user import User
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/system/license", tags=["System License"])
+
+# How long Core waits for the license server before giving up. Short enough
+# that a hung server doesn't leave the admin UI spinning indefinitely; long
+# enough to absorb normal cross-region latency.
+_LICENSE_SERVER_TIMEOUT_SECONDS = 15.0
+
+
+# ============================================================================
+# Schemas
+# ============================================================================
+
+
+class LicenseActivationRequest(BaseModel):
+    """Body for ``POST /system/license/activate``."""
+
+    license_key: str = Field(..., min_length=1, description="License key from purchase email")
+
+
+class LicenseInfoResponse(BaseModel):
+    """Response shape for ``GET /system/license/info`` and activation success."""
+
+    activated: bool
+    tier: str  # community | professional | enterprise
+    features: list[str]
+    install_uuid: str
+    license_key: Optional[str] = None  # masked when returned
+    expires_at: Optional[str] = None
+    activated_at: Optional[str] = None
+    message: Optional[str] = None
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _mask_license_key(key: str) -> str:
+    """Return a license key with the middle masked for display.
+
+    Safe for log lines and admin UI display where exposing the full key
+    would be overkill.
+    """
+    if not key:
+        return ""
+    if len(key) <= 12:
+        return f"{key[:4]}***"
+    return f"{key[:12]}***{key[-4:]}"
+
+
+def _datetime_to_iso(value: object) -> Optional[str]:
+    """Coerce a license-server datetime field to an ISO 8601 string.
+
+    The server returns ``datetime`` (FastAPI serializes to ISO when sending
+    JSON), but a strict client receives a string. Be defensive about both.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _build_info_response(
+    cache: Optional[LicenseCache],
+    install_uuid: str,
+    *,
+    message: Optional[str] = None,
+) -> LicenseInfoResponse:
+    """Map a LicenseCache (or its absence) to the response schema."""
+    if cache is None:
+        return LicenseInfoResponse(
+            activated=False,
+            tier="community",
+            features=[],
+            install_uuid=install_uuid,
+            message=message,
+        )
+    return LicenseInfoResponse(
+        activated=True,
+        tier=cache.tier,
+        features=list(cache.features),
+        install_uuid=install_uuid,
+        license_key=_mask_license_key(cache.license_key),
+        expires_at=cache.expires_at,
+        activated_at=cache.activated_at,
+        message=message,
+    )
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.get("/info", response_model=LicenseInfoResponse)
+async def get_license_info(
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> LicenseInfoResponse:
+    """Read the persisted license state. Returns Community defaults if no license."""
+    install_uuid = get_install_uuid()
+    cache = load_license_cache()
+    return _build_info_response(cache, install_uuid)
+
+
+@router.post("/activate", response_model=LicenseInfoResponse)
+async def activate_license(
+    body: LicenseActivationRequest,
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> LicenseInfoResponse:
+    """Validate a license key against the license server and persist the result.
+
+    Flow:
+      1. Generate (or reuse) the install_uuid for this Core instance
+      2. POST to ``{LICENSE_SERVER_URL}/api/v1/validate`` with X-API-Key
+      3. If the server says ``valid=False``, return 400 with the server's reason
+      4. Otherwise persist a ``LicenseCache`` row and return the new info shape
+    """
+    if not settings.LICENSE_API_KEY:
+        # Surface a clear server-config error rather than a confusing 401 from
+        # the license server. This is most often a missed env var on a fresh
+        # Core deploy.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "License activation is not configured: LICENSE_API_KEY is not set. "
+                "Set it in the Core .env and restart."
+            ),
+        )
+
+    license_key = body.license_key.strip()
+    if not license_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="License key cannot be empty.",
+        )
+
+    install_uuid = get_install_uuid()
+    validate_url = f"{settings.LICENSE_SERVER_URL}/api/v1/validate"
+    payload = {
+        "license_key": license_key,
+        "instance_id": install_uuid,
+        "app_version": settings.VERSION,
+    }
+    headers = {"X-API-Key": settings.LICENSE_API_KEY}
+
+    try:
+        async with httpx.AsyncClient(timeout=_LICENSE_SERVER_TIMEOUT_SECONDS) as client:
+            resp = await client.post(validate_url, json=payload, headers=headers)
+    except httpx.TimeoutException:
+        logger.warning(
+            "License activation timed out talking to %s (key=%s)",
+            validate_url, _mask_license_key(license_key),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="License server did not respond in time. Try again in a moment.",
+        )
+    except httpx.RequestError as exc:
+        # Connection refused, DNS failure, TLS error, etc.
+        logger.warning(
+            "License activation network error to %s: %s",
+            validate_url, exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                "Could not reach the license server. Check internet connectivity "
+                "and the LICENSE_SERVER_URL setting."
+            ),
+        )
+
+    if resp.status_code == 401:
+        # Our server-to-server key was rejected — operator config issue.
+        logger.error(
+            "License server rejected our X-API-Key (license_key=%s)",
+            _mask_license_key(license_key),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                "License server rejected this Core's credentials. "
+                "Verify LICENSE_API_KEY is set to the correct value."
+            ),
+        )
+    if resp.status_code >= 500:
+        logger.error(
+            "License server returned %d on activation: %s",
+            resp.status_code, resp.text[:300],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="License server is having problems. Try again shortly.",
+        )
+
+    try:
+        data = resp.json()
+    except ValueError:
+        logger.error(
+            "License server returned non-JSON body (status=%d): %s",
+            resp.status_code, resp.text[:300],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="License server returned an unexpected response.",
+        )
+
+    valid = bool(data.get("valid"))
+    server_message = data.get("message")
+    if not valid:
+        # Server-rejected — most often "invalid key" or "expired". 400 because
+        # this is a user-input problem, not a server-side issue.
+        logger.info(
+            "License rejected by server: key=%s, message=%s",
+            _mask_license_key(license_key), server_message,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=server_message or "License key was rejected by the license server.",
+        )
+
+    # Valid — persist the LicenseCache. PR-03 will extend this with the
+    # heartbeat-related fields (status, last_verified_at, etc.); for now we
+    # store just enough that PRO can pick up tier + features on next boot.
+    tier = str(data.get("tier") or "community").lower()
+    features = list(data.get("features") or [])
+    expires_at = _datetime_to_iso(data.get("current_period_end"))
+
+    cache = LicenseCache(
+        license_key=license_key,
+        install_uuid=install_uuid,
+        tier=tier,
+        features=features,
+        activated_at=utc_now_iso(),
+        expires_at=expires_at,
+    )
+    save_license_cache(cache)
+
+    logger.info(
+        "License activated: tier=%s, features=%d, key=%s, by=%s",
+        tier, len(features), _mask_license_key(license_key), current_user.email,
+    )
+
+    return _build_info_response(cache, install_uuid, message=server_message)
+
+
+@router.delete("/", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_license(
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """Remove the persisted license cache.
+
+    Does NOT contact the license server (deactivation on the server side is
+    a separate concept managed via Stripe / admin tools). This endpoint just
+    purges the local activation file so a next-boot Core operates as
+    Community.
+
+    install_uuid is preserved — it's stable across activation cycles so any
+    future re-activation reuses the same encryption keys (PR-06).
+    """
+    clear_license_cache()
+    logger.info("License deactivated locally by %s", current_user.email)

--- a/backend/app/api/v1/endpoints/system_license.py
+++ b/backend/app/api/v1/endpoints/system_license.py
@@ -227,6 +227,19 @@ async def activate_license(
                 "Verify LICENSE_API_KEY is set to the correct value."
             ),
         )
+    if 400 <= resp.status_code < 500:
+        # Any other 4xx (403/404/429/...) from the license server is an
+        # upstream/protocol problem, not a user-input problem. Return 502
+        # rather than letting the response body fall through to the
+        # ``valid=false`` path where it would be misclassified as 400.
+        logger.warning(
+            "License server returned unexpected client error %d on activation: %s",
+            resp.status_code, resp.text[:300],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"License server returned unexpected client error: {resp.status_code}",
+        )
     if resp.status_code >= 500:
         logger.error(
             "License server returned %d on activation: %s",
@@ -267,7 +280,8 @@ async def activate_license(
     # heartbeat-related fields (status, last_verified_at, etc.); for now we
     # store just enough that PRO can pick up tier + features on next boot.
     tier = str(data.get("tier") or "community").lower()
-    features = list(data.get("features") or [])
+    raw_features = data.get("features")
+    features = raw_features if isinstance(raw_features, list) else []
     expires_at = _datetime_to_iso(data.get("current_period_end"))
 
     cache = LicenseCache(

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -1,0 +1,189 @@
+"""License cache — filesystem-persisted license state for Core.
+
+PR-02 scope: bootstrap activation. PR-03 extends with heartbeat scheduler +
+grace window + anti-rollback fields (server_timestamp, nonce_history,
+last_verified_at).
+
+Why filesystem instead of DB:
+- Core must function before any PRO migration runs — license activation can
+  happen on a fresh install where DB is healthy but PRO tables don't exist
+  yet, so license state cannot live in a PRO-owned table.
+- License state needs to outlive container restarts. A host-side volume
+  mount (``/var/lib/filaops/config/``) is cleaner than a DB row that PRO
+  would have to reach for on every request.
+- PRO's heartbeat scheduler (PR-03) reads/writes the same file. By making
+  the cache filesystem-based with a known JSON shape, Core and PRO share
+  the contract without sharing a Python module — preserving the Sacred
+  Rule that Core must not import from ``filaops_pro``.
+
+The LicenseCache shape is documented in ``PRO_LAUNCH_PIVOT_v3.md``; this
+module implements the activation-time subset only. PR-03 will extend the
+dataclass and the JSON shape; readers must tolerate unknown fields.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("app.core.license_cache")
+
+# Default location matches v3 plan. Override via ``LICENSE_CONFIG_DIR`` env
+# var in environments where ``/var/lib`` isn't writable (e.g. Windows dev,
+# alternate Docker volume mounts, pytest tmpdir).
+_DEFAULT_CONFIG_DIR = "/var/lib/filaops/config"
+
+LICENSE_CACHE_FILENAME = "license.json"
+INSTALL_UUID_FILENAME = "install_uuid"
+
+
+@dataclass
+class LicenseCache:
+    """Activation-time subset of the LicenseCache shape.
+
+    Fields added by PR-03 (status, last_verified_at, last_server_timestamp,
+    grace_until, nonce_history) are NOT declared here yet — but
+    ``from_dict`` tolerates extra keys so a forward-compatible PR-03 cache
+    can still be read by this PR-02 reader.
+    """
+
+    license_key: str
+    install_uuid: str
+    tier: str  # community | professional | enterprise
+    features: list[str]
+    activated_at: str  # ISO 8601 UTC, set on successful activation
+    expires_at: Optional[str] = None  # ISO 8601 UTC; None for perpetual licenses
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "LicenseCache":
+        """Construct a LicenseCache from JSON, dropping fields we don't know."""
+        return cls(
+            license_key=data["license_key"],
+            install_uuid=data["install_uuid"],
+            tier=data["tier"],
+            features=list(data.get("features", [])),
+            activated_at=data["activated_at"],
+            expires_at=data.get("expires_at"),
+        )
+
+
+def get_config_dir() -> Path:
+    """Return the directory holding ``license.json`` + ``install_uuid``.
+
+    Reads ``LICENSE_CONFIG_DIR`` env var on every call so tests can override
+    via ``monkeypatch.setenv``.
+    """
+    return Path(os.environ.get("LICENSE_CONFIG_DIR", _DEFAULT_CONFIG_DIR))
+
+
+def ensure_config_dir() -> Path:
+    """Create the config directory if missing. Returns the path."""
+    cfg_dir = get_config_dir()
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    return cfg_dir
+
+
+def get_install_uuid() -> str:
+    """Return this installation's stable UUID, generating + persisting on first call.
+
+    This UUID is the secret used by PRO for token encryption (PR-06). Once
+    written it must never change — deleting the file effectively re-installs
+    the instance and any encrypted data (Shopify/QBO tokens) becomes
+    unrecoverable.
+    """
+    cfg_dir = ensure_config_dir()
+    uuid_file = cfg_dir / INSTALL_UUID_FILENAME
+    if uuid_file.exists():
+        existing = uuid_file.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+        # File present but empty — treat as missing and regenerate. This
+        # covers a corrupted-by-truncation edge case.
+        logger.warning("install_uuid file is empty, regenerating")
+
+    new_uuid = str(uuid.uuid4())
+    _atomic_write_text(uuid_file, new_uuid)
+    logger.info("Generated new install_uuid for this instance")
+    return new_uuid
+
+
+def get_license_path() -> Path:
+    """Path to the license cache JSON file."""
+    return ensure_config_dir() / LICENSE_CACHE_FILENAME
+
+
+def load_license_cache() -> Optional[LicenseCache]:
+    """Read the persisted LicenseCache. Returns None if missing or unreadable."""
+    path = get_license_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return LicenseCache.from_dict(data)
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        # An unreadable file is treated like "no license" — safer than
+        # crashing on a malformed cache.
+        logger.warning("license.json present but unreadable: %s", exc)
+        return None
+
+
+def save_license_cache(cache: LicenseCache) -> None:
+    """Atomically persist the LicenseCache to disk."""
+    path = get_license_path()
+    _atomic_write_text(path, json.dumps(cache.to_dict(), indent=2, sort_keys=True))
+    logger.info(
+        "Persisted license cache: tier=%s, features=%d, expires_at=%s",
+        cache.tier,
+        len(cache.features),
+        cache.expires_at or "perpetual",
+    )
+
+
+def clear_license_cache() -> bool:
+    """Remove the license.json file. Returns True if a file was removed."""
+    path = get_license_path()
+    if path.exists():
+        path.unlink()
+        logger.info("Removed license cache at %s", path)
+        return True
+    return False
+
+
+def utc_now_iso() -> str:
+    """Current UTC time as an ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write text to ``path`` atomically (temp file + rename).
+
+    Prevents partial-write corruption if the process is killed mid-write.
+    The temp file lives in the same directory so ``os.replace`` is a true
+    atomic rename rather than a copy across filesystems.
+    """
+    cfg_dir = path.parent
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(
+        dir=str(cfg_dir), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Cleanup the half-written tmp file on any failure.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -32,6 +32,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from app.core.config import settings
+
 logger = logging.getLogger("app.core.license_cache")
 
 # Default location matches v3 plan. Override via ``LICENSE_CONFIG_DIR`` env
@@ -79,10 +81,10 @@ class LicenseCache:
 def get_config_dir() -> Path:
     """Return the directory holding ``license.json`` + ``install_uuid``.
 
-    Reads ``LICENSE_CONFIG_DIR`` env var on every call so tests can override
-    via ``monkeypatch.setenv``.
+    Sourced from ``settings.LICENSE_CONFIG_DIR`` so configuration stays
+    centralized in the Settings model.
     """
-    return Path(os.environ.get("LICENSE_CONFIG_DIR", _DEFAULT_CONFIG_DIR))
+    return Path(settings.LICENSE_CONFIG_DIR)
 
 
 def ensure_config_dir() -> Path:
@@ -179,6 +181,8 @@ def _atomic_write_text(path: Path, content: str) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_path, path)
     except Exception:
         # Cleanup the half-written tmp file on any failure.

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -241,6 +241,40 @@ class Settings(BaseSettings):
     TIER: str = Field(default="community", description="community, pro, enterprise")
 
     # ===================
+    # License Server (PR-02)
+    # ===================
+    # Where Core's activation endpoint sends the license key for validation.
+    # Defaults point at our production instance; override in dev/staging via
+    # env var. License-server API contract is documented in
+    # license-server/CLAUDE.md.
+    LICENSE_SERVER_URL: str = Field(
+        default="https://license.blb3dprinting.com",
+        description="Base URL of the FilaOps license server (no trailing slash)",
+    )
+    LICENSE_API_KEY: Optional[str] = Field(
+        default=None,
+        description=(
+            "Shared X-API-Key sent to the license server for server-to-server "
+            "auth. Required for activation; the license server rejects calls "
+            "without it. Same key across all customer deployments."
+        ),
+    )
+    LICENSE_CONFIG_DIR: str = Field(
+        default="/var/lib/filaops/config",
+        description=(
+            "Directory holding install_uuid + license.json. Override in dev "
+            "(LICENSE_CONFIG_DIR env var) when /var/lib isn't writable."
+        ),
+    )
+
+    @field_validator("LICENSE_SERVER_URL")
+    @classmethod
+    def strip_trailing_slash(cls, v: str) -> str:
+        # The endpoint module concatenates `/api/v1/validate`, so a trailing
+        # slash on the base URL would produce `//api/...` and 404.
+        return v.rstrip("/") if v else v
+
+    # ===================
     # MRP Settings (safe defaults)
     # ===================
     INCLUDE_SALES_ORDERS_IN_MRP: bool = True

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -1,0 +1,584 @@
+"""
+Tests for license_cache + system_license endpoints (PR-02).
+
+Covers:
+- ``app.core.license_cache`` module surface (UUID gen, save/load, malformed
+  JSON, PR-03 forward-compat, atomic write, clear)
+- ``GET /api/v1/system/license/info`` (community default, active state,
+  auth/permission)
+- ``POST /api/v1/system/license/activate`` happy path + every error class
+  (timeout, network, 401, 5xx, non-JSON, ``valid=false``, missing API key,
+  empty body)
+- ``DELETE /api/v1/system/license/`` happy path + auth/permission
+- License key masking in responses
+- ``install_uuid`` preserved across activate/deactivate cycles
+
+The license server is mocked entirely via a swap-in for ``httpx.AsyncClient``.
+"""
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+from app.core.license_cache import (
+    LICENSE_CACHE_FILENAME,
+    INSTALL_UUID_FILENAME,
+    LicenseCache,
+    clear_license_cache,
+    get_install_uuid,
+    load_license_cache,
+    save_license_cache,
+    utc_now_iso,
+)
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+ACTIVATE_URL = "/api/v1/system/license/activate"
+INFO_URL = "/api/v1/system/license/info"
+DEACTIVATE_URL = "/api/v1/system/license/"
+
+VALID_KEY = "FILAOPS-PRO-bef4723f987560ea"
+MASK_RE = re.compile(r"^.{1,12}\*\*\*.{0,4}$")
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limits():
+    from app.core.limiter import limiter
+
+    original = getattr(limiter, "_enabled", True)
+    limiter.enabled = False
+    yield
+    limiter.enabled = original
+
+
+@pytest.fixture(autouse=True)
+def _license_env(monkeypatch, tmp_path):
+    """Each test gets:
+    - A fresh tmpdir for license.json + install_uuid (LICENSE_CONFIG_DIR env)
+    - settings.LICENSE_API_KEY set to a known test value
+    - settings.LICENSE_SERVER_URL pointed at a fake host
+    """
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "LICENSE_API_KEY", "test-api-key", raising=False)
+    monkeypatch.setattr(
+        settings, "LICENSE_SERVER_URL", "http://license-test.local", raising=False
+    )
+    yield tmp_path
+
+
+@pytest.fixture
+def non_admin_user(db):
+    from app.core.security import hash_password
+    from app.models.user import User
+
+    uid = uuid.uuid4().hex[:8]
+    user = User(
+        email=f"nonadmin-{uid}@filaops.dev",
+        password_hash=hash_password("TestPass123!"),
+        first_name="NonAdmin",
+        last_name="User",
+        account_type="customer",
+        status="active",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def non_admin_client(db, non_admin_user):
+    from fastapi.testclient import TestClient
+
+    from app.core.security import create_access_token
+    from app.db.session import get_db
+    from app.main import app
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    token = create_access_token(user_id=non_admin_user.id)
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        yield c
+    app.dependency_overrides.clear()
+
+
+# =============================================================================
+# httpx mocking
+# =============================================================================
+
+
+class _MockResponse:
+    """Minimal stand-in for httpx.Response."""
+
+    def __init__(
+        self,
+        status_code: int,
+        json_data: Optional[dict] = None,
+        text: Optional[str] = None,
+    ):
+        self.status_code = status_code
+        self._json = json_data
+        if text is not None:
+            self.text = text
+        elif json_data is not None:
+            self.text = json.dumps(json_data)
+        else:
+            self.text = ""
+
+    def json(self) -> Any:
+        if self._json is None:
+            # Match real httpx behavior: invalid body raises ValueError.
+            raise ValueError("Expecting value")
+        return self._json
+
+
+@pytest.fixture
+def mock_license_server(monkeypatch):
+    """Swap ``httpx.AsyncClient`` for a controllable test double.
+
+    Returns a setter ``configure(response_or_exception)`` so each test can
+    declare what the next outbound call sees.
+    """
+    state: dict = {"response": None, "exception": None, "calls": []}
+
+    class _MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, json=None, headers=None):
+            state["calls"].append({"url": url, "json": json, "headers": headers})
+            if state["exception"] is not None:
+                raise state["exception"]
+            return state["response"]
+
+    import app.api.v1.endpoints.system_license as mod
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _MockAsyncClient)
+
+    def configure(response_or_exception):
+        if isinstance(response_or_exception, Exception):
+            state["exception"] = response_or_exception
+            state["response"] = None
+        else:
+            state["response"] = response_or_exception
+            state["exception"] = None
+
+    configure.calls = state["calls"]  # type: ignore[attr-defined]
+    return configure
+
+
+def _ok_validate_response(
+    *,
+    tier: str = "professional",
+    features: Optional[list[str]] = None,
+    expires_at: Optional[str] = "2027-01-01T00:00:00+00:00",
+    message: Optional[str] = None,
+) -> _MockResponse:
+    return _MockResponse(
+        200,
+        json_data={
+            "valid": True,
+            "tier": tier,
+            "status": "active",
+            "license_type": "subscription",
+            "limits": {"max_users": -1, "max_printers": -1, "max_sites": 1},
+            "features": features or ["catalogs", "shopify"],
+            "current_period_end": expires_at,
+            "grace_period_end": None,
+            "message": message,
+        },
+    )
+
+
+# =============================================================================
+# license_cache module unit tests
+# =============================================================================
+
+
+def test_install_uuid_is_generated_on_first_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    u = get_install_uuid()
+    assert u
+    assert (tmp_path / INSTALL_UUID_FILENAME).read_text().strip() == u
+
+
+def test_install_uuid_is_stable_across_calls(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    u1 = get_install_uuid()
+    u2 = get_install_uuid()
+    assert u1 == u2
+
+
+def test_install_uuid_regenerates_when_file_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    (tmp_path / INSTALL_UUID_FILENAME).write_text("")
+    u = get_install_uuid()
+    assert u
+    assert (tmp_path / INSTALL_UUID_FILENAME).read_text().strip() == u
+
+
+def test_load_returns_none_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    assert load_license_cache() is None
+
+
+def test_save_then_load_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    cache = LicenseCache(
+        license_key="FILAOPS-PRO-test",
+        install_uuid="uuid-x",
+        tier="professional",
+        features=["catalogs", "shopify"],
+        activated_at=utc_now_iso(),
+        expires_at="2027-01-01T00:00:00+00:00",
+    )
+    save_license_cache(cache)
+    loaded = load_license_cache()
+    assert loaded is not None
+    assert loaded.license_key == "FILAOPS-PRO-test"
+    assert loaded.tier == "professional"
+    assert loaded.features == ["catalogs", "shopify"]
+    assert loaded.expires_at == "2027-01-01T00:00:00+00:00"
+
+
+def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
+    """Forward-compat: PR-03 will add fields like status, last_verified_at,
+    nonce_history. The PR-02 reader must ignore them, not crash."""
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    extended = {
+        "license_key": "FILAOPS-PRO-test",
+        "install_uuid": "uuid-x",
+        "tier": "professional",
+        "features": ["catalogs"],
+        "activated_at": "2026-05-01T00:00:00+00:00",
+        "expires_at": "2027-01-01T00:00:00+00:00",
+        # Fields PR-03 will add:
+        "status": "active",
+        "last_verified_at": "2026-05-01T00:00:00+00:00",
+        "nonce_history": ["abc", "def"],
+    }
+    (tmp_path / LICENSE_CACHE_FILENAME).write_text(json.dumps(extended))
+    loaded = load_license_cache()
+    assert loaded is not None
+    assert loaded.license_key == "FILAOPS-PRO-test"
+
+
+def test_load_returns_none_on_malformed_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    (tmp_path / LICENSE_CACHE_FILENAME).write_text("this is not json {")
+    assert load_license_cache() is None
+
+
+def test_clear_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    cache = LicenseCache(
+        license_key="k",
+        install_uuid="u",
+        tier="community",
+        features=[],
+        activated_at=utc_now_iso(),
+    )
+    save_license_cache(cache)
+    assert clear_license_cache() is True
+    assert clear_license_cache() is False
+
+
+# =============================================================================
+# GET /info
+# =============================================================================
+
+
+def test_info_returns_community_when_no_cache(client):
+    resp = client.get(INFO_URL)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["activated"] is False
+    assert body["tier"] == "community"
+    assert body["features"] == []
+    assert body["install_uuid"]  # generated on demand
+    assert body.get("license_key") is None
+
+
+def test_info_returns_active_state_when_cache_present(client, _license_env):
+    cache = LicenseCache(
+        license_key=VALID_KEY,
+        install_uuid="uuid-x",
+        tier="professional",
+        features=["catalogs", "shopify"],
+        activated_at="2026-05-01T00:00:00+00:00",
+        expires_at="2027-01-01T00:00:00+00:00",
+    )
+    save_license_cache(cache)
+    resp = client.get(INFO_URL)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["activated"] is True
+    assert body["tier"] == "professional"
+    assert body["features"] == ["catalogs", "shopify"]
+    assert body["expires_at"] == "2027-01-01T00:00:00+00:00"
+    # Key is masked, never returned in full
+    assert body["license_key"] != VALID_KEY
+    assert MASK_RE.match(body["license_key"])
+
+
+def test_info_no_auth_returns_401(unauthed_client):
+    resp = unauthed_client.get(INFO_URL)
+    assert resp.status_code == 401
+
+
+def test_info_non_admin_returns_403(non_admin_client):
+    resp = non_admin_client.get(INFO_URL)
+    assert resp.status_code == 403
+
+
+# =============================================================================
+# POST /activate — happy path
+# =============================================================================
+
+
+def test_activate_happy_path_persists_cache(client, mock_license_server, _license_env):
+    mock_license_server(_ok_validate_response())
+
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["activated"] is True
+    assert body["tier"] == "professional"
+    assert body["features"] == ["catalogs", "shopify"]
+    assert MASK_RE.match(body["license_key"])  # masked
+
+    # Verify the cache file actually has the correct contents
+    persisted = load_license_cache()
+    assert persisted is not None
+    assert persisted.license_key == VALID_KEY  # full key in cache
+    assert persisted.tier == "professional"
+
+
+def test_activate_sends_correct_payload_to_server(
+    client, mock_license_server, _license_env
+):
+    mock_license_server(_ok_validate_response())
+
+    client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    calls = mock_license_server.calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["url"].endswith("/api/v1/validate")
+    assert call["json"]["license_key"] == VALID_KEY
+    assert call["json"]["instance_id"]  # install_uuid
+    assert call["headers"]["X-API-Key"] == "test-api-key"
+
+
+def test_activate_strips_whitespace_from_key(
+    client, mock_license_server, _license_env
+):
+    mock_license_server(_ok_validate_response())
+
+    resp = client.post(ACTIVATE_URL, json={"license_key": f"   {VALID_KEY}   "})
+    assert resp.status_code == 200
+    persisted = load_license_cache()
+    assert persisted is not None
+    assert persisted.license_key == VALID_KEY  # stripped
+
+
+def test_activate_install_uuid_preserved_across_cycles(
+    client, mock_license_server, _license_env
+):
+    """install_uuid must be stable across activate / deactivate / activate
+    so PRO's encryption key (PR-06) is preserved."""
+    mock_license_server(_ok_validate_response())
+
+    info1 = client.get(INFO_URL).json()
+    initial_uuid = info1["install_uuid"]
+
+    client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    client.delete(DEACTIVATE_URL)
+    client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    info2 = client.get(INFO_URL).json()
+
+    assert info2["install_uuid"] == initial_uuid
+
+
+# =============================================================================
+# POST /activate — input validation
+# =============================================================================
+
+
+def test_activate_rejects_empty_body_with_422(client, mock_license_server):
+    mock_license_server(_ok_validate_response())  # not actually called
+    resp = client.post(ACTIVATE_URL, json={})
+    assert resp.status_code == 422  # FastAPI / Pydantic
+
+
+def test_activate_rejects_empty_string_with_422(client, mock_license_server):
+    mock_license_server(_ok_validate_response())
+    resp = client.post(ACTIVATE_URL, json={"license_key": ""})
+    assert resp.status_code == 422
+
+
+def test_activate_rejects_whitespace_only_with_400(client, mock_license_server):
+    """Pydantic min_length=1 lets through whitespace; the endpoint strips
+    and rejects empty result with 400."""
+    mock_license_server(_ok_validate_response())
+    resp = client.post(ACTIVATE_URL, json={"license_key": "   "})
+    assert resp.status_code == 400
+
+
+# =============================================================================
+# POST /activate — server-side errors
+# =============================================================================
+
+
+def test_activate_returns_400_when_server_says_invalid(
+    client, mock_license_server
+):
+    mock_license_server(
+        _MockResponse(
+            200,
+            json_data={
+                "valid": False,
+                "tier": "community",
+                "status": "invalid",
+                "license_type": "none",
+                "limits": {"max_users": 1, "max_printers": 4, "max_sites": 1},
+                "features": [],
+                "current_period_end": None,
+                "grace_period_end": None,
+                "message": "License key not found.",
+            },
+        )
+    )
+
+    resp = client.post(ACTIVATE_URL, json={"license_key": "FILAOPS-PRO-bogus"})
+    assert resp.status_code == 400
+    assert "not found" in resp.json()["detail"].lower()
+    assert load_license_cache() is None  # nothing persisted
+
+
+def test_activate_returns_504_on_timeout(client, mock_license_server):
+    mock_license_server(httpx.TimeoutException("simulated timeout"))
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 504
+
+
+def test_activate_returns_502_on_network_error(client, mock_license_server):
+    mock_license_server(httpx.ConnectError("connection refused"))
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 502
+    assert "license server" in resp.json()["detail"].lower()
+
+
+def test_activate_returns_502_on_server_401(client, mock_license_server):
+    mock_license_server(_MockResponse(401, text="invalid api key"))
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 502
+    assert "credentials" in resp.json()["detail"].lower()
+
+
+def test_activate_returns_502_on_server_500(client, mock_license_server):
+    mock_license_server(_MockResponse(500, text="boom"))
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 502
+
+
+def test_activate_returns_502_on_non_json_body(client, mock_license_server):
+    mock_license_server(_MockResponse(200, text="<html>not json</html>"))
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 502
+
+
+# =============================================================================
+# POST /activate — server-config errors
+# =============================================================================
+
+
+def test_activate_returns_500_when_api_key_unset(
+    client, mock_license_server, monkeypatch
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "LICENSE_API_KEY", None, raising=False)
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 500
+    assert "license_api_key" in resp.json()["detail"].lower()
+
+
+def test_activate_no_auth_returns_401(unauthed_client, mock_license_server):
+    mock_license_server(_ok_validate_response())
+    resp = unauthed_client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 401
+
+
+def test_activate_non_admin_returns_403(non_admin_client, mock_license_server):
+    mock_license_server(_ok_validate_response())
+    resp = non_admin_client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 403
+
+
+# =============================================================================
+# DELETE /
+# =============================================================================
+
+
+def test_deactivate_removes_cache_but_preserves_uuid(client, _license_env):
+    cache = LicenseCache(
+        license_key=VALID_KEY,
+        install_uuid="uuid-stable",
+        tier="professional",
+        features=["catalogs"],
+        activated_at=utc_now_iso(),
+    )
+    save_license_cache(cache)
+
+    info_before = client.get(INFO_URL).json()
+    assert info_before["activated"] is True
+
+    resp = client.delete(DEACTIVATE_URL)
+    assert resp.status_code == 204
+
+    info_after = client.get(INFO_URL).json()
+    assert info_after["activated"] is False
+    # install_uuid is preserved across deactivate (it's PRO's encryption secret)
+    assert info_after["install_uuid"] == info_before["install_uuid"]
+
+
+def test_deactivate_when_no_license_returns_204(client):
+    """Idempotent — DELETE on an empty state still returns 204."""
+    resp = client.delete(DEACTIVATE_URL)
+    assert resp.status_code == 204
+
+
+def test_deactivate_no_auth_returns_401(unauthed_client):
+    resp = unauthed_client.delete(DEACTIVATE_URL)
+    assert resp.status_code == 401
+
+
+def test_deactivate_non_admin_returns_403(non_admin_client):
+    resp = non_admin_client.delete(DEACTIVATE_URL)
+    assert resp.status_code == 403

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -45,7 +45,7 @@ ACTIVATE_URL = "/api/v1/system/license/activate"
 INFO_URL = "/api/v1/system/license/info"
 DEACTIVATE_URL = "/api/v1/system/license/"
 
-VALID_KEY = "FILAOPS-PRO-bef4723f987560ea"
+VALID_KEY = "FILAOPS-PRO-test1234567890ab"
 MASK_RE = re.compile(r"^.{1,12}\*\*\*.{0,4}$")
 
 

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 import httpx
 import pytest
 
+from app.core.config import settings
 from app.core.license_cache import (
     LICENSE_CACHE_FILENAME,
     INSTALL_UUID_FILENAME,
@@ -71,9 +72,7 @@ def _license_env(monkeypatch, tmp_path):
     - settings.LICENSE_API_KEY set to a known test value
     - settings.LICENSE_SERVER_URL pointed at a fake host
     """
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
-    from app.core.config import settings
-
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     monkeypatch.setattr(settings, "LICENSE_API_KEY", "test-api-key", raising=False)
     monkeypatch.setattr(
         settings, "LICENSE_SERVER_URL", "http://license-test.local", raising=False
@@ -222,21 +221,21 @@ def _ok_validate_response(
 
 
 def test_install_uuid_is_generated_on_first_call(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     u = get_install_uuid()
     assert u
     assert (tmp_path / INSTALL_UUID_FILENAME).read_text().strip() == u
 
 
 def test_install_uuid_is_stable_across_calls(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     u1 = get_install_uuid()
     u2 = get_install_uuid()
     assert u1 == u2
 
 
 def test_install_uuid_regenerates_when_file_empty(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     (tmp_path / INSTALL_UUID_FILENAME).write_text("")
     u = get_install_uuid()
     assert u
@@ -244,12 +243,12 @@ def test_install_uuid_regenerates_when_file_empty(tmp_path, monkeypatch):
 
 
 def test_load_returns_none_when_missing(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     assert load_license_cache() is None
 
 
 def test_save_then_load_roundtrip(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     cache = LicenseCache(
         license_key="FILAOPS-PRO-test",
         install_uuid="uuid-x",
@@ -270,7 +269,7 @@ def test_save_then_load_roundtrip(tmp_path, monkeypatch):
 def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
     """Forward-compat: PR-03 will add fields like status, last_verified_at,
     nonce_history. The PR-02 reader must ignore them, not crash."""
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     extended = {
         "license_key": "FILAOPS-PRO-test",
         "install_uuid": "uuid-x",
@@ -290,13 +289,13 @@ def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
 
 
 def test_load_returns_none_on_malformed_json(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     (tmp_path / LICENSE_CACHE_FILENAME).write_text("this is not json {")
     assert load_license_cache() is None
 
 
 def test_clear_is_idempotent(tmp_path, monkeypatch):
-    monkeypatch.setenv("LICENSE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     cache = LicenseCache(
         license_key="k",
         install_uuid="u",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,6 +59,7 @@ const AdminSpools = lazy(() => import("./pages/admin/AdminSpools"));
 const AdminSecurity = lazy(() => import("./pages/admin/AdminSecurity"));
 const AdminCycleCount = lazy(() => import("./pages/admin/AdminCycleCount"));
 const AdminPriceLevels = lazy(() => import("./pages/admin/AdminPriceLevels"));
+const AdminLicense = lazy(() => import("./pages/admin/AdminLicense"));
 const AdminAccessRequests = lazy(
   () => import("./pages/admin/AdminAccessRequests"),
 );
@@ -392,6 +393,14 @@ export default function App() {
                       element={
                         <Suspense fallback={<PageLoader />}>
                           <AdminPriceLevels />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path="license"
+                      element={
+                        <Suspense fallback={<PageLoader />}>
+                          <AdminLicense />
                         </Suspense>
                       }
                     />

--- a/frontend/src/pages/admin/AdminLicense.jsx
+++ b/frontend/src/pages/admin/AdminLicense.jsx
@@ -142,7 +142,7 @@ function Header() {
         <a
           href="https://filaops.blb3dprinting.com/"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           className="text-blue-400 hover:text-blue-300 underline"
         >
           filaops.blb3dprinting.com

--- a/frontend/src/pages/admin/AdminLicense.jsx
+++ b/frontend/src/pages/admin/AdminLicense.jsx
@@ -1,0 +1,339 @@
+import { useCallback, useEffect, useState } from "react";
+import { useApi } from "../../hooks/useApi";
+import { useToast } from "../../components/Toast";
+
+/**
+ * AdminLicense — license entry + current-state display.
+ *
+ * Unlike most admin pages, this one is intentionally NOT gated by
+ * `useFeatureFlags().isPro`. It is the page that *enables* PRO, so it
+ * must work before PRO is installed (Community-tier customers reach it
+ * to activate).
+ */
+export default function AdminLicense() {
+  const api = useApi();
+  const toast = useToast();
+
+  const [info, setInfo] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+
+  const [licenseKey, setLicenseKey] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+
+  const [deactivating, setDeactivating] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.get("/api/v1/system/license/info");
+      setInfo(data);
+      setLoadError(null);
+    } catch (err) {
+      setLoadError(err?.message || "Failed to load license info");
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleActivate = async (e) => {
+    e?.preventDefault?.();
+    const key = licenseKey.trim();
+    if (!key) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const data = await api.post("/api/v1/system/license/activate", {
+        license_key: key,
+      });
+      setInfo(data);
+      setLicenseKey("");
+      toast?.success?.(
+        `Activated ${data.tier?.toUpperCase?.() || "PRO"} license. Restart Core to load PRO features.`,
+      );
+    } catch (err) {
+      // Backend returns the most useful detail (e.g. "License key not found",
+      // "Could not reach the license server"). Surface it directly.
+      setSubmitError(err?.message || "Activation failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeactivate = async () => {
+    if (!window.confirm(
+      "Remove this license locally? Core will run as Community until you activate again. " +
+      "Your data is preserved.",
+    )) {
+      return;
+    }
+    setDeactivating(true);
+    try {
+      await api.del("/api/v1/system/license/");
+      await refresh();
+      toast?.success?.("License removed locally. Restart Core to apply.");
+    } catch (err) {
+      toast?.error?.(err?.message || "Failed to deactivate");
+    } finally {
+      setDeactivating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400">
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  const isActivated = !!info?.activated;
+  const tier = info?.tier || "community";
+  const features = info?.features || [];
+
+  return (
+    <div className="space-y-6">
+      <Header />
+
+      <CurrentStateCard
+        info={info}
+        isActivated={isActivated}
+        tier={tier}
+        features={features}
+        onDeactivate={handleDeactivate}
+        deactivating={deactivating}
+      />
+
+      {!isActivated && (
+        <ActivateForm
+          licenseKey={licenseKey}
+          onChange={setLicenseKey}
+          onSubmit={handleActivate}
+          submitting={submitting}
+          error={submitError}
+        />
+      )}
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white">License & PRO Activation</h1>
+      <p className="text-gray-400 mt-1">
+        Enter your FilaOps PRO license key to unlock Professional features. Need
+        a license? Visit{" "}
+        <a
+          href="https://filaops.blb3dprinting.com/"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 hover:text-blue-300 underline"
+        >
+          filaops.blb3dprinting.com
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
+function CurrentStateCard({
+  info,
+  isActivated,
+  tier,
+  features,
+  onDeactivate,
+  deactivating,
+}) {
+  const tierBadge = isActivated
+    ? {
+        label: tier.toUpperCase(),
+        classes: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+      }
+    : {
+        label: "COMMUNITY",
+        classes: "bg-gray-500/15 text-gray-300 border-gray-500/30",
+      };
+
+  return (
+    <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="text-xs text-gray-500 uppercase tracking-wide">
+            Current Tier
+          </div>
+          <div
+            className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold border ${tierBadge.classes}`}
+          >
+            {tierBadge.label}
+          </div>
+        </div>
+        {isActivated && (
+          <button
+            onClick={onDeactivate}
+            disabled={deactivating}
+            className="text-sm text-gray-400 hover:text-red-400 underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {deactivating ? "Removing…" : "Remove license"}
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+        <Field label="License key" value={info?.license_key || "—"} mono />
+        <Field
+          label="Status"
+          value={isActivated ? "Active" : "Not activated"}
+        />
+        <Field
+          label="Expires"
+          value={info?.expires_at ? formatDate(info.expires_at) : isActivated ? "Perpetual" : "—"}
+        />
+        <Field
+          label="Activated"
+          value={info?.activated_at ? formatDate(info.activated_at) : "—"}
+        />
+      </div>
+
+      {isActivated && features.length > 0 && (
+        <div>
+          <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">
+            Enabled Features ({features.length})
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {features.map((f) => (
+              <span
+                key={f}
+                className="text-xs font-mono bg-gray-700/40 border border-gray-600/40 text-gray-300 px-2 py-1 rounded"
+              >
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {info?.install_uuid && (
+        <div className="pt-3 border-t border-gray-700/50">
+          <Field
+            label="Install ID"
+            value={info.install_uuid}
+            mono
+            hint="Stable identifier for this Core instance. Sent to the license server during activation."
+          />
+        </div>
+      )}
+
+      {isActivated && (
+        <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg px-4 py-3 text-sm text-blue-200">
+          <strong>Restart Core</strong> to load PRO features after activation
+          changes.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActivateForm({ licenseKey, onChange, onSubmit, submitting, error }) {
+  const trimmed = licenseKey.trim();
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
+    >
+      <div>
+        <label
+          htmlFor="license-key-input"
+          className="block text-sm font-medium text-gray-200 mb-2"
+        >
+          License Key
+        </label>
+        <input
+          id="license-key-input"
+          type="text"
+          value={licenseKey}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="FILAOPS-PRO-..."
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          disabled={submitting}
+          className="w-full bg-gray-900/60 border border-gray-700 rounded-md px-3 py-2 text-sm text-white font-mono placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-50"
+        />
+        <p className="text-xs text-gray-500 mt-1">
+          Pasted from your purchase confirmation email. Spaces are trimmed
+          automatically.
+        </p>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="bg-red-500/10 border border-red-500/30 rounded-md px-3 py-2 text-sm text-red-300"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={submitting || trimmed.length === 0}
+          className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-500 disabled:cursor-not-allowed text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+        >
+          {submitting ? "Activating…" : "Activate"}
+        </button>
+        <span className="text-xs text-gray-500">
+          Core will contact the license server to validate this key.
+        </span>
+      </div>
+    </form>
+  );
+}
+
+function Field({ label, value, mono, hint }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-xs text-gray-500 uppercase tracking-wide">{label}</div>
+      <div
+        className={`text-gray-200 break-all ${mono ? "font-mono text-xs" : ""}`}
+      >
+        {value}
+      </div>
+      {hint && <div className="text-xs text-gray-500">{hint}</div>}
+    </div>
+  );
+}
+
+function formatDate(iso) {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
## Summary

PR-02 implements the license activation flow on Core: a frontend admin page (/admin/license), backend endpoints for activation and status, and a filesystem persistence layer for the license cache. After this merges, PR-03b layers the heartbeat + grace + anti-rollback cycle on top to close the license loop.

## What's in this PR

- license_cache module — atomic-write JSON persistence at /var/lib/filaops/config/license.json, schema-compatible with PR-03b's PRO-side cache (forward-compat fields included from day one).
- system_license endpoints — POST /system/license/activate and GET /system/license/info.
- Settings — LICENSE_SERVER_URL, LICENSE_API_KEY, LICENSE_CONFIG_DIR.
- Frontend — AdminLicense.jsx with license entry form, status panel, install_uuid display.
- Route registration — /admin/license in App.jsx.
- Backend test coverage — 24+ tests across endpoints and cache module.

## Sacred Rule

Zero filaops_pro imports across all PR-02 files. Sacred Rule acknowledgment in commits 1, 2, 3, and 7 messages. Core remains runnable and complete without PRO installed.

## Forward compatibility

test_load_tolerates_pr03_extra_fields proves the cache schema gracefully accepts PR-03b's last_server_timestamp and nonce_history fields when they appear. PR-03b will populate them; PR-02 code ignores them cleanly until then.

## Intentional spec deviations

Three deviations from the original PR-02 prompt, all intentional:

1. No retry button on activation errors — the form itself is the retry surface.
2. No retryable / non-retryable error distinction in the UI — server categorizes, client displays.
3. No clipboard copy on install_uuid — browser-native triple-click suffices.

## Note on commit 3d37e4e

Commit 3d37e4e replaces a test fixture with a clearly-fake placeholder value. The previous fixture resembled production license format too closely; the replacement makes test data unambiguously synthetic.

## Downstream

PR-03b (license heartbeat client + grace window + anti-rollback) is drafted and depends on this merge. PR-03b's LicenseCache is schema-compatible with this PR's; the contract lives in the JSON shape, not in shared Python modules.

## Commits

| # | SHA | Title |
|---|-----|-------|
| 1 | 25a5c06 | license_cache filesystem persistence layer |
| 2 | abeded7 | LICENSE_SERVER_URL / LICENSE_API_KEY / LICENSE_CONFIG_DIR settings |
| 3 | fc756a6 | system_license activation + info endpoints |
| 4 | 4bb3416 | register system_license router |
| 5 | a2a1804 | backend test coverage |
| 6 | f65c89f | AdminLicense page (Core frontend) |
| 7 | bbd59b1 | register /admin/license route in App.jsx |
| 8 | 3d37e4e | test fixture sanitization (see note above) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-facing system license management: view status, activate, and deactivate licenses.
  * Admin License page under /admin/license with activation form, current state card, and restart notice after activation.
  * License info shows tier, status, enabled features, expiry, activation time, and Install ID; license keys are masked in UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->