### PR TITLE
feat: add quote file download endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Public online quoter endpoints are now explicitly gated by `ENABLE_PUBLIC_QUOTER`, leaving Core manual quote creation independent of PRO.
 - Quotes now expose a Core-owned read-only archive response with retained file and material snapshots for downgrade/retrieval workflows.
+- Quote uploads now have a Core-owned authenticated download endpoint so retained customer files remain retrievable without PRO automation.
 - Staff can create a Core item/product from an approved quote through a deliberate quote action instead of automatic customer upload side effects.
 
 ### Fixed
 
+- Quote file downloads now reject unsafe stored filenames that could escape the Core quote upload directory.
 - Public portal quote uploads now retain `.obj`, `.step`, and `.stp` files as Core quote archives for manual review instead of rejecting them before staff can inspect the model.
 - Public portal quote creation now falls back to a pending manual-review quote when the optional PRO quote automation provider fails, preserving the uploaded file, rolling back partial provider mutations, and avoiding customer-facing slicer 503 errors.
 - Upload format overrides now normalize case and missing leading dots so `.STL`, `stl`, and similar env values behave consistently.

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional
 from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, status, Query, UploadFile, File, Form, HTTPException, Request
-from fastapi.responses import StreamingResponse, Response
+from fastapi.responses import FileResponse, StreamingResponse, Response
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -779,6 +779,48 @@ async def create_item_from_quote(
         "bom_id": bom.id,
         "already_created": False,
     }
+
+
+@router.get("/{quote_id}/files/{file_id}/download")
+async def download_quote_file(
+    quote_id: int,
+    file_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Download a retained quote upload for authorized customers or staff."""
+    quote = db.query(Quote).filter(Quote.id == quote_id).first()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    _authorize_quote_archive_access(quote, current_user)
+
+    quote_file = (
+        db.query(QuoteFile)
+        .filter(QuoteFile.id == file_id, QuoteFile.quote_id == quote_id)
+        .first()
+    )
+    if not quote_file:
+        raise HTTPException(status_code=404, detail="Quote file not found")
+
+    file_path = file_storage.get_file_path(quote_file.stored_filename)
+    if not file_path or not file_path.is_file():
+        raise HTTPException(status_code=404, detail="Quote file not found")
+
+    logger.info(
+        "Quote file %s (%s, %s) downloaded from quote %s by user %s",
+        quote_file.id,
+        quote_file.original_filename,
+        quote_file.mime_type,
+        quote.id,
+        current_user.id,
+    )
+
+    return FileResponse(
+        path=file_path,
+        media_type=quote_file.mime_type or "application/octet-stream",
+        filename=quote_file.original_filename,
+    )
 
 
 @router.get("/{quote_id}", response_model=QuoteDetail)

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -160,14 +160,36 @@ class FileStorageService:
         Returns:
             Path object if file exists, None otherwise
         """
+        if not stored_filename:
+            return None
+
+        stored_path = Path(stored_filename)
+        if (
+            stored_path.is_absolute()
+            or stored_path.name != stored_filename
+            or "/" in stored_filename
+            or "\\" in stored_filename
+        ):
+            logger.warning("Rejected unsafe stored quote filename: %s", stored_filename)
+            return None
+
+        upload_root = self.upload_dir.resolve()
+        if not upload_root.exists():
+            return None
+
         # Search through year/month directories
-        for year_dir in self.upload_dir.iterdir():
+        for year_dir in upload_root.iterdir():
             if not year_dir.is_dir():
                 continue
             for month_dir in year_dir.iterdir():
                 if not month_dir.is_dir():
                     continue
-                file_path = month_dir / stored_filename
+                file_path = (month_dir / stored_filename).resolve()
+                try:
+                    file_path.relative_to(upload_root)
+                except ValueError:
+                    logger.warning("Rejected quote file path outside upload root: %s", file_path)
+                    continue
                 if file_path.exists():
                     return file_path
         return None

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -19,6 +19,7 @@ Covers:
 import pytest
 from decimal import Decimal
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 
 from app.core.config import settings
@@ -111,6 +112,10 @@ class TestQuoteAuth:
         response = unauthed_client.get(f"{BASE_URL}/1/pdf")
         assert response.status_code == 401
 
+    def test_file_download_requires_auth(self, unauthed_client):
+        response = unauthed_client.get(f"{BASE_URL}/1/files/1/download")
+        assert response.status_code == 401
+
 
 
 
@@ -172,6 +177,220 @@ class TestCoreSafeQuoterBoundary:
         assert data["quote"]["id"] == created["quote_id"]
         assert data["files"][0]["original_filename"] == "part.stl"
         assert data["materials"][0]["color_code"] == "JADE_WHITE"
+
+    def test_quote_file_download_returns_original_upload(self, client, db, monkeypatch):
+        from app.models.quote import Quote, QuoteFile
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+        quote.user_id = 1
+        quote.customer_id = 1
+
+        stored_file = Path(__file__)
+        stored_filename = "stored-model.stl"
+        monkeypatch.setattr(
+            file_storage,
+            "get_file_path",
+            lambda filename: stored_file if filename == stored_filename else None,
+        )
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="customer-model.stl",
+            stored_filename=stored_filename,
+            file_path=str(stored_file),
+            file_size_bytes=stored_file.stat().st_size,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="a" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        response = client.get(f"{BASE_URL}/{quote.id}/files/{quote_file.id}/download")
+
+        assert response.status_code == 200, response.text
+        assert response.content == stored_file.read_bytes()
+        assert response.headers["content-type"].startswith("model/stl")
+        assert 'filename="customer-model.stl"' in response.headers["content-disposition"]
+
+    def test_quote_file_download_allows_staff_access_to_any_quote(self, client, db, monkeypatch):
+        from app.core.security import create_access_token
+        from app.models.quote import Quote, QuoteFile
+        from app.models.user import User
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+
+        customer = User(
+            email="file-customer@example.com",
+            password_hash="not-a-real-hash",
+            first_name="File",
+            last_name="Customer",
+            account_type="customer",
+        )
+        staff = User(
+            email="file-staff@example.com",
+            password_hash="not-a-real-hash",
+            first_name="File",
+            last_name="Staff",
+            account_type="operator",
+        )
+        db.add_all([customer, staff])
+        db.flush()
+        quote.user_id = customer.id
+        quote.customer_id = customer.id
+
+        stored_file = Path(__file__)
+        stored_filename = "staff-readable-model.stl"
+        monkeypatch.setattr(
+            file_storage,
+            "get_file_path",
+            lambda filename: stored_file if filename == stored_filename else None,
+        )
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="customer-owned.stl",
+            stored_filename=stored_filename,
+            file_path=str(stored_file),
+            file_size_bytes=stored_file.stat().st_size,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="b" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        response = client.get(
+            f"{BASE_URL}/{quote.id}/files/{quote_file.id}/download",
+            headers={"Authorization": f"Bearer {create_access_token(user_id=staff.id)}"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.content == stored_file.read_bytes()
+
+    def test_quote_file_download_rejects_unowned_customer_quote(self, client, db, monkeypatch):
+        from app.core.security import create_access_token
+        from app.models.quote import Quote, QuoteFile
+        from app.models.user import User
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+
+        owner = User(
+            email="file-owner@example.com",
+            password_hash="not-a-real-hash",
+            first_name="File",
+            last_name="Owner",
+            account_type="customer",
+        )
+        other_customer = User(
+            email="other-file-customer@example.com",
+            password_hash="not-a-real-hash",
+            first_name="Other",
+            last_name="Customer",
+            account_type="customer",
+        )
+        db.add_all([owner, other_customer])
+        db.flush()
+        quote.user_id = owner.id
+        quote.customer_id = owner.id
+
+        stored_file = Path(__file__)
+        stored_filename = "private-model.stl"
+        monkeypatch.setattr(
+            file_storage,
+            "get_file_path",
+            lambda filename: stored_file if filename == stored_filename else None,
+        )
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="private-model.stl",
+            stored_filename=stored_filename,
+            file_path=str(stored_file),
+            file_size_bytes=stored_file.stat().st_size,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="b" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        response = client.get(
+            f"{BASE_URL}/{quote.id}/files/{quote_file.id}/download",
+            headers={"Authorization": f"Bearer {create_access_token(user_id=other_customer.id)}"},
+        )
+
+        assert response.status_code == 403
+        assert "belong" in response.json()["detail"]
+
+    def test_quote_file_download_returns_404_when_file_missing(self, client, db, monkeypatch):
+        from app.models.quote import Quote, QuoteFile
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+        monkeypatch.setattr(file_storage, "get_file_path", lambda filename: None)
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="missing.stl",
+            stored_filename="missing.stl",
+            file_path=str(Path(__file__)),
+            file_size_bytes=123,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="c" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        response = client.get(f"{BASE_URL}/{quote.id}/files/{quote_file.id}/download")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Quote file not found"
+
+    @pytest.mark.parametrize("stored_filename_kind", ["absolute", "relative_traversal"])
+    def test_quote_file_download_rejects_stored_filename_escape(
+        self,
+        client,
+        db,
+        monkeypatch,
+        stored_filename_kind,
+    ):
+        from app.models.quote import Quote, QuoteFile
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+
+        upload_dir = Path("backend/tests")
+        outside_file = Path(__file__).resolve()
+
+        monkeypatch.setattr(file_storage, "upload_dir", upload_dir)
+        unsafe_stored_filename = (
+            str(outside_file)
+            if stored_filename_kind == "absolute"
+            else "../v1/test_quotes.py"
+        )
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="customer-model.stl",
+            stored_filename=unsafe_stored_filename,
+            file_path=str(outside_file),
+            file_size_bytes=outside_file.stat().st_size,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="e" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        response = client.get(f"{BASE_URL}/{quote.id}/files/{quote_file.id}/download")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Quote file not found"
 
     def test_quote_archive_rejects_unowned_customer_quote(self, client, db, monkeypatch):
         from app.models.quote import Quote


### PR DESCRIPTION
## Summary
- add an authenticated Core endpoint to download retained quote upload files
- reuse quote archive authorization so staff can access quote files and customers only access their own
- keep file serving constrained to Core quote storage via `file_storage.get_file_path(stored_filename)`

## Related Issues
- None

## Changes
- `backend/app/api/v1/endpoints/quotes.py`: adds `GET /api/v1/quotes/{quote_id}/files/{file_id}/download`, audit logging, clearer missing-quote/file errors, and centralized stored-file lookup
- `backend/tests/api/v1/test_quotes.py`: covers auth requirement, customer ownership rejection, staff access, successful download, and missing stored file behavior
- `CHANGELOG.md`: documents the Core-owned quote upload download endpoint

## Tests
- `python -m pytest backend/tests/api/v1/test_quotes.py -q` (142 passed)
- `python -m py_compile backend/app/api/v1/endpoints/quotes.py backend/tests/api/v1/test_quotes.py`

## Notes
- No PRO imports or schema migration.
- UI download links can be added in a follow-up ecosystem/quoter PR once this Core endpoint merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quote uploads now include an authenticated download endpoint that returns the original file and MIME type.

* **Security**
  * Hardened file lookup to reject unsafe/path-traversal filenames; missing or invalid stored files return not-found.

* **Documentation**
  * CHANGELOG updated to document the new quote file download capability.

* **Tests**
  * Added tests for auth (401), successful downloads, staff access, unauthorized customer rejection (403), missing-file (404), and stored-filename safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->