### PR TITLE
fix(spa): redirect /api/* paths missing trailing slash instead of serving index.html

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -564,10 +564,12 @@ load_plugin(app)
 # no user input — that's why it's safe.
 if FRONTEND_DIST is not None:
 
-    # Path prefixes the API / static layer owns. The SPA mount must never
-    # serve index.html for these, or apiClient code that parses responses
-    # as JSON will receive HTML and silently mis-interpret it.
-    _RESERVED_PREFIXES = ("api/", "static/")
+    # First URL path segments the API / static layer owns. The SPA mount
+    # must never serve index.html for these — frontend code that expects
+    # JSON would otherwise receive HTML and silently mis-interpret it.
+    # We compare against the FIRST segment (not a prefix substring), so
+    # `apidocs/foo` does not collide with `api/foo`.
+    _RESERVED_FIRST_SEGMENTS = frozenset({"api", "static"})
 
     class _SPAStaticFiles(StaticFiles):
         async def get_response(self, path: str, scope):
@@ -577,15 +579,23 @@ if FRONTEND_DIST is not None:
             # are wrong for HTTP routing decisions, so we consult the raw
             # URL path from the ASGI scope for prefix/trailing-slash checks.
             url_path = scope.get("path", "").lstrip("/")
+            first_segment, sep, _ = url_path.partition("/")
 
-            if url_path.startswith(_RESERVED_PREFIXES):
-                # API paths that reach the SPA mount didn't match any
-                # upstream route. If the path is missing a trailing slash,
-                # the most likely cause is a router whose route was
-                # registered as "/" (canonical form ends with "/"). Mirror
-                # FastAPI's redirect_slashes so the client lands on the
-                # canonical URL instead of getting index.html.
-                if not url_path.endswith("/"):
+            if first_segment in _RESERVED_FIRST_SEGMENTS:
+                # API / static paths that reach the SPA mount didn't match
+                # any upstream route. Three cases reach this branch:
+                #   1. `/api`        — bare prefix, no real endpoint to
+                #                      redirect to. Just 404.
+                #   2. `/api/v1/foo` — extra path, no trailing slash. The
+                #                      most likely cause is a router whose
+                #                      route is registered as `/`
+                #                      (canonical form ends with `/`).
+                #                      Mirror FastAPI's redirect_slashes so
+                #                      the client lands on the canonical
+                #                      URL instead of index.html.
+                #   3. `/api/v1/foo/` — already canonical, still unmatched.
+                #                       Genuine 404.
+                if sep and not url_path.endswith("/"):
                     from fastapi.responses import RedirectResponse
 
                     qs = scope.get("query_string", b"")
@@ -593,9 +603,10 @@ if FRONTEND_DIST is not None:
                     if qs:
                         target += "?" + qs.decode("latin-1")
                     return RedirectResponse(url=target, status_code=307)
-                # Already canonical and still unmatched — genuine 404.
-                # Raising HTTPException lets Starlette's default 404 JSON
-                # response flow, which is what an API client expects.
+                # Cases 1 and 3 — raise HTTPException so the request exits
+                # this mount and re-enters the parent FastAPI app's
+                # exception handler chain, which renders 404 as JSON
+                # (Starlette's bare default would be a plain text body).
                 raise StarletteHTTPException(status_code=404)
 
             try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -547,17 +547,57 @@ load_plugin(app)
 # path-traversal protection that CodeQL recognizes as a safe sink —
 # avoiding an entire category of bug (symlink races, Windows short-name
 # escapes, Unicode normalization edge cases, etc.) that hand-rolled
-# guards routinely get wrong. We subclass only to add SPA-style 404
-# fallback to index.html, which is what client-side routing needs:
-# a request like /admin/items isn't a real file, but the React router
-# can resolve it once index.html boots in the browser.
+# guards routinely get wrong. We subclass to:
+#  1. Emulate FastAPI's redirect_slashes for /api/* and /static/* paths
+#     that arrive without a trailing slash. Mounted apps win the routing
+#     decision before redirect_slashes fires upstream, so without this
+#     guard `/api/v1/purchase-orders` (no slash) would silently fall
+#     back to index.html — and the SPA's apiClient would parse the HTML
+#     body as a string, producing TypeError: pendingPOs.map crashes.
+#  2. Refuse to serve index.html for known server-side prefixes — those
+#     paths belong to the API/static layer, not the React shell.
+#  3. Add SPA-style 404 fallback to index.html for everything else,
+#     so client-side routes (e.g. /admin/items) resolve once the React
+#     router boots in the browser.
 #
 # The fallback opens a fixed path (FRONTEND_DIST / "index.html") with
 # no user input — that's why it's safe.
 if FRONTEND_DIST is not None:
 
+    # Path prefixes the API / static layer owns. The SPA mount must never
+    # serve index.html for these, or apiClient code that parses responses
+    # as JSON will receive HTML and silently mis-interpret it.
+    _RESERVED_PREFIXES = ("api/", "static/")
+
     class _SPAStaticFiles(StaticFiles):
         async def get_response(self, path: str, scope):
+            # `path` here is the os-normalised filesystem path produced by
+            # StaticFiles.get_path — on Windows it uses backslashes and
+            # `os.path.normpath` strips trailing slashes. Both behaviours
+            # are wrong for HTTP routing decisions, so we consult the raw
+            # URL path from the ASGI scope for prefix/trailing-slash checks.
+            url_path = scope.get("path", "").lstrip("/")
+
+            if url_path.startswith(_RESERVED_PREFIXES):
+                # API paths that reach the SPA mount didn't match any
+                # upstream route. If the path is missing a trailing slash,
+                # the most likely cause is a router whose route was
+                # registered as "/" (canonical form ends with "/"). Mirror
+                # FastAPI's redirect_slashes so the client lands on the
+                # canonical URL instead of getting index.html.
+                if not url_path.endswith("/"):
+                    from fastapi.responses import RedirectResponse
+
+                    qs = scope.get("query_string", b"")
+                    target = f"/{url_path}/"
+                    if qs:
+                        target += "?" + qs.decode("latin-1")
+                    return RedirectResponse(url=target, status_code=307)
+                # Already canonical and still unmatched — genuine 404.
+                # Raising HTTPException lets Starlette's default 404 JSON
+                # response flow, which is what an API client expects.
+                raise StarletteHTTPException(status_code=404)
+
             try:
                 return await super().get_response(path, scope)
             except StarletteHTTPException as exc:

--- a/backend/tests/test_main_spa_mount.py
+++ b/backend/tests/test_main_spa_mount.py
@@ -87,6 +87,58 @@ def test_api_path_without_trailing_slash_redirects_to_canonical(spa_app):
     assert "limit=5" in location, "Query string must survive the redirect"
 
 
+def test_static_path_without_trailing_slash_redirects_to_canonical(spa_app):
+    """`static/` is reserved as defense-in-depth: the `/static` StaticFiles
+    mount registers conditionally (only when its directory mkdir succeeds
+    — see backend/app/main.py around the /static mount). On a read-only
+    install the `/static` mount is skipped, and the SPA mount becomes the
+    only thing between a `/static/*` request and an index.html fallback.
+
+    Simulate that scenario by stripping the `/static` mount from the
+    route table after fixture setup, then verify the SPA mount redirects
+    the no-slash request to its canonical form instead of returning the
+    SPA shell."""
+    app, _ = spa_app
+    app.router.routes = [
+        r for r in app.router.routes if getattr(r, "path", "") != "/static"
+    ]
+    client = TestClient(app, follow_redirects=False)
+
+    resp = client.get("/static/uploads/missing-asset?cache=1")
+
+    assert resp.status_code == 307
+    location = resp.headers["location"]
+    assert location.startswith("/static/uploads/missing-asset/")
+    assert "cache=1" in location
+
+
+def test_bare_reserved_prefix_returns_404_not_index_html(spa_app):
+    """A request to `/api` (bare, no path segment after it) used to fall
+    through to the SPA shell because `_RESERVED_PREFIXES` only matched
+    `api/`. After the fix the reserved check operates on the first URL
+    segment, so bare `/api` is recognised and returns a JSON 404."""
+    app, _ = spa_app
+    client = TestClient(app, follow_redirects=False)
+
+    resp = client.get("/api")
+    assert resp.status_code == 404
+    assert "text/html" not in resp.headers.get("content-type", "")
+
+
+def test_unreserved_segment_resembling_reserved_still_falls_back(spa_app):
+    """Routing must compare against the first URL segment as a whole, not
+    a prefix substring. `/apidocs` and `/staticky/items` share opening
+    characters with reserved prefixes but are legitimate client-side
+    routes — they must still resolve to the SPA shell."""
+    app, _ = spa_app
+    client = TestClient(app)
+
+    for path in ("/apidocs", "/staticky/items"):
+        resp = client.get(path)
+        assert resp.status_code == 200, path
+        assert "spa" in resp.text, path
+
+
 def test_canonical_api_path_404_does_not_fall_back_to_index_html(spa_app):
     """Once the path is in canonical form (trailing slash) and still
     doesn't match any route, the SPA mount must let the 404 stand. Falling

--- a/backend/tests/test_main_spa_mount.py
+++ b/backend/tests/test_main_spa_mount.py
@@ -56,10 +56,15 @@ def spa_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # the whole chain — app.main, app.core.config, app.core.settings — so
     # the reload picks up the env var. Stash the prior modules so other
     # tests in the same session aren't disturbed.
+    #
+    # The import + yield both live inside the try/finally so a failure
+    # during import_module doesn't leak the popped entries — without that
+    # guard a regression in app.main would cascade into every subsequent
+    # test that imports the FastAPI app.
     cached_names = ("app.main", "app.core.config", "app.core.settings")
     priors = {name: sys.modules.pop(name, None) for name in cached_names}
-    main = importlib.import_module("app.main")
     try:
+        main = importlib.import_module("app.main")
         yield main.app, dist
     finally:
         for name in cached_names:

--- a/backend/tests/test_main_spa_mount.py
+++ b/backend/tests/test_main_spa_mount.py
@@ -1,0 +1,135 @@
+"""
+Regression tests for the SPA mount in app.main.
+
+Background:
+    PR #605 introduced an `_SPAStaticFiles` mount at "/" that falls back to
+    `index.html` for any unmatched path. That fallback masked a routing
+    quirk: FastAPI registers list endpoints as `/` under a router prefix
+    (e.g. `/api/v1/purchase-orders/`), and relies on `redirect_slashes=True`
+    to redirect `/api/v1/purchase-orders` (no slash) to the canonical
+    trailing-slash form. Mounted apps win route resolution **before**
+    redirect_slashes fires, so the SPA mount caught the no-slash request
+    and returned 200 + HTML. The SPA's `apiClient` then parsed the HTML as
+    text and stored it in dashboard state, where `string.length > 0` is
+    true but `string.map` is undefined → `TypeError: _.map is not a
+    function` on a fresh install.
+
+These tests exercise the fix:
+    * `/api/...` and `/static/...` without trailing slash → 307 to canonical
+    * Canonical-but-still-unmatched API paths → 404 (not index.html)
+    * Genuine client-side routes (e.g. `/admin/items`) → index.html
+    * Real static assets under the SPA dir still serve normally
+
+The fixture spins up a minimal `app.main` with `FRONTEND_DIST` pointed at a
+temporary directory holding a stub `index.html` + one asset, so the tests
+don't depend on the real React build.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def spa_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Reload app.main with FRONTEND_DIST pointed at a temp SPA dir.
+
+    `app.main` resolves FRONTEND_DIST at module-import time, so we have to
+    set the env var and reload the module to exercise the SPA-mount branch.
+    Once we're done we restore the original module so other tests aren't
+    affected.
+    """
+    # Stage a minimal SPA layout: index.html at root, one asset under assets/
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html><html><body>spa</body></html>")
+    (dist / "assets" / "shell.js").write_text("// spa asset")
+
+    monkeypatch.setenv("FRONTEND_DIST", str(dist))
+
+    # pydantic-settings caches the Settings instance at app.core.settings
+    # import time (via @lru_cache on get_settings()), so we have to drop
+    # the whole chain — app.main, app.core.config, app.core.settings — so
+    # the reload picks up the env var. Stash the prior modules so other
+    # tests in the same session aren't disturbed.
+    cached_names = ("app.main", "app.core.config", "app.core.settings")
+    priors = {name: sys.modules.pop(name, None) for name in cached_names}
+    main = importlib.import_module("app.main")
+    try:
+        yield main.app, dist
+    finally:
+        for name in cached_names:
+            sys.modules.pop(name, None)
+        for name, prior in priors.items():
+            if prior is not None:
+                sys.modules[name] = prior
+
+
+def test_api_path_without_trailing_slash_redirects_to_canonical(spa_app):
+    """The bug: `/api/v1/purchase-orders` (no slash) used to return 200 +
+    index.html. After the fix it must 307 to `/api/v1/purchase-orders/`
+    with the query string preserved."""
+    app, _ = spa_app
+    client = TestClient(app, follow_redirects=False)
+
+    resp = client.get("/api/v1/does-not-exist-but-shape-matters?limit=5")
+
+    assert resp.status_code == 307, (
+        "API paths without a trailing slash must redirect to the canonical "
+        "form so the apiClient never sees HTML in a JSON response."
+    )
+    location = resp.headers["location"]
+    assert location.startswith("/api/v1/does-not-exist-but-shape-matters/")
+    assert "limit=5" in location, "Query string must survive the redirect"
+
+
+def test_canonical_api_path_404_does_not_fall_back_to_index_html(spa_app):
+    """Once the path is in canonical form (trailing slash) and still
+    doesn't match any route, the SPA mount must let the 404 stand. Falling
+    back to index.html here would re-introduce the original bug for any
+    URL that actually IS misspelled or removed."""
+    app, _ = spa_app
+    client = TestClient(app, follow_redirects=False)
+
+    resp = client.get("/api/v1/genuinely-missing/")
+    assert resp.status_code == 404
+    assert "text/html" not in resp.headers.get("content-type", "")
+
+
+def test_client_side_route_falls_back_to_index_html(spa_app):
+    """The original SPA-fallback behavior is preserved for non-API paths:
+    a request to a client-side route like `/admin/items` returns the SPA
+    shell so the React router can take over."""
+    app, dist = spa_app
+    client = TestClient(app)
+
+    resp = client.get("/admin/items")
+    assert resp.status_code == 200
+    assert "spa" in resp.text  # the stub index.html body
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_real_spa_asset_serves_from_disk(spa_app):
+    """Real files under the SPA dist (hashed Vite assets, favicon, etc.)
+    must still serve their actual bytes, not the index.html fallback."""
+    app, _ = spa_app
+    client = TestClient(app)
+
+    resp = client.get("/assets/shell.js")
+    assert resp.status_code == 200
+    assert "spa asset" in resp.text
+
+
+def test_root_serves_index_html_when_spa_mounted(spa_app):
+    """When FRONTEND_DIST is set, `GET /` returns the SPA shell rather
+    than the API status JSON — confirms the root handler branch."""
+    app, _ = spa_app
+    client = TestClient(app)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<!doctype html>" in resp.text.lower()


### PR DESCRIPTION
## Summary
- PR #605's `_SPAStaticFiles` mount swallows `/api/v1/*` URLs that arrive without a trailing slash, returning 200 + `index.html` instead of letting the API serve them.
- The SPA's `apiClient` then parses the HTML body as text and stores it in dashboard state, producing `TypeError: _.map is not a function` on a fresh install of the Tauri bundle (visible immediately at `/admin` after onboarding).
- Fix: detect API paths in the mount, emit a 307 redirect to the canonical trailing-slash form (mirroring FastAPI's `redirect_slashes`), and raise 404 for canonical-but-unmatched paths so clients see a real error.

## Related Issues
Follow-up to #605. No tracker issue — surfaced during Tauri install bring-up.

## Changes
- `backend/app/main.py`: extend `_SPAStaticFiles.get_response` to:
  1. Read the raw URL path from `scope["path"]` (not the os-normalised path StaticFiles passes in — it drops trailing slashes and uses backslashes on Windows).
  2. For `api/` prefixes without a trailing slash, return `RedirectResponse(url=/path/, status_code=307)` with the query string preserved.
  3. For canonical (trailing-slash) `api/` paths that still don't match, raise `StarletteHTTPException(404)` so the client receives a proper JSON 404 instead of HTML.
  4. Leave the SPA-shell fallback for all non-reserved paths unchanged (client-side routes still work).
- `backend/tests/test_main_spa_mount.py`: new regression tests covering the redirect, the canonical-404 case, client-side route fallback, real-asset serving, and the root-handler branch.

## Root cause walkthrough
1. `app.include_router(api_v1_router, prefix="/api/v1")` registers list endpoints with `@router.get("/")` — canonical URL is `/api/v1/foo/`.
2. FastAPI's `redirect_slashes=True` normally redirects `/api/v1/foo` → `/api/v1/foo/`.
3. But the `app.mount("/", _SPAStaticFiles(...))` from #605 is a `Mount`, and Starlette tries to match mounts **before** `redirect_slashes` fires. So `/api/v1/foo` (no slash) hits the SPA mount, falls back to `index.html`, returns 200 + `text/html`.
4. The frontend's `apiClient.js:97-102` returns the raw text when JSON-parse fails, so the dashboard receives an HTML string and `pendingPOs.length > 0` evaluates to true (long string) while `pendingPOs.map` is undefined.

Reproduced with `curl http://127.0.0.1:8000/api/v1/purchase-orders?status=draft,ordered&limit=5` → 200 `<!DOCTYPE html>...` on a Tauri-bundled install built from #605.

## Testing
- [x] `pytest tests/test_main_spa_mount.py tests/core/test_paths.py` — 21 passed
- [x] `ruff check` clean on changed files
- [ ] Manual browser validation on a rebuilt Tauri installer (next step after this lands)
- [x] Fresh database tested — the dashboard repro path was on a fresh install

## Checklist
- [x] No secrets or business data committed
- [x] No PRO code in core changes
- [x] Tested on Windows (Windows-specific path-normalisation behaviour is what made the bug Windows-visible — tests cover the `\` separator path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPA fallback is now route-aware: reserved prefixes (api, static) redirect to trailing‑slash canonical URLs (307, query preserved) or return 404 when canonical but unmatched; other client-side routes still fall back to the SPA shell and real static assets continue to serve from disk.

* **Tests**
  * Added regression tests covering redirect behavior, 404 handling, SPA fallback, root serving, and asset delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/606)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->