### PR TITLE
fix(toast): memoize useToast factory to neutralize storm loop

### DIFF
--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback, useMemo } from "react";
 
 const ToastContext = createContext(null);
 
@@ -22,12 +22,22 @@ export function ToastProvider({ children }) {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  const toast = {
-    success: (msg, duration) => addToast(msg, "success", duration),
-    error: (msg, duration) => addToast(msg, "error", duration),
-    warning: (msg, duration) => addToast(msg, "warning", duration),
-    info: (msg, duration) => addToast(msg, "info", duration),
-  };
+  // Memoized — without this, every render of ToastProvider (which happens
+  // on every addToast call, because `toasts` state changes) produces a new
+  // object literal. Consumers that include `toast` in a useCallback /
+  // useEffect dep array would then rebuild on every toast, re-fire their
+  // effects, and — if the effect itself calls toast.error on failure —
+  // enter an infinite "toast storm" loop. addToast is stable via the empty
+  // useCallback dep array, so the memo cache stays valid across renders.
+  const toast = useMemo(
+    () => ({
+      success: (msg, duration) => addToast(msg, "success", duration),
+      error: (msg, duration) => addToast(msg, "error", duration),
+      warning: (msg, duration) => addToast(msg, "warning", duration),
+      info: (msg, duration) => addToast(msg, "info", duration),
+    }),
+    [addToast],
+  );
 
   return (
     <ToastContext.Provider value={toast}>


### PR DESCRIPTION
## Summary

Wraps the `toast` factory object in `ToastProvider` with `useMemo([addToast])` so the context value is stable across renders. Without it, every render of `ToastProvider` (which happens on every `setToasts(...)` call) produces a new object literal, breaking referential equality for every consumer that depends on `toast`.

Closes `cortex_observe #70` (filed against `AdminAccessRequests.jsx` during the 2026-05-10 incident).

## The loop this prevents

[AdminAccessRequests.jsx:31-51](https://github.com/Blb3D/filaops/blob/main/frontend/src/pages/admin/AdminAccessRequests.jsx#L31-L51):

\`\`\`jsx
const fetchRequests = useCallback(async () => {
  try {
    const data = await api.get('/api/v1/pro/portal/admin/access-requests');
    setRequests(data);
  } catch (err) {
    toast.error('Failed to load access requests');
  } finally { setLoading(false); }
}, [api, filter, toast]);

useEffect(() => {
  if (isPro && !flagsLoading) fetchRequests();
}, [isPro, flagsLoading, fetchRequests]);
\`\`\`

If the fetch fails (e.g. PRO routes returning 403 \`no_license\` during a schema drift like Aeonyx #148), the chain is:

1. fetch fails → \`toast.error(...)\`
2. \`addToast\` → \`setToasts(...)\` → \`ToastProvider\` re-renders
3. New \`toast\` object literal → context value changes
4. \`AdminAccessRequests\` re-renders → \`useToast()\` returns new ref
5. \`fetchRequests\` useCallback rebuilds (dep \`toast\` changed) → new ref
6. \`useEffect\` re-fires (dep \`fetchRequests\` changed)
7. Loop back to step 1

Visible as a pile-up of identical toasts plus continuous request load.

## Independence from PR #600

This is an independent defensive fix. PR #600 fixes the underlying \`license_gate\` 403 chain that triggered the loop on the BLB3D VM. This PR ensures the same class of loop can't be triggered by any future 4xx on any admin page that calls \`toast.error\` inside a useEffect. They can land in either order.

## Why useMemo is correct here

\`addToast\` is wrapped in \`useCallback([], ...)\` — its identity is stable across the lifetime of the provider. The memo cache therefore never invalidates (the dep array of \`[addToast]\` is effectively a no-op dep array), and the four method references inside the factory remain stable too.

## Test plan

- [x] Single one-file change, no behavioral surface change beyond ref stability
- [x] Existing \`useToast\` consumers continue to work — the API surface (\`.success/.error/.warning/.info\`) is identical
- [ ] After both this PR and PR #600 merge: load /admin/access-requests; verify single error toast on first 403, no pile-up

## Out of scope

- No Toast.jsx interaction test added; Core's frontend has minimal vitest coverage today.
- The Aeonyx process rule (memory #149) — recall before cross-repo work — is the meta-fix that prevents future incidents of this class. This PR is the immediate code-side patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Agent-Session: 0f282673-19c5-4c14-b7ad-b397d94cc586