### PR TITLE
feat(quotes): gate public quoter behind core flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.
+- Portal multi-color print selections are snapshotted to `QuoteMaterial` rows so selected red/yellow/black slot colors do not collapse back to the default single color.
+
 ## [4.0.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Public online quoter endpoints are now explicitly gated by `ENABLE_PUBLIC_QUOTER`, leaving Core manual quote creation independent of PRO.
+- Quotes now expose a Core-owned read-only archive response with retained file and material snapshots for downgrade/retrieval workflows.
+- Staff can create a Core item/product from an approved quote through a deliberate quote action instead of automatic customer upload side effects.
+
 ### Fixed
 
 - Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -7,14 +7,14 @@ Supports creating quotes, updating status, and converting to sales orders.
 from datetime import datetime, timezone, timedelta
 from inspect import isawaitable
 from typing import Any, List, Optional
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, status, Query, UploadFile, File, Form, HTTPException, Request
 from fastapi.responses import StreamingResponse, Response
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.models.quote import Quote, QuoteFile
+from app.models.quote import Quote, QuoteFile, QuoteMaterial
 from app.models.user import User
 from app.logging_config import get_logger
 from app.api.v1.endpoints.auth import get_current_user
@@ -338,6 +338,50 @@ def _apply_portal_shipping(quote: Quote, current_user: User, payload: PortalShip
         current_user.phone = payload.shipping_phone
 
 
+def _apply_portal_print_selection(
+    db: Session,
+    quote: Quote,
+    payload: PortalShippingSelection,
+) -> None:
+    """Persist customer print-mode choices captured before checkout."""
+    if payload.print_mode != "multi" or not payload.multi_color_info:
+        return
+
+    slot_colors = payload.multi_color_info.get("slot_colors") or []
+    if not isinstance(slot_colors, list) or not slot_colors:
+        return
+
+    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
+        synchronize_session=False
+    )
+
+    quote.color = "MULTI_COLOR"
+    primary_slot = payload.multi_color_info.get("primary_slot")
+    for slot in slot_colors:
+        if not isinstance(slot, dict):
+            continue
+
+        try:
+            slot_number = int(slot.get("slot") or 0)
+            grams = Decimal(str(slot.get("weight_grams") or 0))
+        except (TypeError, ValueError, InvalidOperation):
+            continue
+
+        if slot_number < 1:
+            continue
+
+        db.add(QuoteMaterial(
+            quote_id=quote.id,
+            slot_number=slot_number,
+            is_primary=bool(slot.get("is_primary")) or slot_number == primary_slot,
+            material_type=quote.material_type or "PLA_BASIC",
+            color_code=slot.get("color_code"),
+            color_name=slot.get("color_name"),
+            color_hex=slot.get("color_hex"),
+            material_grams=grams,
+        ))
+
+
 # ============================================================================
 # ENDPOINTS
 # ============================================================================
@@ -454,13 +498,14 @@ async def accept_portal_quote(
     """Snapshot shipping selection and mark a portal quote accepted or awaiting review."""
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
+    _apply_portal_print_selection(db, quote, payload)
 
     requires_review = bool(quote.requires_review_reason)
     if requires_review:
         quote.status = "pending"
         quote.approval_method = "manual"
     else:
-        quote.status = "accepted"
+        quote.status = "approved"
         quote.approval_method = quote.approval_method or "auto"
         quote.approved_at = quote.approved_at or datetime.now(timezone.utc).replace(tzinfo=None)
 
@@ -469,7 +514,7 @@ async def accept_portal_quote(
     return {
         **_portal_quote_payload(quote),
         "requires_review": requires_review,
-        "message": "Quote requires manual review" if requires_review else "Quote accepted",
+        "message": "Quote requires manual review" if requires_review else "Quote ready for checkout",
     }
 
 

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -307,11 +307,19 @@ def _require_public_quoter_enabled() -> None:
         )
 
 
-def _require_admin(current_user: User) -> None:
-    if not getattr(current_user, "is_admin", False):
+def _is_staff_or_admin(current_user: User) -> bool:
+    return bool(
+        getattr(current_user, "is_admin", False)
+        or getattr(current_user, "is_staff", False)
+        or getattr(current_user, "account_type", None) in {"admin", "operator"}
+    )
+
+
+def _require_staff_or_admin(current_user: User) -> None:
+    if not _is_staff_or_admin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin role required",
+            detail="Admin or staff role required",
         )
 
 
@@ -330,6 +338,14 @@ def _portal_quote_or_404(db: Session, quote_id: int, current_user: User) -> Quot
         raise HTTPException(status_code=403, detail="Quote does not belong to current customer")
 
     return quote
+
+
+def _authorize_quote_archive_access(quote: Quote, current_user: User) -> None:
+    if _is_staff_or_admin(current_user):
+        return
+    if quote.user_id == current_user.id or quote.customer_id == current_user.id:
+        return
+    raise HTTPException(status_code=403, detail="Quote does not belong to current customer")
 
 
 def _portal_quote_payload(quote: Quote, extra: Optional[dict[str, Any]] = None) -> dict[str, Any]:
@@ -448,11 +464,15 @@ def _apply_portal_print_selection(
         if slot_number is None or slot_number < 1 or slot_number > 16 or grams < 0:
             continue
 
+        color_code = str(slot.get("color_code") or "").strip()
+        if not color_code:
+            continue
+
         parsed_slots.append({
             "slot_number": slot_number,
             "is_primary": _coerce_bool(slot.get("is_primary")) or slot_number == primary_slot,
             "material_type": quote.material_type or "PLA_BASIC",
-            "color_code": slot.get("color_code"),
+            "color_code": color_code,
             "color_name": slot.get("color_name"),
             "color_hex": slot.get("color_hex"),
             "material_grams": grams,
@@ -639,6 +659,7 @@ async def get_quote_archive(
 ):
     """Read-only Core archive for online quote data after PRO downgrade."""
     quote = quote_service.get_quote_detail(db, quote_id)
+    _authorize_quote_archive_access(quote, current_user)
     files = (
         db.query(QuoteFile)
         .filter(QuoteFile.quote_id == quote_id)
@@ -660,20 +681,22 @@ async def get_quote_archive(
     }
 
 
-@router.post("/{quote_id}/create-item", response_model=QuoteItemCreateResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/{quote_id}/create-item", response_model=QuoteItemCreateResponse)
 async def create_item_from_quote(
     quote_id: int,
+    response: Response,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """Staff action: create a Core item/product from an approved quote."""
-    _require_admin(current_user)
+    _require_staff_or_admin(current_user)
     quote = quote_service.get_quote_detail(db, quote_id)
     if quote.product_id:
         product = db.get(Product, quote.product_id)
         if not product:
             raise HTTPException(status_code=409, detail="Quote links to a missing product")
         bom = product.boms[0] if product.boms else None
+        response.status_code = status.HTTP_200_OK
         return {
             "quote_id": quote.id,
             "product_id": product.id,
@@ -696,6 +719,7 @@ async def create_item_from_quote(
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    response.status_code = status.HTTP_201_CREATED
     return {
         "quote_id": quote.id,
         "product_id": product.id,

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -14,11 +14,14 @@ from fastapi.responses import StreamingResponse, Response
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
+from app.core.config import settings
+from app.models.product import Product
 from app.models.quote import Quote, QuoteFile, QuoteMaterial
 from app.models.user import User
 from app.logging_config import get_logger
 from app.api.v1.endpoints.auth import get_current_user
 from app.services import quote_service
+from app.services import bom_service
 from app.services.file_storage import file_storage
 from pydantic import BaseModel, Field
 
@@ -246,6 +249,72 @@ class PortalShippingSelection(BaseModel):
     multi_color_info: Optional[dict[str, Any]] = None
 
 
+class QuoteArchiveFile(BaseModel):
+    """Read-only file metadata retained by Core after PRO downgrade."""
+    id: int
+    original_filename: str
+    file_format: str
+    file_size_bytes: int
+    file_hash: str
+    uploaded_at: datetime
+    processed: bool = False
+    processing_error: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class QuoteArchiveMaterial(BaseModel):
+    """Read-only material snapshot retained by Core after PRO downgrade."""
+    slot_number: int
+    is_primary: bool
+    material_type: str
+    color_code: Optional[str] = None
+    color_name: Optional[str] = None
+    color_hex: Optional[str] = None
+    material_grams: Decimal
+
+    model_config = {"from_attributes": True}
+
+
+class QuoteArchiveResponse(BaseModel):
+    """Durable quote archive shape that does not require PRO tables."""
+    quote: QuoteDetail
+    files: list[QuoteArchiveFile] = Field(default_factory=list)
+    materials: list[QuoteArchiveMaterial] = Field(default_factory=list)
+    read_only: bool = True
+    pro_actions_available: bool = False
+
+
+class QuoteItemCreateResponse(BaseModel):
+    """Response for staff-created Core item/product from a quote."""
+    quote_id: int
+    product_id: int
+    product_sku: str
+    product_name: str
+    bom_id: Optional[int] = None
+    already_created: bool = False
+
+
+def _public_quoter_enabled() -> bool:
+    return bool(getattr(settings, "ENABLE_PUBLIC_QUOTER", False))
+
+
+def _require_public_quoter_enabled() -> None:
+    if not _public_quoter_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Public online quoter is disabled",
+        )
+
+
+def _require_admin(current_user: User) -> None:
+    if not getattr(current_user, "is_admin", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin role required",
+        )
+
+
 def _customer_display_name(user: User) -> str:
     """Return a stable customer display name without inventing a new customer table."""
     full_name = f"{user.first_name or ''} {user.last_name or ''}".strip()
@@ -445,6 +514,7 @@ async def create_portal_quote(
     db: Session = Depends(get_db),
 ):
     """Create one Core-owned quote for the public portal and optionally let PRO price it."""
+    _require_public_quoter_enabled()
     try:
         stored_file = await file_storage.save_file(file, current_user.id)
     except ValueError as exc:
@@ -518,6 +588,7 @@ async def accept_portal_quote(
     db: Session = Depends(get_db),
 ):
     """Snapshot checkout selections and keep portal quotes approved until payment succeeds."""
+    _require_public_quoter_enabled()
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
     _apply_portal_print_selection(db, quote, payload)
@@ -548,6 +619,7 @@ async def create_portal_quote_checkout(
     db: Session = Depends(get_db),
 ):
     """Create a payment checkout session through an optional payment provider."""
+    _require_public_quoter_enabled()
     quote = _portal_quote_or_404(db, quote_id, current_user)
     provider = getattr(request.app.state, "payment_checkout_provider", None)
     if provider is None:
@@ -557,6 +629,81 @@ async def create_portal_quote_checkout(
     if isawaitable(result):
         result = await result
     return result
+
+
+@router.get("/{quote_id}/archive", response_model=QuoteArchiveResponse)
+async def get_quote_archive(
+    quote_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Read-only Core archive for online quote data after PRO downgrade."""
+    quote = quote_service.get_quote_detail(db, quote_id)
+    files = (
+        db.query(QuoteFile)
+        .filter(QuoteFile.quote_id == quote_id)
+        .order_by(QuoteFile.id)
+        .all()
+    )
+    materials = (
+        db.query(QuoteMaterial)
+        .filter(QuoteMaterial.quote_id == quote_id)
+        .order_by(QuoteMaterial.slot_number)
+        .all()
+    )
+    return {
+        "quote": quote,
+        "files": files,
+        "materials": materials,
+        "read_only": True,
+        "pro_actions_available": _public_quoter_enabled(),
+    }
+
+
+@router.post("/{quote_id}/create-item", response_model=QuoteItemCreateResponse, status_code=status.HTTP_201_CREATED)
+async def create_item_from_quote(
+    quote_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Staff action: create a Core item/product from an approved quote."""
+    _require_admin(current_user)
+    quote = quote_service.get_quote_detail(db, quote_id)
+    if quote.product_id:
+        product = db.get(Product, quote.product_id)
+        if not product:
+            raise HTTPException(status_code=409, detail="Quote links to a missing product")
+        bom = product.boms[0] if product.boms else None
+        return {
+            "quote_id": quote.id,
+            "product_id": product.id,
+            "product_sku": product.sku,
+            "product_name": product.name,
+            "bom_id": bom.id if bom else None,
+            "already_created": True,
+        }
+
+    if quote.status not in {"approved", "accepted", "converted"}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Quote must be approved, accepted, or converted before creating an item",
+        )
+
+    try:
+        product, bom = bom_service.auto_create_product_and_bom(quote, db)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return {
+        "quote_id": quote.id,
+        "product_id": product.id,
+        "product_sku": product.sku,
+        "product_name": product.name,
+        "bom_id": bom.id,
+        "already_created": False,
+    }
 
 
 @router.get("/{quote_id}", response_model=QuoteDetail)

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -351,34 +351,56 @@ def _apply_portal_print_selection(
     if not isinstance(slot_colors, list) or not slot_colors:
         return
 
-    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
-        synchronize_session=False
-    )
+    def _coerce_int(value: Any) -> Optional[int]:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
-    quote.color = "MULTI_COLOR"
-    primary_slot = payload.multi_color_info.get("primary_slot")
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    primary_slot = _coerce_int(payload.multi_color_info.get("primary_slot"))
+    parsed_slots: list[dict[str, Any]] = []
     for slot in slot_colors:
         if not isinstance(slot, dict):
             continue
 
         try:
-            slot_number = int(slot.get("slot") or 0)
+            slot_number = _coerce_int(slot.get("slot"))
             grams = Decimal(str(slot.get("weight_grams") or 0))
         except (TypeError, ValueError, InvalidOperation):
             continue
 
-        if slot_number < 1:
+        if slot_number is None or slot_number < 1 or slot_number > 16 or grams < 0:
             continue
 
+        parsed_slots.append({
+            "slot_number": slot_number,
+            "is_primary": _coerce_bool(slot.get("is_primary")) or slot_number == primary_slot,
+            "material_type": quote.material_type or "PLA_BASIC",
+            "color_code": slot.get("color_code"),
+            "color_name": slot.get("color_name"),
+            "color_hex": slot.get("color_hex"),
+            "material_grams": grams,
+        })
+
+    if not parsed_slots:
+        return
+
+    db.query(QuoteMaterial).filter(QuoteMaterial.quote_id == quote.id).delete(
+        synchronize_session=False
+    )
+
+    quote.color = "MULTI_COLOR"
+    for slot in parsed_slots:
         db.add(QuoteMaterial(
             quote_id=quote.id,
-            slot_number=slot_number,
-            is_primary=bool(slot.get("is_primary")) or slot_number == primary_slot,
-            material_type=quote.material_type or "PLA_BASIC",
-            color_code=slot.get("color_code"),
-            color_name=slot.get("color_name"),
-            color_hex=slot.get("color_hex"),
-            material_grams=grams,
+            **slot,
         ))
 
 
@@ -495,7 +517,7 @@ async def accept_portal_quote(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Snapshot shipping selection and mark a portal quote accepted or awaiting review."""
+    """Snapshot checkout selections and keep portal quotes approved until payment succeeds."""
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
     _apply_portal_print_selection(db, quote, payload)

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -162,6 +162,13 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = Field(
         default="http://localhost:5173", description="Frontend URL for redirects"
     )
+    ENABLE_PUBLIC_QUOTER: bool = Field(
+        default=False,
+        description=(
+            "Enable customer-facing online quote endpoints. Core manual quotes "
+            "must keep working when this is false."
+        ),
+    )
 
     @model_validator(mode="after")
     def add_frontend_url_to_cors(self):

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -115,6 +115,29 @@ class TestQuoteAuth:
 class TestPortalQuoteContract:
     """Public quoter contract: Core owns the durable quote id."""
 
+    @staticmethod
+    def _install_auto_quote_provider(client):
+        def provider(**kwargs):
+            quote = kwargs["quote"]
+            quote.material_grams = Decimal("27.20")
+            quote.print_time_hours = Decimal("0.75")
+            quote.unit_price = Decimal("6.43")
+            quote.subtotal = Decimal("6.43")
+            quote.total_price = Decimal("6.43")
+            quote.status = "approved"
+            quote.approval_method = "auto"
+            quote.auto_approved = True
+            quote.auto_approve_eligible = True
+            quote.requires_review_reason = None
+            return {}
+
+        client.app.state.quote_automation_provider = provider
+
+    @staticmethod
+    def _clear_auto_quote_provider(client):
+        if hasattr(client.app.state, "quote_automation_provider"):
+            delattr(client.app.state, "quote_automation_provider")
+
     def test_portal_create_requires_auth(self, unauthed_client):
         response = unauthed_client.post(
             f"{BASE_URL}/portal",
@@ -176,6 +199,123 @@ class TestPortalQuoteContract:
         assert data["quote_id"] == created["quote_id"]
         assert data["requires_review"] is True
         assert data["message"] == "Quote requires manual review"
+
+    def test_portal_accept_keeps_auto_quote_approved_until_payment(self, client, db):
+        from app.models.quote import Quote
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            ).json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            data = response.json()
+            assert data["requires_review"] is False
+            assert data["status"] == "approved"
+            assert data["message"] == "Quote ready for checkout"
+
+            checkout_response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/checkout"
+            )
+            assert checkout_response.status_code == 503
+
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.status == "approved"
+            assert quote.approval_method == "auto"
+        finally:
+            self._clear_auto_quote_provider(client)
+
+    def test_portal_accept_snapshots_multi_color_slots(self, client, db):
+        from app.models.quote import Quote, QuoteMaterial
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
+            ).json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "print_mode": "multi",
+                    "multi_color_info": {
+                        "primary_slot": 1,
+                        "slot_colors": [
+                            {
+                                "slot": 1,
+                                "color_code": "RED",
+                                "color_name": "Red",
+                                "color_hex": "#ff0000",
+                                "weight_grams": 10.2,
+                                "is_primary": True,
+                            },
+                            {
+                                "slot": 2,
+                                "color_code": "YEL",
+                                "color_name": "Yellow",
+                                "color_hex": "#ffff00",
+                                "weight_grams": 9.1,
+                                "is_primary": False,
+                            },
+                            {
+                                "slot": 3,
+                                "color_code": "BLK",
+                                "color_name": "Black",
+                                "color_hex": "#000000",
+                                "weight_grams": 7.9,
+                                "is_primary": False,
+                            },
+                        ],
+                    },
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.color == "MULTI_COLOR"
+
+            materials = (
+                db.query(QuoteMaterial)
+                .filter(QuoteMaterial.quote_id == created["quote_id"])
+                .order_by(QuoteMaterial.slot_number)
+                .all()
+            )
+            assert [m.color_code for m in materials] == ["RED", "YEL", "BLK"]
+            assert [m.color_name for m in materials] == ["Red", "Yellow", "Black"]
+            assert [m.is_primary for m in materials] == [True, False, False]
+        finally:
+            self._clear_auto_quote_provider(client)
 
 # =============================================================================
 # List - GET /api/v1/quotes/

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -142,11 +142,13 @@ class TestCoreSafeQuoterBoundary:
         from app.models.quote import QuoteMaterial
 
         monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", True)
-        created = client.post(
+        create_response = client.post(
             f"{BASE_URL}/portal",
             data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
             files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
-        ).json()
+        )
+        assert create_response.status_code == 201, create_response.text
+        created = create_response.json()
 
         db.add(QuoteMaterial(
             quote_id=created["quote_id"],
@@ -171,6 +173,36 @@ class TestCoreSafeQuoterBoundary:
         assert data["files"][0]["original_filename"] == "part.stl"
         assert data["materials"][0]["color_code"] == "JADE_WHITE"
 
+    def test_quote_archive_rejects_unowned_customer_quote(self, client, db, monkeypatch):
+        from app.models.quote import Quote
+        from app.models.user import User
+
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", False)
+        created = _create_quote(client)
+
+        other_customer = User(
+            email="archive-owner@example.com",
+            password_hash="not-a-real-hash",
+            first_name="Archive",
+            last_name="Owner",
+            account_type="customer",
+        )
+        db.add(other_customer)
+        db.flush()
+
+        quote = db.get(Quote, created["id"])
+        quote.user_id = other_customer.id
+        quote.customer_id = other_customer.id
+
+        current_user = db.get(User, 1)
+        current_user.account_type = "customer"
+        db.commit()
+
+        response = client.get(f"{BASE_URL}/{created['id']}/archive")
+
+        assert response.status_code == 403
+        assert "belong" in response.json()["detail"]
+
     def test_create_item_from_quote_requires_approved_quote(self, client):
         quote = _create_quote(client)
 
@@ -182,7 +214,12 @@ class TestCoreSafeQuoterBoundary:
     def test_create_item_from_quote_uses_staff_action(self, client, db, monkeypatch):
         from app.models.product import Product
         from app.models.quote import Quote
+        from app.models.user import User
         from app.services import bom_service
+
+        current_user = db.get(User, 1)
+        current_user.account_type = "operator"
+        db.commit()
 
         quote_data = _create_quote(client)
         quote = db.get(Quote, quote_data["id"])
@@ -202,6 +239,7 @@ class TestCoreSafeQuoterBoundary:
             db.add(product)
             db.flush()
             quote.product_id = product.id
+            db.commit()
             return product, SimpleNamespace(id=987)
 
         monkeypatch.setattr(
@@ -219,6 +257,13 @@ class TestCoreSafeQuoterBoundary:
         assert data["bom_id"] == 987
         assert data["already_created"] is False
 
+        duplicate_response = client.post(f"{BASE_URL}/{quote.id}/create-item")
+
+        assert duplicate_response.status_code == 200, duplicate_response.text
+        duplicate_data = duplicate_response.json()
+        assert duplicate_data["product_id"] == data["product_id"]
+        assert duplicate_data["already_created"] is True
+
 
 class TestPortalQuoteContract:
     """Public quoter contract: Core owns the durable quote id."""
@@ -229,6 +274,9 @@ class TestPortalQuoteContract:
 
     @staticmethod
     def _install_auto_quote_provider(client):
+        had_previous = hasattr(client.app.state, "quote_automation_provider")
+        previous_provider = getattr(client.app.state, "quote_automation_provider", None)
+
         def provider(**kwargs):
             quote = kwargs["quote"]
             quote.material_grams = Decimal("27.20")
@@ -244,10 +292,14 @@ class TestPortalQuoteContract:
             return {}
 
         client.app.state.quote_automation_provider = provider
+        return had_previous, previous_provider
 
     @staticmethod
-    def _clear_auto_quote_provider(client):
-        if hasattr(client.app.state, "quote_automation_provider"):
+    def _clear_auto_quote_provider(client, provider_state):
+        had_previous, previous_provider = provider_state
+        if had_previous:
+            client.app.state.quote_automation_provider = previous_provider
+        elif hasattr(client.app.state, "quote_automation_provider"):
             delattr(client.app.state, "quote_automation_provider")
 
     def test_portal_create_requires_auth(self, unauthed_client):
@@ -284,11 +336,13 @@ class TestPortalQuoteContract:
         assert expires_at.tzinfo is None or expires_at.tzinfo.utcoffset(expires_at) is not None
 
     def test_portal_accept_snapshots_shipping_on_owned_quote(self, client):
-        created = client.post(
+        create_response = client.post(
             f"{BASE_URL}/portal",
             data={"material": "PLA_BASIC", "quantity": "1"},
             files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
-        ).json()
+        )
+        assert create_response.status_code == 201, create_response.text
+        created = create_response.json()
 
         response = client.post(
             f"{BASE_URL}/portal/{created['quote_id']}/accept",
@@ -315,13 +369,15 @@ class TestPortalQuoteContract:
     def test_portal_accept_keeps_auto_quote_approved_until_payment(self, client, db):
         from app.models.quote import Quote
 
-        self._install_auto_quote_provider(client)
+        provider_state = self._install_auto_quote_provider(client)
         try:
-            created = client.post(
+            create_response = client.post(
                 f"{BASE_URL}/portal",
                 data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
                 files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
-            ).json()
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
 
             response = client.post(
                 f"{BASE_URL}/portal/{created['quote_id']}/accept",
@@ -354,18 +410,20 @@ class TestPortalQuoteContract:
             assert quote.status == "approved"
             assert quote.approval_method == "auto"
         finally:
-            self._clear_auto_quote_provider(client)
+            self._clear_auto_quote_provider(client, provider_state)
 
     def test_portal_accept_snapshots_multi_color_slots(self, client, db):
         from app.models.quote import Quote, QuoteMaterial
 
-        self._install_auto_quote_provider(client)
+        provider_state = self._install_auto_quote_provider(client)
         try:
-            created = client.post(
+            create_response = client.post(
                 f"{BASE_URL}/portal",
                 data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
                 files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
-            ).json()
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
 
             response = client.post(
                 f"{BASE_URL}/portal/{created['quote_id']}/accept",
@@ -427,18 +485,20 @@ class TestPortalQuoteContract:
             assert [m.color_name for m in materials] == ["Red", "Yellow", "Black"]
             assert [m.is_primary for m in materials] == [False, True, False]
         finally:
-            self._clear_auto_quote_provider(client)
+            self._clear_auto_quote_provider(client, provider_state)
 
     def test_portal_accept_preserves_materials_when_multi_color_slots_are_invalid(self, client, db):
         from app.models.quote import Quote, QuoteMaterial
 
-        self._install_auto_quote_provider(client)
+        provider_state = self._install_auto_quote_provider(client)
         try:
-            created = client.post(
+            create_response = client.post(
                 f"{BASE_URL}/portal",
                 data={"material": "PLA_BASIC", "color": "EXISTING_COLOR", "quantity": "1"},
                 files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
-            ).json()
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
 
             db.add(QuoteMaterial(
                 quote_id=created["quote_id"],
@@ -473,6 +533,7 @@ class TestPortalQuoteContract:
                             {"slot": 17, "color_code": "TOO_HIGH", "weight_grams": 1},
                             {"slot": 2, "color_code": "NEGATIVE", "weight_grams": -1},
                             {"slot": "bad", "color_code": "BAD", "weight_grams": 1},
+                            {"slot": 2, "color_code": "", "weight_grams": 1},
                             "not-a-slot",
                         ],
                     },
@@ -491,7 +552,7 @@ class TestPortalQuoteContract:
             assert len(materials) == 1
             assert materials[0].color_code == "KEEP"
         finally:
-            self._clear_auto_quote_provider(client)
+            self._clear_auto_quote_provider(client, provider_state)
 
 # =============================================================================
 # List - GET /api/v1/quotes/

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -270,7 +270,7 @@ class TestPortalQuoteContract:
                     "shipping_cost": "8.50",
                     "print_mode": "multi",
                     "multi_color_info": {
-                        "primary_slot": 1,
+                        "primary_slot": "2",
                         "slot_colors": [
                             {
                                 "slot": 1,
@@ -278,10 +278,10 @@ class TestPortalQuoteContract:
                                 "color_name": "Red",
                                 "color_hex": "#ff0000",
                                 "weight_grams": 10.2,
-                                "is_primary": True,
+                                "is_primary": "false",
                             },
                             {
-                                "slot": 2,
+                                "slot": "2",
                                 "color_code": "YEL",
                                 "color_name": "Yellow",
                                 "color_hex": "#ffff00",
@@ -313,7 +313,71 @@ class TestPortalQuoteContract:
             )
             assert [m.color_code for m in materials] == ["RED", "YEL", "BLK"]
             assert [m.color_name for m in materials] == ["Red", "Yellow", "Black"]
-            assert [m.is_primary for m in materials] == [True, False, False]
+            assert [m.is_primary for m in materials] == [False, True, False]
+        finally:
+            self._clear_auto_quote_provider(client)
+
+    def test_portal_accept_preserves_materials_when_multi_color_slots_are_invalid(self, client, db):
+        from app.models.quote import Quote, QuoteMaterial
+
+        self._install_auto_quote_provider(client)
+        try:
+            created = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "EXISTING_COLOR", "quantity": "1"},
+                files={"file": ("multi.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
+            ).json()
+
+            db.add(QuoteMaterial(
+                quote_id=created["quote_id"],
+                slot_number=1,
+                is_primary=True,
+                material_type="PLA_BASIC",
+                color_code="KEEP",
+                color_name="Keep Existing",
+                color_hex="#123456",
+                material_grams=Decimal("1.25"),
+            ))
+            db.commit()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "print_mode": "multi",
+                    "multi_color_info": {
+                        "primary_slot": "bad",
+                        "slot_colors": [
+                            {"slot": 0, "color_code": "ZERO", "weight_grams": 1},
+                            {"slot": 17, "color_code": "TOO_HIGH", "weight_grams": 1},
+                            {"slot": 2, "color_code": "NEGATIVE", "weight_grams": -1},
+                            {"slot": "bad", "color_code": "BAD", "weight_grams": 1},
+                            "not-a-slot",
+                        ],
+                    },
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.color == "EXISTING_COLOR"
+
+            materials = (
+                db.query(QuoteMaterial)
+                .filter(QuoteMaterial.quote_id == created["quote_id"])
+                .all()
+            )
+            assert len(materials) == 1
+            assert materials[0].color_code == "KEEP"
         finally:
             self._clear_auto_quote_provider(client)
 

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -19,6 +19,9 @@ Covers:
 import pytest
 from decimal import Decimal
 from datetime import datetime, timezone, timedelta
+from types import SimpleNamespace
+
+from app.core.config import settings
 
 
 BASE_URL = "/api/v1/quotes"
@@ -112,8 +115,117 @@ class TestQuoteAuth:
 
 
 
+class TestCoreSafeQuoterBoundary:
+    """Core manual quoting must not depend on the PRO online quoter."""
+
+    def test_manual_quote_create_works_when_public_quoter_disabled(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", False)
+
+        quote = _create_quote(client, product_name="Manual Core Quote")
+
+        assert quote["product_name"] == "Manual Core Quote"
+        assert quote["status"] == "pending"
+
+    def test_portal_quote_create_is_gated_when_public_quoter_disabled(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", False)
+
+        response = client.post(
+            f"{BASE_URL}/portal",
+            data={"material": "PLA_BASIC", "quantity": "1"},
+            files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Public online quoter is disabled"
+
+    def test_quote_archive_stays_readable_when_public_quoter_disabled(self, client, db, monkeypatch):
+        from app.models.quote import QuoteMaterial
+
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", True)
+        created = client.post(
+            f"{BASE_URL}/portal",
+            data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+            files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+        ).json()
+
+        db.add(QuoteMaterial(
+            quote_id=created["quote_id"],
+            slot_number=1,
+            is_primary=True,
+            material_type="PLA_BASIC",
+            color_code="JADE_WHITE",
+            color_name="Jade White",
+            color_hex="#f4f2df",
+            material_grams=Decimal("12.34"),
+        ))
+        db.commit()
+
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", False)
+        response = client.get(f"{BASE_URL}/{created['quote_id']}/archive")
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["read_only"] is True
+        assert data["pro_actions_available"] is False
+        assert data["quote"]["id"] == created["quote_id"]
+        assert data["files"][0]["original_filename"] == "part.stl"
+        assert data["materials"][0]["color_code"] == "JADE_WHITE"
+
+    def test_create_item_from_quote_requires_approved_quote(self, client):
+        quote = _create_quote(client)
+
+        response = client.post(f"{BASE_URL}/{quote['id']}/create-item")
+
+        assert response.status_code == 409
+        assert "approved" in response.json()["detail"]
+
+    def test_create_item_from_quote_uses_staff_action(self, client, db, monkeypatch):
+        from app.models.product import Product
+        from app.models.quote import Quote
+        from app.services import bom_service
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+        quote.status = "approved"
+        db.commit()
+
+        def fake_auto_create_product_and_bom(quote, db):
+            product = Product(
+                sku=f"PRD-CUS-TEST-{quote.id}",
+                name=f"Custom Print - Quote #{quote.quote_number}",
+                type="custom",
+                item_type="finished_good",
+                procurement_type="make",
+                has_bom=True,
+                active=True,
+            )
+            db.add(product)
+            db.flush()
+            quote.product_id = product.id
+            return product, SimpleNamespace(id=987)
+
+        monkeypatch.setattr(
+            bom_service,
+            "auto_create_product_and_bom",
+            fake_auto_create_product_and_bom,
+        )
+
+        response = client.post(f"{BASE_URL}/{quote.id}/create-item")
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["quote_id"] == quote.id
+        assert data["product_sku"] == f"PRD-CUS-TEST-{quote.id}"
+        assert data["bom_id"] == 987
+        assert data["already_created"] is False
+
+
 class TestPortalQuoteContract:
     """Public quoter contract: Core owns the durable quote id."""
+
+    @pytest.fixture(autouse=True)
+    def enable_public_quoter(self, monkeypatch):
+        monkeypatch.setattr(settings, "ENABLE_PUBLIC_QUOTER", True)
 
     @staticmethod
     def _install_auto_quote_provider(client):


### PR DESCRIPTION
## Summary
- Adds Core `ENABLE_PUBLIC_QUOTER` flag so public online quote endpoints are opt-in
- Keeps manual quote endpoints independent of PRO/provider hooks
- Adds read-only quote archive data from Core `Quote`, `QuoteFile`, and `QuoteMaterial`
- Adds admin/staff create-item action for approved/accepted/converted quotes

## Boundary rule
Core remains the durable system of record. PRO can enrich through optional providers, but Core does not import PRO and manual quotes continue to work with the public quoter disabled.

## Tests
- `python -m pytest backend/tests/api/v1/test_quotes.py::TestCoreSafeQuoterBoundary backend/tests/api/v1/test_quotes.py::TestPortalQuoteContract -q`
- `python -m pytest backend/tests/api/v1/test_quotes.py -q`
- `python -m py_compile backend/app/core/settings.py backend/app/api/v1/endpoints/quotes.py backend/tests/api/v1/test_quotes.py`

Agent-Session: codex-2026-05-18-core-safe-quoter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable gating for public online quoter endpoints
  * Read-only quote archive endpoint returning quote details, files, and materials
  * Staff-only action to create products/items from approved quotes
  * Multi-color selection now snapshots per-quote material entries to preserve selections

* **Bug Fixes**
  * Portal quotes remain approved until payment succeeds
  * Multi-color print selections no longer revert to default options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->