### PR TITLE
Preserve public quote uploads for manual review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Public portal quote uploads now retain `.obj`, `.step`, and `.stp` files as Core quote archives for manual review instead of rejecting them before staff can inspect the model.
+- Public portal quote creation now falls back to a pending manual-review quote when the optional PRO quote automation provider fails, preserving the uploaded file and avoiding customer-facing slicer 503 errors.
 - Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.
 - Portal multi-color print selections are snapshotted to `QuoteMaterial` rows so selected red/yellow/black slot colors do not collapse back to the default single color.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Public portal quote uploads now retain `.obj`, `.step`, and `.stp` files as Core quote archives for manual review instead of rejecting them before staff can inspect the model.
-- Public portal quote creation now falls back to a pending manual-review quote when the optional PRO quote automation provider fails, preserving the uploaded file and avoiding customer-facing slicer 503 errors.
+- Public portal quote creation now falls back to a pending manual-review quote when the optional PRO quote automation provider fails, preserving the uploaded file, rolling back partial provider mutations, and avoiding customer-facing slicer 503 errors.
+- Upload format overrides now normalize case and missing leading dots so `.STL`, `stl`, and similar env values behave consistently.
 - Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.
 - Portal multi-color print selections are snapshotted to `QuoteMaterial` rows so selected red/yellow/black slot colors do not collapse back to the default single color.
 

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -389,6 +389,10 @@ def _set_portal_quote_manual_review(quote: Quote, reason: str) -> None:
     quote.requires_review_reason = reason
 
 
+class _InvalidQuoteAutomationResult(Exception):
+    """Raised when a PRO provider returns a payload Core cannot safely consume."""
+
+
 async def _maybe_enrich_portal_quote(
     request: Request,
     *,
@@ -408,7 +412,17 @@ async def _maybe_enrich_portal_quote(
             result = provider(db=db, quote=quote, stored_file=stored_file, options=options)
             if isawaitable(result):
                 result = await result
+            if result is not None and not isinstance(result, dict):
+                raise _InvalidQuoteAutomationResult
         return result or {}
+    except _InvalidQuoteAutomationResult:
+        _set_portal_quote_manual_review(quote, "Automatic quote engine unavailable")
+        provider_name = getattr(provider, "__name__", type(provider).__name__)
+        logger.warning(
+            "Portal quote automation returned invalid payload from %r",
+            _safe_log_value(provider_name),
+        )
+        return {}
     except HTTPException as exc:
         if exc.status_code >= 500:
             reason = "Automatic quote engine unavailable"

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -371,6 +371,24 @@ def _portal_quote_payload(quote: Quote, extra: Optional[dict[str, Any]] = None) 
     }
 
 
+def _safe_log_value(value: Any, max_length: int = 160) -> str:
+    safe = repr(str(value or ""))[1:-1]
+    return safe[:max_length]
+
+
+def _set_portal_quote_manual_review(quote: Quote, reason: str) -> None:
+    quote.status = "pending"
+    quote.approval_method = "manual"
+    quote.auto_approved = False
+    quote.auto_approve_eligible = False
+    quote.unit_price = Decimal("0.00")
+    quote.subtotal = Decimal("0.00")
+    quote.total_price = Decimal("0.00")
+    quote.material_grams = None
+    quote.print_time_hours = None
+    quote.requires_review_reason = reason
+
+
 async def _maybe_enrich_portal_quote(
     request: Request,
     *,
@@ -382,38 +400,32 @@ async def _maybe_enrich_portal_quote(
     """Let PRO enrich a Core-owned quote when PRO is installed and active."""
     provider = getattr(request.app.state, "quote_automation_provider", None)
     if provider is None:
-        quote.status = "pending"
-        quote.approval_method = "manual"
-        quote.requires_review_reason = "Automatic quote engine unavailable"
+        _set_portal_quote_manual_review(quote, "Automatic quote engine unavailable")
         return {}
 
     try:
-        result = provider(db=db, quote=quote, stored_file=stored_file, options=options)
-        if isawaitable(result):
-            result = await result
+        with db.begin_nested():
+            result = provider(db=db, quote=quote, stored_file=stored_file, options=options)
+            if isawaitable(result):
+                result = await result
         return result or {}
     except HTTPException as exc:
-        quote.status = "pending"
-        quote.approval_method = "manual"
         if exc.status_code >= 500:
-            quote.requires_review_reason = "Automatic quote engine unavailable"
+            reason = "Automatic quote engine unavailable"
         else:
-            quote.requires_review_reason = "Uploaded file requires manual review"
+            reason = "Uploaded file requires manual review"
+        _set_portal_quote_manual_review(quote, reason)
         logger.warning(
-            "Portal quote automation failed for %s (%s): %s",
-            stored_file.get("original_filename"),
+            "Portal quote automation failed for %r (%s)",
+            _safe_log_value(stored_file.get("original_filename")),
             exc.status_code,
-            exc.detail,
         )
         return {}
-    except Exception as exc:
-        quote.status = "pending"
-        quote.approval_method = "manual"
-        quote.requires_review_reason = "Automatic quote engine unavailable"
+    except Exception:
+        _set_portal_quote_manual_review(quote, "Automatic quote engine unavailable")
         logger.exception(
-            "Portal quote automation crashed for %s: %s",
-            stored_file.get("original_filename"),
-            exc,
+            "Portal quote automation crashed for %r",
+            _safe_log_value(stored_file.get("original_filename")),
         )
         return {}
 

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -387,10 +387,35 @@ async def _maybe_enrich_portal_quote(
         quote.requires_review_reason = "Automatic quote engine unavailable"
         return {}
 
-    result = provider(db=db, quote=quote, stored_file=stored_file, options=options)
-    if isawaitable(result):
-        result = await result
-    return result or {}
+    try:
+        result = provider(db=db, quote=quote, stored_file=stored_file, options=options)
+        if isawaitable(result):
+            result = await result
+        return result or {}
+    except HTTPException as exc:
+        quote.status = "pending"
+        quote.approval_method = "manual"
+        if exc.status_code >= 500:
+            quote.requires_review_reason = "Automatic quote engine unavailable"
+        else:
+            quote.requires_review_reason = "Uploaded file requires manual review"
+        logger.warning(
+            "Portal quote automation failed for %s (%s): %s",
+            stored_file.get("original_filename"),
+            exc.status_code,
+            exc.detail,
+        )
+        return {}
+    except Exception as exc:
+        quote.status = "pending"
+        quote.approval_method = "manual"
+        quote.requires_review_reason = "Automatic quote engine unavailable"
+        logger.exception(
+            "Portal quote automation crashed for %s: %s",
+            stored_file.get("original_filename"),
+            exc,
+        )
+        return {}
 
 
 def _apply_portal_shipping(quote: Quote, current_user: User, payload: PortalShippingSelection) -> None:

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -281,8 +281,16 @@ class Settings(BaseSettings):
     @classmethod
     def parse_file_formats(cls, v):
         if isinstance(v, str):
-            return [fmt.strip() for fmt in v.split(",") if fmt.strip()]
-        return v
+            values = [fmt.strip() for fmt in v.split(",") if fmt.strip()]
+        else:
+            values = v
+        if not isinstance(values, list):
+            return values
+        return [
+            normalized if normalized.startswith(".") else f".{normalized}"
+            for normalized in (str(fmt).strip().lower() for fmt in values)
+            if normalized
+        ]
 
     # ===================
     # EasyPost

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -273,7 +273,8 @@ class Settings(BaseSettings):
     )
     MAX_FILE_SIZE_MB: int = Field(default=100, description="Max upload size (MB)")
     ALLOWED_FILE_FORMATS: List[str] = Field(
-        default=[".3mf", ".stl"], description="Allowed upload extensions"
+        default=[".3mf", ".stl", ".obj", ".step", ".stp"],
+        description="Allowed upload extensions",
     )
 
     @field_validator("ALLOWED_FILE_FORMATS", mode="before")

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -373,12 +373,20 @@ class TestPortalQuoteContract:
         from fastapi import HTTPException
         from app.models.quote import Quote
 
-        had_previous = hasattr(client.app.state, "quote_automation_provider")
-        previous_provider = getattr(client.app.state, "quote_automation_provider", None)
-
-        def failing_provider(**_kwargs):
+        def failing_provider(**kwargs):
+            quote = kwargs["quote"]
+            quote.material_grams = Decimal("27.20")
+            quote.print_time_hours = Decimal("0.75")
+            quote.unit_price = Decimal("6.43")
+            quote.subtotal = Decimal("6.43")
+            quote.total_price = Decimal("6.43")
+            quote.status = "approved"
+            quote.approval_method = "auto"
+            quote.auto_approved = True
+            quote.auto_approve_eligible = True
             raise HTTPException(status_code=503, detail="real slicer temporarily unavailable")
 
+        provider_state = self._install_auto_quote_provider(client)
         client.app.state.quote_automation_provider = failing_provider
         try:
             response = client.post(
@@ -393,10 +401,7 @@ class TestPortalQuoteContract:
                 files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
             )
         finally:
-            if had_previous:
-                client.app.state.quote_automation_provider = previous_provider
-            elif hasattr(client.app.state, "quote_automation_provider"):
-                delattr(client.app.state, "quote_automation_provider")
+            self._clear_auto_quote_provider(client, provider_state)
 
         assert response.status_code == 201, response.text
         data = response.json()
@@ -407,6 +412,11 @@ class TestPortalQuoteContract:
 
         quote = db.get(Quote, data["quote_id"])
         assert quote.status == "pending"
+        assert quote.approval_method == "manual"
+        assert quote.auto_approved is False
+        assert quote.auto_approve_eligible is False
+        assert quote.total_price == Decimal("0.00")
+        assert quote.material_grams is None
         assert quote.files[0].original_filename == "part.stl"
 
     def test_portal_accept_snapshots_shipping_on_owned_quote(self, client):

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -419,6 +419,55 @@ class TestPortalQuoteContract:
         assert quote.material_grams is None
         assert quote.files[0].original_filename == "part.stl"
 
+    def test_portal_create_falls_back_when_provider_returns_non_dict(self, client, db):
+        from app.models.quote import Quote
+
+        def bad_provider(**kwargs):
+            quote = kwargs["quote"]
+            quote.material_grams = Decimal("27.20")
+            quote.print_time_hours = Decimal("0.75")
+            quote.unit_price = Decimal("6.43")
+            quote.subtotal = Decimal("6.43")
+            quote.total_price = Decimal("6.43")
+            quote.status = "approved"
+            quote.approval_method = "auto"
+            quote.auto_approved = True
+            quote.auto_approve_eligible = True
+            return "ok"
+
+        provider_state = self._install_auto_quote_provider(client)
+        client.app.state.quote_automation_provider = bad_provider
+        try:
+            response = client.post(
+                f"{BASE_URL}/portal",
+                data={
+                    "material": "PLA_BASIC",
+                    "color": "BLK",
+                    "quality": "standard",
+                    "infill": "20%",
+                    "quantity": "1",
+                },
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            )
+        finally:
+            self._clear_auto_quote_provider(client, provider_state)
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["requires_review"] is True
+        assert data["requires_review_reason"] == "Automatic quote engine unavailable"
+        assert data["total_price"] == "0.00"
+
+        quote = db.get(Quote, data["quote_id"])
+        assert quote.status == "pending"
+        assert quote.approval_method == "manual"
+        assert quote.auto_approved is False
+        assert quote.auto_approve_eligible is False
+        assert quote.total_price == Decimal("0.00")
+        assert quote.material_grams is None
+        assert quote.files[0].original_filename == "part.stl"
+
     def test_portal_accept_snapshots_shipping_on_owned_quote(self, client):
         create_response = client.post(
             f"{BASE_URL}/portal",

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -335,6 +335,80 @@ class TestPortalQuoteContract:
         expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
         assert expires_at.tzinfo is None or expires_at.tzinfo.utcoffset(expires_at) is not None
 
+    @pytest.mark.parametrize(
+        ("filename", "content_type"),
+        [
+            ("part.obj", "model/obj"),
+            ("part.step", "model/step"),
+            ("part.stp", "model/step"),
+        ],
+    )
+    def test_portal_create_retains_cad_and_obj_files_for_manual_review(
+        self, client, db, filename, content_type
+    ):
+        from app.models.quote import Quote
+
+        response = client.post(
+            f"{BASE_URL}/portal",
+            data={
+                "material": "PLA_BASIC",
+                "color": "BLK",
+                "quality": "standard",
+                "infill": "20%",
+                "quantity": "1",
+            },
+            files={"file": (filename, b"manual review model", content_type)},
+        )
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["requires_review"] is True
+
+        quote = db.get(Quote, data["quote_id"])
+        assert quote.file_format == f".{filename.rsplit('.', 1)[1]}"
+        assert quote.files[0].original_filename == filename
+
+    def test_portal_create_falls_back_to_manual_review_when_provider_fails(self, client, db):
+        from fastapi import HTTPException
+        from app.models.quote import Quote
+
+        had_previous = hasattr(client.app.state, "quote_automation_provider")
+        previous_provider = getattr(client.app.state, "quote_automation_provider", None)
+
+        def failing_provider(**_kwargs):
+            raise HTTPException(status_code=503, detail="real slicer temporarily unavailable")
+
+        client.app.state.quote_automation_provider = failing_provider
+        try:
+            response = client.post(
+                f"{BASE_URL}/portal",
+                data={
+                    "material": "PLA_BASIC",
+                    "color": "BLK",
+                    "quality": "standard",
+                    "infill": "20%",
+                    "quantity": "1",
+                },
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            )
+        finally:
+            if had_previous:
+                client.app.state.quote_automation_provider = previous_provider
+            elif hasattr(client.app.state, "quote_automation_provider"):
+                delattr(client.app.state, "quote_automation_provider")
+
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert data["status"] == "pending"
+        assert data["requires_review"] is True
+        assert data["requires_review_reason"] == "Automatic quote engine unavailable"
+        assert data["total_price"] == "0.00"
+
+        quote = db.get(Quote, data["quote_id"])
+        assert quote.status == "pending"
+        assert quote.files[0].original_filename == "part.stl"
+
     def test_portal_accept_snapshots_shipping_on_owned_quote(self, client):
         create_response = client.post(
             f"{BASE_URL}/portal",

--- a/backend/tests/unit/test_settings_validation.py
+++ b/backend/tests/unit/test_settings_validation.py
@@ -124,6 +124,16 @@ class TestDatabaseUrlPasswordValidation:
             )
 
 
+class TestUploadFileFormatSettings:
+    def test_allowed_file_formats_normalizes_env_values(self):
+        s = Settings(
+            _env_file=None,
+            ENVIRONMENT="development",
+            ALLOWED_FILE_FORMATS="3MF, .STL, obj, STEP, .stp",
+        )
+        assert s.ALLOWED_FILE_FORMATS == [".3mf", ".stl", ".obj", ".step", ".stp"]
+
+
 class TestDevelopmentPlaceholderCredentials:
     def test_placeholder_secret_key_logs_warning(self, caplog):
         caplog.set_level(logging.WARNING, logger="app.core.settings")


### PR DESCRIPTION
## Summary
- allow public portal quote uploads for .obj, .step, and .stp so Core can retain them as durable quote files
- downgrade optional automation/provider failures to pending manual review instead of returning customer-facing 503s
- add Core quote contract coverage for CAD/OBJ retention and provider failure fallback

## Cross-repo rollout
- Paired with Blb3D/filaops-ecosystem PR for PRO/quoter behavior.
- Core remains the durable archive and manual quote path stays independent of PRO.

## Tests
- DEBUG=false pytest backend/tests/api/v1/test_quotes.py -q
- py_compile quotes/settings/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for .obj, .step, and .stp file uploads in the quote portal; uploaded filenames and formats are preserved.
  * Upload format configuration now normalizes case and ensures leading dots (e.g., `.STL` → `.stl`).

* **Bug Fixes**
  * Portal quote creation falls back to a pending manual-review quote when automation fails, preserving uploads and avoiding customer-facing errors.

* **Tests**
  * Added tests covering file-format normalization and manual-review fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->