### PR TITLE
fix: scrub real customer name from catalog.py docstring (introduced in #589)

### DIFF
--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -2,7 +2,7 @@
 Catalog models for B2B product visibility control.
 
 Catalogs allow admins to:
-- Create product groupings (e.g., "Public", "KOA Custom", "Wholesale Partners")
+- Create product groupings (e.g., "Public", "Wholesale", "VIP")
 - Assign products to one or more catalogs
 - Assign customers to one or more catalogs
 - Portal shows products from customer's assigned catalogs + public catalogs
@@ -35,8 +35,8 @@ class Catalog(Base):
 
     Examples:
     - PUBLIC: Default catalog, visible to all customers
-    - KOA-CUSTOM: Custom products only for KOA Kampgrounds
     - WHOLESALE: Products available to wholesale partners
+    - VIP: Special pricing for VIP-tier accounts
     """
     __tablename__ = "catalogs"
 


### PR DESCRIPTION
PR #589 (PR-06 Phase 1) copied a docstring example verbatim from the corresponding PRO file into Core's `app/models/catalog.py`. The example contained a real customer name. Core is the open-source public repo — that name shouldn't be there.

## What changes

- `backend/app/models/catalog.py` lines 5 and 38: replace customer-specific examples with generic placeholders (`WHOLESALE`, `VIP`)
- 2 docstring lines, 1 file, 0 runtime changes

## Verification

- `grep -n "KOA\|Kampground" backend/app/models/catalog.py` → empty
- `python -m py_compile backend/app/models/catalog.py` → clean
- `Catalog` ORM class, FK targets, columns, indexes, relationships, `__repr__` all unchanged

## Notes

- The reference also exists in PR #589's commit history (commit `0b1712f` and squash `44060ab` on main). Fix-forward only — not rewriting history. The current main tip after this PR merges will have no occurrences in the working tree.
- The same reference also exists on the PRO side in `filaops-ecosystem/filaops-pro/filaops_pro/models/catalog.py`. PR-06 Phase 2 (separate ecosystem PR, in flight) replaces that file with a re-export shim, eliminating those occurrences as a side effect of the consolidation.
- Future safeguard: a "never put real customer names in code" rule has been recorded as institutional memory so this category of leak doesn't recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated catalog category descriptions to reflect current offerings: VIP category added for special pricing on VIP-tier accounts, KOA-CUSTOM category removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->