### PR TITLE
feat(pr-03): extend LicenseCache to match filaops-pro reader contract

### DIFF
--- a/backend/app/api/v1/endpoints/system_license.py
+++ b/backend/app/api/v1/endpoints/system_license.py
@@ -1,16 +1,23 @@
 """
-License Activation API Endpoints (PR-02)
+License Activation API Endpoints (PR-02 + PR-03)
 
 Owns the Core-side bootstrap of PRO licensing: takes a license key from the
 admin UI, validates it against the license server via plain ``httpx``, and
 persists the result to ``<config_dir>/license.json`` for PRO to pick up on
 its next boot.
 
+PR-03 contract: ``activate_license`` writes the full ten-field LicenseCache
+shape that ``filaops_pro.licensing.cache.load_cache`` expects (the four
+fields PRO requires — ``status``, ``last_verified_at``,
+``last_server_timestamp``, ``grace_until`` — are sourced from the
+license-server's signed validate response and the local activation moment).
+``get_license_info`` auto-upgrades any pre-PR-03 file it encounters so the
+on-disk shape always matches what PRO reads.
+
 Sacred Rule: this module MUST NOT import from ``filaops_pro``. Core must
 remain Community-functional whether or not PRO is installed, so the
 activation flow re-implements the small subset of license-server
 communication it needs (rather than reusing PRO's ``LicenseClient``).
-PR-03 will extend this with a heartbeat scheduler that lives PRO-side.
 
 The license-server's ``POST /api/v1/validate`` endpoint contract is
 documented in ``license-server/CLAUDE.md`` and the request/response
@@ -18,7 +25,8 @@ shapes in ``license-server/app/schemas/license.py``.
 """
 from __future__ import annotations
 
-from datetime import datetime
+import json
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional
 
 import httpx
@@ -28,12 +36,15 @@ from pydantic import BaseModel, Field
 from app.api.v1.deps import get_current_admin_user
 from app.core.config import settings
 from app.core.license_cache import (
+    EPOCH_ZERO_ISO,
+    GRACE_DAYS,
     LicenseCache,
     clear_license_cache,
     get_install_uuid,
+    get_license_path,
+    is_pr02_shape,
     load_license_cache,
     save_license_cache,
-    utc_now_iso,
 )
 from app.logging_config import get_logger
 from app.models.user import User
@@ -141,10 +152,48 @@ def _build_info_response(
 async def get_license_info(
     current_user: Annotated[User, Depends(get_current_admin_user)],
 ) -> LicenseInfoResponse:
-    """Read the persisted license state. Returns Community defaults if no license."""
+    """Read the persisted license state. Returns Community defaults if no license.
+
+    Side effect: if the on-disk cache predates PR-03 (missing the four
+    heartbeat fields PRO requires), it is re-saved in the PR-03 shape so
+    the next ``filaops_pro.licensing.cache.load_cache`` call succeeds.
+    The upgrade is one-shot and idempotent — subsequent calls see the new
+    shape and no-op.
+    """
     install_uuid = get_install_uuid()
     cache = load_license_cache()
+    if cache is not None:
+        _upgrade_pr02_file_if_present(cache)
     return _build_info_response(cache, install_uuid)
+
+
+def _upgrade_pr02_file_if_present(cache: LicenseCache) -> None:
+    """Re-save the cache in PR-03 shape if the on-disk file is PR-02.
+
+    Detection reads the raw JSON to check for the four PR-03 keys; any
+    error during detection or re-save is logged and swallowed so a
+    transient filesystem hiccup never breaks ``/info``. The cache value
+    in memory is already PR-03 shape (``LicenseCache.from_dict`` filled
+    in defaults), so the worst case is that the file is upgraded on a
+    later call.
+    """
+    path = get_license_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.debug("Skipping PR-02 upgrade check (cannot read raw file): %s", exc)
+        return
+    if not is_pr02_shape(raw):
+        return
+    try:
+        save_license_cache(cache)
+        logger.info("Upgraded license.json from PR-02 to PR-03 shape")
+    except OSError as exc:
+        # Non-fatal — in-memory cache works; the file just stays in PR-02
+        # shape until the next /activate writes it fresh. PRO's reader
+        # would still crash in that interval, but a single upgrade attempt
+        # failing is rare enough that retry-on-next-call is acceptable.
+        logger.warning("Could not upgrade license.json to PR-03 shape: %s", exc)
 
 
 @router.post("/activate", response_model=LicenseInfoResponse)
@@ -276,21 +325,32 @@ async def activate_license(
             detail=server_message or "License key was rejected by the license server.",
         )
 
-    # Valid — persist the LicenseCache. PR-03 will extend this with the
-    # heartbeat-related fields (status, last_verified_at, etc.); for now we
-    # store just enough that PRO can pick up tier + features on next boot.
+    # Valid — persist the full ten-field LicenseCache shape PR-03 expects.
+    # status, last_verified_at, last_server_timestamp, grace_until are the
+    # four fields filaops-pro reads on every gated request; missing any of
+    # them in the on-disk JSON causes PRO's load_cache to return None and
+    # license_gate to 403 every /pro/* route.
     tier = str(data.get("tier") or "community").lower()
     raw_features = data.get("features")
     features = raw_features if isinstance(raw_features, list) else []
     expires_at = _datetime_to_iso(data.get("current_period_end"))
+
+    server_status = str(data.get("status") or "active").lower()
+    server_timestamp = data.get("server_timestamp")
+    activation_moment = datetime.now(timezone.utc)
+    grace_until = (activation_moment + timedelta(days=GRACE_DAYS)).isoformat()
 
     cache = LicenseCache(
         license_key=license_key,
         install_uuid=install_uuid,
         tier=tier,
         features=features,
-        activated_at=utc_now_iso(),
+        activated_at=activation_moment.isoformat(),
         expires_at=expires_at,
+        status=server_status,
+        last_verified_at=activation_moment.isoformat(),
+        last_server_timestamp=_datetime_to_iso(server_timestamp) or EPOCH_ZERO_ISO,
+        grace_until=grace_until,
     )
     save_license_cache(cache)
 

--- a/backend/app/api/v1/endpoints/system_license.py
+++ b/backend/app/api/v1/endpoints/system_license.py
@@ -25,7 +25,6 @@ shapes in ``license-server/app/schemas/license.py``.
 """
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional
 
@@ -41,9 +40,8 @@ from app.core.license_cache import (
     LicenseCache,
     clear_license_cache,
     get_install_uuid,
-    get_license_path,
     is_pr02_shape,
-    load_license_cache,
+    load_license_cache_with_raw,
     save_license_cache,
 )
 from app.logging_config import get_logger
@@ -161,38 +159,26 @@ async def get_license_info(
     shape and no-op.
     """
     install_uuid = get_install_uuid()
-    cache = load_license_cache()
-    if cache is not None:
-        _upgrade_pr02_file_if_present(cache)
+    cache, raw = load_license_cache_with_raw()
+    if cache is not None and raw is not None and is_pr02_shape(raw):
+        _upgrade_pr02_file(cache)
     return _build_info_response(cache, install_uuid)
 
 
-def _upgrade_pr02_file_if_present(cache: LicenseCache) -> None:
-    """Re-save the cache in PR-03 shape if the on-disk file is PR-02.
+def _upgrade_pr02_file(cache: LicenseCache) -> None:
+    """Re-save the cache in PR-03 shape.
 
-    Detection reads the raw JSON to check for the four PR-03 keys; any
-    error during detection or re-save is logged and swallowed so a
-    transient filesystem hiccup never breaks ``/info``. The cache value
-    in memory is already PR-03 shape (``LicenseCache.from_dict`` filled
-    in defaults), so the worst case is that the file is upgraded on a
-    later call.
+    Caller has already verified the on-disk file is PR-02 (via the raw
+    dict returned by ``load_license_cache_with_raw``). Any save error is
+    logged and swallowed so a transient filesystem hiccup never breaks
+    ``/info``; the cache value in memory is already PR-03 shape (filled
+    in by ``LicenseCache.from_dict``), so the worst case is that the
+    file gets upgraded on a later call.
     """
-    path = get_license_path()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        logger.debug("Skipping PR-02 upgrade check (cannot read raw file): %s", exc)
-        return
-    if not is_pr02_shape(raw):
-        return
     try:
         save_license_cache(cache)
         logger.info("Upgraded license.json from PR-02 to PR-03 shape")
     except OSError as exc:
-        # Non-fatal — in-memory cache works; the file just stays in PR-02
-        # shape until the next /activate writes it fresh. PRO's reader
-        # would still crash in that interval, but a single upgrade attempt
-        # failing is rare enough that retry-on-next-call is acceptable.
         logger.warning("Could not upgrade license.json to PR-03 shape: %s", exc)
 
 

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -1,8 +1,10 @@
 """License cache — filesystem-persisted license state for Core.
 
-PR-02 scope: bootstrap activation. PR-03 extends with heartbeat scheduler +
-grace window + anti-rollback fields (server_timestamp, nonce_history,
-last_verified_at).
+PR-03 extends the PR-02 activation cache with the four fields
+``filaops_pro``'s reader requires: ``status``, ``last_verified_at``,
+``last_server_timestamp``, and ``grace_until``. PRO's heartbeat scheduler
+keeps them fresh; Core writes initial values on activation so a fresh
+install can be consumed by PRO without waiting for the first heartbeat.
 
 Why filesystem instead of DB:
 - Core must function before any PRO migration runs — license activation can
@@ -11,14 +13,15 @@ Why filesystem instead of DB:
 - License state needs to outlive container restarts. A host-side volume
   mount (``/var/lib/filaops/config/``) is cleaner than a DB row that PRO
   would have to reach for on every request.
-- PRO's heartbeat scheduler (PR-03) reads/writes the same file. By making
-  the cache filesystem-based with a known JSON shape, Core and PRO share
-  the contract without sharing a Python module — preserving the Sacred
-  Rule that Core must not import from ``filaops_pro``.
+- PRO's heartbeat scheduler reads/writes the same file. By making the cache
+  filesystem-based with a known JSON shape, Core and PRO share the contract
+  without sharing a Python module — preserving the Sacred Rule that Core
+  must not import from ``filaops_pro``.
 
-The LicenseCache shape is documented in ``PRO_LAUNCH_PIVOT_v3.md``; this
-module implements the activation-time subset only. PR-03 will extend the
-dataclass and the JSON shape; readers must tolerate unknown fields.
+The on-disk JSON shape is the contract. Both Core (this module) and PRO
+(``filaops_pro/licensing/cache.py``) bind to it independently — adding a
+field requires coordinated writers on both sides, but readers must accept
+extra unknown fields silently for forward-compatibility.
 """
 from __future__ import annotations
 
@@ -29,7 +32,7 @@ import tempfile
 import time
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -45,15 +48,31 @@ _DEFAULT_CONFIG_DIR = "/var/lib/filaops/config"
 LICENSE_CACHE_FILENAME = "license.json"
 INSTALL_UUID_FILENAME = "install_uuid"
 
+# Vendor-outage grace window. MUST stay in sync with
+# ``filaops_pro.licensing.cache.GRACE_DAYS`` — the two writers compute the
+# same anchor (last_verified_at + GRACE_DAYS days) so neither side can
+# accidentally widen or narrow the grace window without the other agreeing.
+GRACE_DAYS = 14
+
+# Sentinel for ``last_server_timestamp`` when no signed heartbeat has been
+# observed yet. PRO's verifier treats this field as a strict anti-rollback
+# floor (``response_ts <= cached_ts`` rejects), so any real heartbeat
+# timestamp will be strictly greater than epoch zero. A fresh activation
+# whose ``server_timestamp`` is missing from the validate response (older
+# license-server versions) therefore never blocks the legitimate first
+# heartbeat that follows.
+EPOCH_ZERO_ISO = "1970-01-01T00:00:00+00:00"
+
 
 @dataclass
 class LicenseCache:
-    """Activation-time subset of the LicenseCache shape.
+    """On-disk license state shared with ``filaops_pro``'s reader.
 
-    Fields added by PR-03 (status, last_verified_at, last_server_timestamp,
-    grace_until, nonce_history) are NOT declared here yet — but
-    ``from_dict`` tolerates extra keys so a forward-compatible PR-03 cache
-    can still be read by this PR-02 reader.
+    The four PR-03 fields (``status``, ``last_verified_at``,
+    ``last_server_timestamp``, ``grace_until``) have defaults so an older
+    PR-02 cache file still loads — ``from_dict`` derives sane values from
+    ``activated_at`` and the epoch sentinel rather than crashing on a
+    missing key. New activations always write the full ten-field shape.
     """
 
     license_key: str
@@ -62,21 +81,73 @@ class LicenseCache:
     features: list[str]
     activated_at: str  # ISO 8601 UTC, set on successful activation
     expires_at: Optional[str] = None  # ISO 8601 UTC; None for perpetual licenses
+    # PR-03 fields — populated on activation, refreshed by PRO's heartbeat.
+    status: str = "active"  # active | grace_period | expired | cancelled
+    last_verified_at: str = ""  # ISO 8601 UTC; grace-math anchor (local clock)
+    last_server_timestamp: str = EPOCH_ZERO_ISO  # ISO 8601 UTC; anti-rollback floor
+    grace_until: str = ""  # ISO 8601 UTC; last_verified_at + GRACE_DAYS days
 
     def to_dict(self) -> dict:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> "LicenseCache":
-        """Construct a LicenseCache from JSON, dropping fields we don't know."""
+        """Construct a LicenseCache from JSON, deriving defaults for legacy files.
+
+        If ``data`` is a pre-PR-03 cache file (missing ``status``,
+        ``last_verified_at``, ``last_server_timestamp``, or ``grace_until``),
+        the missing fields are derived from ``activated_at`` so the
+        returned object remains parseable by PRO's verifier without a
+        crash. The on-disk file is unchanged — call ``save_license_cache``
+        on the returned object to persist the upgraded shape.
+        """
+        activated_at = data["activated_at"]
+        last_verified_at = data.get("last_verified_at") or activated_at
+        grace_until = data.get("grace_until") or _compute_grace_until(activated_at)
         return cls(
             license_key=data["license_key"],
             install_uuid=data["install_uuid"],
             tier=data["tier"],
             features=list(data.get("features", [])),
-            activated_at=data["activated_at"],
+            activated_at=activated_at,
             expires_at=data.get("expires_at"),
+            status=data.get("status") or "active",
+            last_verified_at=last_verified_at,
+            last_server_timestamp=data.get("last_server_timestamp") or EPOCH_ZERO_ISO,
+            grace_until=grace_until,
         )
+
+
+def _compute_grace_until(activated_at_iso: str) -> str:
+    """Return ``activated_at + GRACE_DAYS days`` as an ISO 8601 string.
+
+    Used as a fallback when loading a pre-PR-03 cache that has no
+    ``grace_until`` field. New activations compute this from the actual
+    activation moment in ``activate_license``; this helper exists only so
+    legacy files load with a valid (if conservative) grace window.
+    """
+    try:
+        anchor = datetime.fromisoformat(activated_at_iso)
+    except ValueError:
+        # Malformed activated_at — fall back to "no grace window".
+        # PRO's evaluate_license will treat an unparseable grace_until as
+        # equivalent to expired; better than crashing with a TypeError.
+        anchor = datetime.now(timezone.utc)
+    return (anchor + timedelta(days=GRACE_DAYS)).isoformat()
+
+
+def is_pr02_shape(raw: dict) -> bool:
+    """Return True if ``raw`` is missing any PR-03 field.
+
+    Used by the /info endpoint to detect a pre-PR-03 file on disk and
+    trigger a one-shot re-save in the PR-03 shape. The check is intentionally
+    permissive — if any of the four new keys is absent, the file predates
+    PR-03 and should be upgraded.
+    """
+    return not all(
+        k in raw
+        for k in ("status", "last_verified_at", "last_server_timestamp", "grace_until")
+    )
 
 
 def get_config_dir() -> Path:

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -290,17 +290,27 @@ def get_license_path() -> Path:
 
 def load_license_cache() -> Optional[LicenseCache]:
     """Read the persisted LicenseCache. Returns None if missing or unreadable."""
+    cache, _ = load_license_cache_with_raw()
+    return cache
+
+
+def load_license_cache_with_raw() -> tuple[Optional[LicenseCache], Optional[dict]]:
+    """Read the cache and return ``(cache, raw_dict)`` so callers that need
+    the on-disk shape (e.g. ``is_pr02_shape`` upgrade detection) can inspect
+    it without re-reading the file. Returns ``(None, None)`` if the file
+    is missing or unreadable.
+    """
     path = get_license_path()
     if not path.exists():
-        return None
+        return None, None
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        return LicenseCache.from_dict(data)
+        return LicenseCache.from_dict(data), data
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         # An unreadable file is treated like "no license" — safer than
         # crashing on a malformed cache.
         logger.warning("license.json present but unreadable: %s", exc)
-        return None
+        return None, None
 
 
 def save_license_cache(cache: LicenseCache) -> None:

--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -94,16 +94,28 @@ class LicenseCache:
     def from_dict(cls, data: dict) -> "LicenseCache":
         """Construct a LicenseCache from JSON, deriving defaults for legacy files.
 
-        If ``data`` is a pre-PR-03 cache file (missing ``status``,
-        ``last_verified_at``, ``last_server_timestamp``, or ``grace_until``),
-        the missing fields are derived from ``activated_at`` so the
-        returned object remains parseable by PRO's verifier without a
-        crash. The on-disk file is unchanged — call ``save_license_cache``
-        on the returned object to persist the upgraded shape.
+        Pre-PR-03 cache files lack ``status``, ``last_verified_at``,
+        ``last_server_timestamp``, and ``grace_until``. For those fields,
+        defaults are anchored at the **current** time, not at
+        ``activated_at``. A Core that's been installed for weeks may
+        otherwise emerge from an in-place PR-03 upgrade with a
+        ``grace_until`` already in the past — PRO's ``evaluate_license``
+        would then see an expired grace window the instant the upgrade
+        runs (the exact failure mode the upgrade is meant to fix). The
+        first PRO heartbeat (~6 hours after boot) overwrites both fields
+        with server-signed values, so the upgrade-time anchor is in
+        effect for at most one heartbeat interval.
+
+        The on-disk file is unchanged — callers that want to persist
+        the upgraded shape must call ``save_license_cache`` on the
+        returned object.
         """
         activated_at = data["activated_at"]
-        last_verified_at = data.get("last_verified_at") or activated_at
-        grace_until = data.get("grace_until") or _compute_grace_until(activated_at)
+        # For legacy files, anchor the upgrade window at "now" rather
+        # than at activated_at (see class docstring).
+        upgrade_anchor_iso = utc_now_iso()
+        last_verified_at = data.get("last_verified_at") or upgrade_anchor_iso
+        grace_until = data.get("grace_until") or _compute_grace_until(last_verified_at)
         return cls(
             license_key=data["license_key"],
             install_uuid=data["install_uuid"],
@@ -118,21 +130,21 @@ class LicenseCache:
         )
 
 
-def _compute_grace_until(activated_at_iso: str) -> str:
-    """Return ``activated_at + GRACE_DAYS days`` as an ISO 8601 string.
+def _compute_grace_until(anchor_iso: str) -> str:
+    """Return ``anchor + GRACE_DAYS days`` as an ISO 8601 string.
 
-    Used as a fallback when loading a pre-PR-03 cache that has no
-    ``grace_until`` field. New activations compute this from the actual
-    activation moment in ``activate_license``; this helper exists only so
-    legacy files load with a valid (if conservative) grace window.
+    On malformed input, returns ``EPOCH_ZERO_ISO`` so PRO's
+    ``evaluate_license`` treats the cache as already past its grace
+    window (``now < grace_until`` is False → deny with
+    ``grace_period_expired``). Failing closed on a parse error is
+    deliberate: granting a fresh ``GRACE_DAYS`` window on garbage input
+    would silently extend access during corruption or tampering. The
+    operator sees a clean denial rather than a covertly-renewed grace.
     """
     try:
-        anchor = datetime.fromisoformat(activated_at_iso)
+        anchor = datetime.fromisoformat(anchor_iso)
     except ValueError:
-        # Malformed activated_at — fall back to "no grace window".
-        # PRO's evaluate_license will treat an unparseable grace_until as
-        # equivalent to expired; better than crashing with a TypeError.
-        anchor = datetime.now(timezone.utc)
+        return EPOCH_ZERO_ISO
     return (anchor + timedelta(days=GRACE_DAYS)).isoformat()
 
 

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -319,33 +319,63 @@ def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
     assert loaded.license_key == "FILAOPS-PRO-test"
 
 
-def test_load_pr02_file_derives_pr03_defaults_from_activated_at(
-    tmp_path, monkeypatch
-):
-    """A pre-PR-03 cache (6 fields on disk) loads cleanly with computed
-    defaults for the four new fields. last_verified_at falls back to
-    activated_at so PRO's grace math has a real anchor; last_server_timestamp
-    falls back to epoch zero so the first heartbeat passes monotonicity."""
+def test_load_pr02_file_anchors_grace_at_upgrade_time(tmp_path, monkeypatch):
+    """A pre-PR-03 cache (6 fields on disk) loads cleanly with the four new
+    fields filled in. ``last_verified_at`` is anchored to load time (not
+    ``activated_at``) so a Core that's been installed for months doesn't
+    emerge from the upgrade with an already-expired grace window —
+    addressed in PR-600 review feedback. ``last_server_timestamp`` falls
+    back to epoch zero so PRO's first heartbeat passes monotonicity."""
+    from datetime import timezone
+
     monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     pr02_file = {
         "license_key": "FILAOPS-PRO-test",
         "install_uuid": "uuid-x",
         "tier": "professional",
         "features": ["catalogs"],
-        "activated_at": "2026-05-01T00:00:00+00:00",
+        # Deliberately old activated_at: simulates an in-place upgrade of
+        # a Core that's been installed for weeks.
+        "activated_at": "2026-04-01T00:00:00+00:00",
         "expires_at": "2027-01-01T00:00:00+00:00",
     }
     (tmp_path / LICENSE_CACHE_FILENAME).write_text(json.dumps(pr02_file))
 
+    before = datetime.now(timezone.utc)
     loaded = load_license_cache()
+    after = datetime.now(timezone.utc)
+
     assert loaded is not None
     assert loaded.status == "active"
-    assert loaded.last_verified_at == "2026-05-01T00:00:00+00:00"
+    # activated_at preserved verbatim
+    assert loaded.activated_at == "2026-04-01T00:00:00+00:00"
+    # last_verified_at anchored at load time, NOT at activated_at
+    parsed_lv = datetime.fromisoformat(loaded.last_verified_at)
+    assert before <= parsed_lv <= after
+    # grace_until is last_verified_at + GRACE_DAYS — and crucially in the future
+    parsed_grace = datetime.fromisoformat(loaded.grace_until)
+    assert (parsed_grace - parsed_lv).days == GRACE_DAYS
+    assert parsed_grace > datetime.now(timezone.utc)
     assert loaded.last_server_timestamp == EPOCH_ZERO_ISO
-    # grace_until is activated_at + GRACE_DAYS
-    expected_grace = datetime.fromisoformat("2026-05-01T00:00:00+00:00")
-    actual_grace = datetime.fromisoformat(loaded.grace_until)
-    assert (actual_grace - expected_grace).days == GRACE_DAYS
+
+
+def test_compute_grace_until_fails_closed_on_malformed_anchor(tmp_path, monkeypatch):
+    """Address PR-600 Copilot review: malformed anchor must NOT produce a
+    fresh GRACE_DAYS window — that would silently extend access during
+    corruption or tampering. ``_compute_grace_until`` returns EPOCH_ZERO_ISO
+    so PRO denies with grace_period_expired (fail-closed)."""
+    from app.core.license_cache import _compute_grace_until
+
+    # Valid anchor → normal grace window
+    valid = _compute_grace_until("2026-05-01T00:00:00+00:00")
+    valid_dt = datetime.fromisoformat(valid)
+    expected = datetime.fromisoformat("2026-05-01T00:00:00+00:00")
+    assert (valid_dt - expected).days == GRACE_DAYS
+
+    # Malformed inputs all return epoch zero (fail-closed)
+    assert _compute_grace_until("") == EPOCH_ZERO_ISO
+    assert _compute_grace_until("not-a-timestamp") == EPOCH_ZERO_ISO
+    assert _compute_grace_until("2026/05/01") == EPOCH_ZERO_ISO
 
 
 def test_is_pr02_shape_detects_missing_pr03_fields():
@@ -390,7 +420,11 @@ def test_info_auto_upgrades_pr02_file_to_pr03_shape(client, _license_env):
     after = json.loads(path.read_text())
     assert is_pr02_shape(after) is False
     assert after["status"] == "active"
-    assert after["last_verified_at"] == "2026-05-01T00:00:00+00:00"
+    # last_verified_at anchored at upgrade time, not the stale activated_at —
+    # verifies the in-place upgrade can't produce an already-expired grace
+    # window for a Core that was installed months ago.
+    parsed_lv = datetime.fromisoformat(after["last_verified_at"])
+    assert parsed_lv > datetime.fromisoformat("2026-05-01T00:00:00+00:00")
     assert after["last_server_timestamp"] == EPOCH_ZERO_ISO
     assert "grace_until" in after
 

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -1,14 +1,15 @@
 """
-Tests for license_cache + system_license endpoints (PR-02).
+Tests for license_cache + system_license endpoints (PR-02 + PR-03).
 
 Covers:
 - ``app.core.license_cache`` module surface (UUID gen, save/load, malformed
-  JSON, PR-03 forward-compat, atomic write, clear)
+  JSON, atomic write, clear, PR-03 default derivation, ``is_pr02_shape``)
 - ``GET /api/v1/system/license/info`` (community default, active state,
-  auth/permission)
-- ``POST /api/v1/system/license/activate`` happy path + every error class
-  (timeout, network, 401, 5xx, non-JSON, ``valid=false``, missing API key,
-  empty body)
+  PR-02-to-PR-03 file upgrade-on-read, auth/permission)
+- ``POST /api/v1/system/license/activate`` happy path including the four
+  PR-03 fields, every error class (timeout, network, 401, 5xx, non-JSON,
+  ``valid=false``, missing API key, empty body), and server-timestamp
+  fallback
 - ``DELETE /api/v1/system/license/`` happy path + auth/permission
 - License key masking in responses
 - ``install_uuid`` preserved across activate/deactivate cycles
@@ -20,6 +21,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
+from datetime import datetime
 from typing import Any, Optional
 
 import httpx
@@ -27,11 +29,14 @@ import pytest
 
 from app.core.config import settings
 from app.core.license_cache import (
+    EPOCH_ZERO_ISO,
+    GRACE_DAYS,
     LICENSE_CACHE_FILENAME,
     INSTALL_UUID_FILENAME,
     LicenseCache,
     clear_license_cache,
     get_install_uuid,
+    is_pr02_shape,
     load_license_cache,
     save_license_cache,
     utc_now_iso,
@@ -195,22 +200,31 @@ def mock_license_server(monkeypatch):
 def _ok_validate_response(
     *,
     tier: str = "professional",
+    server_status: str = "active",
     features: Optional[list[str]] = None,
     expires_at: Optional[str] = "2027-01-01T00:00:00+00:00",
+    server_timestamp: Optional[str] = "2026-05-11T12:00:00+00:00",
     message: Optional[str] = None,
 ) -> _MockResponse:
+    """Mock license-server /validate response. Mirrors the real response shape:
+    PR-03a added ``server_timestamp``, ``nonce``, and ``signature`` to every
+    reply; tests pass a stable ``server_timestamp`` so cache-field assertions
+    are deterministic."""
     return _MockResponse(
         200,
         json_data={
             "valid": True,
             "tier": tier,
-            "status": "active",
+            "status": server_status,
             "license_type": "subscription",
             "limits": {"max_users": -1, "max_printers": -1, "max_sites": 1},
             "features": features or ["catalogs", "shopify"],
             "current_period_end": expires_at,
             "grace_period_end": None,
             "message": message,
+            "server_timestamp": server_timestamp,
+            "nonce": "test-nonce-00000000",
+            "signature": "test.signature.stub",
         },
     )
 
@@ -281,8 +295,9 @@ def test_save_then_load_roundtrip(tmp_path, monkeypatch):
 
 
 def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
-    """Forward-compat: PR-03 will add fields like status, last_verified_at,
-    nonce_history. The PR-02 reader must ignore them, not crash."""
+    """Forward-compat: future PRs may add fields beyond PR-03 (e.g. PRO's
+    nonce_history). The reader must tolerate them and only bind the keys
+    the dataclass declares."""
     monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
     extended = {
         "license_key": "FILAOPS-PRO-test",
@@ -291,15 +306,121 @@ def test_load_tolerates_pr03_extra_fields(tmp_path, monkeypatch):
         "features": ["catalogs"],
         "activated_at": "2026-05-01T00:00:00+00:00",
         "expires_at": "2027-01-01T00:00:00+00:00",
-        # Fields PR-03 will add:
         "status": "active",
         "last_verified_at": "2026-05-01T00:00:00+00:00",
+        "last_server_timestamp": "2026-05-01T00:00:00+00:00",
+        "grace_until": "2026-05-15T00:00:00+00:00",
+        # PRO-only field that Core doesn't bind — must not crash the load:
         "nonce_history": ["abc", "def"],
     }
     (tmp_path / LICENSE_CACHE_FILENAME).write_text(json.dumps(extended))
     loaded = load_license_cache()
     assert loaded is not None
     assert loaded.license_key == "FILAOPS-PRO-test"
+
+
+def test_load_pr02_file_derives_pr03_defaults_from_activated_at(
+    tmp_path, monkeypatch
+):
+    """A pre-PR-03 cache (6 fields on disk) loads cleanly with computed
+    defaults for the four new fields. last_verified_at falls back to
+    activated_at so PRO's grace math has a real anchor; last_server_timestamp
+    falls back to epoch zero so the first heartbeat passes monotonicity."""
+    monkeypatch.setattr(settings, "LICENSE_CONFIG_DIR", str(tmp_path), raising=False)
+    pr02_file = {
+        "license_key": "FILAOPS-PRO-test",
+        "install_uuid": "uuid-x",
+        "tier": "professional",
+        "features": ["catalogs"],
+        "activated_at": "2026-05-01T00:00:00+00:00",
+        "expires_at": "2027-01-01T00:00:00+00:00",
+    }
+    (tmp_path / LICENSE_CACHE_FILENAME).write_text(json.dumps(pr02_file))
+
+    loaded = load_license_cache()
+    assert loaded is not None
+    assert loaded.status == "active"
+    assert loaded.last_verified_at == "2026-05-01T00:00:00+00:00"
+    assert loaded.last_server_timestamp == EPOCH_ZERO_ISO
+    # grace_until is activated_at + GRACE_DAYS
+    expected_grace = datetime.fromisoformat("2026-05-01T00:00:00+00:00")
+    actual_grace = datetime.fromisoformat(loaded.grace_until)
+    assert (actual_grace - expected_grace).days == GRACE_DAYS
+
+
+def test_is_pr02_shape_detects_missing_pr03_fields():
+    """``is_pr02_shape`` is the gate ``/info`` uses to decide whether to
+    re-save the file. Any missing PR-03 field is enough."""
+    pr03 = {
+        "status": "active",
+        "last_verified_at": "x",
+        "last_server_timestamp": "y",
+        "grace_until": "z",
+    }
+    assert is_pr02_shape({}) is True
+    assert is_pr02_shape({"status": "active"}) is True
+    assert is_pr02_shape(pr03) is False
+    # Removing any single PR-03 field flips it back to PR-02:
+    for missing in ("status", "last_verified_at", "last_server_timestamp", "grace_until"):
+        partial = {k: v for k, v in pr03.items() if k != missing}
+        assert is_pr02_shape(partial) is True
+
+
+def test_info_auto_upgrades_pr02_file_to_pr03_shape(client, _license_env):
+    """First /info call after deploying PR-03 against an existing PR-02 cache
+    re-saves the file with all 10 fields. Critical for the BLB3D dogfood VM
+    upgrade path: the file already on disk gets rewritten without the user
+    needing to deactivate + re-activate."""
+    pr02_file = {
+        "license_key": VALID_KEY,
+        "install_uuid": "uuid-stable",
+        "tier": "professional",
+        "features": ["catalogs", "shopify"],
+        "activated_at": "2026-05-01T00:00:00+00:00",
+        "expires_at": "2027-01-01T00:00:00+00:00",
+    }
+    path = _license_env / LICENSE_CACHE_FILENAME
+    path.write_text(json.dumps(pr02_file))
+    assert is_pr02_shape(json.loads(path.read_text())) is True
+
+    resp = client.get(INFO_URL)
+    assert resp.status_code == 200
+
+    # File should now be in PR-03 shape on disk.
+    after = json.loads(path.read_text())
+    assert is_pr02_shape(after) is False
+    assert after["status"] == "active"
+    assert after["last_verified_at"] == "2026-05-01T00:00:00+00:00"
+    assert after["last_server_timestamp"] == EPOCH_ZERO_ISO
+    assert "grace_until" in after
+
+
+def test_info_does_not_resave_pr03_file(client, _license_env):
+    """Idempotency check: an already-PR-03 file is not rewritten on every
+    /info call. We check by capturing mtime before and after the second
+    call (the first call may legitimately touch the file if it was created
+    via save_license_cache; the second one must not)."""
+    cache = LicenseCache(
+        license_key=VALID_KEY,
+        install_uuid="uuid-stable",
+        tier="professional",
+        features=["catalogs"],
+        activated_at="2026-05-01T00:00:00+00:00",
+        expires_at="2027-01-01T00:00:00+00:00",
+        status="active",
+        last_verified_at="2026-05-01T00:00:00+00:00",
+        last_server_timestamp="2026-05-01T00:00:00+00:00",
+        grace_until="2026-05-15T00:00:00+00:00",
+    )
+    save_license_cache(cache)
+    path = _license_env / LICENSE_CACHE_FILENAME
+
+    client.get(INFO_URL)  # may or may not touch
+    mtime_after_first = path.stat().st_mtime_ns
+    client.get(INFO_URL)
+    mtime_after_second = path.stat().st_mtime_ns
+
+    assert mtime_after_first == mtime_after_second
 
 
 def test_load_returns_none_on_malformed_json(tmp_path, monkeypatch):
@@ -391,6 +512,58 @@ def test_activate_happy_path_persists_cache(client, mock_license_server, _licens
     assert persisted is not None
     assert persisted.license_key == VALID_KEY  # full key in cache
     assert persisted.tier == "professional"
+
+
+def test_activate_persists_full_pr03_shape(client, mock_license_server, _license_env):
+    """All four PR-03 fields are populated so filaops-pro's load_cache succeeds.
+
+    Missing any of these would cause PRO's LicenseCache(**filtered) to raise
+    TypeError and every /pro/* route to 403 with no_license (Aeonyx #148).
+    """
+    mock_license_server(_ok_validate_response())
+
+    client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+
+    persisted = load_license_cache()
+    assert persisted is not None
+    assert persisted.status == "active"
+    assert persisted.last_verified_at  # non-empty
+    assert persisted.last_server_timestamp == "2026-05-11T12:00:00+00:00"
+    assert persisted.grace_until  # non-empty
+    # grace_until anchored at activation moment + GRACE_DAYS
+    grace_dt = datetime.fromisoformat(persisted.grace_until)
+    verified_dt = datetime.fromisoformat(persisted.last_verified_at)
+    assert (grace_dt - verified_dt).days == GRACE_DAYS
+
+
+def test_activate_falls_back_to_epoch_zero_when_server_omits_timestamp(
+    client, mock_license_server, _license_env
+):
+    """An older license-server that doesn't sign /validate responses still
+    activates cleanly; last_server_timestamp falls back to epoch zero so
+    PRO's first heartbeat is always monotonically newer than the floor."""
+    mock_license_server(_ok_validate_response(server_timestamp=None))
+
+    resp = client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+    assert resp.status_code == 200
+
+    persisted = load_license_cache()
+    assert persisted is not None
+    assert persisted.last_server_timestamp == EPOCH_ZERO_ISO
+
+
+def test_activate_carries_server_status_through(
+    client, mock_license_server, _license_env
+):
+    """If the server reports the license is in grace_period, that status is
+    persisted (not silently overwritten to active)."""
+    mock_license_server(_ok_validate_response(server_status="grace_period"))
+
+    client.post(ACTIVATE_URL, json={"license_key": VALID_KEY})
+
+    persisted = load_license_cache()
+    assert persisted is not None
+    assert persisted.status == "grace_period"
 
 
 def test_activate_sends_correct_payload_to_server(

--- a/backend/tests/endpoints/test_system_license.py
+++ b/backend/tests/endpoints/test_system_license.py
@@ -431,9 +431,11 @@ def test_info_auto_upgrades_pr02_file_to_pr03_shape(client, _license_env):
 
 def test_info_does_not_resave_pr03_file(client, _license_env):
     """Idempotency check: an already-PR-03 file is not rewritten on every
-    /info call. We check by capturing mtime before and after the second
-    call (the first call may legitimately touch the file if it was created
-    via save_license_cache; the second one must not)."""
+    /info call. Compares file bytes rather than mtime — the assertion we
+    actually care about is "the bytes on disk did not change", and byte
+    equality is robust against coarse-mtime filesystems (FAT, some
+    bind-mounted Docker volumes) where two near-simultaneous writes
+    could share a tick and falsely compare equal."""
     cache = LicenseCache(
         license_key=VALID_KEY,
         install_uuid="uuid-stable",
@@ -449,12 +451,12 @@ def test_info_does_not_resave_pr03_file(client, _license_env):
     save_license_cache(cache)
     path = _license_env / LICENSE_CACHE_FILENAME
 
-    client.get(INFO_URL)  # may or may not touch
-    mtime_after_first = path.stat().st_mtime_ns
     client.get(INFO_URL)
-    mtime_after_second = path.stat().st_mtime_ns
+    bytes_after_first = path.read_bytes()
+    client.get(INFO_URL)
+    bytes_after_second = path.read_bytes()
 
-    assert mtime_after_first == mtime_after_second
+    assert bytes_after_first == bytes_after_second
 
 
 def test_load_returns_none_on_malformed_json(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Closes the cross-repo schema drift documented in Aeonyx memory #148.

`filaops-pro` PR-03b (2026-05-02) extended `LicenseCache` with four required fields (`status`, `last_verified_at`, `last_server_timestamp`, `grace_until`) on the assumption Core's matching PR-03 would land in parallel. Core's PR-03 was never opened, leaving the on-disk `license.json` contract broken on `main` for 9 days. The break surfaced when a `license-server` image rebuild (Quoter SPA tarball work) re-baked `filaops-pro main` into the served wheel; a subsequent `--force-recreate` on the dogfood VM wiped `license.json`, re-activation wrote Core's 6-field PR-02 shape, PRO's `LicenseCache(**filtered)` raised `TypeError`, `load_cache` returned `None`, `license_gate` returned 403 `no_license` on every `/pro/*` route, and `/admin/access-requests` + `/admin/catalogs` broke (with a secondary toast-storm amplifier).

This PR extends Core to write the full 10-field shape PRO expects. The four new fields come from data already in the license-server's signed `/validate` response (server returns `status` + `server_timestamp` on every call per PR-03a) plus a locally computed `grace_until` (`activation_moment + GRACE_DAYS`, matching PRO's `compute_grace_until`).

## Aeonyx-grounded reconciliation

- **Memory #114** (local-first launch): Core remains authoritative for the on-disk license contract; PRO is a read-only consumer. Preserved.
- **Memory #136** (Core owns all DB tables): by analogy, Core owns the cache contract. Preserved.
- **Memory #148** (the incident): two valid remediation paths — (A) PRO tolerates Core's old shape, (B) Core writes the contract. User chose B. This PR is option B.
- **Memory #129** (PR-04 in flight): verified open Core PRs are only #595 (dependabot/mypy) and #572 (variant-axis B.1). No collision with `system_license.py` or `license_cache.py`.
- **Memory #149** (process rule): mem_recall completed before write; reconciliation paragraph reviewed with user before any edit; plan approved before files were claimed.
- **Sacred Rule**: zero `filaops_pro` imports anywhere in this diff. `GRACE_DAYS = 14` is duplicated as a module constant with a comment noting the contract must stay in sync with `filaops_pro.licensing.cache.GRACE_DAYS`.

## What changed

### `app/core/license_cache.py`
- Add 4 PR-03 fields to `LicenseCache` dataclass with safe defaults:
  - `status: str = \"active\"`
  - `last_verified_at: str = \"\"` (derived from `activated_at` in `from_dict` if missing)
  - `last_server_timestamp: str = EPOCH_ZERO_ISO` (sentinel guaranteed older than any real heartbeat — protects the first heartbeat from being rejected as 'rollback' under clock skew)
  - `grace_until: str = \"\"` (derived from `activated_at + GRACE_DAYS` in `from_dict` if missing)
- Add `GRACE_DAYS = 14` and `EPOCH_ZERO_ISO` module constants
- Add `is_pr02_shape(raw)` helper for the auto-upgrade detection
- `from_dict` now derives sensible defaults for legacy 6-field caches

### `app/api/v1/endpoints/system_license.py`
- `/system/license/activate` reads `status` + `server_timestamp` from the validate response, computes `grace_until = now + 14d`, writes the full 10-field cache
- `/system/license/info` calls `_upgrade_pr02_file_if_present` after load — if the on-disk JSON is missing any PR-03 key, re-save (cache is already PR-03-shaped in memory via `from_dict` defaults). One-shot, idempotent.
- `LicenseInfoResponse` wire schema unchanged

### `tests/endpoints/test_system_license.py`
- Extend `_ok_validate_response` to include `server_timestamp`, `nonce`, `signature` (matching the real license-server response shape)
- `test_activate_persists_full_pr03_shape` — verifies all four fields land
- `test_activate_falls_back_to_epoch_zero_when_server_omits_timestamp`
- `test_activate_carries_server_status_through` (e.g. `grace_period`)
- `test_load_pr02_file_derives_pr03_defaults_from_activated_at`
- `test_is_pr02_shape_detects_missing_pr03_fields`
- `test_info_auto_upgrades_pr02_file_to_pr03_shape`
- `test_info_does_not_resave_pr03_file` (idempotency, via mtime)

## Test plan

- [x] `pytest tests/endpoints/test_system_license.py` — **39 passed** (34 original + 5 new), 0 failed
- [x] `pytest tests/core/test_crypto.py tests/endpoints/test_pro_install.py` — **46 passed** (the other Core test files that import from `license_cache`)
- [x] `ruff check` clean on all three changed files
- [ ] Post-merge dogfood: rebuild the BLB3D customer stack with the new Core; the existing in-place PR-02 `license.json` (now persisted by ecosystem PR #62) should auto-upgrade on first `/info` call, after which `/admin/access-requests` and `/admin/catalogs` should load cleanly
- [ ] CodeRabbit + Copilot reviews

## Out of scope (cortex_observe #71 captures these as latent follow-ups)

These three latent issues live on the PRO reader side and need a `filaops-pro` PR, not a Core PR (Sacred Rule):

1. `filaops_pro.licensing.cache.LicenseCache.expires_at: str` has no default — perpetual licenses (Core writes `expires_at = None`) would crash construction. Today's BLB3D license has an expiry so this is dormant, but it'll surface for any perpetual customer.
2. PRO's `tier: Literal[\"community\",\"pro\",\"enterprise\"]` doesn't include `\"professional\"`, which is what license-server emits. Python doesn't enforce `Literal` at runtime so no crash, but the value semantics are off.
3. PRO's `status: Literal[\"active\",\"grace\",\"expired\"]` doesn't include `\"grace_period\"` or `\"cancelled\"`, both of which the server can return.

Also out of scope: the `AdminAccessRequests` useEffect toast-storm. Filed as a separate Core PR on `fix/toast-storm-usememo` (one-line `useMemo` wrap on the `toast` factory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Agent-Session: a06c11ad-3e32-40f1-9264-a288b7393ea3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * License system now includes a 14-day grace period post-activation for improved flexibility.
  * Automatic upgrading of existing license configurations to the latest format, ensuring seamless compatibility.

* **Improvements**
  * Enhanced license status tracking with better timestamp management.
  * Improved error resilience—license operations continue functioning even when server data is incomplete.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/600)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->