### PR TITLE
feat(pr-06): catalog + price level schema additions (additive, idempotent)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -47,6 +47,9 @@ from app.models.close_short_record import CloseShortRecord
 # Price Levels (Core manages definitions; PRO manages customer assignment)
 from app.models.price_level import PriceLevel
 
+# Catalogs (Core owns table definitions; PRO consumes via filaops_pro routes)
+from app.models.catalog import Catalog, CatalogProduct, CustomerCatalog
+
 # i18n / Tax Rates
 from app.models.tax_rate import TaxRate
 
@@ -144,6 +147,10 @@ __all__ = [
     "CloseShortRecord",
     # Price Levels
     "PriceLevel",
+    # Catalogs
+    "Catalog",
+    "CatalogProduct",
+    "CustomerCatalog",
     # System Settings
     "SystemSetting",
 ]

--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -76,6 +77,13 @@ class CatalogProduct(Base):
     catalog-specific price override.
     """
     __tablename__ = "catalog_products"
+    __table_args__ = (
+        UniqueConstraint(
+            "catalog_id",
+            "product_id",
+            name="uq_catalog_products_catalog_product",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     catalog_id = Column(
@@ -120,6 +128,13 @@ class CustomerCatalog(Base):
     records with account_type='customer' (not in the customers table).
     """
     __tablename__ = "customer_catalogs"
+    __table_args__ = (
+        UniqueConstraint(
+            "customer_id",
+            "catalog_id",
+            name="uq_customer_catalogs_customer_catalog",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     customer_id = Column(

--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -1,0 +1,148 @@
+"""
+Catalog models for B2B product visibility control.
+
+Catalogs allow admins to:
+- Create product groupings (e.g., "Public", "KOA Custom", "Wholesale Partners")
+- Assign products to one or more catalogs
+- Assign customers to one or more catalogs
+- Portal shows products from customer's assigned catalogs + public catalogs
+
+Core owns the catalog table definitions (PR-06). PRO consumes them via
+filaops_pro/routes/catalogs.py and adds tier-aware pricing on top.
+"""
+from decimal import Decimal
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class Catalog(Base):
+    """
+    Catalog definition for product visibility grouping.
+
+    Examples:
+    - PUBLIC: Default catalog, visible to all customers
+    - KOA-CUSTOM: Custom products only for KOA Kampgrounds
+    - WHOLESALE: Products available to wholesale partners
+    """
+    __tablename__ = "catalogs"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    code = Column(String(50), unique=True, nullable=False, index=True)
+    name = Column(String(100), nullable=False)
+    description = Column(Text, nullable=True)
+
+    is_default = Column(Boolean, nullable=False, default=False)
+    is_public = Column(Boolean, nullable=False, default=True, index=True)
+
+    sort_order = Column(Integer, nullable=False, default=0)
+    active = Column(Boolean, nullable=False, default=True, index=True)
+
+    created_at = Column(DateTime(timezone=False), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=False),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    catalog_products = relationship(
+        "CatalogProduct", back_populates="catalog", cascade="all, delete-orphan"
+    )
+    customer_catalogs = relationship(
+        "CustomerCatalog", back_populates="catalog", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Catalog(code='{self.code}', name='{self.name}', public={self.is_public})>"
+
+
+class CatalogProduct(Base):
+    """
+    Many-to-many relationship between catalogs and products with optional
+    catalog-specific price override.
+    """
+    __tablename__ = "catalog_products"
+
+    id = Column(Integer, primary_key=True, index=True)
+    catalog_id = Column(
+        Integer,
+        ForeignKey("catalogs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    product_id = Column(
+        Integer,
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    price_override = Column(Numeric(12, 4), nullable=True)
+    created_at = Column(
+        DateTime(timezone=False), server_default=func.now(), nullable=False
+    )
+
+    catalog = relationship("Catalog", back_populates="catalog_products")
+    product = relationship("Product")
+
+    def __repr__(self) -> str:
+        return (
+            f"<CatalogProduct(catalog_id={self.catalog_id}, "
+            f"product_id={self.product_id})>"
+        )
+
+    @property
+    def effective_price(self) -> Decimal:
+        """Catalog-specific price override, or fall back to product selling price."""
+        if self.price_override is not None:
+            return Decimal(str(self.price_override))
+        return Decimal(str(self.product.selling_price)) if self.product else Decimal("0")
+
+
+class CustomerCatalog(Base):
+    """
+    Many-to-many between customer-users and catalogs.
+
+    customer_id references users.id because Core stores customers as User
+    records with account_type='customer' (not in the customers table).
+    """
+    __tablename__ = "customer_catalogs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    customer_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    catalog_id = Column(
+        Integer,
+        ForeignKey("catalogs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at = Column(
+        DateTime(timezone=False), server_default=func.now(), nullable=False
+    )
+
+    customer = relationship("User")
+    catalog = relationship("Catalog", back_populates="customer_catalogs")
+
+    def __repr__(self) -> str:
+        return (
+            f"<CustomerCatalog(customer_id={self.customer_id}, "
+            f"catalog_id={self.catalog_id})>"
+        )

--- a/backend/app/models/price_level.py
+++ b/backend/app/models/price_level.py
@@ -27,13 +27,25 @@ class PriceLevel(Base):
     )
 
     id = Column(Integer, primary_key=True)
-    name = Column(String(100), nullable=False, unique=True)       # e.g., "Tier A", "Wholesale"
-    discount_percent = Column(Numeric(5, 2), nullable=False)      # 0.00–100.00
+    code = Column(String(10), unique=True, nullable=True, index=True)  # PR-06: short tier code (TIER-A, WHOLESALE, ...)
+    name = Column(String(100), nullable=False, unique=True)             # e.g., "Tier A", "Wholesale"
+    discount_percent = Column(Numeric(5, 2), nullable=False)            # 0.00–100.00
     description = Column(Text, nullable=True)
+    sort_order = Column(Integer, default=0, nullable=False)             # PR-06: display ordering
     is_active = Column(Boolean, default=True, nullable=False)
 
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=True)
+
+    @property
+    def active(self) -> bool:
+        """Compatibility alias for is_active.
+
+        PRO routes (filaops_pro/routes/catalogs.py) read pricelevel.active.
+        Core's column is is_active. This bridge avoids a schema rename and a
+        backfill — both names refer to the same boolean.
+        """
+        return self.is_active
 
     def __repr__(self) -> str:
         return f"<PriceLevel {self.name}: {self.discount_percent}% off>"

--- a/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
+++ b/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
@@ -3,16 +3,22 @@
 PR-06 Phase 1 (Core). Brings Core's schema in line with what PRO routes
 expect. Additive only:
 
-- price_levels: ADD COLUMN code, ADD COLUMN sort_order
-- catalogs / catalog_products / customer_catalogs: CREATE TABLE
-- pro_customer_price_levels: CREATE TABLE — junction owned by PRO,
-  declared in Core so a Core-only install has the schema available
+- price_levels: ADD COLUMN code, ADD COLUMN sort_order, plus a one-way
+  rename guard for the `active` → `is_active` legacy drift.
+- catalogs / catalog_products / customer_catalogs: CREATE TABLE if absent.
+- pro_customer_price_levels: CREATE TABLE if absent — junction owned by
+  PRO, declared in Core so a Core-only install has the schema available
   even before PRO is installed.
 
 All CREATE TABLE statements are guarded by a runtime existence check so
 the migration is idempotent against databases where PRO migrations
 002/003 already created the tables. Same idempotency pattern PRO
 migration 001 uses for gl_accounts.
+
+The junction-table UniqueConstraints are also added retroactively for
+DBs where PRO migration 003 created the tables without them — so the
+post-082 state is identical regardless of which migration created the
+table first.
 
 Revision ID: 082
 Revises: 081
@@ -65,9 +71,24 @@ def upgrade() -> None:
         op.alter_column(
             "price_levels", "active", new_column_name="is_active"
         )
+        # Defensive backfill: the legacy schema may have allowed NULLs or
+        # lacked a server default. Match the canonical Core model
+        # (Boolean, default=True, nullable=False) explicitly. Same pattern
+        # other Core migrations (077, 079) use after schema-shape changes.
+        op.execute(
+            "UPDATE price_levels SET is_active = TRUE WHERE is_active IS NULL"
+        )
+        op.alter_column(
+            "price_levels",
+            "is_active",
+            existing_type=sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        )
 
     # ------------------------------------------------------------------
-    # 2. catalogs
+    # 2. catalogs — UniqueConstraint("code") provides the backing index;
+    #    no need for a separate ix_catalogs_code. PK is auto-indexed too.
     # ------------------------------------------------------------------
     if "catalogs" not in existing_tables:
         op.create_table(
@@ -103,13 +124,11 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("code", name="uq_catalogs_code"),
         )
-        op.create_index("ix_catalogs_id", "catalogs", ["id"])
-        op.create_index("ix_catalogs_code", "catalogs", ["code"], unique=True)
         op.create_index("ix_catalogs_active", "catalogs", ["active"])
         op.create_index("ix_catalogs_is_public", "catalogs", ["is_public"])
 
     # ------------------------------------------------------------------
-    # 3. catalog_products
+    # 3. catalog_products — junction table; UC enforces one row per pair.
     # ------------------------------------------------------------------
     if "catalog_products" not in existing_tables:
         op.create_table(
@@ -137,13 +156,30 @@ def upgrade() -> None:
                 name="fk_catalog_products_product",
                 ondelete="CASCADE",
             ),
+            sa.UniqueConstraint(
+                "catalog_id",
+                "product_id",
+                name="uq_catalog_products_catalog_product",
+            ),
         )
-        op.create_index("ix_catalog_products_id", "catalog_products", ["id"])
         op.create_index(
             "ix_catalog_products_catalog_id", "catalog_products", ["catalog_id"]
         )
         op.create_index(
             "ix_catalog_products_product_id", "catalog_products", ["product_id"]
+        )
+    # Retro UC-add: PRO migration 003 created this table without a
+    # uniqueness constraint on (catalog_id, product_id). Add it now if
+    # missing, so the post-082 state matches the Core model regardless
+    # of who created the table first.
+    cp_uniques = {
+        c["name"] for c in inspector.get_unique_constraints("catalog_products")
+    }
+    if "uq_catalog_products_catalog_product" not in cp_uniques:
+        op.create_unique_constraint(
+            "uq_catalog_products_catalog_product",
+            "catalog_products",
+            ["catalog_id", "product_id"],
         )
 
     # ------------------------------------------------------------------
@@ -176,8 +212,12 @@ def upgrade() -> None:
                 name="fk_customer_catalogs_catalog",
                 ondelete="CASCADE",
             ),
+            sa.UniqueConstraint(
+                "customer_id",
+                "catalog_id",
+                name="uq_customer_catalogs_customer_catalog",
+            ),
         )
-        op.create_index("ix_customer_catalogs_id", "customer_catalogs", ["id"])
         op.create_index(
             "ix_customer_catalogs_customer_id",
             "customer_catalogs",
@@ -187,6 +227,16 @@ def upgrade() -> None:
             "ix_customer_catalogs_catalog_id",
             "customer_catalogs",
             ["catalog_id"],
+        )
+    # Retro UC-add for the same reason as catalog_products above.
+    cc_uniques = {
+        c["name"] for c in inspector.get_unique_constraints("customer_catalogs")
+    }
+    if "uq_customer_catalogs_customer_catalog" not in cc_uniques:
+        op.create_unique_constraint(
+            "uq_customer_catalogs_customer_catalog",
+            "customer_catalogs",
+            ["customer_id", "catalog_id"],
         )
 
     # ------------------------------------------------------------------
@@ -225,11 +275,6 @@ def upgrade() -> None:
             ),
         )
         op.create_index(
-            "ix_pro_customer_price_levels_id",
-            "pro_customer_price_levels",
-            ["id"],
-        )
-        op.create_index(
             "ix_pro_customer_price_levels_customer_id",
             "pro_customer_price_levels",
             ["customer_id"],
@@ -242,9 +287,15 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Reverse the additive changes. Each drop is guarded so a partial
-    downgrade (e.g., after a partial upgrade against a DB that already
-    had some tables) doesn't fail."""
+    """Reverse the additive changes.
+
+    Asymmetry note: this migration may run on DBs where some tables already
+    existed (created by PRO migration 002/003 before 082 ran). The downgrade
+    drops those tables anyway — if you're rolling Core back past 082, the
+    PRO migrations are also out of scope, so removing the schema is correct.
+    Index drops use ``if_exists=True`` to tolerate cases where indexes were
+    created with different names by PRO migrations.
+    """
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     existing_tables = set(inspector.get_table_names())
@@ -253,47 +304,55 @@ def downgrade() -> None:
         op.drop_index(
             "ix_pro_customer_price_levels_level_id",
             table_name="pro_customer_price_levels",
+            if_exists=True,
         )
         op.drop_index(
             "ix_pro_customer_price_levels_customer_id",
             table_name="pro_customer_price_levels",
-        )
-        op.drop_index(
-            "ix_pro_customer_price_levels_id",
-            table_name="pro_customer_price_levels",
+            if_exists=True,
         )
         op.drop_table("pro_customer_price_levels")
 
     if "customer_catalogs" in existing_tables:
         op.drop_index(
-            "ix_customer_catalogs_catalog_id", table_name="customer_catalogs"
+            "ix_customer_catalogs_catalog_id",
+            table_name="customer_catalogs",
+            if_exists=True,
         )
         op.drop_index(
-            "ix_customer_catalogs_customer_id", table_name="customer_catalogs"
+            "ix_customer_catalogs_customer_id",
+            table_name="customer_catalogs",
+            if_exists=True,
         )
-        op.drop_index("ix_customer_catalogs_id", table_name="customer_catalogs")
         op.drop_table("customer_catalogs")
 
     if "catalog_products" in existing_tables:
         op.drop_index(
-            "ix_catalog_products_product_id", table_name="catalog_products"
+            "ix_catalog_products_product_id",
+            table_name="catalog_products",
+            if_exists=True,
         )
         op.drop_index(
-            "ix_catalog_products_catalog_id", table_name="catalog_products"
+            "ix_catalog_products_catalog_id",
+            table_name="catalog_products",
+            if_exists=True,
         )
-        op.drop_index("ix_catalog_products_id", table_name="catalog_products")
         op.drop_table("catalog_products")
 
     if "catalogs" in existing_tables:
-        op.drop_index("ix_catalogs_is_public", table_name="catalogs")
-        op.drop_index("ix_catalogs_active", table_name="catalogs")
-        op.drop_index("ix_catalogs_code", table_name="catalogs")
-        op.drop_index("ix_catalogs_id", table_name="catalogs")
+        op.drop_index(
+            "ix_catalogs_is_public", table_name="catalogs", if_exists=True
+        )
+        op.drop_index(
+            "ix_catalogs_active", table_name="catalogs", if_exists=True
+        )
         op.drop_table("catalogs")
 
     pl_cols = {c["name"] for c in inspector.get_columns("price_levels")}
     if "sort_order" in pl_cols:
         op.drop_column("price_levels", "sort_order")
     if "code" in pl_cols:
-        op.drop_index("ix_price_levels_code", table_name="price_levels")
+        op.drop_index(
+            "ix_price_levels_code", table_name="price_levels", if_exists=True
+        )
         op.drop_column("price_levels", "code")

--- a/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
+++ b/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
     existing_tables = set(inspector.get_table_names())
 
     # ------------------------------------------------------------------
-    # 1. price_levels — additive columns
+    # 1. price_levels — additive columns + legacy-drift rename guard
     # ------------------------------------------------------------------
     pl_cols = {c["name"] for c in inspector.get_columns("price_levels")}
     if "code" not in pl_cols:
@@ -54,6 +54,16 @@ def upgrade() -> None:
                 nullable=False,
                 server_default="0",
             ),
+        )
+    # Legacy drift: a removed Core migration (041_add_price_levels_and_customers)
+    # created price_levels with column 'active' (PRO-style naming) instead of
+    # the canonical Core 'is_active'. Any DB that bypassed Core migration 078
+    # because the table already existed will have the wrong column name. Rename
+    # only when the drift is observable; this is a one-way fix and intentionally
+    # not reflected in downgrade() (un-renaming on a fresh DB would corrupt it).
+    if "active" in pl_cols and "is_active" not in pl_cols:
+        op.alter_column(
+            "price_levels", "active", new_column_name="is_active"
         )
 
     # ------------------------------------------------------------------

--- a/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
+++ b/backend/migrations/versions/082_add_catalog_and_price_level_columns.py
@@ -1,0 +1,289 @@
+"""Add catalog system + extend price_levels columns
+
+PR-06 Phase 1 (Core). Brings Core's schema in line with what PRO routes
+expect. Additive only:
+
+- price_levels: ADD COLUMN code, ADD COLUMN sort_order
+- catalogs / catalog_products / customer_catalogs: CREATE TABLE
+- pro_customer_price_levels: CREATE TABLE — junction owned by PRO,
+  declared in Core so a Core-only install has the schema available
+  even before PRO is installed.
+
+All CREATE TABLE statements are guarded by a runtime existence check so
+the migration is idempotent against databases where PRO migrations
+002/003 already created the tables. Same idempotency pattern PRO
+migration 001 uses for gl_accounts.
+
+Revision ID: 082
+Revises: 081
+Create Date: 2026-05-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "082"
+down_revision = "081"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    # ------------------------------------------------------------------
+    # 1. price_levels — additive columns
+    # ------------------------------------------------------------------
+    pl_cols = {c["name"] for c in inspector.get_columns("price_levels")}
+    if "code" not in pl_cols:
+        op.add_column(
+            "price_levels",
+            sa.Column("code", sa.String(10), nullable=True),
+        )
+        op.create_index(
+            "ix_price_levels_code", "price_levels", ["code"], unique=True
+        )
+    if "sort_order" not in pl_cols:
+        op.add_column(
+            "price_levels",
+            sa.Column(
+                "sort_order",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 2. catalogs
+    # ------------------------------------------------------------------
+    if "catalogs" not in existing_tables:
+        op.create_table(
+            "catalogs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("code", sa.String(50), nullable=False),
+            sa.Column("name", sa.String(100), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column(
+                "is_default", sa.Boolean(), nullable=False, server_default="false"
+            ),
+            sa.Column(
+                "is_public", sa.Boolean(), nullable=False, server_default="true"
+            ),
+            sa.Column(
+                "sort_order", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "active", sa.Boolean(), nullable=False, server_default="true"
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("code", name="uq_catalogs_code"),
+        )
+        op.create_index("ix_catalogs_id", "catalogs", ["id"])
+        op.create_index("ix_catalogs_code", "catalogs", ["code"], unique=True)
+        op.create_index("ix_catalogs_active", "catalogs", ["active"])
+        op.create_index("ix_catalogs_is_public", "catalogs", ["is_public"])
+
+    # ------------------------------------------------------------------
+    # 3. catalog_products
+    # ------------------------------------------------------------------
+    if "catalog_products" not in existing_tables:
+        op.create_table(
+            "catalog_products",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("catalog_id", sa.Integer(), nullable=False),
+            sa.Column("product_id", sa.Integer(), nullable=False),
+            sa.Column("price_override", sa.Numeric(12, 4), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["catalog_id"],
+                ["catalogs.id"],
+                name="fk_catalog_products_catalog",
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["product_id"],
+                ["products.id"],
+                name="fk_catalog_products_product",
+                ondelete="CASCADE",
+            ),
+        )
+        op.create_index("ix_catalog_products_id", "catalog_products", ["id"])
+        op.create_index(
+            "ix_catalog_products_catalog_id", "catalog_products", ["catalog_id"]
+        )
+        op.create_index(
+            "ix_catalog_products_product_id", "catalog_products", ["product_id"]
+        )
+
+    # ------------------------------------------------------------------
+    # 4. customer_catalogs — FK customer_id → users.id (Core stores
+    #    customers as User records with account_type='customer'; the
+    #    PRO migration's customers.id target was wrong)
+    # ------------------------------------------------------------------
+    if "customer_catalogs" not in existing_tables:
+        op.create_table(
+            "customer_catalogs",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("customer_id", sa.Integer(), nullable=False),
+            sa.Column("catalog_id", sa.Integer(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["customer_id"],
+                ["users.id"],
+                name="fk_customer_catalogs_customer",
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["catalog_id"],
+                ["catalogs.id"],
+                name="fk_customer_catalogs_catalog",
+                ondelete="CASCADE",
+            ),
+        )
+        op.create_index("ix_customer_catalogs_id", "customer_catalogs", ["id"])
+        op.create_index(
+            "ix_customer_catalogs_customer_id",
+            "customer_catalogs",
+            ["customer_id"],
+        )
+        op.create_index(
+            "ix_customer_catalogs_catalog_id",
+            "customer_catalogs",
+            ["catalog_id"],
+        )
+
+    # ------------------------------------------------------------------
+    # 5. pro_customer_price_levels — junction for PRO customer-tier
+    #    assignment. Created in Core so the schema is consistent across
+    #    Core-only and Core+PRO installs. PRO routes read/write; Core
+    #    never references this table directly.
+    # ------------------------------------------------------------------
+    if "pro_customer_price_levels" not in existing_tables:
+        op.create_table(
+            "pro_customer_price_levels",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("customer_id", sa.Integer(), nullable=False),
+            sa.Column("price_level_id", sa.Integer(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["customer_id"],
+                ["users.id"],
+                name="fk_pro_customer_price_levels_customer",
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["price_level_id"],
+                ["price_levels.id"],
+                name="fk_pro_customer_price_levels_level",
+                ondelete="CASCADE",
+            ),
+            sa.UniqueConstraint(
+                "customer_id", name="uq_pro_customer_price_level_customer"
+            ),
+        )
+        op.create_index(
+            "ix_pro_customer_price_levels_id",
+            "pro_customer_price_levels",
+            ["id"],
+        )
+        op.create_index(
+            "ix_pro_customer_price_levels_customer_id",
+            "pro_customer_price_levels",
+            ["customer_id"],
+        )
+        op.create_index(
+            "ix_pro_customer_price_levels_level_id",
+            "pro_customer_price_levels",
+            ["price_level_id"],
+        )
+
+
+def downgrade() -> None:
+    """Reverse the additive changes. Each drop is guarded so a partial
+    downgrade (e.g., after a partial upgrade against a DB that already
+    had some tables) doesn't fail."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "pro_customer_price_levels" in existing_tables:
+        op.drop_index(
+            "ix_pro_customer_price_levels_level_id",
+            table_name="pro_customer_price_levels",
+        )
+        op.drop_index(
+            "ix_pro_customer_price_levels_customer_id",
+            table_name="pro_customer_price_levels",
+        )
+        op.drop_index(
+            "ix_pro_customer_price_levels_id",
+            table_name="pro_customer_price_levels",
+        )
+        op.drop_table("pro_customer_price_levels")
+
+    if "customer_catalogs" in existing_tables:
+        op.drop_index(
+            "ix_customer_catalogs_catalog_id", table_name="customer_catalogs"
+        )
+        op.drop_index(
+            "ix_customer_catalogs_customer_id", table_name="customer_catalogs"
+        )
+        op.drop_index("ix_customer_catalogs_id", table_name="customer_catalogs")
+        op.drop_table("customer_catalogs")
+
+    if "catalog_products" in existing_tables:
+        op.drop_index(
+            "ix_catalog_products_product_id", table_name="catalog_products"
+        )
+        op.drop_index(
+            "ix_catalog_products_catalog_id", table_name="catalog_products"
+        )
+        op.drop_index("ix_catalog_products_id", table_name="catalog_products")
+        op.drop_table("catalog_products")
+
+    if "catalogs" in existing_tables:
+        op.drop_index("ix_catalogs_is_public", table_name="catalogs")
+        op.drop_index("ix_catalogs_active", table_name="catalogs")
+        op.drop_index("ix_catalogs_code", table_name="catalogs")
+        op.drop_index("ix_catalogs_id", table_name="catalogs")
+        op.drop_table("catalogs")
+
+    pl_cols = {c["name"] for c in inspector.get_columns("price_levels")}
+    if "sort_order" in pl_cols:
+        op.drop_column("price_levels", "sort_order")
+    if "code" in pl_cols:
+        op.drop_index("ix_price_levels_code", table_name="price_levels")
+        op.drop_column("price_levels", "code")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { createApiClient } from "./lib/apiClient";
 import { API_URL } from "./config/api";
 import { AppProvider } from "./contexts/AppContext";
 import { LocaleProvider } from "./contexts/LocaleContext";
+import { useFeatureFlags } from "./hooks/useFeatureFlags";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ApiErrorToaster from "./components/ApiErrorToaster";
 import AdminLayout from "./components/AdminLayout";
@@ -85,6 +86,17 @@ function PageLoader() {
       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
     </div>
   );
+}
+
+// Route-level gate for PRO-only pages. Nav entries already filter out
+// proOnly items in AdminLayout, so this only fires when a user navigates
+// to the URL directly. Redirects to the License page so the upgrade path
+// is one click away.
+function ProGate({ children }) {
+  const { isPro, loading } = useFeatureFlags();
+  if (loading) return <PageLoader />;
+  if (!isPro) return <Navigate to="/admin/license" replace />;
+  return children;
 }
 
 export default function App() {
@@ -395,7 +407,9 @@ export default function App() {
                       path="price-levels"
                       element={
                         <Suspense fallback={<PageLoader />}>
-                          <AdminPriceLevels />
+                          <ProGate>
+                            <AdminPriceLevels />
+                          </ProGate>
                         </Suspense>
                       }
                     />

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -524,6 +524,7 @@ const navGroups = [
         label: "Price Levels",
         icon: AccountingIcon,
         adminOnly: true,
+        proOnly: true,
       },
     ],
   },


### PR DESCRIPTION
PR-06 brings Core's schema in line with what PRO routes expect. Core owns all tables; PRO layers behavior on top via license_gate.

## What's in this PR

- Catalog tables: catalogs, catalog_products, customer_catalogs (new, Core-owned)
- pro_customer_price_levels junction table (new, Core-owned)
- price_levels extended: added code and sort_order columns, active property bridge for PRO compatibility
- Migration 082: fully idempotent via inspector checks — safe on fresh installs, PRO-migrated DBs, and legacy environments
- Legacy drift fix: guarded rename of active→is_active for DBs where deleted migration 041 created the table with PRO-style naming
- Price levels page gated behind PRO activation via ProGate component
- Stale .pyc cleanup (dead catalog model + old migration bytecode)

## Architecture

Core owns ALL database tables including those used exclusively by PRO features (memory #136). PRO routes consume these tables via license_gate. Community installs have the tables (empty/inert) with no routes to access them.

## Safety

- Additive only: no columns dropped, no constraints changed, no existing routes modified
- Idempotent migration: CREATE TABLE IF NOT EXISTS + column existence checks
- 4884 backend tests pass, 35 frontend tests pass, zero regressions
- ProGate prevents community users from accessing PRO-only pages via direct URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced catalog management system enabling product grouping, customer catalog assignment, and price overrides.

* **Enhancements**
  * Added code and sort order fields to price levels for improved organization and tracking.
  * Price Levels feature now restricted to PRO tier users only.

* **Database**
  * Added new tables and schema updates to support catalog functionality and enhanced price level management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->