### PR TITLE
fix(forms): apply canonical ?? null pattern to nullable FK form fields

### DIFF
--- a/backend/app/api/v1/endpoints/spools.py
+++ b/backend/app/api/v1/endpoints/spools.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints.auth import get_current_user
 from app.models import User, MaterialSpool, ProductionOrderSpool, Product
 from app.models.production_order import ProductionOrder
 from app.models.inventory import InventoryTransaction, Inventory
+from app.schemas.spool import SpoolCreate, SpoolUpdate
 from app.services.inventory_helpers import is_material
 from app.logging_config import get_logger
 
@@ -144,53 +145,45 @@ async def get_spool(
 
 @router.post("/")
 async def create_spool(
-    spool_number: str = Query(..., description="Unique spool identifier"),
-    product_id: int = Query(..., description="Product/material ID"),
-    initial_weight_kg: float = Query(..., description="Initial weight (grams)"),
-    current_weight_kg: Optional[float] = Query(None, description="Current weight in grams (defaults to initial)"),
-    location_id: Optional[int] = Query(None, description="Storage location"),
-    supplier_lot_number: Optional[str] = Query(None, description="Supplier lot/batch number"),
-    expiry_date: Optional[datetime] = Query(None, description="Material expiry date"),
-    notes: Optional[str] = Query(None, description="Additional notes"),
+    body: SpoolCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """
     Create a new material spool.
+
+    Body fields documented in ``app.schemas.spool.SpoolCreate``. Weights are
+    in grams despite the ``_kg`` naming (pre-existing project quirk).
     """
-    # Check if spool number already exists
-    existing = db.query(MaterialSpool).filter(MaterialSpool.spool_number == spool_number).first()
+    existing = db.query(MaterialSpool).filter(MaterialSpool.spool_number == body.spool_number).first()
     if existing:
-        raise HTTPException(status_code=400, detail=f"Spool number {spool_number} already exists")
-    
-    # Verify product exists
-    product = db.query(Product).filter(Product.id == product_id).first()
+        raise HTTPException(status_code=400, detail=f"Spool number {body.spool_number} already exists")
+
+    product = db.query(Product).filter(Product.id == body.product_id).first()
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
-    
-    # Use initial weight as current if not specified
-    if current_weight_kg is None:
-        current_weight_kg = initial_weight_kg
-    
+
+    current_weight = body.current_weight_kg if body.current_weight_kg is not None else body.initial_weight_kg
+
     spool = MaterialSpool(
-        spool_number=spool_number,
-        product_id=product_id,
-        initial_weight_kg=Decimal(str(initial_weight_kg)),
-        current_weight_kg=Decimal(str(current_weight_kg)),
+        spool_number=body.spool_number,
+        product_id=body.product_id,
+        initial_weight_kg=Decimal(str(body.initial_weight_kg)),
+        current_weight_kg=Decimal(str(current_weight)),
         status="active",
-        location_id=location_id,
-        supplier_lot_number=supplier_lot_number,
-        expiry_date=expiry_date,
-        notes=notes,
+        location_id=body.location_id,
+        supplier_lot_number=body.supplier_lot_number,
+        expiry_date=body.expiry_date,
+        notes=body.notes,
         created_by=current_user.email if current_user else None,
     )
-    
+
     db.add(spool)
     db.commit()
     db.refresh(spool)
-    
-    logger.info(f"Created spool {spool_number} for product {product_id} by {current_user.email if current_user else 'system'}")
-    
+
+    logger.info(f"Created spool {body.spool_number} for product {body.product_id} by {current_user.email if current_user else 'system'}")
+
     return {
         "id": spool.id,
         "spool_number": spool.spool_number,
@@ -201,28 +194,41 @@ async def create_spool(
 @router.patch("/{spool_id}")
 async def update_spool(
     spool_id: int,
-    current_weight_g: Optional[float] = Query(None, description="Update current weight (grams)"),
-    status: Optional[str] = Query(None, description="Update status"),
-    location_id: Optional[int] = Query(None, description="Update location"),
-    notes: Optional[str] = Query(None, description="Update notes"),
-    reason: Optional[str] = Query(None, description="Reason for weight adjustment (required if adjusting weight)"),
+    body: SpoolUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """
     Update spool information (weight, status, location, notes).
-    
+
+    Uses ``model_dump(exclude_unset=True)`` so callers can:
+      - omit a field to leave it unchanged
+      - set ``location_id`` or ``notes`` to ``null`` to clear them
+      - send a concrete value to set it
+
+    Status is left under a truthy check to preserve its prior behavior
+    (sending ``"status": null`` does NOT clear status — status has no
+    meaningful null state in this system).
+
     When updating weight, this creates an inventory adjustment transaction
     and updates the product's inventory level to maintain accuracy.
     """
     spool = db.query(MaterialSpool).filter(MaterialSpool.id == spool_id).first()
     if not spool:
         raise HTTPException(status_code=404, detail="Spool not found")
-    
+
+    update_data = body.model_dump(exclude_unset=True)
     transaction_created = None
-    
+
     # Handle weight adjustment with inventory transaction
-    if current_weight_g is not None:
+    if "current_weight_g" in update_data:
+        current_weight_g = update_data["current_weight_g"]
+        if current_weight_g is None:
+            raise HTTPException(
+                status_code=400,
+                detail="current_weight_g cannot be null; omit the field to leave weight unchanged",
+            )
+        reason = update_data.get("reason")
         if not reason:
             raise HTTPException(
                 status_code=400,
@@ -336,15 +342,20 @@ async def update_spool(
             spool.status = "empty"  # type: ignore[assignment]
             logger.info(f"Spool {spool.spool_number} automatically marked as empty (weight: {float(new_weight_g)}g)")
     
-    # Handle other updates
-    if status:
-        spool.status = status  # type: ignore[assignment]
-    
-    if location_id is not None:
-        spool.location_id = location_id  # type: ignore[assignment]
-    
-    if notes is not None:
-        spool.notes = notes  # type: ignore[assignment]
+    # Status — truthy check preserves the prior behavior where
+    # null / empty does NOT clear status (no meaningful null state).
+    if update_data.get("status"):
+        spool.status = update_data["status"]  # type: ignore[assignment]
+
+    # location_id — exclude_unset semantics so an explicit null clears the FK.
+    # Pre-Copilot-fix, this used ``if location_id is not None`` which made
+    # "No location" silently no-op on edited spools.
+    if "location_id" in update_data:
+        spool.location_id = update_data["location_id"]  # type: ignore[assignment]
+
+    # notes — exclude_unset semantics so explicit null or "" clears the field.
+    if "notes" in update_data:
+        spool.notes = update_data["notes"]  # type: ignore[assignment]
     
     spool.updated_at = datetime.now(timezone.utc)  # type: ignore[assignment]
     

--- a/backend/app/schemas/spool.py
+++ b/backend/app/schemas/spool.py
@@ -1,0 +1,67 @@
+"""
+Material Spool Pydantic Schemas
+
+Body schemas for spool CRUD endpoints. PATCH uses ``model_dump(exclude_unset=True)``
+in the endpoint so callers can distinguish three intents:
+
+- field absent from body          -> leave column unchanged
+- field present with concrete value -> set column to value
+- field present with explicit null -> clear column (location_id, notes only)
+
+Without this, a UI sending ``location_id: null`` could not differentiate
+"don't touch this" from "set this to NULL" — the bug Copilot flagged on
+PR #603 where picking "No location" in AdminSpools failed to clear an
+existing location.
+
+Weight fields keep the existing project quirk: form / API field names use
+the ``_kg`` suffix while values are GRAMS. The suffix matches the
+``current_weight_kg`` DB column name; correcting the naming is out of
+scope here.
+"""
+from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SpoolCreate(BaseModel):
+    """Body for ``POST /api/v1/spools/``."""
+    spool_number: str = Field(..., min_length=1, description="Unique spool identifier")
+    product_id: int = Field(..., description="Product/material ID")
+    initial_weight_kg: float = Field(..., gt=0, description="Initial weight in grams")
+    current_weight_kg: Optional[float] = Field(
+        None, ge=0,
+        description="Current weight in grams (defaults to initial_weight_kg)",
+    )
+    location_id: Optional[int] = Field(None, description="Storage location")
+    supplier_lot_number: Optional[str] = Field(None, description="Supplier lot/batch number")
+    expiry_date: Optional[datetime] = Field(None, description="Material expiry date")
+    notes: Optional[str] = Field(None, description="Additional notes")
+
+
+class SpoolUpdate(BaseModel):
+    """Body for ``PATCH /api/v1/spools/{spool_id}``.
+
+    The endpoint inspects ``model_dump(exclude_unset=True)`` so a caller can
+    omit a field to leave it unchanged or send it explicitly as ``null`` to
+    clear it (location_id, notes). Status is left under a truthy-check in
+    the endpoint to preserve its prior behavior — sending ``"status": null``
+    will NOT clear status, matching how the field worked before this refactor.
+    """
+    current_weight_g: Optional[float] = Field(
+        None, ge=0,
+        description="Update current weight in grams; requires ``reason``",
+    )
+    status: Optional[str] = Field(None, description="Update status")
+    location_id: Optional[int] = Field(
+        None,
+        description="Update storage location; send explicit null to clear",
+    )
+    notes: Optional[str] = Field(
+        None,
+        description="Update notes; send explicit null or empty string to clear",
+    )
+    reason: Optional[str] = Field(
+        None,
+        description="Reason for weight adjustment (required when current_weight_g is set)",
+    )

--- a/backend/tests/api/v1/test_spools.py
+++ b/backend/tests/api/v1/test_spools.py
@@ -276,6 +276,44 @@ class TestUpdateWeight:
         assert resp.status_code == 400
 
 
+class TestFrontendBodyShape:
+    """Guards against the regression CodeRabbit caught: AdminSpools modal
+    used to send current_weight_g on every edit (no reason), which 400'd
+    the backend before reaching the location_id branch and silently
+    blocked the whole modal. The frontend now omits current_weight_g
+    unless the user actually edited it. These tests pin the body shapes
+    the modal sends after that fix."""
+
+    def test_modal_edit_clearing_location(self, client, db, spool):
+        """Body shape when user picks "No location" without touching weight."""
+        resp = client.patch(
+            f"{BASE_URL}/{spool.id}",
+            json={
+                "status": "active",
+                "location_id": None,
+                "notes": None,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(spool)
+        assert spool.location_id is None
+
+    def test_modal_edit_moving_location(self, client, db, spool, other_location):
+        """Body shape when user changes location to a different value."""
+        resp = client.patch(
+            f"{BASE_URL}/{spool.id}",
+            json={
+                "status": "active",
+                "location_id": other_location.id,
+                "notes": "moved to WHB",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(spool)
+        assert spool.location_id == other_location.id
+        assert spool.notes == "moved to WHB"
+
+
 # =============================================================================
 # 404 behavior
 # =============================================================================

--- a/backend/tests/api/v1/test_spools.py
+++ b/backend/tests/api/v1/test_spools.py
@@ -1,0 +1,286 @@
+"""
+Tests for Material Spool API endpoints (/api/v1/spools).
+
+Focuses on the JSON-body refactor landed alongside the canonical ?? null
+form-state pattern: ``PATCH {"location_id": null}`` must clear the column,
+while ``PATCH {}`` must leave it unchanged. This was the Copilot finding
+on PR #603 that the original URLSearchParams-based PATCH could not satisfy.
+
+Covers:
+- Auth requirements (POST and PATCH)
+- Create happy path + duplicate / unknown product validation
+- Create with location_id null
+- Update location_id (set + clear + leave-unchanged)
+- Update notes (set + clear via null + clear via empty string)
+- Update status (truthy-preserved — null does NOT clear)
+- Weight update validation (missing reason, null weight)
+"""
+from decimal import Decimal
+
+import pytest
+
+from app.models import InventoryLocation, MaterialSpool
+
+
+BASE_URL = "/api/v1/spools"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+@pytest.fixture
+def location(db):
+    """Create a storage location for spool placement."""
+    loc = InventoryLocation(name="Test Warehouse A", code="WHA")
+    db.add(loc)
+    db.commit()
+    db.refresh(loc)
+    return loc
+
+
+@pytest.fixture
+def other_location(db):
+    """A second location, for tests that move a spool between locations."""
+    loc = InventoryLocation(name="Test Warehouse B", code="WHB")
+    db.add(loc)
+    db.commit()
+    db.refresh(loc)
+    return loc
+
+
+@pytest.fixture
+def material_product(make_product):
+    """A material-type product so MaterialSpool FK is valid."""
+    return make_product(item_type="supply", unit="G")
+
+
+@pytest.fixture
+def spool(db, material_product, location):
+    """Persist a MaterialSpool directly so PATCH tests can target it."""
+    s = MaterialSpool(
+        spool_number=f"SP-{material_product.id}-A",
+        product_id=material_product.id,
+        initial_weight_kg=Decimal("1000"),
+        current_weight_kg=Decimal("950"),
+        status="active",
+        location_id=location.id,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+class TestAuth:
+    def test_create_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/",
+            json={"spool_number": "X", "product_id": 1, "initial_weight_kg": 1.0},
+        )
+        assert resp.status_code == 401
+
+    def test_update_requires_auth(self, unauthed_client):
+        resp = unauthed_client.patch(f"{BASE_URL}/1", json={"location_id": None})
+        assert resp.status_code == 401
+
+
+# =============================================================================
+# Create (POST /spools/)
+# =============================================================================
+
+class TestCreate:
+    def test_create_happy_path(self, client, material_product, location):
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "spool_number": "SP-CREATE-001",
+                "product_id": material_product.id,
+                "initial_weight_kg": 1000.0,
+                "current_weight_kg": 950.0,
+                "location_id": location.id,
+                "supplier_lot_number": "LOT-123",
+                "notes": "fresh spool",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+        data = resp.json()
+        assert data["spool_number"] == "SP-CREATE-001"
+        assert "id" in data
+
+    def test_create_without_optional_fields(self, client, material_product):
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "spool_number": "SP-CREATE-002",
+                "product_id": material_product.id,
+                "initial_weight_kg": 1000.0,
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    def test_create_with_explicit_null_location(self, client, material_product):
+        """location_id=null at create time is valid (spool with no location)."""
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "spool_number": "SP-CREATE-003",
+                "product_id": material_product.id,
+                "initial_weight_kg": 1000.0,
+                "location_id": None,
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    def test_create_duplicate_spool_number_400(self, client, material_product, spool):
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "spool_number": spool.spool_number,
+                "product_id": material_product.id,
+                "initial_weight_kg": 1000.0,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_create_unknown_product_404(self, client):
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "spool_number": "SP-CREATE-004",
+                "product_id": 999_999,
+                "initial_weight_kg": 1000.0,
+            },
+        )
+        assert resp.status_code == 404
+
+
+# =============================================================================
+# Update (PATCH /spools/{id}) — the core of this PR
+# =============================================================================
+
+class TestUpdateLocation:
+    """The Copilot fix: explicit-null in JSON body must clear location_id."""
+
+    def test_patch_explicit_null_clears_location(self, client, db, spool):
+        assert spool.location_id is not None  # baseline
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={"location_id": None})
+        assert resp.status_code == 200, resp.text
+
+        db.refresh(spool)
+        assert spool.location_id is None, "PATCH location_id=null must clear the column"
+
+    def test_patch_empty_body_leaves_location_unchanged(self, client, db, spool):
+        original_location_id = spool.location_id
+        assert original_location_id is not None
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={})
+        assert resp.status_code == 200, resp.text
+
+        db.refresh(spool)
+        assert spool.location_id == original_location_id, (
+            "PATCH {} must leave location_id untouched (exclude_unset semantics)"
+        )
+
+    def test_patch_sets_new_location(self, client, db, spool, other_location):
+        resp = client.patch(
+            f"{BASE_URL}/{spool.id}",
+            json={"location_id": other_location.id},
+        )
+        assert resp.status_code == 200, resp.text
+
+        db.refresh(spool)
+        assert spool.location_id == other_location.id
+
+
+class TestUpdateNotes:
+    def test_patch_explicit_null_clears_notes(self, client, db, spool):
+        spool.notes = "some text"
+        db.commit()
+        db.refresh(spool)
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={"notes": None})
+        assert resp.status_code == 200
+
+        db.refresh(spool)
+        assert spool.notes is None
+
+    def test_patch_empty_string_clears_notes(self, client, db, spool):
+        spool.notes = "some text"
+        db.commit()
+        db.refresh(spool)
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={"notes": ""})
+        assert resp.status_code == 200
+
+        db.refresh(spool)
+        assert spool.notes == ""
+
+    def test_patch_empty_body_leaves_notes_unchanged(self, client, db, spool):
+        spool.notes = "keep me"
+        db.commit()
+        db.refresh(spool)
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={})
+        assert resp.status_code == 200
+
+        db.refresh(spool)
+        assert spool.notes == "keep me"
+
+
+class TestUpdateStatus:
+    """Status preserves the truthy check — null does NOT clear (no meaningful null state)."""
+
+    def test_patch_sets_status(self, client, db, spool):
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={"status": "empty"})
+        assert resp.status_code == 200
+
+        db.refresh(spool)
+        assert spool.status == "empty"
+
+    def test_patch_null_status_does_not_clear(self, client, db, spool):
+        original_status = spool.status
+        assert original_status is not None
+
+        resp = client.patch(f"{BASE_URL}/{spool.id}", json={"status": None})
+        assert resp.status_code == 200
+
+        db.refresh(spool)
+        assert spool.status == original_status, (
+            "Status uses truthy-preserve; null must not clear it"
+        )
+
+
+class TestUpdateWeight:
+    """Weight-adjustment validation that the refactor must preserve."""
+
+    def test_patch_weight_requires_reason(self, client, spool):
+        resp = client.patch(
+            f"{BASE_URL}/{spool.id}",
+            json={"current_weight_g": 900.0},
+        )
+        assert resp.status_code == 400
+        assert "reason" in resp.text.lower()
+
+    def test_patch_null_weight_400(self, client, spool):
+        """Sending current_weight_g: null is nonsensical — must 400, not no-op."""
+        resp = client.patch(
+            f"{BASE_URL}/{spool.id}",
+            json={"current_weight_g": None, "reason": "test"},
+        )
+        assert resp.status_code == 400
+
+
+# =============================================================================
+# 404 behavior
+# =============================================================================
+
+class TestNotFound:
+    def test_patch_unknown_spool_404(self, client):
+        resp = client.patch(f"{BASE_URL}/999999", json={"location_id": None})
+        assert resp.status_code == 404

--- a/frontend/src/components/purchasing/POCreateModal.jsx
+++ b/frontend/src/components/purchasing/POCreateModal.jsx
@@ -70,7 +70,7 @@ export default function POCreateModal({
   };
 
   const [form, setForm] = useState({
-    vendor_id: po?.vendor_id || "",
+    vendor_id: po?.vendor_id ?? null,
     order_date: po?.order_date || new Date().toISOString().split("T")[0], // Default to today
     expected_date: po?.expected_date || "",
     tracking_number: po?.tracking_number || "",
@@ -328,9 +328,12 @@ export default function POCreateModal({
                   Vendor *
                 </label>
                 <select
-                  value={form.vendor_id}
+                  value={form.vendor_id ?? ""}
                   onChange={(e) =>
-                    setForm({ ...form, vendor_id: e.target.value })
+                    setForm({
+                      ...form,
+                      vendor_id: e.target.value ? parseInt(e.target.value, 10) : null,
+                    })
                   }
                   className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-white"
                   required

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -282,13 +282,25 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
         // to clear them. Picking "No location" must reach the backend as an
         // explicit null, not be silently dropped (Copilot PR #603 finding).
         const body = {};
-        if (form.current_weight_kg) {
-          // Pre-existing quirk preserved: form input is labeled grams but
-          // the submit historically multiplied by 1000. The modal also has
-          // no `reason` input, so weight edits via this form currently
-          // 400 on the backend regardless. Out of scope for this PR.
-          body.current_weight_g = parseFloat(form.current_weight_kg) * 1000;
+
+        // Weight: the form initializes current_weight_kg from the spool, so
+        // it's always populated. Only send current_weight_g when the user
+        // has actually edited it — otherwise every PATCH would trigger the
+        // backend's weight-adjustment branch, which requires a `reason` this
+        // modal doesn't collect (the 400 then blocks status/location/notes
+        // edits entirely). The dedicated weight-adjustment flow lives
+        // elsewhere; we surface a clear error if the user tries to use this
+        // form for it (CodeRabbit PR #603 finding).
+        const originalWeight = Number(
+          spool.current_weight_kg ?? spool.initial_weight_kg ?? 0
+        );
+        const editedWeight = Number(form.current_weight_kg);
+        if (editedWeight !== originalWeight) {
+          throw new Error(
+            "Weight updates require a reason and aren't supported from this modal yet. Use the inventory adjustment flow."
+          );
         }
+
         if (form.status) body.status = form.status;
         // Always send location_id, even when null, so "No location" clears.
         body.location_id = form.location_id;

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -260,11 +260,11 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
   const api = useApi();
   const [form, setForm] = useState({
     spool_number: spool?.spool_number || "",
-    product_id: spool?.product_id || "",
+    product_id: spool?.product_id ?? null,
     initial_weight_kg: spool?.initial_weight_kg || "",
     current_weight_kg: spool?.current_weight_kg || spool?.initial_weight_kg || "",
     status: spool?.status || "active",
-    location_id: spool?.location_id || "",
+    location_id: spool?.location_id ?? null,
     supplier_lot_number: spool?.supplier_lot_number || "",
     expiry_date: spool?.expiry_date ? spool.expiry_date.split("T")[0] : "",
     notes: spool?.notes || "",
@@ -334,8 +334,13 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
             <label className="block text-sm text-gray-400 mb-1">Material *</label>
             <select
               required
-              value={form.product_id}
-              onChange={(e) => setForm({ ...form, product_id: e.target.value })}
+              value={form.product_id ?? ""}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  product_id: e.target.value ? parseInt(e.target.value, 10) : null,
+                })
+              }
               disabled={!!spool}
               className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white disabled:opacity-50"
             >
@@ -391,8 +396,13 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
             <div>
               <label className="block text-sm text-gray-400 mb-1">Location</label>
               <select
-                value={form.location_id}
-                onChange={(e) => setForm({ ...form, location_id: e.target.value })}
+                value={form.location_id ?? ""}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    location_id: e.target.value ? parseInt(e.target.value, 10) : null,
+                  })
+                }
                 className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white"
               >
                 <option value="">No location</option>

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -276,29 +276,40 @@ function SpoolModal({ spool, products, locations, onClose, onSave }) {
     setSaving(true);
 
     try {
-      const endpoint = spool
-        ? `/api/v1/spools/${spool.id}`
-        : "/api/v1/spools";
-
-      const params = new URLSearchParams();
-      if (!spool) {
-        params.set("spool_number", form.spool_number);
-        params.set("product_id", form.product_id);
-        params.set("initial_weight_kg", form.initial_weight_kg);
-        if (form.current_weight_kg) params.set("current_weight_kg", form.current_weight_kg);
-      } else {
-        if (form.current_weight_kg) params.set("current_weight_g", form.current_weight_kg * 1000);
-        if (form.status) params.set("status", form.status);
-      }
-      if (form.location_id) params.set("location_id", form.location_id);
-      if (form.supplier_lot_number) params.set("supplier_lot_number", form.supplier_lot_number);
-      if (form.expiry_date) params.set("expiry_date", form.expiry_date);
-      if (form.notes) params.set("notes", form.notes);
-
       if (spool) {
-        await api.patch(`${endpoint}?${params}`);
+        // EDIT — JSON body with exclude_unset semantics on the backend:
+        // omit a field to leave it unchanged; send location_id/notes as null
+        // to clear them. Picking "No location" must reach the backend as an
+        // explicit null, not be silently dropped (Copilot PR #603 finding).
+        const body = {};
+        if (form.current_weight_kg) {
+          // Pre-existing quirk preserved: form input is labeled grams but
+          // the submit historically multiplied by 1000. The modal also has
+          // no `reason` input, so weight edits via this form currently
+          // 400 on the backend regardless. Out of scope for this PR.
+          body.current_weight_g = parseFloat(form.current_weight_kg) * 1000;
+        }
+        if (form.status) body.status = form.status;
+        // Always send location_id, even when null, so "No location" clears.
+        body.location_id = form.location_id;
+        // Always send notes so the user can clear them by emptying the field.
+        body.notes = form.notes || null;
+        await api.patch(`/api/v1/spools/${spool.id}`, body);
       } else {
-        await api.post(`${endpoint}?${params}`);
+        // CREATE — full body. Optional fields included only when set.
+        const body = {
+          spool_number: form.spool_number,
+          product_id: form.product_id,
+          initial_weight_kg: parseFloat(form.initial_weight_kg),
+        };
+        if (form.current_weight_kg) {
+          body.current_weight_kg = parseFloat(form.current_weight_kg);
+        }
+        if (form.location_id !== null) body.location_id = form.location_id;
+        if (form.supplier_lot_number) body.supplier_lot_number = form.supplier_lot_number;
+        if (form.expiry_date) body.expiry_date = form.expiry_date;
+        if (form.notes) body.notes = form.notes;
+        await api.post("/api/v1/spools/", body);
       }
 
       toast.success(spool ? "Spool updated" : "Spool created");


### PR DESCRIPTION
## Summary

Surfaced by the launch-readiness audit script (2026-05-12). Two related changes:

### 1. Form-state cleanup — canonical `?? null` pattern (commit `3fdc51f`)

Three admin-modal nullable FK fields migrated to the PR #578 three-part pattern:

- **AdminSpools.jsx** — `product_id` (FK → `products.id`) + `location_id` (FK → `inventory_locations.id`)
- **POCreateModal.jsx** — `vendor_id` (FK → `vendors.id`)

```js
// init
field_id: entity?.field_id ?? null,
// select control value (coerce null → "" for DOM)
value={form.field_id ?? ""}
// onChange (parse int, or null if placeholder selected)
onChange={(e) => setForm({
  ...form,
  field_id: e.target.value ? parseInt(e.target.value, 10) : null,
})}
```

### 2. Spool endpoints — JSON body so `null` actually clears (commit `a0f4743`, addresses Copilot finding)

Copilot correctly flagged ([discussion r3227260648](https://github.com/Blb3D/filaops/pull/603#discussion_r3227260648)) that the form-state cleanup alone couldn't make "No location" clear an existing `location_id` on an edited spool. Root cause:

- `URLSearchParams` can't transmit a true `null` distinct from "field absent"
- Pydantic `Optional[int] = Query(None, ...)` rejects `""` at the validation layer
- So the prior submit pipeline silently dropped the clear-intent

Fixed by matching the full PR #578 (PrinterModal) pattern end-to-end:

- **NEW** `backend/app/schemas/spool.py` — `SpoolCreate`, `SpoolUpdate`
- `backend/app/api/v1/endpoints/spools.py` — `POST /spools/` and `PATCH /spools/{spool_id}` switched to JSON body. PATCH uses `body.model_dump(exclude_unset=True)` so callers distinguish:
  - field absent → don't touch the column
  - field present with a concrete value → set it
  - field present with explicit `null` → clear it (location_id and notes only)
- `status` keeps the prior truthy-preserve behavior — it has no meaningful null state
- `frontend/src/pages/admin/AdminSpools.jsx` `handleSubmit` rewritten to use `api.post / api.patch` with a JSON body

### 3. Don't send `current_weight_g` on every PATCH (commit `f709806`, addresses CodeRabbit finding)

CodeRabbit caught ([discussion r3228933847](https://github.com/Blb3D/filaops/pull/603#discussion_r3228933847)) that `form.current_weight_kg` is always populated from the loaded spool, so every PATCH triggered the backend's weight-adjustment branch and 400'd on the missing `reason` — short-circuiting the request before the location_id branch could run. The location-clear fix from `a0f4743` was effectively unreachable from the UI.

Fixed by comparing form weight to original on submit, only sending `current_weight_g` when the user actually edited it (and throwing a clear error if they did, since this modal has no `reason` field). Also drops the `*1000` unit-conversion bug — input is grams, backend param is grams.

## Tests

- **NEW** `backend/tests/api/v1/test_spools.py` — **20 tests** covering auth, create paths, the three core PATCH semantics (`{location_id: null}` clears, `{}` leaves unchanged, `{location_id: <id>}` sets), notes clear/set, status truthy-preserve, weight validation, and frontend-body-shape regression guards for the CodeRabbit fix.
- All 20 tests pass locally and in CI Backend Unit & Integration Tests job.

## Audit false positive — left untouched

The audit also flagged `ResourceModal.jsx:14 — bambu_device_id`. That column is `String(100), nullable=True` (backend type `Optional[str]`), not an Integer FK. Pydantic accepts `""` for `Optional[str]`, so this is **not** an antipattern instance. Memory note updated so future audits don't re-trip the same false positive.

## Compatibility

- No external callers affected. The filaspool tag-reader integration uses only GET `/spools/{id}/tag-data`, POST `/spools/report-usage`, and GET `/spools/by-nfc/{uid}` — none touched.
- Other Core frontend usages (GET `/api/v1/spools`, GET `/api/v1/spools/product/{id}/available`) unchanged.
- `POCreateModal` was already using a JSON body via `onSave(data)`; `vendor_id` is a required field with three layers of validation (form `required`, handler check, explicit `parseInt`), so its clear-path doesn't exist in the first place.

## Test plan — VERIFIED

Backend (pytest):

- [x] `pytest backend/tests/api/v1/test_spools.py -v` — **20/20 pass** locally and in CI

UI (verified via Playwright against locally-built Docker stack on commit `f709806`, fresh DB):

- [x] Create a new spool with no location → saves correctly; DB column `current_weight_kg = 1000.000` for a user-entered `1000`g (verifies no `*1000` unit bug)
- [x] Edit a spool with no location → set to Warehouse A → save → reload → location shows Warehouse A (DB: `location_id = 1`)
- [x] Edit a spool with a location set → pick "No location" → save → reload → location shows "—" (DB: `location_id = None`) — **the original Copilot finding, end-to-end verified**
- [x] Edit a spool → change Status → save → location stays unchanged (verifies `exclude_unset` semantics for non-edited fields)
- [x] Edit a spool → change Current Weight → click Update → toast error "Weight updates require a reason and aren't supported from this modal yet"; DB weight unchanged; backend logs show no PATCH sent — **the CodeRabbit finding, end-to-end verified**
- [x] Edit a spool → set Notes → save → DB `notes` updated
- [x] Edit a spool → clear Notes → save → DB `notes = None`
- [x] No new browser console warnings about controlled/uncontrolled input transitions on the modified selects

Not verified in UI (out of scope for what was changed in this PR):

- [ ] POCreateModal vendor_id round-trip — covered by static + unit reasoning; the POCreateModal change is state-shape only (its submit path was already JSON, with three-layer required-field validation that prevents the clear-path being reachable)

## Out of scope

- The audit surfaced **36 unauthenticated routes** (HIGH) — triaged separately into 4 buckets (1 B / 9 C / 27 D + 0 false positives). Auth fixes will land in `fix/unauth-route-gaps`.
- The audit surfaced **29 models without Pydantic schemas** (MEDIUM) — separate triage analysis, no code changes yet. Note: this PR partially addresses `MaterialSpool` by adding `SpoolCreate` + `SpoolUpdate` (no `SpoolResponse` yet — the GET endpoints still return raw dicts).
- Two pre-existing quirks in `AdminSpools.jsx` are preserved verbatim and **not** fixed here: (a) the edit modal lacks a `reason` input so weight updates aren't supported from this modal (now surfaced as a clear error instead of a silent 400), (b) `supplier_lot_number` and `expiry_date` fields in the edit modal aren't editable because the backend PATCH schema doesn't accept them — same as prior behavior, just now done in JSON instead of being silently dropped from URLSearchParams. Both are tracked for a follow-up sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)