### PR TITLE
feat(pr-05): token encryption foundation + integration settings page

### DIFF
--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -1,0 +1,118 @@
+"""
+Token encryption via Fernet + HKDF.
+
+Root key material: install_uuid (persisted at /var/lib/filaops/config/install_uuid).
+Key derivation: HKDF-SHA256 with domain separation via `info` parameter.
+Encryption: Fernet (symmetric, authenticated, timestamped).
+
+Usage:
+    from app.core.crypto import encrypt_token, decrypt_token, EncryptedString
+
+    # Direct use:
+    ciphertext = encrypt_token("my-secret-api-key")
+    plaintext = decrypt_token(ciphertext)
+
+    # SQLAlchemy column type:
+    class MyModel(Base):
+        secret = Column(EncryptedString(length=500), nullable=True)
+"""
+import base64
+import logging
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from sqlalchemy import String, TypeDecorator
+
+from app.core.license_cache import get_install_uuid
+
+logger = logging.getLogger(__name__)
+
+# Domain separation constant — change this to derive a different key
+# for a different encryption context (e.g., backup encryption)
+_TOKEN_ENCRYPTION_INFO = b"filaops-token-encryption-v1"
+
+
+def _derive_key() -> bytes:
+    """Derive a Fernet key from install_uuid via HKDF."""
+    install_uuid = get_install_uuid()
+    if not install_uuid:
+        raise RuntimeError(
+            "install_uuid not available — cannot derive encryption key. "
+            "Ensure the license cache is initialized before encrypting tokens."
+        )
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        info=_TOKEN_ENCRYPTION_INFO,
+        salt=None,  # install_uuid is unique per install; salt not needed
+    )
+    raw_key = hkdf.derive(install_uuid.encode("utf-8"))
+    return base64.urlsafe_b64encode(raw_key)
+
+
+def encrypt_token(plaintext: str) -> str:
+    """Encrypt a plaintext string. Returns base64 Fernet token."""
+    if not plaintext:
+        return plaintext
+    key = _derive_key()
+    f = Fernet(key)
+    return f.encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_token(ciphertext: str) -> str:
+    """Decrypt a Fernet token. Returns plaintext string."""
+    if not ciphertext:
+        return ciphertext
+    key = _derive_key()
+    f = Fernet(key)
+    return f.decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+
+
+class EncryptedString(TypeDecorator):
+    """SQLAlchemy column type that transparently encrypts/decrypts string values.
+
+    Stores Fernet tokens in the database. Application code sees plaintext.
+    Handles migration gracefully: if a stored value fails to decrypt
+    (e.g., it's still plaintext from before encryption was added),
+    returns the raw value and logs a warning.
+
+    Usage:
+        class MyModel(Base):
+            api_key = Column(EncryptedString(length=500), nullable=True)
+    """
+
+    impl = String
+    cache_ok = True
+
+    def __init__(self, length=500, **kwargs):
+        super().__init__(**kwargs)
+        self.impl = String(length)
+
+    def process_bind_param(self, value, dialect):
+        """Encrypt on write."""
+        if value is None or value == "":
+            return value
+        try:
+            return encrypt_token(value)
+        except Exception as e:
+            logger.error(f"Failed to encrypt token: {e}")
+            raise
+
+    def process_result_value(self, value, dialect):
+        """Decrypt on read. Falls back to raw value if decryption fails (migration grace)."""
+        if value is None or value == "":
+            return value
+        try:
+            return decrypt_token(value)
+        except InvalidToken:
+            # Value is probably plaintext from before encryption was added.
+            # Return as-is — next write will encrypt it.
+            logger.warning(
+                "Token decryption failed — returning raw value. "
+                "This is expected during migration from plaintext to encrypted storage."
+            )
+            return value
+        except Exception as e:
+            logger.error(f"Failed to decrypt token: {e}")
+            return value

--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -12,9 +12,12 @@ Usage:
     ciphertext = encrypt_token("my-secret-api-key")
     plaintext = decrypt_token(ciphertext)
 
-    # SQLAlchemy column type:
+    # SQLAlchemy column type — backed by TEXT, so no length math required.
+    # Fernet ciphertext is ~1.5x the plaintext plus ~57 bytes of overhead;
+    # storing in TEXT means callers never have to size the column for the
+    # expansion.
     class MyModel(Base):
-        secret = Column(EncryptedString(length=500), nullable=True)
+        secret = Column(EncryptedString, nullable=True)
 """
 import base64
 import logging
@@ -22,7 +25,7 @@ import logging
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from sqlalchemy import String, TypeDecorator
+from sqlalchemy import Text, TypeDecorator
 
 from app.core.license_cache import get_install_uuid
 
@@ -31,6 +34,13 @@ logger = logging.getLogger(__name__)
 # Domain separation constant — change this to derive a different key
 # for a different encryption context (e.g., backup encryption)
 _TOKEN_ENCRYPTION_INFO = b"filaops-token-encryption-v1"
+
+# Fernet tokens are URL-safe base64 of (version=0x80 || timestamp || IV || ciphertext || HMAC).
+# Base64-encoding a leading 0x80 byte produces "gAAAAA" — every legitimate
+# Fernet token starts with this prefix. We use it to distinguish "this row
+# holds Fernet ciphertext" from "this row holds legacy plaintext from before
+# encryption was enabled" during the migration grace window.
+_FERNET_PREFIX = "gAAAAA"
 
 
 def _derive_key() -> bytes:
@@ -72,47 +82,66 @@ def decrypt_token(ciphertext: str) -> str:
 class EncryptedString(TypeDecorator):
     """SQLAlchemy column type that transparently encrypts/decrypts string values.
 
-    Stores Fernet tokens in the database. Application code sees plaintext.
-    Handles migration gracefully: if a stored value fails to decrypt
-    (e.g., it's still plaintext from before encryption was added),
-    returns the raw value and logs a warning.
+    Backed by TEXT (no length cap) so callers don't have to size for Fernet's
+    ~1.5x + 57-byte expansion. Application code sees plaintext; the database
+    stores Fernet ciphertext.
+
+    Migration grace: rows that pre-date encryption hold legacy plaintext that
+    won't decode as Fernet. We detect that case via the Fernet prefix
+    (`gAAAAA`) and return the raw value with a warning, letting the next save
+    re-encrypt it. Anything that *looks* like a Fernet token but fails to
+    decrypt (corrupted ciphertext, install_uuid changed) is treated as an
+    operational failure: we log an error and return None rather than handing
+    the application what it might mistake for a plaintext key.
+
+    Other exceptions — most importantly RuntimeError from _derive_key when
+    install_uuid is missing — propagate. They indicate a configuration
+    problem that must be loud, not silently masked.
 
     Usage:
         class MyModel(Base):
-            api_key = Column(EncryptedString(length=500), nullable=True)
+            api_key = Column(EncryptedString, nullable=True)
     """
 
-    impl = String
+    impl = Text
     cache_ok = True
-
-    def __init__(self, length=500, **kwargs):
-        super().__init__(**kwargs)
-        self.impl = String(length)
 
     def process_bind_param(self, value, dialect):
         """Encrypt on write."""
         if value is None or value == "":
             return value
-        try:
-            return encrypt_token(value)
-        except Exception as e:
-            logger.error(f"Failed to encrypt token: {e}")
-            raise
+        return encrypt_token(value)
 
     def process_result_value(self, value, dialect):
-        """Decrypt on read. Falls back to raw value if decryption fails (migration grace)."""
+        """Decrypt on read.
+
+        - Empty / None: passthrough.
+        - Doesn't start with the Fernet prefix: treat as legacy plaintext
+          (migration grace), return raw with a warning.
+        - Looks like a Fernet token but fails to decrypt: corrupted ciphertext
+          or key drift — log error, return None, do NOT return raw.
+        - Any other exception (e.g., install_uuid missing): propagate.
+        """
         if value is None or value == "":
+            return value
+        if not value.startswith(_FERNET_PREFIX):
+            # Legacy plaintext from before EncryptedString was introduced.
+            # The next write will encrypt it.
+            logger.warning(
+                "Stored value lacks Fernet prefix — assuming legacy plaintext "
+                "(migration grace). Next save will encrypt it."
+            )
             return value
         try:
             return decrypt_token(value)
         except InvalidToken:
-            # Value is probably plaintext from before encryption was added.
-            # Return as-is — next write will encrypt it.
-            logger.warning(
-                "Token decryption failed — returning raw value. "
-                "This is expected during migration from plaintext to encrypted storage."
+            # Looks like ciphertext but won't decode: corruption, truncation,
+            # or install_uuid change. Returning the raw blob would hand the
+            # application a Fernet token masquerading as a real secret —
+            # worse than returning None, which surfaces as "not configured."
+            logger.error(
+                "Fernet-shaped value failed to decrypt — possible corruption "
+                "or install_uuid change. Returning None to avoid handing "
+                "ciphertext to the application."
             )
-            return value
-        except Exception as e:
-            logger.error(f"Failed to decrypt token: {e}")
-            return value
+            return None

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -97,7 +97,7 @@ def ensure_config_dir() -> Path:
 def get_install_uuid() -> str:
     """Return this installation's stable UUID, generating + persisting on first call.
 
-    This UUID is the secret used by PRO for token encryption (PR-06). Once
+    This UUID is the secret used by PRO for token encryption (PR-05). Once
     written it must never change — deleting the file effectively re-installs
     the instance and any encrypted data (Shopify/QBO tokens) becomes
     unrecoverable.

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -101,6 +101,15 @@ def get_install_uuid() -> str:
     written it must never change — deleting the file effectively re-installs
     the instance and any encrypted data (Shopify/QBO tokens) becomes
     unrecoverable.
+
+    TODO(pre-existing race, surfaced by PR-05 review):
+        This is a check-then-write — two concurrent first-callers can each
+        observe the file as missing and generate different UUIDs before one
+        wins the atomic write. Under PR-05's encryption-at-rest, a request
+        that derives a Fernet key from the losing UUID would persist
+        ciphertext that no future request can decrypt. Fix is a separate PR:
+        use os.O_EXCL to fail-fast on race, or take a flock around the
+        check-then-write. Tracked as cortex_observe #50.
     """
     cfg_dir = ensure_config_dir()
     uuid_file = cfg_dir / INSTALL_UUID_FILENAME

--- a/backend/app/models/company_settings.py
+++ b/backend/app/models/company_settings.py
@@ -9,6 +9,7 @@ Stores company-wide settings including:
 """
 from sqlalchemy import Column, Integer, String, Numeric, Boolean, DateTime, LargeBinary, func
 
+from app.core.crypto import EncryptedString
 from app.db.base import Base
 
 
@@ -76,8 +77,11 @@ class CompanySettings(Base):
     # AI Configuration (for invoice parsing, etc.)
     # Provider: 'anthropic', 'ollama', or None (disabled)
     ai_provider = Column(String(20), nullable=True)
-    # API key for Anthropic (stored - consider encryption in production)
-    ai_api_key = Column(String(500), nullable=True)
+    # API key for Anthropic — encrypted at rest via Fernet+HKDF (PR-05).
+    # The TypeDecorator transparently encrypts on INSERT and decrypts on SELECT,
+    # falling back to raw value on decrypt failure to handle the plaintext→encrypted
+    # migration grace period.
+    ai_api_key = Column(EncryptedString(length=500), nullable=True)
     # Ollama URL (default: http://localhost:11434)
     ai_ollama_url = Column(String(255), nullable=True, default="http://localhost:11434")
     # Ollama model name (default: llama3.2)

--- a/backend/app/models/company_settings.py
+++ b/backend/app/models/company_settings.py
@@ -78,10 +78,10 @@ class CompanySettings(Base):
     # Provider: 'anthropic', 'ollama', or None (disabled)
     ai_provider = Column(String(20), nullable=True)
     # API key for Anthropic — encrypted at rest via Fernet+HKDF (PR-05).
-    # The TypeDecorator transparently encrypts on INSERT and decrypts on SELECT,
-    # falling back to raw value on decrypt failure to handle the plaintext→encrypted
-    # migration grace period.
-    ai_api_key = Column(EncryptedString(length=500), nullable=True)
+    # Stored as TEXT (no length cap) since Fernet ciphertext is ~1.5x the
+    # plaintext plus ~57 bytes of overhead. Migration 081 widened this column
+    # from VARCHAR(500) so longer integration secrets in PR-06+ also fit.
+    ai_api_key = Column(EncryptedString, nullable=True)
     # Ollama URL (default: http://localhost:11434)
     ai_ollama_url = Column(String(255), nullable=True, default="http://localhost:11434")
     # Ollama model name (default: llama3.2)

--- a/backend/migrations/versions/081_pr05_ai_api_key_to_text.py
+++ b/backend/migrations/versions/081_pr05_ai_api_key_to_text.py
@@ -1,0 +1,48 @@
+"""Widen company_settings.ai_api_key to TEXT for encrypted storage (PR-05).
+
+PR-05 introduces app.core.crypto.EncryptedString, a TypeDecorator that stores
+Fernet ciphertext in place of plaintext. Fernet output is roughly 1.5x the
+plaintext length plus ~57 bytes of overhead (version byte, timestamp, IV,
+HMAC, then URL-safe base64). A VARCHAR(500) column therefore only fits about
+303 bytes of plaintext — fine for current Anthropic API keys (~108 chars) but
+a footgun for future longer secrets (Shopify/QBO OAuth tokens in PR-06+).
+
+Switching to TEXT removes the size cap so EncryptedString can be used safely
+on any sensitive column without per-call sizing math.
+
+Revision ID: 081
+Revises: 080
+Create Date: 2026-05-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "081"
+down_revision = "080"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Postgres VARCHAR(N) -> TEXT is a metadata-only change (no table rewrite).
+    op.alter_column(
+        "company_settings",
+        "ai_api_key",
+        existing_type=sa.String(length=500),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # NOTE: this can fail if a row contains an encrypted ai_api_key whose
+    # ciphertext exceeds 500 chars — which is exactly why we widened the
+    # column. Operators rolling back must clear or shorten the value first.
+    op.alter_column(
+        "company_settings",
+        "ai_api_key",
+        existing_type=sa.Text(),
+        type_=sa.String(length=500),
+        existing_nullable=True,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,10 @@ pydantic==2.13.3
 pydantic-settings==2.14.0
 email-validator==2.3.0
 PyJWT==2.12.1
+# Direct dep (PR-05 token encryption — Fernet+HKDF in app/core/crypto.py).
+# Pulled in transitively by PyJWT/python-jose/passlib in many envs, but CI's
+# install path doesn't always get those extras, so declare it explicitly.
+cryptography>=47.0.0
 bcrypt>=5.0.0,<6
 python-dotenv==1.2.2
 slowapi==0.1.9

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ Provides:
 - Data factory fixtures for common domain objects
 """
 import os
+import tempfile
 import uuid
 import pytest
 import sys
@@ -20,6 +21,17 @@ from pathlib import Path
 # Settings are loaded at import time from env vars / .env file.
 # =============================================================================
 os.environ["DB_NAME"] = "filaops_test"
+
+# PR-05: EncryptedString-typed columns (e.g. company_settings.ai_api_key)
+# call get_install_uuid() on every write, which mkdir's LICENSE_CONFIG_DIR.
+# The prod default is /var/lib/filaops/config — not writable by CI runners,
+# and not appropriate for tests anyway. Point at a stable per-machine tmpdir
+# so the install_uuid file is reused across runs and individual tests that
+# want isolation can still monkeypatch settings.LICENSE_CONFIG_DIR to their
+# own tmp_path (as test_system_license.py and test_crypto.py already do).
+_test_license_dir = Path(tempfile.gettempdir()) / "filaops_test_license"
+_test_license_dir.mkdir(parents=True, exist_ok=True)
+os.environ["LICENSE_CONFIG_DIR"] = str(_test_license_dir)
 
 # Add the backend directory to the path so imports work correctly
 backend_dir = Path(__file__).parent.parent

--- a/backend/tests/core/test_crypto.py
+++ b/backend/tests/core/test_crypto.py
@@ -1,0 +1,338 @@
+"""
+Tests for app.core.crypto — Fernet+HKDF token encryption foundation (PR-05).
+
+Coverage:
+- encrypt_token / decrypt_token round-trip
+- Empty string and None passthrough
+- Different install_uuid produces different ciphertext (key isolation)
+- decrypt_token gracefully handles corrupted ciphertext
+- EncryptedString TypeDecorator: encrypt-on-write, decrypt-on-read via SQLAlchemy
+- EncryptedString migration grace: plaintext value reads back as plaintext
+"""
+import logging
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, Table, create_engine, insert, select
+from sqlalchemy.orm import Session
+
+from app.core import crypto
+from app.core.crypto import (
+    EncryptedString,
+    _TOKEN_ENCRYPTION_INFO,
+    _derive_key,
+    decrypt_token,
+    encrypt_token,
+)
+from app.core.settings import settings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_install_uuid(monkeypatch, tmp_path):
+    """Each test gets a fresh LICENSE_CONFIG_DIR so install_uuid is regenerated.
+
+    Without this, all tests would share the host's persistent install_uuid,
+    making 'different uuid produces different ciphertext' impossible to
+    verify and leaking encryption state between test runs.
+    """
+    monkeypatch.setattr(
+        settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False
+    )
+    yield tmp_path
+
+
+# ---------------------------------------------------------------------------
+# encrypt_token / decrypt_token
+# ---------------------------------------------------------------------------
+
+
+def test_encrypt_decrypt_round_trip():
+    """Round-trip: plaintext → ciphertext → plaintext."""
+    plaintext = "sk-ant-api-key-supersecret"
+    ciphertext = encrypt_token(plaintext)
+
+    assert ciphertext != plaintext
+    assert decrypt_token(ciphertext) == plaintext
+
+
+def test_encrypt_token_returns_different_ciphertext_each_call():
+    """Fernet includes a random IV → same plaintext encrypts to different ciphertext."""
+    plaintext = "hello"
+    c1 = encrypt_token(plaintext)
+    c2 = encrypt_token(plaintext)
+
+    assert c1 != c2
+    assert decrypt_token(c1) == plaintext
+    assert decrypt_token(c2) == plaintext
+
+
+def test_encrypt_empty_string_passthrough():
+    """encrypt_token('') returns '' — falsy values bypass Fernet."""
+    assert encrypt_token("") == ""
+
+
+def test_encrypt_none_passthrough():
+    """encrypt_token(None) returns None — falsy values bypass Fernet."""
+    assert encrypt_token(None) is None
+
+
+def test_decrypt_empty_string_passthrough():
+    assert decrypt_token("") == ""
+
+
+def test_decrypt_none_passthrough():
+    assert decrypt_token(None) is None
+
+
+def test_decrypt_unicode_round_trip():
+    """Non-ASCII plaintext survives encrypt → decrypt."""
+    plaintext = "café-token-™-日本語"
+    ciphertext = encrypt_token(plaintext)
+    assert decrypt_token(ciphertext) == plaintext
+
+
+# ---------------------------------------------------------------------------
+# Key derivation isolation
+# ---------------------------------------------------------------------------
+
+
+def test_different_install_uuid_produces_different_ciphertext(monkeypatch):
+    """Key isolation — changing install_uuid changes the derived Fernet key,
+    so a token encrypted under one UUID cannot be decrypted under another.
+
+    NOTE: crypto.py does `from app.core.license_cache import get_install_uuid`
+    at import time, binding the name into the crypto module's namespace.
+    Monkeypatching license_cache.get_install_uuid does NOT affect crypto's
+    bound reference — we have to patch crypto.get_install_uuid directly.
+    """
+    plaintext = "shared-plaintext"
+
+    monkeypatch.setattr(crypto, "get_install_uuid", lambda: "uuid-a" * 4)
+    ciphertext_a = encrypt_token(plaintext)
+    key_a = _derive_key()
+
+    monkeypatch.setattr(crypto, "get_install_uuid", lambda: "uuid-b" * 4)
+    ciphertext_b = encrypt_token(plaintext)
+    key_b = _derive_key()
+
+    assert key_a != key_b
+    assert ciphertext_a != ciphertext_b
+
+    # And ciphertext_a cannot be decrypted under key_b — raw decrypt_token
+    # raises InvalidToken (the EncryptedString TypeDecorator is what swallows
+    # this for migration grace, not the bare function).
+    from cryptography.fernet import InvalidToken
+
+    with pytest.raises(InvalidToken):
+        decrypt_token(ciphertext_a)  # current key is uuid-b, ciphertext was uuid-a
+
+
+def test_derive_key_raises_when_install_uuid_missing(monkeypatch):
+    """If install_uuid resolves empty, _derive_key raises with a clear message."""
+    monkeypatch.setattr(crypto, "get_install_uuid", lambda: "")
+    with pytest.raises(RuntimeError, match="install_uuid not available"):
+        _derive_key()
+
+
+def test_derive_key_uses_domain_separation_constant():
+    """Sanity-check: the info parameter that gives us key isolation across
+    encryption contexts is the documented constant. Future PRs that add a
+    second context (e.g. backup encryption) must use a different `info`."""
+    assert _TOKEN_ENCRYPTION_INFO == b"filaops-token-encryption-v1"
+
+
+# ---------------------------------------------------------------------------
+# Corrupted / plaintext input handling
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_corrupted_ciphertext_raises():
+    """Raw decrypt_token raises InvalidToken on garbage — the EncryptedString
+    type decorator is what swallows this for migration grace, not the bare
+    function."""
+    from cryptography.fernet import InvalidToken
+
+    with pytest.raises(InvalidToken):
+        decrypt_token("not-a-real-fernet-token")
+
+
+# ---------------------------------------------------------------------------
+# EncryptedString TypeDecorator (SQLAlchemy round-trip)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_engine():
+    """In-memory SQLite engine + a single test table with one EncryptedString column.
+
+    Using SQLite (not the shared filaops_test PG) keeps the test self-contained
+    and avoids leaking a junk table into the dev DB.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table = Table(
+        "secrets_test",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("token", EncryptedString(length=500), nullable=True),
+    )
+    metadata.create_all(engine)
+    return engine, table
+
+
+def test_encrypted_string_round_trip(sqlite_engine):
+    """INSERT plaintext → DB stores ciphertext → SELECT returns plaintext."""
+    engine, table = sqlite_engine
+    plaintext = "sk-ant-roundtrip-12345"
+
+    with Session(engine) as session:
+        session.execute(insert(table).values(token=plaintext))
+        session.commit()
+
+        # Read back through ORM/Core — TypeDecorator decrypts
+        row = session.execute(select(table.c.token)).scalar_one()
+        assert row == plaintext
+
+    # Read raw column bypassing the type decorator: should be ciphertext.
+    # Use a fresh connection with a metadata that types the column as plain String.
+    from sqlalchemy import String as _PlainString
+
+    raw_meta = MetaData()
+    raw_table = Table(
+        "secrets_test",
+        raw_meta,
+        Column("id", Integer, primary_key=True),
+        Column("token", _PlainString(500)),
+    )
+    with engine.connect() as conn:
+        raw = conn.execute(select(raw_table.c.token)).scalar_one()
+        assert raw != plaintext
+        assert raw.startswith("gAAAAA")  # Fernet token signature
+
+
+def test_encrypted_string_none_passthrough(sqlite_engine):
+    """NULL stays NULL through the TypeDecorator — no encryption attempt."""
+    engine, table = sqlite_engine
+    with Session(engine) as session:
+        session.execute(insert(table).values(token=None))
+        session.commit()
+        row = session.execute(select(table.c.token)).scalar_one()
+        assert row is None
+
+
+def test_encrypted_string_empty_string_passthrough(sqlite_engine):
+    """Empty string stays empty — no encryption attempt."""
+    engine, table = sqlite_engine
+    with Session(engine) as session:
+        session.execute(insert(table).values(token=""))
+        session.commit()
+        row = session.execute(select(table.c.token)).scalar_one()
+        assert row == ""
+
+
+def test_encrypted_string_migration_grace_plaintext(sqlite_engine, caplog):
+    """Migration grace: a row that contains plaintext (from before encryption
+    was added) must read back as the raw value — not crash — and emit a
+    warning log so operators know to re-save it."""
+    engine, table = sqlite_engine
+    legacy_plaintext = "legacy-plaintext-api-key"
+
+    # Bypass the TypeDecorator on insert by binding to a plain-String view
+    from sqlalchemy import String as _PlainString
+
+    raw_meta = MetaData()
+    raw_table = Table(
+        "secrets_test",
+        raw_meta,
+        Column("id", Integer, primary_key=True),
+        Column("token", _PlainString(500)),
+    )
+    with engine.connect() as conn:
+        conn.execute(insert(raw_table).values(token=legacy_plaintext))
+        conn.commit()
+
+    # Now read through the EncryptedString-typed table — should return raw,
+    # log a warning, NOT raise.
+    with caplog.at_level(logging.WARNING, logger="app.core.crypto"):
+        with Session(engine) as session:
+            row = session.execute(select(table.c.token)).scalar_one()
+
+    assert row == legacy_plaintext
+    assert any(
+        "Token decryption failed" in rec.message for rec in caplog.records
+    ), "expected a migration-grace warning to be logged"
+
+
+def test_encrypted_string_corrupted_ciphertext_returns_raw(sqlite_engine, caplog):
+    """A row containing garbage that decrypts to InvalidToken should be
+    returned raw with a warning — never raise into the application."""
+    engine, table = sqlite_engine
+    garbage = "this-is-not-a-fernet-token-at-all"
+
+    from sqlalchemy import String as _PlainString
+
+    raw_meta = MetaData()
+    raw_table = Table(
+        "secrets_test",
+        raw_meta,
+        Column("id", Integer, primary_key=True),
+        Column("token", _PlainString(500)),
+    )
+    with engine.connect() as conn:
+        conn.execute(insert(raw_table).values(token=garbage))
+        conn.commit()
+
+    with caplog.at_level(logging.WARNING, logger="app.core.crypto"):
+        with Session(engine) as session:
+            row = session.execute(select(table.c.token)).scalar_one()
+
+    assert row == garbage
+    assert any(
+        "Token decryption failed" in rec.message for rec in caplog.records
+    )
+
+
+def test_encrypted_string_overwrite_re_encrypts(sqlite_engine):
+    """Writing a new value to a row that previously held plaintext stores
+    proper ciphertext on the next save — confirming the migration completes
+    naturally on the next user save."""
+    engine, table = sqlite_engine
+
+    from sqlalchemy import String as _PlainString, update
+
+    raw_meta = MetaData()
+    raw_table = Table(
+        "secrets_test",
+        raw_meta,
+        Column("id", Integer, primary_key=True),
+        Column("token", _PlainString(500)),
+    )
+
+    # Seed plaintext directly
+    with engine.connect() as conn:
+        result = conn.execute(insert(raw_table).values(token="old-plaintext"))
+        row_id = result.inserted_primary_key[0]
+        conn.commit()
+
+    # Update via the EncryptedString-typed table
+    new_value = "freshly-encrypted-key"
+    with Session(engine) as session:
+        session.execute(
+            update(table).where(table.c.id == row_id).values(token=new_value)
+        )
+        session.commit()
+
+        # Read back through encrypted column → plaintext
+        assert (
+            session.execute(
+                select(table.c.token).where(table.c.id == row_id)
+            ).scalar_one()
+            == new_value
+        )
+
+    # Read back raw → ciphertext, not plaintext
+    with engine.connect() as conn:
+        raw = conn.execute(
+            select(raw_table.c.token).where(raw_table.c.id == row_id)
+        ).scalar_one()
+        assert raw != new_value
+        assert raw.startswith("gAAAAA")

--- a/backend/tests/core/test_crypto.py
+++ b/backend/tests/core/test_crypto.py
@@ -173,7 +173,7 @@ def sqlite_engine():
         "secrets_test",
         metadata,
         Column("id", Integer, primary_key=True, autoincrement=True),
-        Column("token", EncryptedString(length=500), nullable=True),
+        Column("token", EncryptedString, nullable=True),
     )
     metadata.create_all(engine)
     return engine, table
@@ -193,20 +193,35 @@ def test_encrypted_string_round_trip(sqlite_engine):
         assert row == plaintext
 
     # Read raw column bypassing the type decorator: should be ciphertext.
-    # Use a fresh connection with a metadata that types the column as plain String.
-    from sqlalchemy import String as _PlainString
+    # Underlying impl is now Text, so the raw view types it as plain Text too.
+    from sqlalchemy import Text as _PlainText
 
     raw_meta = MetaData()
     raw_table = Table(
         "secrets_test",
         raw_meta,
         Column("id", Integer, primary_key=True),
-        Column("token", _PlainString(500)),
+        Column("token", _PlainText()),
     )
     with engine.connect() as conn:
         raw = conn.execute(select(raw_table.c.token)).scalar_one()
         assert raw != plaintext
         assert raw.startswith("gAAAAA")  # Fernet token signature
+
+
+def test_encrypted_string_handles_long_plaintext(sqlite_engine):
+    """Text-backed impl accepts long plaintext that VARCHAR(500) wouldn't fit
+    after Fernet expansion. Guards against the PR-05 sizing-trap regression
+    flagged by reviewers."""
+    engine, table = sqlite_engine
+    # 1500 chars — would produce ~2300+ bytes of Fernet ciphertext, well past
+    # any reasonable VARCHAR cap.
+    plaintext = "x" * 1500
+
+    with Session(engine) as session:
+        session.execute(insert(table).values(token=plaintext))
+        session.commit()
+        assert session.execute(select(table.c.token)).scalar_one() == plaintext
 
 
 def test_encrypted_string_none_passthrough(sqlite_engine):
@@ -229,66 +244,85 @@ def test_encrypted_string_empty_string_passthrough(sqlite_engine):
         assert row == ""
 
 
-def test_encrypted_string_migration_grace_plaintext(sqlite_engine, caplog):
-    """Migration grace: a row that contains plaintext (from before encryption
-    was added) must read back as the raw value — not crash — and emit a
-    warning log so operators know to re-save it."""
-    engine, table = sqlite_engine
-    legacy_plaintext = "legacy-plaintext-api-key"
+def _seed_raw(engine, value):
+    """Insert *value* into the test table bypassing the TypeDecorator.
 
-    # Bypass the TypeDecorator on insert by binding to a plain-String view
-    from sqlalchemy import String as _PlainString
+    Used to simulate two distinct corruption modes: legacy plaintext (which
+    won't have a Fernet prefix) and Fernet-shaped-but-undecryptable (which
+    will, but won't decode under the active key)."""
+    from sqlalchemy import Text as _PlainText
 
     raw_meta = MetaData()
     raw_table = Table(
         "secrets_test",
         raw_meta,
         Column("id", Integer, primary_key=True),
-        Column("token", _PlainString(500)),
+        Column("token", _PlainText()),
     )
     with engine.connect() as conn:
-        conn.execute(insert(raw_table).values(token=legacy_plaintext))
+        conn.execute(insert(raw_table).values(token=value))
         conn.commit()
 
-    # Now read through the EncryptedString-typed table — should return raw,
-    # log a warning, NOT raise.
+
+def test_encrypted_string_migration_grace_plaintext(sqlite_engine, caplog):
+    """Migration grace: a row that contains legacy plaintext (no Fernet
+    prefix) must read back as the raw value with a warning. The next save
+    will re-encrypt it."""
+    engine, table = sqlite_engine
+    legacy_plaintext = "legacy-plaintext-api-key"  # no "gAAAAA" prefix
+    _seed_raw(engine, legacy_plaintext)
+
     with caplog.at_level(logging.WARNING, logger="app.core.crypto"):
         with Session(engine) as session:
             row = session.execute(select(table.c.token)).scalar_one()
 
     assert row == legacy_plaintext
     assert any(
-        "Token decryption failed" in rec.message for rec in caplog.records
+        "lacks Fernet prefix" in rec.message for rec in caplog.records
     ), "expected a migration-grace warning to be logged"
 
 
-def test_encrypted_string_corrupted_ciphertext_returns_raw(sqlite_engine, caplog):
-    """A row containing garbage that decrypts to InvalidToken should be
-    returned raw with a warning — never raise into the application."""
+def test_encrypted_string_corrupted_fernet_returns_none(sqlite_engine, caplog):
+    """A Fernet-shaped value that fails to decrypt (corrupted ciphertext,
+    install_uuid drift) must NOT be returned as raw — that would hand the
+    application a ciphertext blob masquerading as a plaintext key. Return
+    None and log an error instead, so the app surfaces "not configured"
+    rather than misuse the value. This is the behavior change requested by
+    PR-05 review."""
     engine, table = sqlite_engine
-    garbage = "this-is-not-a-fernet-token-at-all"
+    # Looks like a Fernet token (right prefix) but the body is junk.
+    fake_fernet = "gAAAAAabc-not-real-ciphertext-but-prefix-matches"
+    _seed_raw(engine, fake_fernet)
 
-    from sqlalchemy import String as _PlainString
-
-    raw_meta = MetaData()
-    raw_table = Table(
-        "secrets_test",
-        raw_meta,
-        Column("id", Integer, primary_key=True),
-        Column("token", _PlainString(500)),
-    )
-    with engine.connect() as conn:
-        conn.execute(insert(raw_table).values(token=garbage))
-        conn.commit()
-
-    with caplog.at_level(logging.WARNING, logger="app.core.crypto"):
+    with caplog.at_level(logging.ERROR, logger="app.core.crypto"):
         with Session(engine) as session:
             row = session.execute(select(table.c.token)).scalar_one()
 
-    assert row == garbage
+    assert row is None, "corrupted Fernet ciphertext should NOT be returned raw"
     assert any(
-        "Token decryption failed" in rec.message for rec in caplog.records
-    )
+        "failed to decrypt" in rec.message for rec in caplog.records
+    ), "expected an error log for Fernet-shaped-but-undecryptable input"
+
+
+def test_encrypted_string_propagates_install_uuid_missing(
+    sqlite_engine, monkeypatch
+):
+    """If install_uuid is unavailable at read time, _derive_key raises
+    RuntimeError. The TypeDecorator must NOT swallow it — operational
+    failures need to be loud, not masked as 'not configured'."""
+    engine, table = sqlite_engine
+
+    # First, write a real Fernet token under the normal install_uuid.
+    plaintext = "configured-key"
+    with Session(engine) as session:
+        session.execute(insert(table).values(token=plaintext))
+        session.commit()
+
+    # Now break the install_uuid resolution and try to read.
+    monkeypatch.setattr(crypto, "get_install_uuid", lambda: "")
+    with pytest.raises(RuntimeError, match="install_uuid not available"):
+        with Session(engine) as session:
+            session.execute(select(table.c.token)).scalar_one()
 
 
 def test_encrypted_string_overwrite_re_encrypts(sqlite_engine):
@@ -297,14 +331,14 @@ def test_encrypted_string_overwrite_re_encrypts(sqlite_engine):
     naturally on the next user save."""
     engine, table = sqlite_engine
 
-    from sqlalchemy import String as _PlainString, update
+    from sqlalchemy import Text as _PlainText, update
 
     raw_meta = MetaData()
     raw_table = Table(
         "secrets_test",
         raw_meta,
         Column("id", Integer, primary_key=True),
-        Column("token", _PlainString(500)),
+        Column("token", _PlainText()),
     )
 
     # Seed plaintext directly

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,9 @@ const AdminSecurity = lazy(() => import("./pages/admin/AdminSecurity"));
 const AdminCycleCount = lazy(() => import("./pages/admin/AdminCycleCount"));
 const AdminPriceLevels = lazy(() => import("./pages/admin/AdminPriceLevels"));
 const AdminLicense = lazy(() => import("./pages/admin/AdminLicense"));
+const AdminIntegrations = lazy(
+  () => import("./pages/admin/AdminIntegrations"),
+);
 const AdminAccessRequests = lazy(
   () => import("./pages/admin/AdminAccessRequests"),
 );
@@ -401,6 +404,14 @@ export default function App() {
                       element={
                         <Suspense fallback={<PageLoader />}>
                           <AdminLicense />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path="integrations"
+                      element={
+                        <Suspense fallback={<PageLoader />}>
+                          <AdminIntegrations />
                         </Suspense>
                       }
                     />

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -324,6 +324,25 @@ const AccountingIcon = () => (
   </svg>
 );
 
+// Two interlocking links — distinct from the cog used by Settings/Scrap
+// Reasons so the collapsed sidebar reads as "connections," not "more gears."
+const IntegrationsIcon = () => (
+  <svg
+    className="w-5 h-5"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+    />
+  </svg>
+);
+
 const SettingsIcon = () => (
   <svg
     className="w-5 h-5"
@@ -567,7 +586,7 @@ const navGroups = [
       {
         path: "/admin/integrations",
         label: "Integrations",
-        icon: SettingsIcon,
+        icon: IntegrationsIcon,
         adminOnly: true,
       },
       {

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -565,6 +565,12 @@ const navGroups = [
         adminOnly: true,
       },
       {
+        path: "/admin/integrations",
+        label: "Integrations",
+        icon: SettingsIcon,
+        adminOnly: true,
+      },
+      {
         path: "/admin/security",
         label: "Security Audit",
         icon: QualityIcon,

--- a/frontend/src/pages/admin/AdminIntegrations.jsx
+++ b/frontend/src/pages/admin/AdminIntegrations.jsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useState } from "react";
+import { useApi } from "../../hooks/useApi";
+import AiSettingsSection from "../../components/settings/AiSettingsSection";
+
+/**
+ * AdminIntegrations — settings page for third-party integrations.
+ *
+ * PR-05 ships this page as the framework that PR-06/07 (Shopify, QuickBooks)
+ * extend. The IntegrationCard component below is the pattern future integrations
+ * follow: title, description, status badge, and a children slot for the actual
+ * configuration form.
+ *
+ * For PR-05:
+ * - AI Assistant card wraps the existing AiSettingsSection (now backed by
+ *   the EncryptedString-typed `ai_api_key` column — the encryption is
+ *   transparent, no UI changes required).
+ * - Shopify and QuickBooks cards render placeholder content describing
+ *   what those integrations will do.
+ */
+export default function AdminIntegrations() {
+  const api = useApi();
+  const [aiStatus, setAiStatus] = useState("loading");
+
+  const refreshAiStatus = useCallback(async () => {
+    try {
+      const data = await api.get("/api/v1/settings/ai");
+      // The backend reports ai_status directly: "configured" | "error" | "not_configured".
+      // Falling back to ai_api_key_set covers older backends that didn't return ai_status.
+      if (data?.ai_status === "configured" || data?.ai_status === "error") {
+        setAiStatus(data.ai_status);
+      } else if (data?.ai_api_key_set || data?.ai_provider) {
+        setAiStatus("configured");
+      } else {
+        setAiStatus("not_configured");
+      }
+    } catch {
+      setAiStatus("not_configured");
+    }
+  }, [api]);
+
+  useEffect(() => {
+    refreshAiStatus();
+  }, [refreshAiStatus]);
+
+  return (
+    <div className="space-y-6">
+      <Header />
+
+      <IntegrationCard
+        title="AI Assistant"
+        description="Configure AI-powered features like invoice parsing. API keys are encrypted at rest."
+        status={aiStatus}
+        testId="integration-card-ai"
+      >
+        <AiSettingsSection />
+      </IntegrationCard>
+
+      <IntegrationCard
+        title="Shopify"
+        description="Sync orders, inventory, and customers with your Shopify store."
+        status="not_configured"
+        testId="integration-card-shopify"
+      >
+        <ComingSoonBody
+          headline="Coming in a future update."
+          bullets={[
+            "Pull paid Shopify orders into FilaOps as production orders",
+            "Push inventory levels back to Shopify when items are produced",
+            "Map Shopify customers to FilaOps customer records",
+          ]}
+        />
+      </IntegrationCard>
+
+      <IntegrationCard
+        title="QuickBooks Online"
+        description="Sync invoices, payments, and chart of accounts."
+        status="not_configured"
+        testId="integration-card-qbo"
+      >
+        <ComingSoonBody
+          headline="Coming in a future update."
+          bullets={[
+            "Push FilaOps invoices to QuickBooks Online",
+            "Reconcile QuickBooks payments back to FilaOps invoices",
+            "Map FilaOps GL accounts to your QuickBooks chart of accounts",
+          ]}
+        />
+      </IntegrationCard>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white">
+        Integrations &amp; Connections
+      </h1>
+      <p className="text-gray-400 mt-1">
+        Connect FilaOps to outside services. Each integration stores its
+        credentials encrypted at rest.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * IntegrationCard — reusable pattern for an integration section.
+ *
+ * Future integrations (PR-06 Shopify, PR-07 QBO) follow this same shape:
+ *   <IntegrationCard title=... description=... status=... testId=...>
+ *     <ConfigForm />
+ *   </IntegrationCard>
+ *
+ * Status values: "configured" | "not_configured" | "error" | "loading".
+ */
+export function IntegrationCard({
+  title,
+  description,
+  status = "not_configured",
+  testId,
+  children,
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <p className="text-sm text-gray-400">{description}</p>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  const variants = {
+    configured: {
+      label: "Configured",
+      classes: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+    },
+    not_configured: {
+      label: "Not configured",
+      classes: "bg-gray-500/15 text-gray-300 border-gray-500/30",
+    },
+    error: {
+      label: "Error",
+      classes: "bg-red-500/15 text-red-300 border-red-500/30",
+    },
+    loading: {
+      label: "Loading…",
+      classes: "bg-gray-500/15 text-gray-400 border-gray-500/30",
+    },
+  };
+  const v = variants[status] || variants.not_configured;
+  return (
+    <span
+      role="status"
+      aria-label={`Status: ${v.label}`}
+      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border whitespace-nowrap ${v.classes}`}
+    >
+      {v.label}
+    </span>
+  );
+}
+
+function ComingSoonBody({ headline, bullets }) {
+  return (
+    <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-4 space-y-2">
+      <p className="text-sm font-medium text-gray-200">{headline}</p>
+      <ul className="text-sm text-gray-400 list-disc pl-5 space-y-1">
+        {bullets.map((b) => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminIntegrations.jsx
+++ b/frontend/src/pages/admin/AdminIntegrations.jsx
@@ -33,8 +33,12 @@ export default function AdminIntegrations() {
       } else {
         setAiStatus("not_configured");
       }
-    } catch {
-      setAiStatus("not_configured");
+    } catch (err) {
+      // A network or server error is NOT the same as "not configured" —
+      // treating them the same hides real problems and makes the "error"
+      // badge state unreachable. Log + surface an explicit error state.
+      console.error("Failed to fetch AI integration status:", err);
+      setAiStatus("error");
     }
   }, [api]);
 

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { API_URL } from "../../config/api";
 import { useToast } from "../../components/Toast";
@@ -7,7 +8,6 @@ import { getCurrentVersion, getCurrentVersionSync, formatVersion } from "../../u
 import { formatPhoneNumber, timezoneOptions } from "../../components/settings/constants";
 import { currencyOptions, localeOptions } from "../../components/settings/i18nConstants";
 import { useLocale } from "../../contexts/LocaleContext";
-import AiSettingsSection from "../../components/settings/AiSettingsSection";
 import LicenseSection from "../../components/LicenseSection";
 import { useApp } from "../../contexts/AppContext";
 
@@ -875,8 +875,26 @@ const AdminSettings = () => {
           </div>
         </div>
 
-        {/* AI Configuration */}
-        <AiSettingsSection />
+        {/* AI Configuration moved to /admin/integrations in PR-05.
+            Operators with bookmarks/muscle memory pointing here would
+            otherwise think the section disappeared — leave a small
+            sign-post pointing to the new home. */}
+        <div className="bg-gray-800 rounded-lg p-6">
+          <h2 className="text-xl font-semibold text-white mb-2">
+            AI Configuration
+          </h2>
+          <p className="text-sm text-gray-400">
+            AI provider setup (Anthropic, Ollama) moved to the new{" "}
+            <Link
+              to="/admin/integrations"
+              className="text-blue-400 hover:text-blue-300 underline"
+            >
+              Integrations
+            </Link>
+            {" "}page, where it lives alongside Shopify, QuickBooks, and other
+            connector configuration. API keys are now encrypted at rest.
+          </p>
+        </div>
 
         {/* License & Subscription */}
         <LicenseSection />

--- a/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('../../../hooks/useApi', () => {
+  const api = { get: mocks.get, post: vi.fn(), patch: vi.fn(), del: vi.fn() }
+  return { useApi: () => api }
+})
+
+// Stub AiSettingsSection — its internals (provider selector, API key input,
+// save/test buttons) are exercised by its own tests. AdminIntegrations only
+// cares that the section is rendered inside the AI IntegrationCard.
+vi.mock('../../../components/settings/AiSettingsSection', () => ({
+  default: () => (
+    <div data-testid="ai-settings-section-stub">AI Settings Section</div>
+  ),
+}))
+
+import AdminIntegrations, { IntegrationCard } from '../AdminIntegrations'
+
+beforeEach(() => {
+  mocks.get.mockReset()
+})
+
+describe('AdminIntegrations', () => {
+  it('renders header and all three integration cards', async () => {
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+    render(<AdminIntegrations />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Integrations & Connections/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('integration-card-ai')).toBeInTheDocument()
+    expect(screen.getByTestId('integration-card-shopify')).toBeInTheDocument()
+    expect(screen.getByTestId('integration-card-qbo')).toBeInTheDocument()
+  })
+
+  it('AI card embeds the AiSettingsSection', async () => {
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+    render(<AdminIntegrations />)
+
+    const aiCard = await screen.findByTestId('integration-card-ai')
+    expect(
+      within(aiCard).getByTestId('ai-settings-section-stub'),
+    ).toBeInTheDocument()
+  })
+
+  it('AI card status reads "Configured" when ai_api_key_set is true', async () => {
+    mocks.get.mockResolvedValue({
+      ai_provider: 'anthropic',
+      ai_api_key_set: true,
+      ai_status: 'configured',
+    })
+    render(<AdminIntegrations />)
+
+    const aiCard = await screen.findByTestId('integration-card-ai')
+    await waitFor(() => {
+      expect(within(aiCard).getByText('Configured')).toBeInTheDocument()
+    })
+  })
+
+  it('AI card status reads "Not configured" when no provider/key is set', async () => {
+    mocks.get.mockResolvedValue({
+      ai_provider: null,
+      ai_api_key_set: false,
+      ai_status: 'not_configured',
+    })
+    render(<AdminIntegrations />)
+
+    const aiCard = await screen.findByTestId('integration-card-ai')
+    await waitFor(() => {
+      expect(within(aiCard).getByText('Not configured')).toBeInTheDocument()
+    })
+  })
+
+  it('AI card status reads "Error" when backend reports ai_status=error', async () => {
+    mocks.get.mockResolvedValue({
+      ai_provider: 'anthropic',
+      ai_api_key_set: true,
+      ai_status: 'error',
+    })
+    render(<AdminIntegrations />)
+
+    const aiCard = await screen.findByTestId('integration-card-ai')
+    await waitFor(() => {
+      expect(within(aiCard).getByText('Error')).toBeInTheDocument()
+    })
+  })
+
+  it('AI card falls back to "Not configured" when the GET fails', async () => {
+    mocks.get.mockRejectedValue(new Error('boom'))
+    render(<AdminIntegrations />)
+
+    const aiCard = await screen.findByTestId('integration-card-ai')
+    await waitFor(() => {
+      expect(within(aiCard).getByText('Not configured')).toBeInTheDocument()
+    })
+  })
+
+  it('Shopify card renders coming-soon placeholder with feature bullets', async () => {
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+    render(<AdminIntegrations />)
+
+    const shopifyCard = await screen.findByTestId('integration-card-shopify')
+    expect(within(shopifyCard).getByText('Shopify')).toBeInTheDocument()
+    expect(
+      within(shopifyCard).getByText(/Coming in a future update/i),
+    ).toBeInTheDocument()
+    expect(
+      within(shopifyCard).getByText(/Pull paid Shopify orders/i),
+    ).toBeInTheDocument()
+    expect(within(shopifyCard).getByText('Not configured')).toBeInTheDocument()
+  })
+
+  it('QuickBooks card renders coming-soon placeholder with feature bullets', async () => {
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+    render(<AdminIntegrations />)
+
+    const qboCard = await screen.findByTestId('integration-card-qbo')
+    expect(within(qboCard).getByText('QuickBooks Online')).toBeInTheDocument()
+    expect(
+      within(qboCard).getByText(/Coming in a future update/i),
+    ).toBeInTheDocument()
+    expect(
+      within(qboCard).getByText(/Push FilaOps invoices to QuickBooks/i),
+    ).toBeInTheDocument()
+    expect(within(qboCard).getByText('Not configured')).toBeInTheDocument()
+  })
+
+  it('only fires one GET on mount (no fetch storm from re-renders)', async () => {
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+    render(<AdminIntegrations />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('integration-card-ai')).toBeInTheDocument()
+    })
+    // Exactly one initial fetch — useEffect with stable useCallback dep
+    expect(mocks.get).toHaveBeenCalledTimes(1)
+    expect(mocks.get).toHaveBeenCalledWith('/api/v1/settings/ai')
+  })
+})
+
+describe('IntegrationCard (status badge variants)', () => {
+  it.each([
+    ['configured', 'Configured'],
+    ['not_configured', 'Not configured'],
+    ['error', 'Error'],
+    ['loading', 'Loading…'],
+  ])('renders %s badge with label %s', (status, label) => {
+    render(
+      <IntegrationCard
+        title="Test"
+        description="desc"
+        status={status}
+        testId="card-under-test"
+      >
+        <span>body</span>
+      </IntegrationCard>,
+    )
+    const card = screen.getByTestId('card-under-test')
+    expect(within(card).getByText(label)).toBeInTheDocument()
+    expect(within(card).getByText('Test')).toBeInTheDocument()
+    expect(within(card).getByText('body')).toBeInTheDocument()
+  })
+
+  it('falls back to "Not configured" badge for an unknown status string', () => {
+    render(
+      <IntegrationCard
+        title="Test"
+        description="desc"
+        status="some-future-state"
+        testId="card-under-test"
+      >
+        <span>body</span>
+      </IntegrationCard>,
+    )
+    const card = screen.getByTestId('card-under-test')
+    expect(within(card).getByText('Not configured')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
@@ -93,14 +93,20 @@ describe('AdminIntegrations', () => {
     })
   })
 
-  it('AI card falls back to "Not configured" when the GET fails', async () => {
+  it('AI card surfaces "Error" badge when the GET fails (not silently "not configured")', async () => {
+    // Suppress the deliberate console.error from the catch block so the test
+    // log stays clean — we still assert the error was logged below.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mocks.get.mockRejectedValue(new Error('boom'))
     render(<AdminIntegrations />)
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     await waitFor(() => {
-      expect(within(aiCard).getByText('Not configured')).toBeInTheDocument()
+      expect(within(aiCard).getByText('Error')).toBeInTheDocument()
     })
+    expect(within(aiCard).queryByText('Not configured')).not.toBeInTheDocument()
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
   })
 
   it('Shopify card renders coming-soon placeholder with feature bullets', async () => {


### PR DESCRIPTION
PR-05 adds the Fernet+HKDF encryption layer and the integration settings page framework. Every future integration token is encrypted at rest by declaring EncryptedString(length=500) as the column type. The AdminIntegrations page provides the IntegrationCard pattern that PR-06/07 extend for Shopify and QuickBooks.

## What's in this PR

- crypto.py: Fernet+HKDF key derivation from install_uuid, encrypt/decrypt functions, EncryptedString SQLAlchemy TypeDecorator with migration grace
- ai_api_key encrypted: existing plaintext column now uses EncryptedString — transparent migration, no schema change needed
- AdminIntegrations page: AI Settings (functional, wraps existing AiSettingsSection), Shopify placeholder, QuickBooks placeholder
- IntegrationCard component: reusable pattern with status badge (configured/not_configured/error/loading)
- Route + sidebar nav registration at /admin/integrations
- 17 backend crypto tests + 14 frontend Interaction tests (31 total new)
- Fixed stale PR-06 docstring reference in license_cache.py

## Depends on

- PR-01 (CORS, merged)
- PR-04 (installer, merged PR #585)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin "Integrations & Connections" page with AI Assistant card and placeholders for Shopify/QuickBooks; AI status badges (Configured / Not configured / Error).

* **UI Improvements**
  * Added "Integrations" item to admin sidebar and an "AI Configuration" link from Admin Settings.

* **Security**
  * API keys are now encrypted at rest.

* **Tests**
  * End-to-end tests covering encryption behavior and admin integrations UI.

* **Chores**
  * DB migration to support encrypted API keys and dependency bump for crypto library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->