### PR TITLE
fix(quotes): keep portal checkout pending until payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.
+- Portal multi-color print selections are snapshotted to `QuoteMaterial` rows so selected red/yellow/black slot colors do not collapse back to the default single color.
+
 ## [4.0.0] - 2026-04-14
 
 ### Added

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -7,14 +7,14 @@ Supports creating quotes, updating status, and converting to sales orders.
 from datetime import datetime, timezone, timedelta
 from inspect import isawaitable
 from typing import Any, List, Optional
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, status, Query, UploadFile, File, Form, HTTPException, Request
 from fastapi.responses import StreamingResponse, Response
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.models.quote import Quote, QuoteFile
+from app.models.quote import Quote, QuoteFile, QuoteMaterial
 from app.models.user import User
 from app.logging_config import get_logger
 from app.api.v1.endpoints.auth import get_current_user
@@ -338,6 +338,50 @@ def _apply_portal_shipping(quote: Quote, current_user: User, payload: PortalShip
         current_user.phone = payload.shipping_phone
 
 
+def _apply_portal_print_selection(
+    db: Session,
+    quote: Quote,
+    payload: PortalShippingSelection,
+) -> None:
+    """Persist customer print-mode choices captured before checkout."""
+    if payload.print_mode != "multi" or not payload.multi_color_info:
+        return
+
+    slot_colors = payload.multi_color_info.get("slot_colors") or []
+    if not isinstance(slot_colors, list) or not slot_colors:
+        return
+
+    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
+        synchronize_session=False
+    )
+
+    quote.color = "MULTI_COLOR"
+    primary_slot = payload.multi_color_info.get("primary_slot")
+    for slot in slot_colors:
+        if not isinstance(slot, dict):
+            continue
+
+        try:
+            slot_number = int(slot.get("slot") or 0)
+            grams = Decimal(str(slot.get("weight_grams") or 0))
+        except (TypeError, ValueError, InvalidOperation):
+            continue
+
+        if slot_number < 1:
+            continue
+
+        db.add(QuoteMaterial(
+            quote_id=quote.id,
+            slot_number=slot_number,
+            is_primary=bool(slot.get("is_primary")) or slot_number == primary_slot,
+            material_type=quote.material_type or "PLA_BASIC",
+            color_code=slot.get("color_code"),
+            color_name=slot.get("color_name"),
+            color_hex=slot.get("color_hex"),
+            material_grams=grams,
+        ))
+
+
 # ============================================================================
 # ENDPOINTS
 # ============================================================================
@@ -454,13 +498,14 @@ async def accept_portal_quote(
     """Snapshot shipping selection and mark a portal quote accepted or awaiting review."""
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
+    _apply_portal_print_selection(db, quote, payload)
 
     requires_review = bool(quote.requires_review_reason)
     if requires_review:
         quote.status = "pending"
         quote.approval_method = "manual"
     else:
-        quote.status = "accepted"
+        quote.status = "approved"
         quote.approval_method = quote.approval_method or "auto"
         quote.approved_at = quote.approved_at or datetime.now(timezone.utc).replace(tzinfo=None)
 
@@ -469,7 +514,7 @@ async def accept_portal_quote(
     return {
         **_portal_quote_payload(quote),
         "requires_review": requires_review,
-        "message": "Quote requires manual review" if requires_review else "Quote accepted",
+        "message": "Quote requires manual review" if requires_review else "Quote ready for checkout",
     }
 
 

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -351,34 +351,56 @@ def _apply_portal_print_selection(
     if not isinstance(slot_colors, list) or not slot_colors:
         return
 
-    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
-        synchronize_session=False
-    )
+    def _coerce_int(value: Any) -> Optional[int]:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
-    quote.color = "MULTI_COLOR"
-    primary_slot = payload.multi_color_info.get("primary_slot")
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    primary_slot = _coerce_int(payload.multi_color_info.get("primary_slot"))
+    parsed_slots: list[dict[str, Any]] = []
     for slot in slot_colors:
         if not isinstance(slot, dict):
             continue
 
         try:
-            slot_number = int(slot.get("slot") or 0)
+            slot_number = _coerce_int(slot.get("slot"))
             grams = Decimal(str(slot.get("weight_grams") or 0))
         except (TypeError, ValueError, InvalidOperation):
             continue
 
-        if slot_number < 1:
+        if slot_number is None or slot_number < 1 or slot_number > 16 or grams < 0:
             continue
 
+        parsed_slots.append({
+            "slot_number": slot_number,
+            "is_primary": _coerce_bool(slot.get("is_primary")) or slot_number == primary_slot,
+            "material_type": quote.material_type or "PLA_BASIC",
+            "color_code": slot.get("color_code"),
+            "color_name": slot.get("color_name"),
+            "color_hex": slot.get("color_hex"),
+            "material_grams": grams,
+        })
+
+    if not parsed_slots:
+        return
+
+    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
+        synchronize_session=False
+    )
+
+    quote.color = "MULTI_COLOR"
+    for slot in parsed_slots:
         db.add(QuoteMaterial(
             quote_id=quote.id,
-            slot_number=slot_number,
-            is_primary=bool(slot.get("is_primary")) or slot_number == primary_slot,
-            material_type=quote.material_type or "PLA_BASIC",
-            color_code=slot.get("color_code"),
-            color_name=slot.get("color_name"),
-            color_hex=slot.get("color_hex"),
-            material_grams=grams,
+            **slot,
         ))
 
 
@@ -495,7 +517,7 @@ async def accept_portal_quote(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Snapshot shipping selection and mark a portal quote accepted or awaiting review."""
+    """Snapshot checkout selections and keep portal quotes approved until payment succeeds."""
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
     _apply_portal_print_selection(db, quote, payload)

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -115,6 +115,29 @@ class TestQuoteAuth:
 class TestPortalQuoteContract:
     """Public quoter contract: Core owns the durable quote id."""
 
+    @staticmethod
+    def _install_auto_quote_provider(client):
+        def provider(**kwargs):
+            quote = kwargs["quote"]
+            quote.material_grams = Decimal("27.20")
+            quote.print_time_hours = Decimal("0.75")
+            quote.unit_price = Decimal("6.43")
+            quote.subtotal = Decimal("6.43")
+            quote.total_price = Decimal("6.43")
+            quote.status = "approved"
+            quote.approval_method = "auto"
+            quote.auto_approved = True
+            quote.auto_approve_eligible = True
+            quote.requires_review_reason = None
+            return {}
+
+        client.app.state.quote_automation_provider = provider
+
+    @staticmethod
+    def _clear_auto_quote_provider(client):
+        if hasattr(client.app.state, "quote_automation_provider"):
+            delattr(client.app.state, "quote_automation_provider")
+
     def test_portal_create_requires_auth(self, unauthed_client):
         response = unauthed_client.post(
             f"{BASE_URL}/portal",
@@ -176,6 +199,123 @@ class TestPortalQuoteContract:
         assert data["quote_id"] == created["quote_id"]
         assert data["requires_review"] is True
         assert data["message"] == "Quote requires manual review"
+
+    def test_portal_accept_keeps_auto_quote_approved_until_payment(self, client, db):
+        from app.models.quote import Quote
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            ).json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            data = response.json()
+            assert data["requires_review"] is False
+            assert data["status"] == "approved"
+            assert data["message"] == "Quote ready for checkout"
+
+            checkout_response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/checkout"
+            )
+            assert checkout_response.status_code == 503
+
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.status == "approved"
+            assert quote.approval_method == "auto"
+        finally:
+            self._clear_auto_quote_provider(client)
+
+    def test_portal_accept_snapshots_multi_color_slots(self, client, db):
+        from app.models.quote import Quote, QuoteMaterial
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
+            ).json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "print_mode": "multi",
+                    "multi_color_info": {
+                        "primary_slot": 1,
+                        "slot_colors": [
+                            {
+                                "slot": 1,
+                                "color_code": "RED",
+                                "color_name": "Red",
+                                "color_hex": "#ff0000",
+                                "weight_grams": 10.2,
+                                "is_primary": True,
+                            },
+                            {
+                                "slot": 2,
+                                "color_code": "YEL",
+                                "color_name": "Yellow",
+                                "color_hex": "#ffff00",
+                                "weight_grams": 9.1,
+                                "is_primary": False,
+                            },
+                            {
+                                "slot": 3,
+                                "color_code": "BLK",
+                                "color_name": "Black",
+                                "color_hex": "#000000",
+                                "weight_grams": 7.9,
+                                "is_primary": False,
+                            },
+                        ],
+                    },
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.color == "MULTI_COLOR"
+
+            materials = (
+                db.query(QuoteMaterial)
+                .filter(QuoteMaterial.quote_id == created["quote_id"])
+                .order_by(QuoteMaterial.slot_number)
+                .all()
+            )
+            assert [m.color_code for m in materials] == ["RED", "YEL", "BLK"]
+            assert [m.color_name for m in materials] == ["Red", "Yellow", "Black"]
+            assert [m.is_primary for m in materials] == [True, False, False]
+        finally:
+            self._clear_auto_quote_provider(client)
 
 # =============================================================================
 # List - GET /api/v1/quotes/

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -270,7 +270,7 @@ class TestPortalQuoteContract:
                     "shipping_cost": "8.50",
                     "print_mode": "multi",
                     "multi_color_info": {
-                        "primary_slot": 1,
+                        "primary_slot": "2",
                         "slot_colors": [
                             {
                                 "slot": 1,
@@ -278,10 +278,10 @@ class TestPortalQuoteContract:
                                 "color_name": "Red",
                                 "color_hex": "#ff0000",
                                 "weight_grams": 10.2,
-                                "is_primary": True,
+                                "is_primary": "false",
                             },
                             {
-                                "slot": 2,
+                                "slot": "2",
                                 "color_code": "YEL",
                                 "color_name": "Yellow",
                                 "color_hex": "#ffff00",
@@ -313,7 +313,71 @@ class TestPortalQuoteContract:
             )
             assert [m.color_code for m in materials] == ["RED", "YEL", "BLK"]
             assert [m.color_name for m in materials] == ["Red", "Yellow", "Black"]
-            assert [m.is_primary for m in materials] == [True, False, False]
+            assert [m.is_primary for m in materials] == [False, True, False]
+        finally:
+            self._clear_auto_quote_provider(client)
+
+    def test_portal_accept_preserves_materials_when_multi_color_slots_are_invalid(self, client, db):
+        from app.models.quote import Quote, QuoteMaterial
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "EXISTING_COLOR", "quantity": "1"},
+                files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
+            ).json()
+
+            db.add(QuoteMaterial(
+                quote_id=created["quote_id"],
+                slot_number=1,
+                is_primary=True,
+                material_type="PLA_BASIC",
+                color_code="KEEP",
+                color_name="Keep Existing",
+                color_hex="#123456",
+                material_grams=Decimal("1.25"),
+            ))
+            db.commit()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "print_mode": "multi",
+                    "multi_color_info": {
+                        "primary_slot": "bad",
+                        "slot_colors": [
+                            {"slot": 0, "color_code": "ZERO", "weight_grams": 1},
+                            {"slot": 17, "color_code": "TOO_HIGH", "weight_grams": 1},
+                            {"slot": 2, "color_code": "NEGATIVE", "weight_grams": -1},
+                            {"slot": "bad", "color_code": "BAD", "weight_grams": 1},
+                            "not-a-slot",
+                        ],
+                    },
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.color == "EXISTING_COLOR"
+
+            materials = (
+                db.query(QuoteMaterial)
+                .filter(QuoteMaterial.quote_id == created["quote_id"])
+                .all()
+            )
+            assert len(materials) == 1
+            assert materials[0].color_code == "KEEP"
         finally:
             self._clear_auto_quote_provider(client)
 


### PR DESCRIPTION
## Summary
- Keep auto-priced portal quotes in approved status when the customer snapshots shipping and starts checkout; do not mark accepted until a future payment-success path does it.
- Persist multi-color portal selections into Core QuoteMaterial rows and set the header color to MULTI_COLOR so selected slot colors do not collapse to the default color.
- Document the dogfood quote lifecycle fix in CHANGELOG.

## Verification
- DEBUG=false python -m pytest backend/tests/api/v1/test_quotes.py -q
- DEBUG=false python -m py_compile backend/app/api/v1/endpoints/quotes.py backend/tests/api/v1/test_quotes.py
- git diff --check
- Quoter UI smoke: npm run test:ui from C:\\repos\\filaops-ecosystem\\quoter

Agent-Session: codex-20260518-portal-quote-payment-lifecycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the quote checkout flow to preserve approved quote status until payment succeeds, preventing status changes during checkout initiation or failures
  * Fixed portal multi-color print selections to persist correctly, preventing selected colors from reverting to the default single color option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->