### PR TITLE
chore: ignore local runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,12 +107,15 @@ logs/
 # Uploads (user content)
 uploads/*
 !uploads/.gitkeep
+backend/uploads/*
+!backend/uploads/.gitkeep
 
 # Testing
 /playwright-report/
 **/test-results/
 /coverage/
 .nyc_output/
+.playwright-mcp/
 
 # OS
 .DS_Store
@@ -151,6 +154,8 @@ tables_output.txt
 # Code Conclave / Review Council (runtime artifacts + local skills)
 .code-conclave/
 .review-council/
+.agents/
+.codex/
 .claude/reviews/
 .claude/skills/review-council*
 *-review-log.txt


### PR DESCRIPTION
## Summary
- ignore backend runtime upload files generated by quote/manual testing
- ignore local Playwright MCP snapshots and local agent/Codex hook artifacts
- leave AGENTS.md and the draft install runbook visible for separate review

## Tests
- Not run; .gitignore-only cleanup

## Notes
- No runtime code changes.
- Existing local uploaded files are not deleted; they are just no longer shown as untracked source-control noise.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-ignore-local-artifacts-20260521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for file tracking and local development tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->