### PR TITLE
feat(auth): /auth/portal/login + /auth/portal/register for customer SPAs

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -27,6 +27,7 @@ from app.schemas.auth import (
     PasswordResetApprovalResponse,
     PasswordResetComplete,
     PasswordResetStatus,
+    PortalLoginRequest,
 )
 import secrets
 from app.core.config import settings
@@ -257,6 +258,193 @@ async def login_user(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Login failed due to an internal error"
         )
+
+
+# ============================================================================
+# PORTAL CUSTOMER AUTH (Quoter SPA, B2B portal)
+# ============================================================================
+#
+# Sibling endpoints to /auth/register + /auth/login above. NOT replacements:
+#   /auth/register + /auth/login    serve admin/staff via OAuth2 form data
+#   /auth/portal/register + /login  serve customer-facing SPAs via JSON
+#
+# Both write/read the same User table. account_type distinguishes them:
+#   - portal/register always creates account_type="customer"
+#     (UserRegister body has no account_type field; can't be escalated)
+#   - portal/login authenticates ONLY account_type="customer" users.
+#     Admin users get the same 401-with-generic-message that wrong-password
+#     attempts get — no enumeration of which accounts are admin vs customer.
+#
+# Tokens (JWT cookies or bearer) interoperate: a portal-customer token
+# satisfies get_current_user on any route gated by user-only auth (e.g.
+# PRO /quotes/*, which is license_gated, not admin_gated). It does NOT
+# satisfy get_current_admin_user — that still requires account_type="admin".
+#
+# Built 2026-05-11 to close the Quoter SPA login gap: the SPA was
+# calling /auth/portal/login + /auth/portal/register against URLs that
+# didn't exist, returning 404 to the user. See chat history + the install
+# runbook draft for the full context.
+
+
+@router.post("/portal/register", status_code=status.HTTP_201_CREATED)
+@limiter.limit("3/minute")  # type: ignore
+async def register_portal_customer(
+    request: Request,
+    response: Response,
+    user_data: UserRegister,
+    db: Session = Depends(get_db),
+):
+    """Register a portal customer account from a public-facing SPA.
+
+    Identical to ``/auth/register`` except:
+      - This is the customer-flow entry point (e.g. quote.<customer>.com).
+      - The account_type is hardcoded to ``"customer"`` regardless of body
+        content (UserRegister has no account_type field; admin escalation
+        is impossible at this layer).
+      - Cookie / bearer token behavior is the same: respects AUTH_MODE.
+    """
+    existing_user = db.query(User).filter(User.email == user_data.email).first()
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    password_hashed = hash_password(user_data.password)
+    new_user = User(
+        email=user_data.email,
+        password_hash=password_hashed,
+        first_name=user_data.first_name,
+        last_name=user_data.last_name,
+        company_name=user_data.company_name,
+        phone=user_data.phone,
+        status="active",
+        account_type="customer",  # explicit, not user-controlled
+        email_verified=False,
+    )
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+
+    access_token = create_access_token(new_user.id)  # type: ignore[arg-type]
+    refresh_token = create_refresh_token(new_user.id)  # type: ignore[arg-type]
+
+    token_hash = hash_refresh_token(refresh_token)
+    refresh_token_record = RefreshToken(
+        user_id=new_user.id,
+        token_hash=token_hash,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(refresh_token_record)
+    db.commit()
+
+    user_dict = UserResponse.model_validate(new_user).model_dump()
+
+    if _USE_COOKIES:
+        set_auth_cookies(response, access_token, refresh_token)
+        return {**user_dict, "token_type": "cookie"}
+
+    return {
+        **user_dict,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
+
+
+@router.post("/portal/login")
+@limiter.limit("5/minute")  # type: ignore
+async def login_portal_customer(
+    request: Request,
+    response: Response,
+    body: PortalLoginRequest,
+    db: Session = Depends(get_db),
+):
+    """Portal customer login (JSON body, not OAuth2 form).
+
+    Filters to account_type="customer" so admin users cannot authenticate
+    via the public-facing customer flow. The 401 message is intentionally
+    identical for "no such user", "wrong password", and "is an admin" —
+    that prevents the endpoint from being used to enumerate admin
+    accounts. Admins log in via ``/auth/login`` exclusively.
+    """
+    user = db.query(User).filter(User.email == body.email).first()
+
+    # Generic 401 for: no user, admin user, wrong password — same response.
+    # Prevents account-type / existence enumeration via the customer endpoint.
+    if not user or user.account_type != "customer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        password_valid = verify_password(body.password, user.password_hash)  # type: ignore[arg-type]
+    except Exception as e:
+        logger.error(f"Password verification error for user {user.id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication error. Please contact support.",
+        )
+
+    if not password_valid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User account is inactive",
+        )
+
+    # Transparent rehash (matches /auth/login)
+    if needs_rehash(body.password, user.password_hash):  # type: ignore[arg-type]
+        user.password_hash = hash_password(body.password)  # type: ignore[assignment]
+
+    user.last_login_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+    db.commit()
+    db.refresh(user)
+
+    access_token = create_access_token(user.id)  # type: ignore[arg-type]
+    refresh_token = create_refresh_token(user.id)  # type: ignore[arg-type]
+
+    token_hash = hash_refresh_token(refresh_token)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+
+    refresh_token_record = RefreshToken(
+        user_id=user.id,
+        token_hash=token_hash,
+        expires_at=expires_at,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(refresh_token_record)
+
+    # Purge expired/revoked tokens for this user (matches /auth/login pattern)
+    db.query(RefreshToken).filter(
+        RefreshToken.user_id == user.id,
+        (RefreshToken.revoked.is_(True))
+        | (RefreshToken.expires_at < datetime.now(timezone.utc).replace(tzinfo=None)),
+    ).delete(synchronize_session=False)
+
+    db.commit()
+
+    user_dict = UserResponse.model_validate(user).model_dump()
+
+    if _USE_COOKIES:
+        set_auth_cookies(response, access_token, refresh_token)
+        return {**user_dict, "message": "Login successful", "token_type": "cookie"}
+
+    return {
+        **user_dict,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
 
 
 # ============================================================================

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -79,6 +79,20 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class PortalLoginRequest(BaseModel):
+    """JSON login body for the portal customer flow (Quoter SPA, B2B portal).
+
+    Distinct from the admin login endpoint (``/auth/login``) which takes
+    OAuth2 form data (``username`` field). The Quoter SPA's
+    ``Account.jsx`` posts JSON with an ``email`` field, which this schema
+    matches. Password is required but length is not validated on login
+    (validation lives on registration); we don't want to leak password
+    policy details to login attempts.
+    """
+    email: EmailStr
+    password: str = Field(..., min_length=1)
+
+
 class UserWithTokens(UserResponse):
     """Schema for user registration response (includes tokens)"""
     access_token: str

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -16,7 +16,6 @@ Covers:
 - POST /api/v1/auth/password-reset/complete
 """
 import pytest
-from unittest.mock import patch, MagicMock
 
 BASE_URL = "/api/v1/auth"
 
@@ -540,3 +539,175 @@ class TestCookieMode:
         data = resp.json()
         assert data["token_type"] == "cookie"
         assert "access_token" not in data
+
+
+# =============================================================================
+# POST /api/v1/auth/portal/register  +  POST /api/v1/auth/portal/login
+# =============================================================================
+# Customer-facing auth for the Quoter SPA and B2B portal. Sibling endpoints
+# to /auth/register + /auth/login. Key differences:
+#   - JSON body (not OAuth2 form)
+#   - account_type always "customer" on register; filtered to "customer" on login
+#   - Admin accounts CANNOT authenticate via portal/login (same 401 as wrong
+#     password — no enumeration of which accounts are admin)
+
+@pytest.fixture
+def admin_user(db):
+    """An admin-type user, for proving the portal/login endpoint refuses them."""
+    import uuid
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    unique = uuid.uuid4().hex[:8]
+    user = User(
+        email=f"admin-{unique}@filaops.dev",
+        password_hash=hash_password("AdminPass123!"),
+        first_name="Admin",
+        last_name="User",
+        account_type="admin",
+        status="active",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+class TestPortalRegister:
+
+    def test_portal_register_creates_customer_account(self, unauthed_client, db):
+        import uuid
+        from app.models.user import User
+
+        email = f"portal-{uuid.uuid4().hex[:8]}@example.com"
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/register",
+            json={
+                "email": email,
+                "password": "SecurePass123!",
+                "first_name": "Portal",
+                "last_name": "Customer",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["email"] == email
+        assert data["account_type"] == "customer"
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+        # Verify the user landed in the DB with account_type=customer specifically.
+        # A future regression where the body let a caller escalate account_type
+        # would fail this assertion.
+        persisted = db.query(User).filter(User.email == email).first()
+        assert persisted is not None
+        assert persisted.account_type == "customer"
+
+    def test_portal_register_ignores_account_type_in_body(self, unauthed_client, db):
+        """Even if a caller sneaks `account_type` into the JSON body, it must NOT
+        escalate to admin. UserRegister has no account_type field; the endpoint
+        hardcodes ``"customer"``. This test pins that contract."""
+        import uuid
+        from app.models.user import User
+
+        email = f"escalate-{uuid.uuid4().hex[:8]}@example.com"
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/register",
+            json={
+                "email": email,
+                "password": "SecurePass123!",
+                "account_type": "admin",  # ignored by Pydantic; pin behavior
+            },
+        )
+        assert resp.status_code == 201
+        persisted = db.query(User).filter(User.email == email).first()
+        assert persisted.account_type == "customer"
+
+    def test_portal_register_duplicate_email(self, unauthed_client, registered_user):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/register",
+            json={"email": registered_user.email, "password": "SecurePass123!"},
+        )
+        assert resp.status_code == 400
+
+    def test_portal_register_weak_password(self, unauthed_client):
+        """Password policy comes from UserRegister.validate_password_strength
+        and is inherited by the portal endpoint for free."""
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/register",
+            json={"email": "weak@example.com", "password": "short"},
+        )
+        assert resp.status_code == 422
+
+    def test_portal_register_invalid_email(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/register",
+            json={"email": "not-an-email", "password": "SecurePass123!"},
+        )
+        assert resp.status_code == 422
+
+
+class TestPortalLogin:
+
+    def test_portal_login_success(self, unauthed_client, registered_user):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": registered_user.email, "password": "TestPass123!"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email"] == registered_user.email
+        assert data["account_type"] == "customer"
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_portal_login_wrong_password(self, unauthed_client, registered_user):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": registered_user.email, "password": "WrongPass456!"},
+        )
+        assert resp.status_code == 401
+        assert "email or password" in resp.json()["detail"].lower()
+
+    def test_portal_login_no_such_user(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": "nobody@example.com", "password": "WhateverPass1!"},
+        )
+        assert resp.status_code == 401
+        # Generic message — no enumeration of which emails exist
+        assert "email or password" in resp.json()["detail"].lower()
+
+    def test_portal_login_refuses_admin_account(self, unauthed_client, admin_user):
+        """SECURITY: admin accounts must NOT authenticate via the portal endpoint.
+        Returns the same generic 401 as a wrong password — no enumeration of
+        which emails belong to admins vs customers."""
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": admin_user.email, "password": "AdminPass123!"},
+        )
+        assert resp.status_code == 401
+        assert "email or password" in resp.json()["detail"].lower()
+
+    def test_portal_login_inactive_customer_returns_403(self, unauthed_client, inactive_user):
+        """An inactive customer should get a different signal (403) than a
+        wrong-credentials attempt (401) so the customer-facing UI can show a
+        'contact support' message rather than a 'wrong password' message."""
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": inactive_user.email, "password": "TestPass123!"},
+        )
+        assert resp.status_code == 403
+
+    def test_portal_login_missing_password(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": "missing@example.com"},
+        )
+        assert resp.status_code == 422
+
+    def test_portal_login_invalid_email_format(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/portal/login",
+            json={"email": "not-an-email", "password": "WhateverPass1!"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Closes the **Quoter SPA login gap** discovered today while deploying PR #65 (Quoter customer-side deploy) to the BLB3D dogfood VM. The SPA's `Account.jsx` was calling `POST /api/v1/auth/portal/{login,register}` against URLs that never existed in Core — returning 404 to every customer attempting to sign in or register.

This PR adds the two missing endpoints as **siblings** of `/auth/register` + `/auth/login`, NOT replacements. The admin/staff endpoints stay exactly as they are.

## Why two flavors instead of one

| Endpoint | Body shape | account_type filter | Use case |
|---|---|---|---|
| `/auth/register` | JSON | creates `"customer"` by default | Admin signup (rare) |
| `/auth/login` | **OAuth2 form data** | none (any active user) | Admin/staff ERP UI |
| `/auth/portal/register` | JSON | **hardcoded** `"customer"` | Quoter SPA, B2B portal |
| `/auth/portal/login` | **JSON** | **filtered** `"customer"` only | Quoter SPA, B2B portal |

Two separate flows = clean security boundary. Admin accounts cannot authenticate via the customer endpoint (which a public-facing SPA exposes). Customer accounts cannot escalate to admin via the portal register flow (the schema has no `account_type` field).

## What changed

**`app/api/v1/endpoints/auth.py`**: two new endpoints in a dedicated `PORTAL CUSTOMER AUTH` section. Reuses the existing `UserRegister` schema + JWT/refresh-token logic so password policy and token semantics stay identical.

**`app/schemas/auth.py`**: new `PortalLoginRequest` (JSON body — `email: EmailStr`, `password: str(min_length=1)`).

**`tests/api/v1/test_auth.py`**: 12 new tests across `TestPortalRegister` + `TestPortalLogin`. Drive-by cleanup of two pre-existing unused imports (`patch`, `MagicMock`) that ruff was already flagging.

## Security pins (locked in by tests)

1. **`test_portal_login_refuses_admin_account`** — admin accounts get the same generic 401 as wrong-password attempts. No enumeration of admin vs customer accounts via the portal endpoint.
2. **`test_portal_register_ignores_account_type_in_body`** — even if a caller sneaks `account_type: \"admin\"` into the JSON body, the new user gets `account_type=\"customer\"`. UserRegister has no such field, the endpoint hardcodes `\"customer\"`. Pin against future regressions.
3. **`test_portal_login_inactive_customer_returns_403`** — inactive customers get 403, not 401. This is a different signal so the SPA can show a meaningful \"contact support\" message rather than the generic wrong-credentials message.

## Token interop

A portal-customer JWT satisfies `get_current_user` on any route gated by user-only auth — including the PRO `/api/v1/pro/quotes/*` routes (which are `license_gated` only, not admin-gated). It does NOT satisfy `get_current_admin_user` — that still requires `account_type=\"admin\"`.

So after this lands, a customer can register on quote.blb3dprinting.com, get a JWT, and successfully upload an STL + get a quote without any further wiring. Same in-flight admin token reaches every admin route as before.

## Tests

- ✅ 49/49 in `tests/api/v1/test_auth.py` pass (37 existing + 12 new)
- ✅ Ruff clean on all three changed files

## Aeonyx context

- Memory #114 — local-first launch architecture: customers host the SPA, this auth lives in Core (their local Core, not a vendor service)
- Memory #149 — mem_recall before cross-repo work: done; this is the missing piece the Quoter SPA needs to function as designed
- Sacred Rule — user explicitly approved option B in chat (\"Build /api/v1/auth/portal/* customer endpoints in Core — the 'right' fix at this layer\")

## Deploy path

After merge, the BLB3D dogfood VM redeploys Core (next `--build`). Then `https://quote.blb3dprinting.com/account` → register works, login works, → upload STL works against existing PRO quote routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Agent-Session: 29a292a1-c8ba-48a5-b596-994b40fba4bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customer portal registration and login with password-based authentication.
  * Implemented automatic refresh token rotation supporting both httpOnly cookie and bearer token authentication modes.

* **Tests**
  * Expanded authentication test coverage for portal customer endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/602)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->