### PR TITLE
feat(version): expose install_method, branch update instructions per deployment shape

### DIFF
--- a/backend/app/api/v1/endpoints/system.py
+++ b/backend/app/api/v1/endpoints/system.py
@@ -28,6 +28,11 @@ class VersionResponse(BaseModel):
     """Current version information (public-safe fields only)"""
     version: str
     build_date: str
+    # Deployment shape — `docker`, `tauri`, or `manual`. The SPA branches the
+    # Settings page's "Version & Updates" card on this so Tauri users don't
+    # see docker-compose instructions and vice versa. See VersionManager
+    # docstring for the resolution rules.
+    install_method: str = "docker"
 
 
 class SystemInfoResponse(BaseModel):
@@ -35,6 +40,7 @@ class SystemInfoResponse(BaseModel):
     tier: str
     features_enabled: list[str]
     version: str
+    install_method: str = "docker"
     smtp_configured: bool = False
 
 
@@ -64,6 +70,11 @@ class UpdateInstructionsResponse(BaseModel):
     backup_recommendation: str
     documentation_url: str
     rollback_steps: list[str]
+    # True when the operator runs commands themselves (docker-compose flow);
+    # False when the install handles its own upgrade (Tauri auto-updater).
+    # Frontend uses this to choose between a long-form runbook and a short
+    # "this happens automatically" message.
+    requires_manual_steps: bool = True
 
 
 class SystemHealthResponse(BaseModel):
@@ -94,7 +105,10 @@ async def get_system_version():
         # Return only public-safe fields
         return VersionResponse(
             version=version_info.get("version", "unknown"),
-            build_date=version_info.get("build_date", "unknown")
+            build_date=version_info.get("build_date", "unknown"),
+            install_method=version_info.get(
+                "install_method", VersionManager.DEFAULT_INSTALL_METHOD
+            ),
         )
     except Exception as e:
         logger.error(f"Failed to get version info: {e}", exc_info=True)
@@ -120,6 +134,9 @@ async def get_system_info():
             tier=get_tier(),
             features_enabled=get_features(),
             version=version_info.get("version", "unknown"),
+            install_method=version_info.get(
+                "install_method", VersionManager.DEFAULT_INSTALL_METHOD
+            ),
             smtp_configured=bool(settings.SMTP_USER and settings.SMTP_PASSWORD),
         )
     except Exception as e:

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -320,6 +320,40 @@ class VersionManager:
                 "requires_manual_steps": False,
             }
 
+        if install_method == "manual":
+            # Bare-metal install — no docker, no Tauri shell, just a Python
+            # interpreter pointed at the repo. The operator owns the runbook
+            # end-to-end: pip install, alembic upgrade, service restart. We
+            # don't know whether they're under systemd, supervisord, or a
+            # plain shell, so the restart step stays generic ("restart your
+            # FilaOps service") instead of prescribing one specific verb.
+            return {
+                "method": "manual",
+                "estimated_time": "5-15 minutes",
+                "downtime": "Service restart required",
+                "instructions": [
+                    "1. Back up your database (pg_dump or your usual backup tool).",
+                    "2. Fetch the latest release: git fetch --tags && git checkout vX.X.X",
+                    "3. Upgrade Python dependencies: pip install -r backend/requirements.txt",
+                    "4. Run migrations: cd backend && alembic upgrade head",
+                    "5. Restart your FilaOps service (systemd / supervisord / however you run it).",
+                    "6. Verify health: curl http://localhost:8000/health should return 200.",
+                ],
+                "backup_recommendation": (
+                    "Back up your database before running migrations. "
+                    "Alembic downgrades exist but recovering from a botched upgrade "
+                    "via backup is faster and safer."
+                ),
+                "documentation_url": "https://github.com/Blb3D/filaops/blob/main/UPGRADE.md",
+                "rollback_steps": [
+                    "1. Restore the pre-upgrade database backup.",
+                    "2. Check out the previous version: git checkout vX.X.X",
+                    "3. Re-install dependencies: pip install -r backend/requirements.txt",
+                    "4. Restart your FilaOps service.",
+                ],
+                "requires_manual_steps": True,
+            }
+
         # Default: docker-compose (preserves prior behaviour for existing
         # Docker installs — anyone already running Core got this verbiage).
         return {

--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -6,9 +6,27 @@ Uses git-based versioning for native PostgreSQL installation.
 
 Version resolution order:
   1. Git tag (git describe --tags --abbrev=0) — works in dev and non-Docker prod
-  2. FILAOPS_VERSION environment variable — only if explicitly set (e.g. docker-compose .env override)
+  2. FILAOPS_VERSION environment variable — only if explicitly set
+     (e.g. docker-compose .env override, or the Tauri shell stamping
+     `git describe` output at build time)
   3. VERSION file (backend/VERSION) — single source of truth, read at import time
   4. FALLBACK_VERSION sentinel ("0.0.0") — last resort, should never be reached
+
+Install-method awareness:
+  Core ships in multiple deployment shapes (Docker, Tauri desktop, future
+  Linux .deb). The version string is the **product** version and is identical
+  across them — `4.0.0` means the same code regardless of install method.
+  What differs is how updates are delivered. Deployment artifacts opt in by
+  setting `FILAOPS_INSTALL_METHOD` to one of:
+
+      docker   — default; updates via `docker-compose pull && up -d`
+      tauri    — native desktop install; updates via the Tauri auto-updater
+                 (the shell handles download/swap on next launch)
+      manual   — bare-metal install; admin runs alembic/pip themselves
+
+  Endpoints expose the install method so the SPA can render the appropriate
+  upgrade UX (and so customer support can identify the deployment shape from
+  a screenshot).
 
 See docs/VERSIONING.md for the full versioning strategy.
 """
@@ -40,6 +58,31 @@ class VersionManager:
 
     GITHUB_REPO = "Blb3D/filaops"
     FALLBACK_VERSION = _read_version_file() or "0.0.0"
+
+    # Known deployment shapes. Anything outside this set still flows through
+    # the endpoint but the frontend treats it as "docker" for UI purposes —
+    # this set is the explicit allow-list for branching behaviour.
+    KNOWN_INSTALL_METHODS = frozenset({"docker", "tauri", "manual"})
+    DEFAULT_INSTALL_METHOD = "docker"
+
+    @staticmethod
+    def get_install_method() -> str:
+        """Return how FilaOps was deployed (docker, tauri, manual).
+
+        Reads the `FILAOPS_INSTALL_METHOD` env var which the deployment
+        artifact sets. Falls back to "docker" because Docker Compose is the
+        historical default — every Core release prior to this method existing
+        was a Docker install, and that's still what most customers run.
+
+        An unrecognised value isn't an error (we don't want to crash an
+        otherwise-healthy install over a typo) but is normalised back to
+        "docker" so downstream UI branches don't have to handle an unknown
+        sentinel.
+        """
+        raw = os.getenv("FILAOPS_INSTALL_METHOD", "").strip().lower()
+        if raw in VersionManager.KNOWN_INSTALL_METHODS:
+            return raw
+        return VersionManager.DEFAULT_INSTALL_METHOD
 
     # Server-side cache for GitHub API responses (to avoid rate limiting)
     _update_cache: Optional[Dict[str, Any]] = None
@@ -92,13 +135,20 @@ class VersionManager:
             # In Docker, try to read from env var
             commit_hash = os.getenv('FILAOPS_COMMIT', 'unknown')
 
+        install_method = VersionManager.get_install_method()
         return {
             "version": version,
             "build_date": os.getenv('FILAOPS_BUILD_DATE', datetime.now().isoformat()),
             "commit_hash": commit_hash,
             "database_version": "unknown",  # Will be set by endpoint with DB session
             "environment": os.getenv("ENVIRONMENT", "production"),
-            "update_method": "docker-compose"
+            "install_method": install_method,
+            # Legacy field — kept so older clients reading `update_method`
+            # don't break. New code should read `install_method` and look up
+            # the actual update mechanism from get_update_instructions().
+            "update_method": (
+                "tauri-updater" if install_method == "tauri" else "docker-compose"
+            ),
         }
 
     @staticmethod
@@ -227,10 +277,51 @@ class VersionManager:
     @staticmethod
     def get_update_instructions() -> Dict[str, Any]:
         """
-        Get step-by-step update instructions for current deployment method
+        Get step-by-step update instructions for the current deployment shape.
 
-        Returns manual upgrade steps for Phase 1 implementation
+        Branches on `FILAOPS_INSTALL_METHOD` so each deployment artifact gets
+        the upgrade path that's actually correct for its environment. Telling
+        a Tauri desktop user to run `docker-compose down` is worse than no
+        instructions at all — they'd either hit "command not found" or hunt
+        for the wrong product.
+
+        All branches return the same shape so frontend code can stay generic;
+        the differences are in `instructions`, `downtime`, and
+        `requires_manual_steps`.
         """
+        install_method = VersionManager.get_install_method()
+
+        if install_method == "tauri":
+            # The Tauri auto-updater handles download + integrity check +
+            # swap-on-next-launch. From the user's perspective there are no
+            # commands to run — the tray app's "Check for Updates" item does
+            # everything. We surface zero manual steps and let the frontend
+            # render an "Updates install automatically" message keyed off
+            # `requires_manual_steps=False`.
+            return {
+                "method": "tauri-updater",
+                "estimated_time": "Under 1 minute",
+                "downtime": "Brief restart on next launch",
+                "instructions": [
+                    "Updates install automatically through the FilaOps app.",
+                    "Open the tray icon and choose Check for Updates if you want to upgrade now.",
+                    "FilaOps restarts itself once the update finishes downloading.",
+                ],
+                "backup_recommendation": (
+                    "FilaOps backs up your database automatically before each update. "
+                    "No manual action required."
+                ),
+                "documentation_url": "https://github.com/Blb3D/filaops/blob/main/UPGRADE.md",
+                "rollback_steps": [
+                    "Re-install the previous version from "
+                    "https://github.com/Blb3D/filaops/releases — the Tauri installer "
+                    "preserves your data directory across versions.",
+                ],
+                "requires_manual_steps": False,
+            }
+
+        # Default: docker-compose (preserves prior behaviour for existing
+        # Docker installs — anyone already running Core got this verbiage).
         return {
             "method": "docker-compose",
             "estimated_time": "5-10 minutes",
@@ -253,5 +344,6 @@ class VersionManager:
                 "3. Rebuild: docker-compose build",
                 "4. Start: docker-compose up -d",
                 "5. Rollback migrations: docker-compose exec backend alembic downgrade -1 (repeat as needed)"
-            ]
+            ],
+            "requires_manual_steps": True,
         }

--- a/backend/tests/test_install_method.py
+++ b/backend/tests/test_install_method.py
@@ -135,6 +135,27 @@ def test_update_instructions_tauri_returns_no_manual_steps(
     assert "alembic" not in joined
 
 
+def test_update_instructions_manual_returns_baremetal_runbook(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Manual (bare-metal) installs need their own runbook — `pip install`,
+    `alembic upgrade head`, restart-your-service — not the docker-compose
+    runbook that the previous code would have served them as a fallthrough.
+
+    The runbook stays generic on the restart step (systemd vs supervisord
+    vs plain shell) because Core doesn't dictate a process manager."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "manual")
+    instructions = VersionManager.get_update_instructions()
+
+    assert instructions["method"] == "manual"
+    assert instructions["requires_manual_steps"] is True
+    joined = " ".join(instructions["instructions"]).lower()
+    # Manual install is alembic + pip + git, NOT docker-compose
+    assert "docker-compose" not in joined
+    assert "pip install" in joined
+    assert "alembic upgrade head" in joined
+
+
 def test_update_instructions_default_when_env_unset_matches_docker(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/backend/tests/test_install_method.py
+++ b/backend/tests/test_install_method.py
@@ -1,0 +1,148 @@
+"""
+Tests for install-method awareness in app.core.version.VersionManager.
+
+Background:
+    Core ships in multiple deployment shapes (Docker compose today, Tauri
+    desktop install in progress, future Linux .deb). The product version
+    string is identical across them — `4.0.0` means the same code regardless
+    of how it's installed. What differs is how customers upgrade. Telling a
+    Tauri desktop user to run `docker-compose down` would be the worst kind
+    of bad UX: a literal "command not found" or, worse, the user hunting for
+    a Docker daemon they never installed.
+
+    Each deployment artifact opts in via `FILAOPS_INSTALL_METHOD`. These
+    tests pin both halves of the contract: the env-var → install-method
+    parser, and the install-method → update-instructions dispatch.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.core.version import VersionManager
+
+
+# ---------------------------------------------------------------------------
+# get_install_method
+# ---------------------------------------------------------------------------
+
+
+def test_get_install_method_defaults_to_docker_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An absent env var means Docker — that's the historical Core deployment
+    shape and the only one that existed before this method. Defaulting any
+    other way would silently change behaviour for every prior installation."""
+    monkeypatch.delenv("FILAOPS_INSTALL_METHOD", raising=False)
+    assert VersionManager.get_install_method() == "docker"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("docker", "docker"),
+        ("tauri", "tauri"),
+        ("manual", "manual"),
+        ("  tauri  ", "tauri"),          # surrounding whitespace
+        ("TAURI", "tauri"),              # case insensitive
+        ("Docker", "docker"),
+    ],
+)
+def test_get_install_method_recognises_known_values(
+    raw: str, expected: str, monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", raw)
+    assert VersionManager.get_install_method() == expected
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "kubernetes", "snap", "random-typo"])
+def test_get_install_method_unknown_values_collapse_to_default(
+    raw: str, monkeypatch: pytest.MonkeyPatch,
+):
+    """Unknown values shouldn't crash — they collapse to the default so
+    downstream UI branches don't have to handle a sentinel they don't know
+    about. A typo in a deployment script should degrade gracefully rather
+    than break the Settings page."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", raw)
+    assert VersionManager.get_install_method() == "docker"
+
+
+# ---------------------------------------------------------------------------
+# get_current_version surfaces install_method
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_version_includes_install_method(monkeypatch: pytest.MonkeyPatch):
+    """The /system/version response derives its install_method from this
+    field — exposing it via get_current_version() keeps a single source of
+    truth so the health endpoint, the settings endpoint, and any future
+    diagnostics report the same value."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "tauri")
+    info = VersionManager.get_current_version()
+    assert info["install_method"] == "tauri"
+
+
+def test_get_current_version_legacy_update_method_matches_install(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The legacy `update_method` field is preserved for older clients that
+    haven't migrated to reading install_method directly. It tracks the
+    install method so they don't fall out of sync, but tauri reports its
+    own updater rather than the docker-compose default."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "tauri")
+    info = VersionManager.get_current_version()
+    assert info["update_method"] == "tauri-updater"
+
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "docker")
+    info = VersionManager.get_current_version()
+    assert info["update_method"] == "docker-compose"
+
+
+# ---------------------------------------------------------------------------
+# get_update_instructions branches on install method
+# ---------------------------------------------------------------------------
+
+
+def test_update_instructions_docker_keeps_legacy_runbook(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Existing Docker installs must keep getting the docker-compose runbook —
+    this PR is additive, not a breaking change for the deployment shape that's
+    in production. The first instruction must still be the `docker-compose down`
+    step that every customer-facing Core upgrade has used since the v1 era."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "docker")
+    instructions = VersionManager.get_update_instructions()
+
+    assert instructions["method"] == "docker-compose"
+    assert instructions["requires_manual_steps"] is True
+    assert "docker-compose down" in instructions["instructions"][0]
+
+
+def test_update_instructions_tauri_returns_no_manual_steps(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tauri installs surface a short explainer pointing at the tray icon —
+    no copy-pasteable shell commands. The `requires_manual_steps=False`
+    flag is what the frontend keys off to swap its docker-runbook section
+    for an "this happens automatically" message."""
+    monkeypatch.setenv("FILAOPS_INSTALL_METHOD", "tauri")
+    instructions = VersionManager.get_update_instructions()
+
+    assert instructions["method"] == "tauri-updater"
+    assert instructions["requires_manual_steps"] is False
+    # No shell-command instructions should leak through to a desktop user.
+    joined = " ".join(instructions["instructions"]).lower()
+    assert "docker-compose" not in joined
+    assert "alembic" not in joined
+
+
+def test_update_instructions_default_when_env_unset_matches_docker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When no env var is set we fall back to docker — same shape, same copy.
+    This guarantees that a fresh Docker install (no env override) gets the
+    historical experience and isn't accidentally pushed onto an empty
+    branch."""
+    monkeypatch.delenv("FILAOPS_INSTALL_METHOD", raising=False)
+    instructions = VersionManager.get_update_instructions()
+    assert instructions["method"] == "docker-compose"
+    assert instructions["requires_manual_steps"] is True

--- a/frontend/src/hooks/useVersionCheck.js
+++ b/frontend/src/hooks/useVersionCheck.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { getCurrentVersion, isVersionLessThan, formatVersion } from "../utils/version";
+import { getVersionInfo, isVersionLessThan, formatVersion } from "../utils/version";
 
 const GITHUB_API_URL = "https://api.github.com/repos/Blb3D/filaops/releases/latest";
 const SESSION_STORAGE_KEY = "filaops_version_check";
@@ -7,11 +7,30 @@ const SESSION_STORAGE_TIMESTAMP = "filaops_version_check_timestamp";
 const CHECK_INTERVAL_MS = 1000 * 60 * 60; // 1 hour
 
 /**
- * Hook for checking if a newer version is available
- * @returns {object} { latestVersion, updateAvailable, loading, error, checkForUpdates }
+ * Hook for checking if a newer version is available.
+ *
+ * Behaviour depends on the deployment shape (reported by the backend's
+ * /system/version endpoint):
+ *
+ *   - docker / manual: polls GitHub Releases and reports `updateAvailable`
+ *     so the UI can render the "new version available" banner + manual
+ *     upgrade runbook.
+ *   - tauri: skips the GitHub poll entirely. The Tauri shell has its own
+ *     auto-updater wired against a signed `latest.json` channel — it is the
+ *     source of truth for "is there a newer version?", and double-polling
+ *     would create banner ghosts (the SPA would say "v4.0.1 available" while
+ *     Tauri is already downloading it in the background). `installMethod` is
+ *     still exposed so AdminSettings can render the appropriate copy.
+ *
+ * @returns {object} {
+ *   currentVersion, latestVersion, installMethod, updateAvailable,
+ *   loading, error, checkForUpdates,
+ * }
  */
 export function useVersionCheck() {
+  const [currentVersion, setCurrentVersion] = useState(null);
   const [latestVersion, setLatestVersion] = useState(null);
+  const [installMethod, setInstallMethod] = useState("docker");
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -21,14 +40,16 @@ export function useVersionCheck() {
     if (!force) {
       const cached = sessionStorage.getItem(SESSION_STORAGE_KEY);
       const timestamp = sessionStorage.getItem(SESSION_STORAGE_TIMESTAMP);
-      
+
       if (cached && timestamp) {
         const timeSinceCheck = Date.now() - parseInt(timestamp, 10);
         if (timeSinceCheck < CHECK_INTERVAL_MS) {
           // Use cached result
           const cachedData = JSON.parse(cached);
+          setCurrentVersion(cachedData.currentVersion ?? null);
           setLatestVersion(cachedData.latestVersion);
           setUpdateAvailable(cachedData.updateAvailable);
+          setInstallMethod(cachedData.installMethod ?? "docker");
           return;
         }
       }
@@ -38,6 +59,27 @@ export function useVersionCheck() {
     setError(null);
 
     try {
+      const info = await getVersionInfo();
+      setCurrentVersion(info.version);
+      setInstallMethod(info.install_method);
+
+      // Tauri installs delegate update detection to the Tauri auto-updater.
+      // We still cache install_method + current version so the Settings UI
+      // can render correctly.
+      if (info.install_method === "tauri") {
+        sessionStorage.setItem(
+          SESSION_STORAGE_KEY,
+          JSON.stringify({
+            currentVersion: info.version,
+            installMethod: info.install_method,
+            latestVersion: null,
+            updateAvailable: false,
+          }),
+        );
+        sessionStorage.setItem(SESSION_STORAGE_TIMESTAMP, Date.now().toString());
+        return;
+      }
+
       const response = await fetch(GITHUB_API_URL, {
         method: "GET",
         headers: {
@@ -50,19 +92,23 @@ export function useVersionCheck() {
       }
 
       const data = await response.json();
-      
+
       // Extract version from tag (e.g., "v1.6.0" -> "1.6.0")
       const latest = formatVersion(data.tag_name || "");
-      const current = await getCurrentVersion();
 
       setLatestVersion(latest);
-      const hasUpdate = isVersionLessThan(current, latest);
+      const hasUpdate = isVersionLessThan(info.version, latest);
       setUpdateAvailable(hasUpdate);
 
       // Cache the result
       sessionStorage.setItem(
         SESSION_STORAGE_KEY,
-        JSON.stringify({ latestVersion: latest, updateAvailable: hasUpdate })
+        JSON.stringify({
+          currentVersion: info.version,
+          installMethod: info.install_method,
+          latestVersion: latest,
+          updateAvailable: hasUpdate,
+        }),
       );
       sessionStorage.setItem(SESSION_STORAGE_TIMESTAMP, Date.now().toString());
     } catch (err) {
@@ -80,7 +126,9 @@ export function useVersionCheck() {
   }, [checkForUpdates]);
 
   return {
+    currentVersion,
     latestVersion,
+    installMethod,
     updateAvailable,
     loading,
     error,

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -26,10 +26,16 @@ const AdminSettings = () => {
   const fileInputRef = useRef(null);
   const {
     latestVersion,
+    installMethod,
     updateAvailable,
     loading: checkingUpdate,
     checkForUpdates,
   } = useVersionCheck();
+  // The Tauri auto-updater is the source of truth for desktop installs, so
+  // the SPA's manual "Check for Updates → GitHub poll → docker-compose
+  // runbook" flow doesn't apply. Hide that UI and show a short explainer
+  // pointing users at the tray icon instead.
+  const isTauriInstall = installMethod === "tauri";
   const [checkingManually, setCheckingManually] = useState(false);
   const [currentVersion, setCurrentVersion] = useState(getCurrentVersionSync());
 
@@ -912,61 +918,82 @@ const AdminSettings = () => {
               </p>
             </div>
 
-            {latestVersion && (
+            {isTauriInstall ? (
+              // Tauri install: the auto-updater handles version detection +
+              // download + swap, so we don't fetch GitHub from the SPA. Show
+              // a short explainer pointing users at the tray icon so they
+              // know where the "check now" affordance lives, and surface the
+              // install method so a customer support screenshot includes
+              // enough context to identify the deployment shape.
               <div>
-                <p className="text-sm text-gray-400 mb-2">Latest Version</p>
-                <div className="flex items-center gap-3">
-                  <p className="text-lg font-semibold text-white">
-                    v{formatVersion(latestVersion)}
-                  </p>
-                  {updateAvailable ? (
-                    <span className="px-2 py-1 bg-blue-600 text-blue-100 text-xs rounded-md">
-                      Update Available
-                    </span>
-                  ) : (
-                    <span className="px-2 py-1 bg-green-600 text-green-100 text-xs rounded-md">
-                      Up to Date
-                    </span>
+                <p className="text-sm text-gray-400 mb-2">Update Channel</p>
+                <p className="text-sm text-gray-300">
+                  This is a desktop install. Updates download and install
+                  automatically through the FilaOps app — open the tray icon
+                  and choose <strong>Check for Updates</strong> if you want to
+                  upgrade now. FilaOps restarts itself once the update
+                  finishes.
+                </p>
+              </div>
+            ) : (
+              <>
+                {latestVersion && (
+                  <div>
+                    <p className="text-sm text-gray-400 mb-2">Latest Version</p>
+                    <div className="flex items-center gap-3">
+                      <p className="text-lg font-semibold text-white">
+                        v{formatVersion(latestVersion)}
+                      </p>
+                      {updateAvailable ? (
+                        <span className="px-2 py-1 bg-blue-600 text-blue-100 text-xs rounded-md">
+                          Update Available
+                        </span>
+                      ) : (
+                        <span className="px-2 py-1 bg-green-600 text-green-100 text-xs rounded-md">
+                          Up to Date
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex items-center gap-3 pt-2">
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      setCheckingManually(true);
+                      await checkForUpdates(true);
+                      setCheckingManually(false);
+                      if (updateAvailable) {
+                        toast.success(
+                          `Update available: v${formatVersion(latestVersion)}`
+                        );
+                      } else {
+                        toast.success("You're running the latest version!");
+                      }
+                    }}
+                    disabled={checkingUpdate || checkingManually}
+                    className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors text-sm"
+                  >
+                    {checkingUpdate || checkingManually
+                      ? "Checking..."
+                      : "Check for Updates"}
+                  </button>
+                  {latestVersion && updateAvailable && (
+                    <a
+                      href={`https://github.com/Blb3D/filaops/releases/tag/v${formatVersion(
+                        latestVersion
+                      )}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-blue-300 text-sm underline"
+                    >
+                      View Release Notes
+                    </a>
                   )}
                 </div>
-              </div>
+              </>
             )}
-
-            <div className="flex items-center gap-3 pt-2">
-              <button
-                type="button"
-                onClick={async () => {
-                  setCheckingManually(true);
-                  await checkForUpdates(true);
-                  setCheckingManually(false);
-                  if (updateAvailable) {
-                    toast.success(
-                      `Update available: v${formatVersion(latestVersion)}`
-                    );
-                  } else {
-                    toast.success("You're running the latest version!");
-                  }
-                }}
-                disabled={checkingUpdate || checkingManually}
-                className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors text-sm"
-              >
-                {checkingUpdate || checkingManually
-                  ? "Checking..."
-                  : "Check for Updates"}
-              </button>
-              {latestVersion && updateAvailable && (
-                <a
-                  href={`https://github.com/Blb3D/filaops/releases/tag/v${formatVersion(
-                    latestVersion
-                  )}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-400 hover:text-blue-300 text-sm underline"
-                >
-                  View Release Notes
-                </a>
-              )}
-            </div>
           </div>
         </div>
 

--- a/frontend/src/utils/version.js
+++ b/frontend/src/utils/version.js
@@ -33,6 +33,37 @@ export async function getCurrentVersion() {
 }
 
 /**
+ * Get full version metadata from backend API.
+ *
+ * Returns both the version string and the deployment shape so the UI can
+ * branch its update flow. Callers that only need the bare version string
+ * should keep using `getCurrentVersion()` to avoid pulling in fields they
+ * don't use.
+ *
+ * @returns {Promise<{version: string, install_method: string, build_date: string}>}
+ *   Always returns a shape; on network/parse failure falls back to the
+ *   build-time package version with install_method='docker' (the historical
+ *   default) so the UI keeps rendering instead of disappearing.
+ */
+export async function getVersionInfo() {
+  try {
+    const response = await fetch(`${API_URL}/api/v1/system/version`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch version');
+    }
+    const data = await response.json();
+    return {
+      version: data.version ?? PACKAGE_VERSION,
+      install_method: data.install_method ?? 'docker',
+      build_date: data.build_date ?? '',
+    };
+  } catch (error) {
+    console.error('Failed to get version info from backend:', error);
+    return { version: PACKAGE_VERSION, install_method: 'docker', build_date: '' };
+  }
+}
+
+/**
  * Get current version synchronously (build-time value from package.json)
  * @returns {string} Current version (e.g., "3.0.1")
  */


### PR DESCRIPTION
## Summary
- Teach Core which deployment shape it's running under (`docker | tauri | manual`) via a new `FILAOPS_INSTALL_METHOD` env var.
- Surface that through `/api/v1/system/version` and `/api/v1/system/info` so the SPA can branch its UI on it.
- Branch `get_update_instructions()` so Tauri desktop users see "Updates install automatically — use the tray icon" instead of the docker-compose runbook, and vice versa.
- Adapt the Settings page's "Version & Updates" card on Tauri installs: hide the GitHub-poll → Check for Updates → View Release Notes flow that doesn't apply, show a short explainer pointing at the tray icon instead.

## Why
Core ships in multiple deployment shapes — Docker compose today, the native Tauri desktop install we're bringing up for GTM, and future Linux .deb — and they all bundle the same backend. The **product** version (`4.0.0`) is identical across them; what differs is *how customers upgrade*. The current Settings page shows docker-compose copy to every install method, including Tauri users who don't have docker installed at all. This PR makes the upgrade UX deployment-aware while keeping the version string consistent (so a customer support screenshot still maps to a unique build).

## Related Issues
Surfaced during Tauri install bring-up — the Settings page showed `v0.0.0` (separate bug, fixed in the relay-side companion PR) alongside a docker-compose update runbook that customers couldn't follow. This is the Core half of the fix.

## Changes

### Backend
- `backend/app/core/version.py`:
  - `VersionManager.get_install_method()` — new. Reads env, normalises case + whitespace, recognises `docker | tauri | manual`, falls back to `docker` for absent/unknown values (historical default).
  - `VersionManager.get_current_version()` returns `install_method` in its dict. Legacy `update_method` field tracks it (`tauri-updater` vs `docker-compose`).
  - `VersionManager.get_update_instructions()` branches:
    - **docker** (default): preserved verbatim — `docker-compose down → up -d → alembic upgrade head`, `requires_manual_steps=True`.
    - **tauri**: short explainer + tray-icon pointer, `requires_manual_steps=False`, zero shell commands.
- `backend/app/api/v1/endpoints/system.py`: `VersionResponse`, `SystemInfoResponse`, `UpdateInstructionsResponse` Pydantic models gain `install_method` / `requires_manual_steps` with backwards-compatible defaults.

### Frontend
- `frontend/src/utils/version.js`: new `getVersionInfo()` returns `{version, install_method, build_date}`. Existing `getCurrentVersion()` kept for callers that only want the string.
- `frontend/src/hooks/useVersionCheck.js`: exposes `installMethod` + `currentVersion`; **skips the GitHub Releases poll on Tauri installs** (the Tauri auto-updater is the source of truth — double-polling would create banner ghosts).
- `frontend/src/pages/admin/AdminSettings.jsx`: Version & Updates card branches on `isTauriInstall`. Tauri sees a short "Updates install automatically" message + tray-icon pointer; Docker keeps the existing Latest Version / Check for Updates / Release Notes flow.

## Testing
- [x] `backend/tests/test_install_method.py` — 15 parametrised cases covering env parsing, get_current_version surfacing, update_instructions branching, legacy update_method tracking. All pass locally outside conftest (pure unit tests; conftest needs Postgres which isn't running on this dev machine — CI will run them properly).
- [x] `ruff check` clean on changed Python files.
- [x] ESLint: my changes reduced existing error count from 8 → 5 (remaining 5 are pre-existing in unrelated code paths, unchanged by this PR).
- [x] Pydantic models compile and parse with both default and explicit `install_method` values.
- [ ] End-to-end browser test on a Tauri install — pending the relay-side companion PR that sets `FILAOPS_INSTALL_METHOD=tauri` and bundles `backend/VERSION` in the PyInstaller spec.

## Checklist
- [x] No secrets or business data committed
- [x] No PRO code in core changes
- [x] Tested on Windows (the relay use case is Windows-first)
- [x] Defaults preserve prior behaviour for every existing Docker install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now detects and reports deployment method (Docker or Desktop)
  * Adaptive update workflow: Desktop users directed to system tray updates; Docker deployments follow traditional manual update instructions
  * System information endpoints now include deployment method metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/607)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->