### PR TITLE
fix: correct Update Now button endpoint path (cortex #48)

### DIFF
--- a/frontend/src/components/UpdateNotification.jsx
+++ b/frontend/src/components/UpdateNotification.jsx
@@ -32,21 +32,36 @@ const UpdateNotification = () => {
 
     try {
       setLoading(true);
-      // Show immediate feedback
-      alert("Upgrade started!\n\nContainers are rebuilding. This page will automatically reload in 60 seconds.\n\nDo not close this window.");
-      
-      const startTime = Date.now();
-      const maxWait = 120000;
-      const pollInterval = 5000;
-      
-      // Fire upgrade request (may not get response as server restarts)
-      fetch(`${API_URL}/api/v1/admin/system/update/start`, {
+
+      // Confirm the server accepted the request before showing success.
+      // The backend validates prerequisites (admin auth, docker, git, no
+      // in-progress update) and responds before kicking off the background
+      // task that eventually restarts the server, so this fetch will return.
+      const startResponse = await fetch(`${API_URL}/api/v1/admin/system/update/start`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
-      }).catch(() => {/* Connection loss expected during upgrade */});
-      
+      });
+
+      if (!startResponse.ok) {
+        let detail = `${startResponse.status} ${startResponse.statusText}`;
+        try {
+          const data = await startResponse.json();
+          if (data?.detail) detail = data.detail;
+        } catch { /* response body was not JSON */ }
+        alert(`Failed to start upgrade:\n\n${detail}`);
+        setLoading(false);
+        return;
+      }
+
+      // Server accepted — background task is running. Show feedback and poll.
+      alert("Upgrade started!\n\nContainers are rebuilding. This page will automatically reload in 60 seconds.\n\nDo not close this window.");
+
+      const startTime = Date.now();
+      const maxWait = 120000;
+      const pollInterval = 5000;
+
       // Wait for upgrade to start
       await new Promise(resolve => setTimeout(resolve, 10000));
       

--- a/frontend/src/components/UpdateNotification.jsx
+++ b/frontend/src/components/UpdateNotification.jsx
@@ -40,10 +40,11 @@ const UpdateNotification = () => {
       const pollInterval = 5000;
       
       // Fire upgrade request (may not get response as server restarts)
-      fetch(`${API_URL}/api/v1/system/updates/upgrade`, {
+      fetch(`${API_URL}/api/v1/admin/system/update/start`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
       }).catch(() => {/* Connection loss expected during upgrade */});
       
       // Wait for upgrade to start


### PR DESCRIPTION
UpdateNotification.jsx POSTs to /api/v1/system/updates/upgrade which doesn't exist. Real endpoint is POST /api/v1/admin/system/update/start. Banner button has been silently 404ing. Ten-line fix, no backend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how system upgrades are initiated to align with backend changes; upgrade flow (confirmation, status monitoring, restart) remains intact.

* **Bug Fixes**
  * Upgrade initiation now confirms success or failure with immediate alerts—shows an error if start fails or "Upgrade started!" if it succeeds, then continues normal polling and reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->