### PR TITLE
feat(pr-04): PRO installer — admin UI + background task + wheel download

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from . import (
     bom, dashboard, fulfillment_queue, fulfillment_shipping, audit, accounting, traceability,
     customers, inventory_transactions, analytics, export, data_import, orders,
-    users, uom, locations, system, uploads
+    users, uom, locations, system, uploads, pro_install
 )
 
 router = APIRouter()
@@ -56,6 +56,9 @@ router.include_router(locations.router)
 
 # System Management (updates, maintenance)
 router.include_router(system.router)
+
+# PRO Installer (PR-04 — wheel download + pip install, Core-only, no PRO imports)
+router.include_router(pro_install.router)
 
 # File Uploads (product images, etc.)
 router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])

--- a/backend/app/api/v1/endpoints/admin/pro_install.py
+++ b/backend/app/api/v1/endpoints/admin/pro_install.py
@@ -1,0 +1,352 @@
+"""
+PRO Installer API Endpoints (PR-04)
+
+Orchestrates the post-activation download + pip install of the FilaOps PRO
+wheel from the license server. After PR-02 the customer has a license.json
+on disk; this module is what turns that into an actually-installed PRO
+package, surfacing progress through a polled status endpoint so the admin UI
+can show download/install progress without the customer ever touching a
+terminal.
+
+Sacred Rule: this module MUST NOT ``import filaops_pro``. Detection of an
+already-installed PRO uses ``importlib.util.find_spec``, which only walks
+the import system without executing module code, so Core's module graph
+stays free of PRO references whether or not the wheel is present.
+
+Patterns reused:
+  - Background task + module-level status dict:
+      app/api/v1/endpoints/admin/system.py:_update_status
+  - subprocess pip install against sys.executable:
+      app/api/v1/endpoints/settings.py:install_anthropic_package
+  - httpx + admin-auth conventions:
+      app/api/v1/endpoints/system_license.py
+
+License-server endpoint contract (per the deployed PR-04 server impl,
+documented in `tests/test_wheel_download.py` on the license-server side):
+  GET /api/v1/download/wheel?license_key=<key>
+  Headers: X-API-Key: <server-to-server credential>
+  Response: wheel binary (application/octet-stream)
+  Response headers: X-Wheel-SHA256 (hex digest)
+
+State machine:
+  idle -> downloading -> verifying -> installing -> restart_required
+                                                 -> error (from any phase)
+An ``error`` state is retryable. ``restart_required`` is not retryable from
+this endpoint — Core has to be restarted so main.py:load_plugin can pick
+up the freshly-installed wheel.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Optional
+
+import httpx
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
+from app.api.v1.deps import get_current_admin_user
+from app.core.config import settings
+from app.core.license_cache import load_license_cache
+from app.logging_config import get_logger
+from app.models.user import User
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/system/pro", tags=["Admin - PRO Installer"])
+
+# Network read-budget for the wheel download. Wheels are 1-5MB today, but
+# customer connections vary widely; 60s absorbs the long tail without leaving
+# the UI hanging when the server is genuinely down.
+_DOWNLOAD_TIMEOUT_SECONDS = 60.0
+# pip install runtime budget. Mirrors settings.install_anthropic_package,
+# which also installs a small no-deps wheel.
+_PIP_INSTALL_TIMEOUT_SECONDS = 120
+
+# ---- State machine ---------------------------------------------------------
+#
+# A module-level dict instead of Redis/DB because install state is inherently
+# ephemeral: the only post-install action is restarting Core, which clears it
+# anyway. A persisted state would just become a stale row to clean up.
+_install_status: dict = {
+    "state": "idle",            # idle | downloading | verifying | installing | restart_required | error
+    "progress": "",             # human-readable progress string for the UI
+    "error": None,              # error message when state == error, else None
+    "installed_version": None,  # version string parsed from wheel filename
+    "started_at": None,         # ISO 8601 UTC timestamp
+    "completed_at": None,       # ISO 8601 UTC timestamp
+}
+
+# States during which a fresh install attempt must be rejected.
+_BUSY_STATES = {"downloading", "verifying", "installing"}
+
+
+class InstallError(Exception):
+    """Internal exception used to short-circuit the install pipeline.
+
+    Caught by the background-task wrapper, which converts it into the error
+    state. Never raised across the FastAPI surface — callers see install
+    failures only via the polling endpoint.
+    """
+
+
+# ---- Helpers ---------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_pro_installed() -> bool:
+    """Whether ``filaops_pro`` is importable from the current environment.
+
+    Uses ``importlib.util.find_spec`` so Core never pulls PRO into its own
+    module graph — see Sacred Rule note in the module docstring.
+    """
+    return importlib.util.find_spec("filaops_pro") is not None
+
+
+def _compute_sha256(path: Path) -> str:
+    """Return the hex SHA-256 digest of a file, streamed in 64KB chunks."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _extract_version_from_filename(wheel_path: Path) -> Optional[str]:
+    """Best-effort version extraction from a PEP 427 wheel filename.
+
+    Layout: ``<dist>-<version>(-<build>)?-<python>-<abi>-<platform>.whl``
+    Example: ``filaops_pro-1.2.3-py3-none-any.whl`` -> ``"1.2.3"``
+    Returns None if the filename doesn't match — the install still succeeds.
+    """
+    match = re.match(r"^[A-Za-z0-9_]+-([^-]+)-", wheel_path.stem)
+    return match.group(1) if match else None
+
+
+async def _download_wheel(
+    *,
+    license_server_url: str,
+    license_key: str,
+    api_key: str,
+    dest_dir: Path,
+) -> tuple[Path, Optional[str]]:
+    """Fetch the PRO wheel from the license server.
+
+    Returns ``(wheel_path, expected_sha256)``. ``expected_sha256`` may be
+    None if the server omits the ``X-Wheel-SHA256`` header — the install
+    still proceeds, but the integrity check becomes a no-op (forward-compat
+    with older license-server builds).
+
+    Raises InstallError on any network failure or non-200 response.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    url = f"{license_server_url}/api/v1/download/wheel"
+    headers = {"X-API-Key": api_key}
+    params = {"license_key": license_key}
+
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT_SECONDS) as client:
+        try:
+            resp = await client.get(url, headers=headers, params=params)
+        except httpx.TimeoutException as exc:
+            raise InstallError("License server did not respond in time.") from exc
+        except httpx.RequestError as exc:
+            raise InstallError(f"Could not reach the license server: {exc}") from exc
+
+    if resp.status_code != 200:
+        # Cap the error body so a runaway HTML response doesn't pollute the
+        # status field that the UI displays verbatim.
+        body = (resp.text or "")[:200]
+        raise InstallError(
+            f"License server returned {resp.status_code}: {body}".rstrip(": ")
+        )
+
+    expected_sha256 = resp.headers.get("X-Wheel-SHA256")
+    # Honor the server-supplied filename when present so version detection
+    # works on the install side; fall back to a deterministic name otherwise.
+    filename = "filaops_pro.whl"
+    cd = resp.headers.get("Content-Disposition", "")
+    cd_match = re.search(r'filename="?([^"]+)"?', cd)
+    if cd_match:
+        filename = cd_match.group(1)
+
+    wheel_path = dest_dir / filename
+    wheel_path.write_bytes(resp.content)
+    return wheel_path, expected_sha256
+
+
+async def _do_pro_install() -> None:
+    """Background install pipeline: download -> verify -> pip install -> done.
+
+    Mutates ``_install_status`` so the polling endpoint can surface progress.
+    Every exception is converted into the error state — Core must keep
+    running even when PRO install fails (Layer-0 non-regression constraint).
+    """
+    try:
+        # Phase 1: Download
+        _install_status["state"] = "downloading"
+        _install_status["progress"] = "Downloading PRO package from license server..."
+        _install_status["error"] = None
+        _install_status["started_at"] = _now_iso()
+        _install_status["completed_at"] = None
+        _install_status["installed_version"] = None
+
+        cache = load_license_cache()
+        if cache is None:
+            # Defensive: the trigger endpoint already checks this, but the
+            # cache could be cleared between trigger and the bg task firing.
+            raise InstallError("No license activated. Activate first.")
+
+        api_key = settings.LICENSE_API_KEY
+        if not api_key:
+            raise InstallError(
+                "Server is not configured for PRO install: LICENSE_API_KEY is not set."
+            )
+
+        dest_dir = Path(tempfile.gettempdir()) / "filaops-pro-install"
+        wheel_path, expected_hash = await _download_wheel(
+            license_server_url=settings.LICENSE_SERVER_URL,
+            license_key=cache.license_key,
+            api_key=api_key,
+            dest_dir=dest_dir,
+        )
+
+        # Phase 2: Verify
+        _install_status["state"] = "verifying"
+        _install_status["progress"] = "Verifying package integrity..."
+        if expected_hash:
+            actual_hash = _compute_sha256(wheel_path)
+            if actual_hash.lower() != expected_hash.lower():
+                # Refuse to install a wheel whose hash doesn't match the
+                # server's declared digest. The wheel is left on disk for
+                # post-mortem inspection but never reaches pip.
+                raise InstallError(
+                    f"Wheel hash mismatch: expected {expected_hash[:16]}..., "
+                    f"got {actual_hash[:16]}..."
+                )
+
+        # Phase 3: Install
+        _install_status["state"] = "installing"
+        _install_status["progress"] = "Installing PRO package..."
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", str(wheel_path), "--no-deps"],
+            capture_output=True,
+            text=True,
+            timeout=_PIP_INSTALL_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            raise InstallError(f"pip install failed: {result.stderr[:500]}")
+
+        # Phase 4: Done
+        _install_status["state"] = "restart_required"
+        _install_status["progress"] = (
+            "PRO installed successfully. Restart Core to activate."
+        )
+        _install_status["installed_version"] = _extract_version_from_filename(wheel_path)
+        _install_status["completed_at"] = _now_iso()
+        logger.info(
+            "PRO installed successfully (version=%s, wheel=%s)",
+            _install_status["installed_version"],
+            wheel_path.name,
+        )
+
+    except InstallError as exc:
+        _install_status["state"] = "error"
+        _install_status["error"] = str(exc)
+        _install_status["progress"] = f"Installation failed: {exc}"
+        _install_status["completed_at"] = _now_iso()
+        logger.warning("PRO install failed: %s", exc)
+    except subprocess.TimeoutExpired:
+        _install_status["state"] = "error"
+        _install_status["error"] = "pip install timed out."
+        _install_status["progress"] = "Installation failed: pip install timed out."
+        _install_status["completed_at"] = _now_iso()
+        logger.warning("PRO install pip step timed out")
+    except Exception as exc:  # pragma: no cover - defensive catch-all
+        _install_status["state"] = "error"
+        _install_status["error"] = str(exc)
+        _install_status["progress"] = f"Installation failed: {exc}"
+        _install_status["completed_at"] = _now_iso()
+        logger.exception("Unexpected error during PRO install")
+
+
+# ---- Endpoints -------------------------------------------------------------
+
+
+@router.post("/install")
+async def start_pro_install(
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+) -> dict:
+    """Trigger a PRO wheel download + install in the background.
+
+    Returns immediately after scheduling the background task. The frontend
+    polls ``GET /system/pro/install/status`` for state updates.
+
+    Rejects with:
+      400 — no license activated (no license.json on disk)
+      409 — install already in progress, or PRO already installed
+      500 — server is missing LICENSE_API_KEY (operator config issue)
+    """
+    cache = load_license_cache()
+    if cache is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No license activated. Activate a license before installing PRO.",
+        )
+
+    if _install_status["state"] in _BUSY_STATES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"PRO install already in progress (state={_install_status['state']})."
+            ),
+        )
+
+    if _install_status["state"] == "restart_required":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="PRO is installed. Restart Core to activate it.",
+        )
+
+    if _is_pro_installed():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="PRO is already installed in this environment.",
+        )
+
+    if not settings.LICENSE_API_KEY:
+        # Operator config error — surface clearly rather than letting the
+        # background task fail with a vaguer message later.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "Server is not configured for PRO install: LICENSE_API_KEY is not set."
+            ),
+        )
+
+    # Reset error fields so a retry-from-error has a clean slate.
+    _install_status["state"] = "idle"
+    _install_status["error"] = None
+
+    background_tasks.add_task(_do_pro_install)
+    logger.info("PRO install triggered by %s", current_user.email)
+    return {
+        "message": "PRO install started.",
+        "state": "downloading",
+    }
+
+
+@router.get("/install/status")
+async def get_pro_install_status(
+    current_user: Annotated[User, Depends(get_current_admin_user)],
+) -> dict:
+    """Return the current PRO install state for frontend polling."""
+    return dict(_install_status)

--- a/backend/app/api/v1/endpoints/admin/pro_install.py
+++ b/backend/app/api/v1/endpoints/admin/pro_install.py
@@ -175,7 +175,15 @@ async def _download_wheel(
     cd = resp.headers.get("Content-Disposition", "")
     cd_match = re.search(r'filename="?([^"]+)"?', cd)
     if cd_match:
-        filename = cd_match.group(1)
+        # Strip path components — defense-in-depth against a server (compromised
+        # or buggy) returning "../../something.whl" and escaping dest_dir. The
+        # license-server endpoint is server-to-server-authenticated, but the
+        # cost of `Path.name` is one call so there's no reason to trust it.
+        filename = Path(cd_match.group(1)).name
+    if not filename.endswith(".whl"):
+        raise InstallError(
+            f"License server returned a non-wheel filename: {filename!r}"
+        )
 
     wheel_path = dest_dir / filename
     wheel_path.write_bytes(resp.content)
@@ -190,14 +198,12 @@ async def _do_pro_install() -> None:
     running even when PRO install fails (Layer-0 non-regression constraint).
     """
     try:
-        # Phase 1: Download
-        _install_status["state"] = "downloading"
-        _install_status["progress"] = "Downloading PRO package from license server..."
-        _install_status["error"] = None
-        _install_status["started_at"] = _now_iso()
-        _install_status["completed_at"] = None
-        _install_status["installed_version"] = None
-
+        # Phase 1: Download.
+        # State + started_at + cleared error fields are set synchronously by
+        # the trigger endpoint (start_pro_install) so a /status poll that
+        # races the bg task firing sees "downloading", not "idle". Don't
+        # overwrite started_at here — that would re-stamp the install with
+        # the bg task's wake time instead of the user's click.
         cache = load_license_cache()
         if cache is None:
             # Defensive: the trigger endpoint already checks this, but the
@@ -221,16 +227,24 @@ async def _do_pro_install() -> None:
         # Phase 2: Verify
         _install_status["state"] = "verifying"
         _install_status["progress"] = "Verifying package integrity..."
-        if expected_hash:
-            actual_hash = _compute_sha256(wheel_path)
-            if actual_hash.lower() != expected_hash.lower():
-                # Refuse to install a wheel whose hash doesn't match the
-                # server's declared digest. The wheel is left on disk for
-                # post-mortem inspection but never reaches pip.
-                raise InstallError(
-                    f"Wheel hash mismatch: expected {expected_hash[:16]}..., "
-                    f"got {actual_hash[:16]}..."
-                )
+        if not expected_hash:
+            # Fail closed. The PR-04 license-server endpoint always sets
+            # X-Wheel-SHA256; missing it means a server regression or a
+            # stripping proxy upstream — both are conditions where silent
+            # install would defeat the integrity gate.
+            raise InstallError(
+                "License server did not provide X-Wheel-SHA256 header. "
+                "Refusing to install an unverified wheel."
+            )
+        actual_hash = _compute_sha256(wheel_path)
+        if actual_hash.lower() != expected_hash.lower():
+            # Refuse to install a wheel whose hash doesn't match the
+            # server's declared digest. The wheel is left on disk for
+            # post-mortem inspection but never reaches pip.
+            raise InstallError(
+                f"Wheel hash mismatch: expected {expected_hash[:16]}..., "
+                f"got {actual_hash[:16]}..."
+            )
 
         # Phase 3: Install
         _install_status["state"] = "installing"
@@ -332,9 +346,24 @@ async def start_pro_install(
             ),
         )
 
-    # Reset error fields so a retry-from-error has a clean slate.
-    _install_status["state"] = "idle"
-    _install_status["error"] = None
+    # Mark in-flight SYNCHRONOUSLY before scheduling the bg task. Two reasons:
+    #   1. A /status poll between this return and the bg task firing must
+    #      see "downloading", not "idle" — otherwise useProInstaller stops
+    #      polling on a real install (its IN_PROGRESS_STATES check excludes
+    #      idle).
+    #   2. Closes the concurrent-POST race: a second request that arrives
+    #      before the bg task starts hits the busy-state check and gets 409
+    #      instead of scheduling a duplicate install.
+    _install_status.update(
+        {
+            "state": "downloading",
+            "progress": "Downloading PRO package from license server...",
+            "error": None,
+            "installed_version": None,
+            "started_at": _now_iso(),
+            "completed_at": None,
+        }
+    )
 
     background_tasks.add_task(_do_pro_install)
     logger.info("PRO install triggered by %s", current_user.email)

--- a/backend/tests/endpoints/test_pro_install.py
+++ b/backend/tests/endpoints/test_pro_install.py
@@ -471,14 +471,20 @@ def test_install_hash_mismatch_marks_state_error_and_skips_pip(
     assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
 
 
-def test_install_proceeds_when_server_omits_hash_header(
+def test_install_fails_closed_when_hash_header_missing(
     client,
     with_license,
     mock_pro_not_installed,
     mock_license_server,
     mock_pip_success,
 ):
-    """Forward-compat: missing ``X-Wheel-SHA256`` is treated as no-op verify."""
+    """Refuse to install when X-Wheel-SHA256 is missing.
+
+    The PR-04 license-server endpoint always sets this header. Missing it
+    means a server regression, a stripped proxy header, or a man-in-the-
+    middle — never "older server build" (the endpoint is brand-new). Fail
+    closed; the integrity gate is the whole point of the verify phase.
+    """
     resp_no_hash = _MockResponse(
         200,
         content=WHEEL_BYTES,
@@ -488,7 +494,114 @@ def test_install_proceeds_when_server_omits_hash_header(
 
     client.post(INSTALL_URL)
     body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert (
+        "x-wheel-sha256" in body["error"].lower()
+        or "header" in body["error"].lower()
+    )
+    # pip never invoked when integrity verification fails closed
+    assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_install_sanitizes_filename_against_path_traversal(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """A Content-Disposition filename containing path separators must be
+    reduced to its basename before being joined with dest_dir.
+
+    Defense-in-depth against a compromised license server returning
+    "../../etc/something.whl" and escaping the temp install directory.
+    """
+    evil_resp = _MockResponse(
+        200,
+        content=WHEEL_BYTES,
+        headers={
+            "X-Wheel-SHA256": WHEEL_SHA256,
+            "Content-Disposition": 'attachment; filename="../../etc/passwd.whl"',
+        },
+    )
+    mock_license_server(evil_resp)
+
+    client.post(INSTALL_URL)
+    body = client.get(STATUS_URL).json()
+    # Sanitization stripped path components → basename "passwd.whl" remains,
+    # passes the .whl suffix check, install proceeds normally.
     assert body["state"] == "restart_required"
+
+    calls = mock_pip_success.calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    wheel_arg = calls[0]["args"][4]
+    # The path passed to pip must be inside dest_dir, not above it.
+    assert "../" not in wheel_arg
+    assert "..\\" not in wheel_arg
+    assert wheel_arg.endswith("passwd.whl")  # basename preserved
+
+
+def test_install_rejects_non_whl_filename(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """Reject a filename that doesn't end with ``.whl``.
+
+    Combined with the path-traversal sanitization, this prevents a
+    compromised server from steering pip toward an arbitrary file type.
+    """
+    bad_resp = _MockResponse(
+        200,
+        content=WHEEL_BYTES,
+        headers={
+            "X-Wheel-SHA256": WHEEL_SHA256,
+            "Content-Disposition": 'attachment; filename="evil.txt"',
+        },
+    )
+    mock_license_server(bad_resp)
+
+    client.post(INSTALL_URL)
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert (
+        "wheel" in body["error"].lower()
+        or "filename" in body["error"].lower()
+        or "non-wheel" in body["error"].lower()
+    )
+    assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_install_marks_state_downloading_synchronously_before_background_task(
+    client, with_license, mock_pro_not_installed, monkeypatch
+):
+    """The trigger MUST set state=downloading synchronously before add_task.
+
+    Regression guard for the race CodeRabbit flagged: if the trigger leaves
+    state at "idle" until the bg task fires, an immediate /status poll sees
+    "idle" and useProInstaller stops polling on a real install. Also closes
+    the concurrent-POST window where two near-simultaneous requests both
+    pass the busy-state check.
+
+    Test stubs the bg task to a no-op so any state change observed via
+    /status must have come from the trigger, not the pipeline.
+    """
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    async def noop():
+        pass
+
+    monkeypatch.setattr(mod, "_do_pro_install", noop)
+
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 200
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "downloading"
+    assert body["started_at"] is not None
+    assert body["error"] is None
 
 
 def test_install_pip_failure_marks_state_error(

--- a/backend/tests/endpoints/test_pro_install.py
+++ b/backend/tests/endpoints/test_pro_install.py
@@ -1,0 +1,609 @@
+"""
+Tests for PRO installer endpoints (PR-04).
+
+Covers POST /api/v1/admin/system/pro/install + GET .../install/status:
+- Trigger validation: no license (400), busy (409), already-installed (409),
+  restart-pending (409), missing LICENSE_API_KEY (500)
+- Happy path: state transitions to ``restart_required`` after the background
+  task runs (FastAPI BackgroundTasks executes inline in TestClient, so the
+  pipeline finishes before the next request)
+- License-server contract: GET to ``/api/v1/download/wheel`` with
+  ``X-API-Key`` header + ``license_key`` query param
+- Error pipeline: download network error, download timeout, server 4xx,
+  hash mismatch, pip non-zero exit, pip timeout — all leave Core running
+  and surface as ``state=error`` (retryable)
+- pip invocation contract: subprocess called with ``--no-deps`` and
+  ``sys.executable``, never the system pip
+- Status endpoint reflects mutated state without polling
+- Auth: 401 when unauthenticated, 403 for non-admin
+
+The license server is mocked via an httpx.AsyncClient swap-in (same shape
+as test_system_license.py); subprocess.run is mocked with a CompletedProcess
+stub so pip never actually executes.
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import uuid
+from typing import Optional
+
+import httpx
+import pytest
+
+from app.core.config import settings
+from app.core.license_cache import LicenseCache, save_license_cache, utc_now_iso
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+INSTALL_URL = "/api/v1/admin/system/pro/install"
+STATUS_URL = "/api/v1/admin/system/pro/install/status"
+
+VALID_KEY = "FILAOPS-PRO-test1234567890ab"
+WHEEL_BYTES = b"PK\x03\x04fake-wheel-content-for-testing"
+WHEEL_SHA256 = hashlib.sha256(WHEEL_BYTES).hexdigest()
+WHEEL_FILENAME = "filaops_pro-1.2.3-py3-none-any.whl"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limits():
+    from app.core.limiter import limiter
+
+    original = getattr(limiter, "_enabled", True)
+    limiter.enabled = False
+    yield
+    limiter.enabled = original
+
+
+@pytest.fixture(autouse=True)
+def _reset_install_status():
+    """Module-level state outlives a single test — reset before each one."""
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status.update(
+        {
+            "state": "idle",
+            "progress": "",
+            "error": None,
+            "installed_version": None,
+            "started_at": None,
+            "completed_at": None,
+        }
+    )
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _license_env(monkeypatch, tmp_path):
+    """Each test gets a fresh tmpdir for license.json and known server config."""
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(settings, "LICENSE_API_KEY", "test-api-key", raising=False)
+    monkeypatch.setattr(
+        settings, "LICENSE_SERVER_URL", "http://license-test.local", raising=False
+    )
+    yield tmp_path
+
+
+@pytest.fixture
+def with_license(_license_env):
+    """Persist a valid LicenseCache so the install endpoint accepts the call."""
+    cache = LicenseCache(
+        license_key=VALID_KEY,
+        install_uuid="uuid-test",
+        tier="professional",
+        features=["catalogs", "shopify"],
+        activated_at=utc_now_iso(),
+        expires_at="2027-01-01T00:00:00+00:00",
+    )
+    save_license_cache(cache)
+    return cache
+
+
+@pytest.fixture
+def non_admin_user(db):
+    from app.core.security import hash_password
+    from app.models.user import User
+
+    uid = uuid.uuid4().hex[:8]
+    user = User(
+        email=f"nonadmin-{uid}@filaops.dev",
+        password_hash=hash_password("TestPass123!"),
+        first_name="NonAdmin",
+        last_name="User",
+        account_type="customer",
+        status="active",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def non_admin_client(db, non_admin_user):
+    from fastapi.testclient import TestClient
+
+    from app.core.security import create_access_token
+    from app.db.session import get_db
+    from app.main import app
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    token = create_access_token(user_id=non_admin_user.id)
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        yield c
+    app.dependency_overrides.clear()
+
+
+# =============================================================================
+# httpx + subprocess mocking
+# =============================================================================
+
+
+class _MockResponse:
+    """Minimal stand-in for ``httpx.Response`` (only the fields we touch)."""
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        content: Optional[bytes] = None,
+        text: Optional[str] = None,
+        headers: Optional[dict] = None,
+    ):
+        self.status_code = status_code
+        self.content = content if content is not None else b""
+        self.text = text if text is not None else ""
+        self.headers = headers or {}
+
+
+@pytest.fixture
+def mock_license_server(monkeypatch):
+    """Swap ``httpx.AsyncClient`` inside pro_install for a controllable double.
+
+    Returns a setter ``configure(response_or_exception)`` so each test can
+    declare what the next outbound GET sees, plus ``configure.calls`` for
+    contract assertions on URL / headers / params.
+    """
+    state: dict = {"response": None, "exception": None, "calls": []}
+
+    class _MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, url, *, headers=None, params=None):
+            state["calls"].append({"url": url, "headers": headers, "params": params})
+            if state["exception"] is not None:
+                raise state["exception"]
+            return state["response"]
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _MockAsyncClient)
+
+    def configure(response_or_exception):
+        if isinstance(response_or_exception, BaseException):
+            state["exception"] = response_or_exception
+            state["response"] = None
+        else:
+            state["response"] = response_or_exception
+            state["exception"] = None
+
+    configure.calls = state["calls"]  # type: ignore[attr-defined]
+    return configure
+
+
+@pytest.fixture
+def mock_pip_success(monkeypatch):
+    """Replace subprocess.run inside pro_install with a 0-exit stub."""
+    calls: list = []
+
+    def fake_run(args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout="ok", stderr=""
+        )
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    fake_run.calls = calls  # type: ignore[attr-defined]
+    return fake_run
+
+
+@pytest.fixture
+def mock_pro_not_installed(monkeypatch):
+    """Force ``_is_pro_installed()`` to False regardless of the dev environment.
+
+    Most CI runners don't have ``filaops_pro`` installed, but a developer
+    machine might — and the prod-server install absolutely will. Pin the
+    answer so the test is environment-independent.
+    """
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod, "_is_pro_installed", lambda: False)
+
+
+def _ok_wheel_response(*, sha256: str = WHEEL_SHA256) -> _MockResponse:
+    return _MockResponse(
+        200,
+        content=WHEEL_BYTES,
+        headers={
+            "X-Wheel-SHA256": sha256,
+            "Content-Disposition": f'attachment; filename="{WHEEL_FILENAME}"',
+        },
+    )
+
+
+# =============================================================================
+# POST /install — input / state validation
+# =============================================================================
+
+
+def test_install_rejects_when_no_license(client, mock_pro_not_installed):
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 400
+    assert "license" in resp.json()["detail"].lower()
+
+
+def test_install_rejects_when_already_in_progress(
+    client, with_license, mock_pro_not_installed
+):
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status["state"] = "downloading"
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 409
+    assert "in progress" in resp.json()["detail"].lower()
+
+
+def test_install_rejects_when_verifying(
+    client, with_license, mock_pro_not_installed
+):
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status["state"] = "verifying"
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 409
+
+
+def test_install_rejects_when_installing(
+    client, with_license, mock_pro_not_installed
+):
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status["state"] = "installing"
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 409
+
+
+def test_install_rejects_when_restart_required(
+    client, with_license, mock_pro_not_installed
+):
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status["state"] = "restart_required"
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 409
+    assert "restart" in resp.json()["detail"].lower()
+
+
+def test_install_rejects_when_pro_already_installed(
+    client, with_license, monkeypatch
+):
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod, "_is_pro_installed", lambda: True)
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 409
+    assert "already" in resp.json()["detail"].lower()
+
+
+def test_install_rejects_when_api_key_unset(
+    client, with_license, mock_pro_not_installed, monkeypatch
+):
+    monkeypatch.setattr(settings, "LICENSE_API_KEY", None, raising=False)
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 500
+    assert "license_api_key" in resp.json()["detail"].lower()
+
+
+# =============================================================================
+# POST /install — happy path
+# =============================================================================
+
+
+def test_install_happy_path_transitions_to_restart_required(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """Full pipeline: trigger -> download -> verify -> install -> done."""
+    mock_license_server(_ok_wheel_response())
+
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "downloading"
+
+    # FastAPI BackgroundTasks runs inline in TestClient, so the pipeline has
+    # already completed by the time we call /status.
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "restart_required"
+    assert body["error"] is None
+    assert body["installed_version"] == "1.2.3"
+    assert body["started_at"] is not None
+    assert body["completed_at"] is not None
+    assert "restart" in body["progress"].lower()
+
+
+def test_install_calls_license_server_with_correct_credentials(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """Contract test: ``X-API-Key`` header + ``license_key`` query param."""
+    mock_license_server(_ok_wheel_response())
+    client.post(INSTALL_URL)
+
+    calls = mock_license_server.calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["url"] == "http://license-test.local/api/v1/download/wheel"
+    assert call["headers"]["X-API-Key"] == "test-api-key"
+    assert call["params"]["license_key"] == VALID_KEY
+
+
+def test_install_invokes_pip_with_no_deps_and_current_python(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """pip is invoked via ``sys.executable -m pip install <wheel> --no-deps``."""
+    import sys
+
+    mock_license_server(_ok_wheel_response())
+    client.post(INSTALL_URL)
+
+    calls = mock_pip_success.calls  # type: ignore[attr-defined]
+    assert len(calls) == 1
+    args = calls[0]["args"]
+    assert args[0] == sys.executable
+    assert args[1:4] == ["-m", "pip", "install"]
+    assert "--no-deps" in args
+    # Wheel path is the last positional before the flag
+    wheel_arg = args[4]
+    assert wheel_arg.endswith(WHEEL_FILENAME)
+
+
+# =============================================================================
+# Background pipeline error states
+# =============================================================================
+
+
+def test_install_download_network_error_marks_state_error(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    mock_license_server(httpx.ConnectError("connection refused"))
+    client.post(INSTALL_URL)
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert body["error"]
+    # pip must never run when the download fails
+    assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_install_download_timeout_marks_state_error(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    mock_license_server(httpx.TimeoutException("simulated timeout"))
+    client.post(INSTALL_URL)
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "time" in body["error"].lower()
+
+
+def test_install_server_4xx_marks_state_error_and_skips_pip(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """A 403 from the license server should never reach pip."""
+    mock_license_server(_MockResponse(403, text="forbidden"))
+    client.post(INSTALL_URL)
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "403" in body["error"]
+    assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_install_hash_mismatch_marks_state_error_and_skips_pip(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """A hash mismatch is the hard integrity gate — wheel must NOT be installed."""
+    bad_hash = "0" * 64
+    mock_license_server(_ok_wheel_response(sha256=bad_hash))
+    client.post(INSTALL_URL)
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "hash" in body["error"].lower() or "mismatch" in body["error"].lower()
+    assert len(mock_pip_success.calls) == 0  # type: ignore[attr-defined]
+
+
+def test_install_proceeds_when_server_omits_hash_header(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """Forward-compat: missing ``X-Wheel-SHA256`` is treated as no-op verify."""
+    resp_no_hash = _MockResponse(
+        200,
+        content=WHEEL_BYTES,
+        headers={"Content-Disposition": f'attachment; filename="{WHEEL_FILENAME}"'},
+    )
+    mock_license_server(resp_no_hash)
+
+    client.post(INSTALL_URL)
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "restart_required"
+
+
+def test_install_pip_failure_marks_state_error(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    monkeypatch,
+):
+    mock_license_server(_ok_wheel_response())
+
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="ERROR: dependency conflict"
+        )
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    client.post(INSTALL_URL)
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "pip" in body["error"].lower()
+
+
+def test_install_pip_timeout_marks_state_error(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    monkeypatch,
+):
+    mock_license_server(_ok_wheel_response())
+
+    def fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=120)
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    client.post(INSTALL_URL)
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "time" in body["error"].lower()
+
+
+def test_install_retry_after_error_succeeds(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    mock_pip_success,
+):
+    """``error`` is retryable: a second POST proceeds and reaches restart_required."""
+    # Attempt 1: network failure
+    mock_license_server(httpx.ConnectError("offline"))
+    client.post(INSTALL_URL)
+    assert client.get(STATUS_URL).json()["state"] == "error"
+
+    # Attempt 2: server is back
+    mock_license_server(_ok_wheel_response())
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 200
+    assert client.get(STATUS_URL).json()["state"] == "restart_required"
+
+
+# =============================================================================
+# GET /install/status
+# =============================================================================
+
+
+def test_status_returns_idle_initially(client):
+    resp = client.get(STATUS_URL)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state"] == "idle"
+    assert body["error"] is None
+    assert body["installed_version"] is None
+    assert body["started_at"] is None
+    assert body["completed_at"] is None
+
+
+def test_status_reflects_in_progress_state(client):
+    """Status endpoint is a pure read of ``_install_status``."""
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    mod._install_status["state"] = "installing"
+    mod._install_status["progress"] = "Installing PRO package..."
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "installing"
+    assert body["progress"] == "Installing PRO package..."
+
+
+# =============================================================================
+# Auth / permission
+# =============================================================================
+
+
+def test_install_no_auth_returns_401(unauthed_client):
+    resp = unauthed_client.post(INSTALL_URL)
+    assert resp.status_code == 401
+
+
+def test_install_non_admin_returns_403(non_admin_client):
+    resp = non_admin_client.post(INSTALL_URL)
+    assert resp.status_code == 403
+
+
+def test_status_no_auth_returns_401(unauthed_client):
+    resp = unauthed_client.get(STATUS_URL)
+    assert resp.status_code == 401
+
+
+def test_status_non_admin_returns_403(non_admin_client):
+    resp = non_admin_client.get(STATUS_URL)
+    assert resp.status_code == 403

--- a/frontend/src/hooks/useProInstaller.js
+++ b/frontend/src/hooks/useProInstaller.js
@@ -50,6 +50,11 @@ export function useProInstaller() {
   // Tracks whether the component is still mounted so async work doesn't
   // call setState after unmount (React will warn otherwise).
   const mountedRef = useRef(true);
+  // Guards against overlapping polls. setInterval doesn't await — if a
+  // /status response takes longer than POLL_INTERVAL_MS, the next tick
+  // would queue a concurrent request, leading to extra load and out-of-
+  // order setState. Skip the tick when one is already in flight.
+  const inFlightRef = useRef(false);
 
   const stopPolling = useCallback(() => {
     if (pollTimerRef.current !== null) {
@@ -60,6 +65,11 @@ export function useProInstaller() {
   }, []);
 
   const fetchStatus = useCallback(async () => {
+    // Drop overlapping polls — see inFlightRef declaration. The 2s cadence
+    // is best-effort, not a hard guarantee; missing one tick is preferable
+    // to corrupting state with out-of-order responses.
+    if (inFlightRef.current) return null;
+    inFlightRef.current = true;
     try {
       const data = await api.get(STATUS_URL);
       if (!mountedRef.current) return null;
@@ -80,6 +90,8 @@ export function useProInstaller() {
         error: err?.message || "Failed to fetch install status",
       }));
       return null;
+    } finally {
+      inFlightRef.current = false;
     }
   }, [api, stopPolling]);
 

--- a/frontend/src/hooks/useProInstaller.js
+++ b/frontend/src/hooks/useProInstaller.js
@@ -1,0 +1,169 @@
+/**
+ * useProInstaller — drives the PRO wheel install flow from AdminLicense.
+ *
+ * Wraps the PR-04 backend endpoints:
+ *   POST /api/v1/admin/system/pro/install        — schedules background install
+ *   GET  /api/v1/admin/system/pro/install/status — polls progress
+ *
+ * Returns:
+ *   installState — { state, progress, error, installed_version,
+ *                    started_at, completed_at }
+ *   startInstall() — POSTs and starts polling; safe to call from idle/error
+ *   resetInstall() — local-only reset to idle (clears error UI for retry)
+ *   isPolling      — true while a setInterval poll is active
+ *
+ * State machine mirrors the backend:
+ *   idle -> downloading -> verifying -> installing -> restart_required
+ *                                                  -> error (retryable)
+ *
+ * Polling cadence: every 2s while state is one of the in-progress values.
+ * Stops automatically on terminal states (restart_required, error) and on
+ * unmount. Auth is delegated to useApi (httpOnly cookie + credentials:
+ * 'include'); the hook does not touch localStorage.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useApi } from "./useApi";
+
+const STATUS_URL = "/api/v1/admin/system/pro/install/status";
+const INSTALL_URL = "/api/v1/admin/system/pro/install";
+const POLL_INTERVAL_MS = 2000;
+const IN_PROGRESS_STATES = new Set(["downloading", "verifying", "installing"]);
+
+const INITIAL_STATE = Object.freeze({
+  state: "idle",
+  progress: "",
+  error: null,
+  installed_version: null,
+  started_at: null,
+  completed_at: null,
+});
+
+export function useProInstaller() {
+  const api = useApi();
+
+  const [installState, setInstallState] = useState(INITIAL_STATE);
+  const [isPolling, setIsPolling] = useState(false);
+
+  // setInterval handle. Held in a ref because the cleanup needs to read the
+  // *current* timer regardless of which render scheduled it.
+  const pollTimerRef = useRef(null);
+  // Tracks whether the component is still mounted so async work doesn't
+  // call setState after unmount (React will warn otherwise).
+  const mountedRef = useRef(true);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    setIsPolling(false);
+  }, []);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const data = await api.get(STATUS_URL);
+      if (!mountedRef.current) return null;
+      setInstallState((prev) => ({ ...prev, ...data }));
+      // Terminal state -> stop polling. The check happens here (not in an
+      // effect) so the interval terminates the same tick the state lands.
+      if (!IN_PROGRESS_STATES.has(data.state)) {
+        stopPolling();
+      }
+      return data;
+    } catch (err) {
+      // A failed poll is non-fatal — the install pipeline lives server-side
+      // and the next poll may succeed. We surface the error in installState
+      // so the UI can show it without losing prior progress info.
+      if (!mountedRef.current) return null;
+      setInstallState((prev) => ({
+        ...prev,
+        error: err?.message || "Failed to fetch install status",
+      }));
+      return null;
+    }
+  }, [api, stopPolling]);
+
+  const startPolling = useCallback(() => {
+    if (pollTimerRef.current !== null) return; // already polling
+    setIsPolling(true);
+    pollTimerRef.current = setInterval(fetchStatus, POLL_INTERVAL_MS);
+  }, [fetchStatus]);
+
+  const startInstall = useCallback(async () => {
+    // Optimistically reflect the trigger so the UI flips to a busy state
+    // immediately, before the first poll lands.
+    setInstallState((prev) => ({
+      ...prev,
+      state: "downloading",
+      error: null,
+      progress: "Starting install...",
+    }));
+    try {
+      await api.post(INSTALL_URL, {});
+      startPolling();
+      // Kick an immediate poll so the UI surfaces real backend progress
+      // ~instantly instead of waiting a full POLL_INTERVAL_MS.
+      fetchStatus();
+    } catch (err) {
+      if (!mountedRef.current) return;
+      // Trigger failed (400/409/500). Surface it in error state — same
+      // shape as backend-pipeline failures so the UI has one error path.
+      stopPolling();
+      setInstallState((prev) => ({
+        ...prev,
+        state: "error",
+        error: err?.message || "Failed to start install",
+      }));
+    }
+  }, [api, fetchStatus, startPolling, stopPolling]);
+
+  const resetInstall = useCallback(() => {
+    stopPolling();
+    setInstallState(INITIAL_STATE);
+  }, [stopPolling]);
+
+  // On mount: read the current backend state once so navigating to the page
+  // mid-install reflects reality (e.g. a different admin tab triggered it,
+  // or the user reloaded during downloading). If the state is in-progress,
+  // resume polling automatically.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api.get(STATUS_URL);
+        if (cancelled || !mountedRef.current) return;
+        setInstallState((prev) => ({ ...prev, ...data }));
+        if (IN_PROGRESS_STATES.has(data.state)) {
+          startPolling();
+        }
+      } catch {
+        // Initial read failure is silent — the install button still works,
+        // and a real attempt will surface a real error.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally only on mount — re-running on api identity change would
+    // re-poll on every render given useMemo's referential stability.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (pollTimerRef.current !== null) {
+        clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    installState,
+    startInstall,
+    resetInstall,
+    isPolling,
+  };
+}

--- a/frontend/src/pages/admin/AdminLicense.jsx
+++ b/frontend/src/pages/admin/AdminLicense.jsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useApi } from "../../hooks/useApi";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
+import { useProInstaller } from "../../hooks/useProInstaller";
 import { useToast } from "../../components/Toast";
 
 /**
@@ -13,6 +15,8 @@ import { useToast } from "../../components/Toast";
 export default function AdminLicense() {
   const api = useApi();
   const toast = useToast();
+  const { isPro } = useFeatureFlags();
+  const { installState, startInstall, resetInstall } = useProInstaller();
 
   const [info, setInfo] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -105,6 +109,10 @@ export default function AdminLicense() {
   const isActivated = !!info?.activated;
   const tier = info?.tier || "community";
   const features = info?.features || [];
+  // Show the install section only when the license is activated but PRO
+  // hasn't been loaded into the running Python process. After restart,
+  // useFeatureFlags().isPro flips to true and this block disappears.
+  const needsInstall = isActivated && !isPro;
 
   return (
     <div className="space-y-6">
@@ -118,6 +126,14 @@ export default function AdminLicense() {
         onDeactivate={handleDeactivate}
         deactivating={deactivating}
       />
+
+      {needsInstall && (
+        <ProInstallSection
+          installState={installState}
+          onInstall={startInstall}
+          onReset={resetInstall}
+        />
+      )}
 
       {!isActivated && (
         <ActivateForm
@@ -304,6 +320,147 @@ function ActivateForm({ licenseKey, onChange, onSubmit, submitting, error }) {
         </span>
       </div>
     </form>
+  );
+}
+
+function ProInstallSection({ installState, onInstall, onReset }) {
+  const { state, progress, error, installed_version: installedVersion } = installState;
+  const isBusy = state === "downloading" || state === "verifying" || state === "installing";
+  const isError = state === "error";
+  const isDone = state === "restart_required";
+
+  const stateLabel = {
+    downloading: "Downloading PRO package…",
+    verifying: "Verifying package integrity…",
+    installing: "Installing PRO package…",
+  }[state];
+
+  return (
+    <div
+      data-testid="pro-install-section"
+      className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
+    >
+      <div className="space-y-1">
+        <div className="text-xs text-gray-500 uppercase tracking-wide">
+          PRO Installation
+        </div>
+        <h2 className="text-lg font-semibold text-white">Install PRO Package</h2>
+        <p className="text-sm text-gray-400">
+          Your license is active, but the PRO package isn't loaded yet. Install
+          it from the FilaOps license server to unlock Professional features.
+        </p>
+      </div>
+
+      {state === "idle" && (
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onInstall}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+          >
+            Install PRO
+          </button>
+          <span className="text-xs text-gray-500">
+            Downloads the wheel from the license server and installs it locally.
+            No terminal access required.
+          </span>
+        </div>
+      )}
+
+      {isBusy && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="bg-blue-500/10 border border-blue-500/30 rounded-md px-4 py-3 flex items-center gap-3"
+        >
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-400 flex-shrink-0" />
+          <div className="text-sm text-blue-200">
+            <div className="font-medium">{stateLabel}</div>
+            {progress && progress !== stateLabel && (
+              <div className="text-xs text-blue-300/80 mt-0.5">{progress}</div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {isDone && (
+        <div className="space-y-3">
+          <div
+            role="status"
+            className="bg-emerald-500/10 border border-emerald-500/30 rounded-md px-4 py-3 text-sm text-emerald-200"
+          >
+            <div className="font-medium">
+              PRO installed successfully
+              {installedVersion ? ` (v${installedVersion})` : ""}.
+            </div>
+            <div className="text-xs text-emerald-300/80 mt-1">
+              Restart Core to activate PRO features. Core will continue to run
+              in Community mode until you restart.
+            </div>
+          </div>
+          <RestartInstructions />
+        </div>
+      )}
+
+      {isError && (
+        <div className="space-y-3">
+          <div
+            role="alert"
+            className="bg-red-500/10 border border-red-500/30 rounded-md px-4 py-3 text-sm text-red-300"
+          >
+            <div className="font-medium">Installation failed</div>
+            <div className="text-xs text-red-300/80 mt-1 break-words">
+              {error || "Unknown error"}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                onReset();
+                onInstall();
+              }}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={onReset}
+              className="text-sm text-gray-400 hover:text-gray-200 underline transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RestartInstructions() {
+  // Deployment-agnostic on purpose: customers run Core via Docker, pip, or
+  // a future .exe installer. We list the common shapes rather than guess.
+  return (
+    <div className="text-xs text-gray-400 space-y-1">
+      <div className="font-medium text-gray-300 uppercase tracking-wide">
+        How to restart
+      </div>
+      <ul className="list-disc pl-5 space-y-0.5">
+        <li>
+          <span className="font-medium text-gray-300">Docker:</span>{" "}
+          <code className="font-mono text-gray-200">docker compose restart backend</code>
+        </li>
+        <li>
+          <span className="font-medium text-gray-300">systemd:</span>{" "}
+          <code className="font-mono text-gray-200">sudo systemctl restart filaops</code>
+        </li>
+        <li>
+          <span className="font-medium text-gray-300">Manual:</span> stop and
+          re-start the Python process running uvicorn / Core
+        </li>
+      </ul>
+    </div>
   );
 }
 

--- a/frontend/src/pages/admin/__tests__/AdminLicense.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminLicense.test.jsx
@@ -8,6 +8,21 @@ const { mocks } = vi.hoisted(() => ({
     del: vi.fn(),
     toastSuccess: vi.fn(),
     toastError: vi.fn(),
+    // useFeatureFlags + useProInstaller. Defaults represent "PRO already
+    // loaded, no install pending" so existing pre-PR-04 tests pass unchanged
+    // (the install section is hidden in that state). Install-flow tests
+    // override isPro=false and feed their own installState.
+    isPro: true,
+    startInstall: vi.fn(),
+    resetInstall: vi.fn(),
+    installState: {
+      state: 'idle',
+      progress: '',
+      error: null,
+      installed_version: null,
+      started_at: null,
+      completed_at: null,
+    },
   },
 }))
 
@@ -26,6 +41,26 @@ vi.mock('../../../components/Toast', () => {
   return { useToast: () => toast }
 })
 
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    tier: mocks.isPro ? 'professional' : 'community',
+    features: [],
+    hasFeature: () => false,
+    isPro: mocks.isPro,
+    isEnterprise: false,
+    loading: false,
+  }),
+}))
+
+vi.mock('../../../hooks/useProInstaller', () => ({
+  useProInstaller: () => ({
+    installState: mocks.installState,
+    startInstall: mocks.startInstall,
+    resetInstall: mocks.resetInstall,
+    isPolling: false,
+  }),
+}))
+
 import AdminLicense from '../AdminLicense'
 
 beforeEach(() => {
@@ -34,6 +69,19 @@ beforeEach(() => {
   mocks.del.mockReset()
   mocks.toastSuccess.mockReset()
   mocks.toastError.mockReset()
+  mocks.startInstall.mockReset()
+  mocks.resetInstall.mockReset()
+  // Reset PRO-install mocks to "PRO loaded, idle" defaults so any test that
+  // doesn't explicitly opt into the install flow keeps pre-PR-04 behavior.
+  mocks.isPro = true
+  mocks.installState = {
+    state: 'idle',
+    progress: '',
+    error: null,
+    installed_version: null,
+    started_at: null,
+    completed_at: null,
+  }
 })
 
 describe('AdminLicense', () => {
@@ -277,5 +325,213 @@ describe('AdminLicense', () => {
     expect(link).toHaveAttribute('href', 'https://filaops.blb3dprinting.com/')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  // ===========================================================================
+  // PR-04 — PRO install flow
+  // ===========================================================================
+  //
+  // The install section appears IFF license is activated AND PRO isn't loaded
+  // into the running Python process (license.json says professional, but
+  // /system/info still reports community because filaops_pro hasn't been
+  // imported yet). After restart, useFeatureFlags().isPro flips true and the
+  // section disappears — so these tests pin isPro=false explicitly.
+
+  describe('PRO install section (PR-04)', () => {
+    const activatedLicense = {
+      activated: true,
+      tier: 'professional',
+      license_key: 'FILAOPS-PRO-X',
+      install_uuid: 'install-uuid-123',
+      features: ['portal', 'quotes'],
+      activated_at: '2026-05-04T12:00:00Z',
+    }
+
+    it('hides the install section when license is not activated', async () => {
+      mocks.isPro = false
+      mocks.get.mockResolvedValue({
+        activated: false,
+        tier: 'community',
+        features: [],
+      })
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByText('COMMUNITY')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('pro-install-section')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Install PRO/i })).not.toBeInTheDocument()
+    })
+
+    it('hides the install section when PRO is already loaded into the runtime', async () => {
+      // License activated AND isPro=true means PRO is loaded → no install needed
+      mocks.isPro = true
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByText('PROFESSIONAL')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('pro-install-section')).not.toBeInTheDocument()
+    })
+
+    it('shows the Install PRO button when activated but PRO not loaded yet', async () => {
+      mocks.isPro = false
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('button', { name: /^Install PRO$/i })).toBeInTheDocument()
+      expect(screen.getByText(/license is active, but the PRO package isn't loaded/i)).toBeInTheDocument()
+    })
+
+    it('clicking Install PRO calls startInstall', async () => {
+      mocks.isPro = false
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^Install PRO$/i })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^Install PRO$/i }))
+      expect(mocks.startInstall).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows download progress with a spinner when state is "downloading"', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'downloading',
+        progress: 'Downloading PRO package from license server...',
+        error: null,
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: null,
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('status')).toHaveTextContent(/Downloading PRO package/i)
+      expect(screen.queryByRole('button', { name: /^Install PRO$/i })).not.toBeInTheDocument()
+    })
+
+    it('shows verifying progress when state is "verifying"', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'verifying',
+        progress: 'Verifying package integrity...',
+        error: null,
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: null,
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('status')).toHaveTextContent(/Verifying package integrity/i)
+    })
+
+    it('shows installing progress when state is "installing"', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'installing',
+        progress: 'Installing PRO package...',
+        error: null,
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: null,
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('status')).toHaveTextContent(/Installing PRO package/i)
+    })
+
+    it('shows success message and restart instructions when state is "restart_required"', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'restart_required',
+        progress: 'PRO installed successfully. Restart Core to activate.',
+        error: null,
+        installed_version: '1.2.3',
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: '2026-05-04T12:00:30Z',
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      expect(screen.getByText(/PRO installed successfully \(v1\.2\.3\)/i)).toBeInTheDocument()
+      expect(screen.getByText(/Restart Core to activate/i)).toBeInTheDocument()
+      // Deployment-agnostic restart hints
+      expect(screen.getByText(/Docker:/i)).toBeInTheDocument()
+      expect(screen.getByText(/systemd:/i)).toBeInTheDocument()
+    })
+
+    it('shows error and Retry button when state is "error"', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'error',
+        progress: 'Installation failed: connection refused',
+        error: 'Could not reach the license server: connection refused',
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: '2026-05-04T12:00:05Z',
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByTestId('pro-install-section')).toBeInTheDocument()
+      })
+      const alert = screen.getByRole('alert')
+      expect(alert).toHaveTextContent(/Installation failed/i)
+      expect(alert).toHaveTextContent(/connection refused/i)
+      expect(screen.getByRole('button', { name: /^Retry$/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^Dismiss$/i })).toBeInTheDocument()
+    })
+
+    it('clicking Retry resets state and triggers a new install', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'error',
+        progress: 'Installation failed',
+        error: 'connection refused',
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: '2026-05-04T12:00:05Z',
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^Retry$/i })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^Retry$/i }))
+      expect(mocks.resetInstall).toHaveBeenCalledTimes(1)
+      expect(mocks.startInstall).toHaveBeenCalledTimes(1)
+    })
+
+    it('clicking Dismiss in the error state calls resetInstall but not startInstall', async () => {
+      mocks.isPro = false
+      mocks.installState = {
+        state: 'error',
+        progress: 'Installation failed',
+        error: 'connection refused',
+        installed_version: null,
+        started_at: '2026-05-04T12:00:00Z',
+        completed_at: '2026-05-04T12:00:05Z',
+      }
+      mocks.get.mockResolvedValue(activatedLicense)
+      render(<AdminLicense />)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^Dismiss$/i })).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^Dismiss$/i }))
+      expect(mocks.resetInstall).toHaveBeenCalledTimes(1)
+      expect(mocks.startInstall).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
PR-04 implements the in-app PRO installer. After activating a license (PR-02), customers click 'Install PRO' in the admin UI. Core downloads the wheel from the license server, verifies its hash, pip-installs it, and prompts for restart. No terminal, no config files, no Docker knowledge required (decision 7).

## What's in this PR

- POST /api/v1/admin/system/pro/install — background task: download wheel, verify hash, pip install
- GET /api/v1/admin/system/pro/install/status — poll install progress
- Install PRO section in AdminLicense.jsx — button, progress states, restart instructions
- useProInstaller hook — install trigger + 2-second status polling
- 24 backend tests + 11 frontend Interaction tests (35 total new tests)

## Architecture

- Sacred Rule maintained: no filaops_pro imports, PRO detection via importlib.util.find_spec
- Wheel downloaded from license server (GET /api/v1/download/wheel, shipped in ecosystem PR #42)
- pip install --no-deps in subprocess (same pattern as existing anthropic package installer)
- State machine: idle -> downloading -> verifying -> installing -> restart_required | error
- All failures caught — Core continues running in community mode

## Customer journey after this PR

buy -> paste key -> activate -> click Install PRO -> restart -> PRO active

## Depends on

- PR-02 (license activation, merged PR #579)
- PR-03b (heartbeat client, merged PR #39)
- Ecosystem PR #42 (wheel download endpoint, merged)

---
Co-authored-by: Claude <claude@anthropic.com>
Agent-Session: d081cbb8-9582-4113-b1fa-7ee3f5a1b0af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PRO installer to admin interface with installation progress monitoring
  * Users can now download and install the PRO package directly from the license server when an active license is available
  * Installation includes integrity verification and automatic retry on failure
  * Real-time status updates display download, verification, and installation progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->