### PR TITLE
feat: add manual quote attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Manual quotes now support Core-owned file attachments with staff upload, download, list, and delete actions.
 - Public online quoter endpoints are now explicitly gated by `ENABLE_PUBLIC_QUOTER`, leaving Core manual quote creation independent of PRO.
 - Quotes now expose a Core-owned read-only archive response with retained file and material snapshots for downgrade/retrieval workflows.
 - Quote uploads now have a Core-owned authenticated download endpoint so retained customer files remain retrievable without PRO automation.

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -910,7 +910,18 @@ async def delete_quote_file(
 
     stored_filename = quote_file.stored_filename
     original_filename = quote_file.original_filename
-    file_storage.delete_file(stored_filename)
+    if not file_storage.delete_file(stored_filename):
+        logger.error(
+            "Failed to delete stored quote file %s for quote file %s on quote %s",
+            stored_filename,
+            file_id,
+            quote.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Stored quote file could not be deleted",
+        )
+
     db.delete(quote_file)
     db.commit()
 

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -823,6 +823,107 @@ async def download_quote_file(
     )
 
 
+@router.get("/{quote_id}/files", response_model=list[QuoteArchiveFile])
+async def list_quote_files(
+    quote_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List retained files attached to a quote."""
+    quote = db.query(Quote).filter(Quote.id == quote_id).first()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    _authorize_quote_archive_access(quote, current_user)
+
+    return (
+        db.query(QuoteFile)
+        .filter(QuoteFile.quote_id == quote_id)
+        .order_by(QuoteFile.id)
+        .all()
+    )
+
+
+@router.post("/{quote_id}/files", response_model=QuoteArchiveFile, status_code=status.HTTP_201_CREATED)
+async def upload_quote_file(
+    quote_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Staff action: attach a retained file to a manual or online quote."""
+    _require_staff_or_admin(current_user)
+    quote = db.query(Quote).filter(Quote.id == quote_id).first()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    try:
+        file_info = await file_storage.save_file(file, user_id=current_user.id, quote_id=quote.id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    quote_file = QuoteFile(
+        quote_id=quote.id,
+        original_filename=file_info["original_filename"],
+        stored_filename=file_info["stored_filename"],
+        file_path=file_info["file_path"],
+        file_size_bytes=file_info["file_size_bytes"],
+        file_format=file_info["file_format"],
+        mime_type=file_info["mime_type"],
+        file_hash=file_info["file_hash"],
+    )
+    db.add(quote_file)
+    db.commit()
+    db.refresh(quote_file)
+
+    logger.info(
+        "Quote file %s (%s, %s) uploaded to quote %s by user %s",
+        quote_file.id,
+        quote_file.original_filename,
+        quote_file.mime_type,
+        quote.id,
+        current_user.id,
+    )
+    return quote_file
+
+
+@router.delete("/{quote_id}/files/{file_id}")
+async def delete_quote_file(
+    quote_id: int,
+    file_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Staff action: remove a retained file from a quote."""
+    _require_staff_or_admin(current_user)
+    quote = db.query(Quote).filter(Quote.id == quote_id).first()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    quote_file = (
+        db.query(QuoteFile)
+        .filter(QuoteFile.id == file_id, QuoteFile.quote_id == quote_id)
+        .first()
+    )
+    if not quote_file:
+        raise HTTPException(status_code=404, detail="Quote file not found")
+
+    stored_filename = quote_file.stored_filename
+    original_filename = quote_file.original_filename
+    file_storage.delete_file(stored_filename)
+    db.delete(quote_file)
+    db.commit()
+
+    logger.info(
+        "Quote file %s (%s) deleted from quote %s by user %s",
+        file_id,
+        original_filename,
+        quote.id,
+        current_user.id,
+    )
+    return {"message": "Quote file deleted"}
+
+
 @router.get("/{quote_id}", response_model=QuoteDetail)
 async def get_quote(
     quote_id: int,

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -826,6 +826,8 @@ async def download_quote_file(
 @router.get("/{quote_id}/files", response_model=list[QuoteArchiveFile])
 async def list_quote_files(
     quote_id: int,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -840,6 +842,8 @@ async def list_quote_files(
         db.query(QuoteFile)
         .filter(QuoteFile.quote_id == quote_id)
         .order_by(QuoteFile.id)
+        .offset(skip)
+        .limit(limit)
         .all()
     )
 

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -116,6 +116,21 @@ class TestQuoteAuth:
         response = unauthed_client.get(f"{BASE_URL}/1/files/1/download")
         assert response.status_code == 401
 
+    def test_file_list_requires_auth(self, unauthed_client):
+        response = unauthed_client.get(f"{BASE_URL}/1/files")
+        assert response.status_code == 401
+
+    def test_file_upload_requires_auth(self, unauthed_client):
+        response = unauthed_client.post(
+            f"{BASE_URL}/1/files",
+            files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+        )
+        assert response.status_code == 401
+
+    def test_file_delete_requires_auth(self, unauthed_client):
+        response = unauthed_client.delete(f"{BASE_URL}/1/files/1")
+        assert response.status_code == 401
+
 
 
 
@@ -391,6 +406,98 @@ class TestCoreSafeQuoterBoundary:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Quote file not found"
+
+    def test_manual_quote_file_upload_list_and_delete(self, client, db, monkeypatch):
+        from app.models.quote import Quote, QuoteFile
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+
+        async def fake_save_file(file, user_id, quote_id=None):
+            return {
+                "original_filename": file.filename,
+                "stored_filename": "manual-attachment.stl",
+                "file_path": str(Path(__file__)),
+                "file_size_bytes": 25,
+                "file_format": ".stl",
+                "file_hash": "f" * 64,
+                "mime_type": file.content_type or "application/octet-stream",
+                "gcs_backed_up": False,
+            }
+
+        deleted = []
+        monkeypatch.setattr(file_storage, "save_file", fake_save_file)
+        monkeypatch.setattr(file_storage, "delete_file", lambda stored_filename: deleted.append(stored_filename) or True)
+
+        upload_response = client.post(
+            f"{BASE_URL}/{quote.id}/files",
+            files={"file": ("manual-part.stl", b"solid test\nendsolid test\n", "model/stl")},
+        )
+
+        assert upload_response.status_code == 201, upload_response.text
+        uploaded = upload_response.json()
+        assert uploaded["original_filename"] == "manual-part.stl"
+        assert uploaded["file_format"] == ".stl"
+
+        list_response = client.get(f"{BASE_URL}/{quote.id}/files")
+
+        assert list_response.status_code == 200, list_response.text
+        files = list_response.json()
+        assert len(files) == 1
+        assert files[0]["id"] == uploaded["id"]
+        assert files[0]["original_filename"] == "manual-part.stl"
+
+        delete_response = client.delete(f"{BASE_URL}/{quote.id}/files/{uploaded['id']}")
+
+        assert delete_response.status_code == 200, delete_response.text
+        assert deleted == ["manual-attachment.stl"]
+        assert db.get(QuoteFile, uploaded["id"]) is None
+
+    def test_customer_cannot_upload_or_delete_quote_files(self, client, db):
+        from app.core.security import create_access_token
+        from app.models.quote import Quote, QuoteFile
+        from app.models.user import User
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+        customer = User(
+            email="attachment-customer@example.com",
+            password_hash="not-a-real-hash",
+            first_name="Attachment",
+            last_name="Customer",
+            account_type="customer",
+        )
+        db.add(customer)
+        db.flush()
+        quote.user_id = customer.id
+        quote.customer_id = customer.id
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="existing.stl",
+            stored_filename="existing.stl",
+            file_path=str(Path(__file__)),
+            file_size_bytes=123,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="1" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+        auth = {"Authorization": f"Bearer {create_access_token(user_id=customer.id)}"}
+
+        upload_response = client.post(
+            f"{BASE_URL}/{quote.id}/files",
+            files={"file": ("customer-upload.stl", b"solid test\nendsolid test\n", "model/stl")},
+            headers=auth,
+        )
+        delete_response = client.delete(
+            f"{BASE_URL}/{quote.id}/files/{quote_file.id}",
+            headers=auth,
+        )
+
+        assert upload_response.status_code == 403
+        assert delete_response.status_code == 403
 
     def test_quote_archive_rejects_unowned_customer_quote(self, client, db, monkeypatch):
         from app.models.quote import Quote

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -499,6 +499,33 @@ class TestCoreSafeQuoterBoundary:
         assert upload_response.status_code == 403
         assert delete_response.status_code == 403
 
+    def test_quote_file_delete_failure_keeps_db_record(self, client, db, monkeypatch):
+        from app.models.quote import Quote, QuoteFile
+        from app.services.file_storage import file_storage
+
+        quote_data = _create_quote(client)
+        quote = db.get(Quote, quote_data["id"])
+        quote_file = QuoteFile(
+            quote_id=quote.id,
+            original_filename="existing.stl",
+            stored_filename="existing.stl",
+            file_path=str(Path(__file__)),
+            file_size_bytes=123,
+            file_format=".stl",
+            mime_type="model/stl",
+            file_hash="2" * 64,
+        )
+        db.add(quote_file)
+        db.commit()
+
+        monkeypatch.setattr(file_storage, "delete_file", lambda stored_filename: False)
+
+        response = client.delete(f"{BASE_URL}/{quote.id}/files/{quote_file.id}")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Stored quote file could not be deleted"
+        assert db.get(QuoteFile, quote_file.id) is not None
+
     def test_quote_archive_rejects_unowned_customer_quote(self, client, db, monkeypatch):
         from app.models.quote import Quote
         from app.models.user import User

--- a/frontend/src/components/quotes/QuoteDetailModal.jsx
+++ b/frontend/src/components/quotes/QuoteDetailModal.jsx
@@ -3,7 +3,7 @@
  *
  * Extracted from AdminQuotes.jsx (ARCHITECT-002)
  */
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 
@@ -45,22 +45,28 @@ export default function QuoteDetailModal({
   const canConvert =
     (q.status === "approved" || q.status === "accepted") && !isExpired && !q.sales_order_id;
 
-  const loadQuoteFiles = async () => {
+  const loadQuoteFiles = useCallback(async ({ signal } = {}) => {
     try {
       const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/files`, {
         credentials: "include",
+        signal,
       });
       if (!res.ok) throw new Error("Failed to load quote files");
-      setQuoteFiles(await res.json());
-    } catch {
+      const files = await res.json();
+      if (signal?.aborted) return;
+      setQuoteFiles(files);
+    } catch (err) {
+      if (err.name === "AbortError") return;
       setQuoteFiles([]);
     }
-  };
+  }, [quote.id]);
 
   useEffect(() => {
+    const controller = new AbortController();
     setQuoteFiles([]);
-    loadQuoteFiles();
-  }, [quote.id]);
+    loadQuoteFiles({ signal: controller.signal });
+    return () => controller.abort();
+  }, [loadQuoteFiles]);
 
   // Load image if quote has one (fetch with auth and create blob URL)
   useEffect(() => {

--- a/frontend/src/components/quotes/QuoteDetailModal.jsx
+++ b/frontend/src/components/quotes/QuoteDetailModal.jsx
@@ -23,6 +23,8 @@ export default function QuoteDetailModal({
 }) {
   const toast = useToast();
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [uploadingFile, setUploadingFile] = useState(false);
+  const [quoteFiles, setQuoteFiles] = useState([]);
   const [imageUrl, setImageUrl] = useState(null);
   const imageUrlRef = useRef(null);
 
@@ -42,6 +44,23 @@ export default function QuoteDetailModal({
   const isExpired = new Date(q.expires_at) < new Date();
   const canConvert =
     (q.status === "approved" || q.status === "accepted") && !isExpired && !q.sales_order_id;
+
+  const loadQuoteFiles = async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/files`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to load quote files");
+      setQuoteFiles(await res.json());
+    } catch {
+      setQuoteFiles([]);
+    }
+  };
+
+  useEffect(() => {
+    setQuoteFiles([]);
+    loadQuoteFiles();
+  }, [quote.id]);
 
   // Load image if quote has one (fetch with auth and create blob URL)
   useEffect(() => {
@@ -150,6 +169,91 @@ export default function QuoteDetailModal({
     } catch (err) {
       toast.error(err.message);
     }
+  };
+
+  const handleFileUpload = async (e) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    setUploadingFile(true);
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/files`, {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || "Failed to upload quote file");
+      }
+
+      toast.success("Quote file uploaded");
+      await loadQuoteFiles();
+      if (onRefresh) onRefresh();
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setUploadingFile(false);
+    }
+  };
+
+  const handleFileDownload = async (quoteFile) => {
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/quotes/${quote.id}/files/${quoteFile.id}/download`,
+        { credentials: "include" },
+      );
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || "Failed to download quote file");
+      }
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = quoteFile.original_filename || "quote-file";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
+  const handleFileDelete = async (quoteFile) => {
+    if (!confirm(`Delete ${quoteFile.original_filename}?`)) return;
+
+    try {
+      const res = await fetch(`${API_URL}/api/v1/quotes/${quote.id}/files/${quoteFile.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || "Failed to delete quote file");
+      }
+
+      toast.success("Quote file deleted");
+      await loadQuoteFiles();
+      if (onRefresh) onRefresh();
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
+  const formatFileSize = (bytes) => {
+    if (!bytes) return "0 B";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
   return (
@@ -339,6 +443,63 @@ export default function QuoteDetailModal({
                     />
                     <span className="text-xs text-gray-500">PNG, JPG, WebP up to 5MB</span>
                   </label>
+                </div>
+              )}
+            </div>
+
+            {/* Quote Files */}
+            <div className="bg-gray-800 rounded-lg p-4">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <h4 className="text-sm font-medium text-gray-300">Quote Files</h4>
+                <label className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded cursor-pointer hover:bg-blue-700 disabled:opacity-50">
+                  {uploadingFile ? "Uploading..." : "Upload"}
+                  <input
+                    type="file"
+                    accept=".3mf,.stl,.obj,.step,.stp"
+                    onChange={handleFileUpload}
+                    className="hidden"
+                    disabled={uploadingFile}
+                  />
+                </label>
+              </div>
+              {quoteFiles.length > 0 ? (
+                <div className="space-y-2">
+                  {quoteFiles.map((quoteFile) => (
+                    <div
+                      key={quoteFile.id}
+                      className="flex items-center justify-between gap-3 rounded border border-gray-700 bg-gray-900 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm text-white">{quoteFile.original_filename}</p>
+                        <p className="text-xs text-gray-500">
+                          {quoteFile.file_format} · {formatFileSize(quoteFile.file_size_bytes)}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleFileDownload(quoteFile)}
+                          className="px-2.5 py-1.5 text-xs bg-gray-700 text-white rounded hover:bg-gray-600"
+                        >
+                          Download
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleFileDelete(quoteFile)}
+                          className="px-2.5 py-1.5 text-xs bg-red-600/20 text-red-400 rounded hover:bg-red-600/30"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="border-2 border-dashed border-gray-700 rounded-lg p-4 text-center">
+                  <p className="text-sm text-gray-400">
+                    Attach model files or customer-provided documents for this quote.
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500">3MF, STL, OBJ, STEP, STP</p>
                 </div>
               )}
             </div>

--- a/frontend/src/components/quotes/QuoteDetailModal.jsx
+++ b/frontend/src/components/quotes/QuoteDetailModal.jsx
@@ -7,6 +7,10 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 
+const QUOTE_FILE_EXTENSIONS = [".3mf", ".stl", ".obj", ".step", ".stp"];
+const QUOTE_FILE_ACCEPT = QUOTE_FILE_EXTENSIONS.join(",");
+const QUOTE_FILE_MAX_SIZE_BYTES = 50 * 1024 * 1024;
+
 export default function QuoteDetailModal({
   quote,
   onClose,
@@ -60,6 +64,22 @@ export default function QuoteDetailModal({
       setQuoteFiles([]);
     }
   }, [quote.id]);
+
+  const parseErrorResponse = async (res, fallback) => {
+    let detail = fallback;
+    try {
+      const err = await res.clone().json();
+      if (err?.detail) detail = err.detail;
+    } catch {
+      try {
+        const text = await res.text();
+        if (text) detail = text;
+      } catch {
+        detail = `${fallback} (${res.status} ${res.statusText || "error"})`;
+      }
+    }
+    return detail;
+  };
 
   useEffect(() => {
     const controller = new AbortController();
@@ -182,6 +202,19 @@ export default function QuoteDetailModal({
     e.target.value = "";
     if (!file) return;
 
+    const extension = file.name.includes(".")
+      ? file.name.slice(file.name.lastIndexOf(".")).toLowerCase()
+      : "";
+    if (!QUOTE_FILE_EXTENSIONS.includes(extension)) {
+      toast.error("Unsupported file type");
+      return;
+    }
+
+    if (file.size > QUOTE_FILE_MAX_SIZE_BYTES) {
+      toast.error("File must be less than 50MB");
+      return;
+    }
+
     setUploadingFile(true);
     const formData = new FormData();
     formData.append("file", file);
@@ -194,8 +227,7 @@ export default function QuoteDetailModal({
       });
 
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to upload quote file");
+        throw new Error(await parseErrorResponse(res, "Failed to upload quote file"));
       }
 
       toast.success("Quote file uploaded");
@@ -215,8 +247,7 @@ export default function QuoteDetailModal({
         { credentials: "include" },
       );
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to download quote file");
+        throw new Error(await parseErrorResponse(res, "Failed to download quote file"));
       }
 
       const blob = await res.blob();
@@ -243,8 +274,7 @@ export default function QuoteDetailModal({
       });
 
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to delete quote file");
+        throw new Error(await parseErrorResponse(res, "Failed to delete quote file"));
       }
 
       toast.success("Quote file deleted");
@@ -461,7 +491,7 @@ export default function QuoteDetailModal({
                   {uploadingFile ? "Uploading..." : "Upload"}
                   <input
                     type="file"
-                    accept=".3mf,.stl,.obj,.step,.stp"
+                    accept={QUOTE_FILE_ACCEPT}
                     onChange={handleFileUpload}
                     className="hidden"
                     disabled={uploadingFile}
@@ -501,12 +531,21 @@ export default function QuoteDetailModal({
                   ))}
                 </div>
               ) : (
-                <div className="border-2 border-dashed border-gray-700 rounded-lg p-4 text-center">
+                <label className="block cursor-pointer border-2 border-dashed border-gray-700 rounded-lg p-4 text-center hover:border-gray-600">
                   <p className="text-sm text-gray-400">
-                    Attach model files or customer-provided documents for this quote.
+                    {uploadingFile
+                      ? "Uploading..."
+                      : "Click to attach model files or customer-provided documents for this quote."}
                   </p>
                   <p className="mt-1 text-xs text-gray-500">3MF, STL, OBJ, STEP, STP</p>
-                </div>
+                  <input
+                    type="file"
+                    accept={QUOTE_FILE_ACCEPT}
+                    onChange={handleFileUpload}
+                    className="hidden"
+                    disabled={uploadingFile}
+                  />
+                </label>
               )}
             </div>
 

--- a/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
@@ -48,7 +48,7 @@ const renderModal = () => render(
 
 describe("QuoteDetailModal attachments", () => {
   beforeEach(() => {
-    global.fetch = vi.fn((url) => {
+    vi.stubGlobal("fetch", vi.fn((url) => {
       if (String(url).endsWith("/api/v1/quotes/42")) {
         return Promise.resolve({
           ok: true,
@@ -76,10 +76,11 @@ describe("QuoteDetailModal attachments", () => {
         ok: true,
         json: () => Promise.resolve({}),
       });
-    });
+    }));
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import QuoteDetailModal from "../QuoteDetailModal";
 import { ToastProvider } from "../../Toast";
@@ -27,7 +27,20 @@ const quote = {
   lines: [],
 };
 
-const renderModal = () => render(
+const attachment = {
+  id: 7,
+  original_filename: "manual-part.stl",
+  file_format: ".stl",
+  file_size_bytes: 2048,
+  file_hash: "a".repeat(64),
+  uploaded_at: "2026-05-21T12:01:00Z",
+  processed: false,
+  processing_error: null,
+};
+
+let quoteFiles;
+
+const renderModal = (props = {}) => render(
   <ToastProvider>
     <QuoteDetailModal
       quote={quote}
@@ -42,34 +55,45 @@ const renderModal = () => render(
       onDelete={vi.fn()}
       getStatusStyle={() => "bg-gray-700 text-gray-200"}
       onRefresh={vi.fn()}
+      {...props}
     />
   </ToastProvider>,
 );
 
 describe("QuoteDetailModal attachments", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn((url) => {
+    quoteFiles = [attachment];
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    vi.stubGlobal("fetch", vi.fn((url, options = {}) => {
+      const method = options.method || "GET";
       if (String(url).endsWith("/api/v1/quotes/42")) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(quote),
         });
       }
-      if (String(url).endsWith("/api/v1/quotes/42/files")) {
+      if (String(url).endsWith("/api/v1/quotes/42/files") && method === "GET") {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve([
-            {
-              id: 7,
-              original_filename: "manual-part.stl",
-              file_format: ".stl",
-              file_size_bytes: 2048,
-              file_hash: "a".repeat(64),
-              uploaded_at: "2026-05-21T12:01:00Z",
-              processed: false,
-              processing_error: null,
-            },
-          ]),
+          json: () => Promise.resolve(quoteFiles),
+        });
+      }
+      if (String(url).endsWith("/api/v1/quotes/42/files") && method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ...attachment, id: 8, original_filename: "upload.stl" }),
+        });
+      }
+      if (String(url).endsWith("/api/v1/quotes/42/files/7/download")) {
+        return Promise.resolve({
+          ok: true,
+          blob: () => Promise.resolve(new Blob(["solid test"], { type: "model/stl" })),
+        });
+      }
+      if (String(url).endsWith("/api/v1/quotes/42/files/7") && method === "DELETE") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ message: "Quote file deleted" }),
         });
       }
       return Promise.resolve({
@@ -77,6 +101,9 @@ describe("QuoteDetailModal attachments", () => {
         json: () => Promise.resolve({}),
       });
     }));
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:quote-file");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -97,6 +124,64 @@ describe("QuoteDetailModal attachments", () => {
 
     expect(screen.getByText(".stl · 2.0 KB")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Delete" }).length).toBeGreaterThan(0);
+    const row = screen.getByText("manual-part.stl").closest("div").parentElement;
+    expect(within(row).getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("uploads, downloads, and deletes quote attachments", async () => {
+    const onRefresh = vi.fn();
+    renderModal({ onRefresh });
+
+    await waitFor(() => {
+      expect(screen.getByText("manual-part.stl")).toBeInTheDocument();
+    });
+
+    const uploadInput = screen.getByText("Upload").closest("label").querySelector("input");
+    fireEvent.change(uploadInput, {
+      target: {
+        files: [new File(["solid test"], "upload.stl", { type: "model/stl" })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/quotes/42/files"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(onRefresh).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/quotes/42/files/7/download"),
+        expect.objectContaining({ credentials: "include" }),
+      );
+    });
+    expect(URL.createObjectURL).toHaveBeenCalled();
+
+    const row = screen.getByText("manual-part.stl").closest("div").parentElement;
+    fireEvent.click(within(row).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/quotes/42/files/7"),
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+  });
+
+  it("uses the empty quote-file panel as an upload target", () => {
+    quoteFiles = [];
+    renderModal();
+
+    const emptyPanel = screen
+      .getByText("Click to attach model files or customer-provided documents for this quote.")
+      .closest("label");
+
+    expect(emptyPanel.querySelector("input[type='file']")).toHaveAttribute(
+      "accept",
+      ".3mf,.stl,.obj,.step,.stp",
+    );
   });
 });

--- a/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import QuoteDetailModal from "../QuoteDetailModal";
+import { ToastProvider } from "../../Toast";
+
+const quote = {
+  id: 42,
+  quote_number: "Q-2026-000042",
+  product_name: "Manual Quote Part",
+  quantity: 1,
+  unit_price: "12.50",
+  subtotal: "12.50",
+  total_price: "12.50",
+  status: "pending",
+  customer_name: "Example Customer",
+  customer_email: "customer@example.com",
+  material_type: "PLA",
+  color: "Black",
+  has_image: false,
+  line_count: 1,
+  created_at: "2026-05-21T12:00:00Z",
+  expires_at: "2026-08-19T12:00:00Z",
+  sales_order_id: null,
+  updated_at: "2026-05-21T12:00:00Z",
+  approved_at: null,
+  converted_at: null,
+  lines: [],
+};
+
+const renderModal = () => render(
+  <ToastProvider>
+    <QuoteDetailModal
+      quote={quote}
+      onClose={vi.fn()}
+      onEdit={vi.fn()}
+      onUpdateStatus={vi.fn()}
+      onConvert={vi.fn()}
+      onDownloadPDF={vi.fn()}
+      onPrintPDF={vi.fn()}
+      onDuplicate={vi.fn()}
+      onCopyLink={vi.fn()}
+      onDelete={vi.fn()}
+      getStatusStyle={() => "bg-gray-700 text-gray-200"}
+      onRefresh={vi.fn()}
+    />
+  </ToastProvider>,
+);
+
+describe("QuoteDetailModal attachments", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn((url) => {
+      if (String(url).endsWith("/api/v1/quotes/42")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(quote),
+        });
+      }
+      if (String(url).endsWith("/api/v1/quotes/42/files")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: 7,
+              original_filename: "manual-part.stl",
+              file_format: ".stl",
+              file_size_bytes: 2048,
+              file_hash: "a".repeat(64),
+              uploaded_at: "2026-05-21T12:01:00Z",
+              processed: false,
+              processing_error: null,
+            },
+          ]),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows manual quote attachments with upload and download controls", async () => {
+    renderModal();
+
+    expect(screen.getByText("Quote Files")).toBeInTheDocument();
+    expect(screen.getByText("Upload")).toBeInTheDocument();
+    expect(screen.getByText("3MF, STL, OBJ, STEP, STP")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("manual-part.stl")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(".stl · 2.0 KB")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Delete" }).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Core quote-file list/upload/delete endpoints for manual and online quotes
- add staff quote modal controls to upload, download, and delete retained quote files
- add backend and frontend coverage for manual quote attachments

## Core/PRO boundary
- quote attachments remain Core-owned business data and are not gated by PRO
- public quoter automation can still feed this Core path, but manual quoting works without PRO installed

## Tests
- `$env:DEBUG='false'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; .\backend\venv\Scripts\python.exe -m pytest backend/tests/api/v1/test_quotes.py -q` (150 passed)
- `.\backend\venv\Scripts\python.exe -m py_compile backend/app/api/v1/endpoints/quotes.py backend/tests/api/v1/test_quotes.py` (passed)
- `.\backend\venv\Scripts\python.exe -m ruff check backend/app/api/v1/endpoints/quotes.py backend/tests/api/v1/test_quotes.py` (passed)
- `npm run test:unit -- src/components/quotes/__tests__/QuoteDetailModal.test.jsx` (3 passed)
- `npm run build` (passed; existing Vite config.js bundling warning only)

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-manual-quote-attachments-20260521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file attachment support for quotes with upload, download, delete, and list capabilities.
  * Staff can upload Core-owned files to quotes and manage attachments.
  * Customers can view and download attached quote files.
  * File listings include pagination and formatted file size information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->