### PR TITLE
feat: add PRO Bambuddy connector UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -55,6 +55,7 @@ const AdminSettings = lazy(() => import("./pages/admin/AdminSettings"));
 const AdminLocations = lazy(() => import("./pages/admin/AdminLocations"));
 const AdminAccounting = lazy(() => import("./pages/admin/AdminAccounting"));
 const AdminPrinters = lazy(() => import("./pages/admin/AdminPrinters"));
+const AdminBambuddy = lazy(() => import("./pages/admin/AdminBambuddy"));
 const AdminScrapReasons = lazy(() => import("./pages/admin/AdminScrapReasons"));
 const AdminSpools = lazy(() => import("./pages/admin/AdminSpools"));
 const AdminSecurity = lazy(() => import("./pages/admin/AdminSecurity"));
@@ -344,6 +345,16 @@ export default function App() {
                       element={
                         <Suspense fallback={<PageLoader />}>
                           <AdminPrinters />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path="bambuddy"
+                      element={
+                        <Suspense fallback={<PageLoader />}>
+                          <ProGate>
+                            <AdminBambuddy />
+                          </ProGate>
                         </Suspense>
                       }
                     />

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -498,6 +498,13 @@ const navGroups = [
         icon: ManufacturingIcon,
       },
       { path: "/admin/printers", label: "Printers", icon: PrintersIcon },
+      {
+        path: "/admin/bambuddy",
+        label: "Bambuddy",
+        icon: PrintersIcon,
+        adminOnly: true,
+        proOnly: true,
+      },
       { path: "/admin/purchasing", label: "Purchasing", icon: PurchasingIcon },
       { path: "/admin/shipping", label: "Shipping", icon: ShippingIcon },
     ],

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -504,6 +504,7 @@ const navGroups = [
         icon: PrintersIcon,
         adminOnly: true,
         proOnly: true,
+        feature: "bambu_integration",
       },
       { path: "/admin/purchasing", label: "Purchasing", icon: PurchasingIcon },
       { path: "/admin/shipping", label: "Shipping", icon: ShippingIcon },

--- a/frontend/src/components/ApiErrorToaster.jsx
+++ b/frontend/src/components/ApiErrorToaster.jsx
@@ -68,17 +68,14 @@ export default function ApiErrorToaster() {
         return;
       }
 
-      // Handle server unavailable (502, 503, network errors) gracefully
-      // Don't spam toasts - just redirect to login once
+      // Handle server unavailable (502, 503, network errors) gracefully.
+      // Keep the user on the current screen so recoverable integration errors
+      // (for example Bambuddy sync/storage issues) do not look like auth expiry.
       if (status === 502 || status === 503 || status === 0 || msg.includes("Failed to fetch") || msg.includes("Network")) {
         if (!serverDownShown.current) {
           serverDownShown.current = true;
           toast.info("Unable to connect to server. Please check your connection.");
-          // Redirect to login after a brief delay
           setTimeout(() => {
-            if (window.location.pathname !== "/admin/login") {
-              window.location.href = "/admin/login";
-            }
             serverDownShown.current = false;
           }, 2000);
         }
@@ -90,4 +87,3 @@ export default function ApiErrorToaster() {
   }, [toast]);
   return null;
 }
-

--- a/frontend/src/components/ApiErrorToaster.jsx
+++ b/frontend/src/components/ApiErrorToaster.jsx
@@ -44,10 +44,13 @@ export default function ApiErrorToaster() {
 
   useEffect(() => {
     return on("api:error", (e) => {
-      const _url = e?.url || "";  // Reserved for future logging
+      const url = e?.url || "";
       const status = e?.status ?? "";
       const msg = e?.message || "Request failed";
       const detail = e?.detail;
+      const isRecoverableIntegrationError =
+        url.includes("/api/v1/pro/integrations/bambuddy") ||
+        url.includes("/api/v1/pro/printer-providers/bambuddy");
 
       // Check if this is a tier limit error
       if (status === 403 && detail && typeof detail === "object" && detail.code === "TIER_LIMIT_EXCEEDED") {
@@ -69,12 +72,21 @@ export default function ApiErrorToaster() {
       }
 
       // Handle server unavailable (502, 503, network errors) gracefully.
-      // Keep the user on the current screen so recoverable integration errors
-      // (for example Bambuddy sync/storage issues) do not look like auth expiry.
+      // Bambuddy failures are recoverable integration errors; core API outages
+      // block the page and should return users to the login/start point.
       if (status === 502 || status === 503 || status === 0 || msg.includes("Failed to fetch") || msg.includes("Network")) {
         if (!serverDownShown.current) {
           serverDownShown.current = true;
-          toast.info("Unable to connect to server. Please check your connection.");
+          if (isRecoverableIntegrationError) {
+            toast.info("Unable to connect to Bambuddy. FilaOps is still available.");
+          } else {
+            toast.info("Unable to connect to FilaOps. Returning to login...");
+            setTimeout(() => {
+              if (!window.location.pathname.includes("/admin/login")) {
+                window.location.href = "/admin/login";
+              }
+            }, 3000);
+          }
           setTimeout(() => {
             serverDownShown.current = false;
           }, 2000);

--- a/frontend/src/components/__tests__/Breadcrumbs.test.jsx
+++ b/frontend/src/components/__tests__/Breadcrumbs.test.jsx
@@ -154,6 +154,7 @@ describe("ROUTE_LABELS coverage", () => {
       "/admin/production",
       "/admin/manufacturing",
       "/admin/printers",
+      "/admin/bambuddy",
       "/admin/purchasing",
       "/admin/shipping",
       // Quality

--- a/frontend/src/components/breadcrumbs.utils.js
+++ b/frontend/src/components/breadcrumbs.utils.js
@@ -36,6 +36,7 @@ export const ROUTE_LABELS = {
   "/admin/production": "Production",
   "/admin/manufacturing": "Manufacturing",
   "/admin/printers": "Printers",
+  "/admin/bambuddy": "Bambuddy",
   "/admin/purchasing": "Purchasing",
   "/admin/shipping": "Shipping",
   // Quality

--- a/frontend/src/pages/admin/AdminBambuddy.jsx
+++ b/frontend/src/pages/admin/AdminBambuddy.jsx
@@ -1,21 +1,27 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useToast } from "../../components/Toast";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import { useApi } from "../../hooks/useApi";
-
-const DEFAULT_BAMBUDDY_URL = "http://127.0.0.1:8080";
+import {
+  BambuddyAccessLock,
+  BambuddyConnectionForm,
+  BambuddyHeader,
+  BambuddyLegalNotice,
+  BambuddyMachinesTable,
+  BambuddyStatusPanel,
+  LinkPrinterModal,
+} from "./bambuddy";
+import { DEFAULT_BAMBUDDY_URL, getSyncMessage } from "./bambuddy/utils";
 
 export default function AdminBambuddy() {
   const api = useApi();
   const toast = useToast();
-  const { isPro, loading: featuresLoading } = useFeatureFlags();
+  const { isPro, hasFeature, loading: featuresLoading } = useFeatureFlags();
+  const bambuddyAvailable = isPro && hasFeature("bambu_integration");
+  const apiKeyInputRef = useRef(null);
   const [status, setStatus] = useState(null);
   const [machines, setMachines] = useState([]);
-  const [form, setForm] = useState({
-    base_url: DEFAULT_BAMBUDDY_URL,
-    api_key: "",
-  });
+  const [form, setForm] = useState({ base_url: DEFAULT_BAMBUDDY_URL });
   const [loading, setLoading] = useState(true);
   const [connecting, setConnecting] = useState(false);
   const [syncing, setSyncing] = useState(false);
@@ -23,6 +29,7 @@ export default function AdminBambuddy() {
   const [selectedMachine, setSelectedMachine] = useState(null);
   const [selectedPrinterId, setSelectedPrinterId] = useState("");
   const [linking, setLinking] = useState(false);
+  const [unlinkingId, setUnlinkingId] = useState(null);
   const [machineError, setMachineError] = useState("");
 
   const connected = Boolean(status?.connected);
@@ -30,21 +37,21 @@ export default function AdminBambuddy() {
     () => status?.base_url || form.base_url || DEFAULT_BAMBUDDY_URL,
     [form.base_url, status?.base_url],
   );
+  const visibleMachines = connected ? machines : [];
 
   const loadMachines = useCallback(async () => {
-    if (!connected) {
-      setMachines([]);
+    if (!bambuddyAvailable || !connected) {
       return;
     }
     try {
-      setMachineError("");
       const data = await api.get("/api/v1/pro/printer-providers/bambuddy/machines");
+      setMachineError("");
       setMachines(Array.isArray(data) ? data : []);
     } catch (err) {
       setMachines([]);
       setMachineError(err.message);
     }
-  }, [api, connected]);
+  }, [api, bambuddyAvailable, connected]);
 
   const loadStatus = useCallback(async () => {
     try {
@@ -72,29 +79,39 @@ export default function AdminBambuddy() {
   }, [api, toast]);
 
   useEffect(() => {
-    if (featuresLoading || !isPro) return;
+    if (featuresLoading) return;
+    if (!bambuddyAvailable) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Fetch-on-enable updates state after the async API response.
     loadStatus();
     loadPrinters();
-  }, [featuresLoading, isPro, loadPrinters, loadStatus]);
+  }, [bambuddyAvailable, featuresLoading, loadPrinters, loadStatus]);
 
   useEffect(() => {
+    if (featuresLoading || !bambuddyAvailable || !connected) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Fetch-on-connect updates state after the async API response.
     loadMachines();
-  }, [loadMachines]);
+  }, [bambuddyAvailable, connected, featuresLoading, loadMachines]);
 
   const handleConnect = async (event) => {
     event.preventDefault();
+    const apiKey = apiKeyInputRef.current?.value?.trim() || "";
     setConnecting(true);
     try {
       const data = await api.post("/api/v1/pro/integrations/bambuddy/connect", {
         base_url: form.base_url.trim(),
-        api_key: form.api_key.trim(),
+        api_key: apiKey,
       });
       setStatus(data);
-      setForm((prev) => ({ ...prev, api_key: "" }));
+      if (data?.base_url) {
+        setForm((prev) => ({ ...prev, base_url: data.base_url }));
+      }
       toast.success("Bambuddy connected");
     } catch (err) {
       toast.error(err.message);
     } finally {
+      if (apiKeyInputRef.current) {
+        apiKeyInputRef.current.value = "";
+      }
       setConnecting(false);
     }
   };
@@ -105,7 +122,7 @@ export default function AdminBambuddy() {
       const result = await api.post("/api/v1/pro/integrations/bambuddy/sync", {});
       await loadStatus();
       await loadMachines();
-      toast.success(`Synced ${result.synced || 0} Bambuddy records`);
+      toast.success(getSyncMessage(result));
     } catch (err) {
       toast.error(err.message);
     } finally {
@@ -147,7 +164,7 @@ export default function AdminBambuddy() {
   };
 
   const handleUnlink = async (machine) => {
-    setLinking(true);
+    setUnlinkingId(machine.external_id);
     try {
       await api.del(
         `/api/v1/pro/printer-providers/bambuddy/printers/${encodeURIComponent(
@@ -159,11 +176,11 @@ export default function AdminBambuddy() {
     } catch (err) {
       toast.error(err.message);
     } finally {
-      setLinking(false);
+      setUnlinkingId(null);
     }
   };
 
-  if (featuresLoading || loading) {
+  if (featuresLoading || (bambuddyAvailable && loading)) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
@@ -171,347 +188,52 @@ export default function AdminBambuddy() {
     );
   }
 
-  if (!isPro) {
-    return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
-        <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6">
-          <h2 className="text-lg font-semibold text-white">PRO required</h2>
-          <p className="text-sm text-gray-400 mt-2">
-            Bambuddy printer orchestration is available with FilaOps PRO.
-          </p>
-          <Link
-            to="/admin/license"
-            className="inline-flex mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium"
-          >
-            Open License
-          </Link>
-        </div>
-      </div>
-    );
+  if (!bambuddyAvailable) {
+    return <BambuddyAccessLock isPro={isPro} />;
   }
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
-          <p className="text-gray-400 mt-1">
-            Connect FilaOps PRO to the managed Bambuddy service for Bambu printer operations.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => window.open(openUrl, "_blank", "noopener,noreferrer")}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
-          >
-            Open Bambuddy
-          </button>
-          <button
-            type="button"
-            onClick={loadStatus}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
-          >
-            Refresh
-          </button>
-        </div>
-      </div>
+      <BambuddyHeader openUrl={openUrl} onRefresh={loadStatus} />
 
       <section className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-6">
-        <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-white">Connector Status</h2>
-              <p className="text-sm text-gray-400 mt-1">
-                {connected
-                  ? "FilaOps is connected to Bambuddy."
-                  : "FilaOps is not connected to Bambuddy."}
-              </p>
-            </div>
-            <StatusBadge health={status?.health} connected={connected} />
-          </div>
-
-          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-            <InfoItem label="Service URL" value={status?.base_url || "Not set"} />
-            <InfoItem label="Health" value={status?.health || "Disconnected"} />
-            <InfoItem label="Version" value={status?.version || "Unknown"} />
-            <InfoItem label="Last Sync" value={formatDate(status?.last_sync)} />
-          </dl>
-
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={handleSync}
-              disabled={!connected || syncing}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
-            >
-              {syncing ? "Syncing..." : "Sync Printers"}
-            </button>
-            <Link
-              to="/admin/printers"
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
-            >
-              View FilaOps Printers
-            </Link>
-          </div>
-        </div>
-
-        <form
+        <BambuddyStatusPanel
+          connected={connected}
+          status={status}
+          syncing={syncing}
+          onSync={handleSync}
+        />
+        <BambuddyConnectionForm
+          baseUrl={form.base_url}
+          connected={connected}
+          connecting={connecting}
+          inputRef={apiKeyInputRef}
+          onBaseUrlChange={(base_url) => setForm({ base_url })}
           onSubmit={handleConnect}
-          className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
-        >
-          <div>
-            <h2 className="text-lg font-semibold text-white">Connection</h2>
-            <p className="text-sm text-gray-400 mt-1">
-              Use the API key generated in Bambuddy.
-            </p>
-          </div>
-          <label className="block">
-            <span className="text-sm font-medium text-gray-300">Bambuddy URL</span>
-            <input
-              type="url"
-              value={form.base_url}
-              onChange={(event) =>
-                setForm((prev) => ({ ...prev, base_url: event.target.value }))
-              }
-              className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder={DEFAULT_BAMBUDDY_URL}
-              required
-            />
-          </label>
-          <label className="block">
-            <span className="text-sm font-medium text-gray-300">API Key</span>
-            <input
-              type="password"
-              value={form.api_key}
-              onChange={(event) =>
-                setForm((prev) => ({ ...prev, api_key: event.target.value }))
-              }
-              className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              autoComplete="off"
-              required
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={connecting}
-            className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
-          >
-            {connecting ? "Connecting..." : connected ? "Update Connection" : "Connect"}
-          </button>
-        </form>
+        />
       </section>
 
-      <section className="bg-gray-800/40 border border-gray-700 rounded-lg overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-700 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-white">Bambuddy Machines</h2>
-            <p className="text-sm text-gray-400">
-              Synced printers appear here before they are dispatched through FilaOps jobs.
-            </p>
-          </div>
-          <span className="text-sm text-gray-400">{machines.length} machine(s)</span>
-        </div>
+      <BambuddyMachinesTable
+        connected={connected}
+        linking={linking}
+        machineError={machineError}
+        machines={visibleMachines}
+        onLink={openLinkDialog}
+        onUnlink={handleUnlink}
+        unlinkingId={unlinkingId}
+      />
 
-        {machineError ? (
-          <div className="p-6 text-sm text-red-300 bg-red-500/10 border-t border-red-500/20">
-            {machineError}
-          </div>
-        ) : machines.length === 0 ? (
-          <div className="p-8 text-center text-gray-400">
-            {connected
-              ? "No Bambuddy printers returned yet."
-              : "Connect Bambuddy to list managed printers."}
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-900/60 text-gray-400">
-                <tr>
-                  <th className="py-3 px-4 text-left font-medium">Machine</th>
-                  <th className="py-3 px-4 text-left font-medium">Model</th>
-                  <th className="py-3 px-4 text-left font-medium">IP Address</th>
-                  <th className="py-3 px-4 text-left font-medium">Status</th>
-                  <th className="py-3 px-4 text-left font-medium">FilaOps Printer</th>
-                  <th className="py-3 px-4 text-right font-medium">Action</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-700">
-                {machines.map((machine) => (
-                  <tr key={machine.external_id} className="hover:bg-gray-700/30">
-                    <td className="py-3 px-4 text-white font-medium">
-                      {machine.name}
-                      <div className="text-xs text-gray-500">{machine.external_id}</div>
-                    </td>
-                    <td className="py-3 px-4 text-gray-300">{machine.model || "-"}</td>
-                    <td className="py-3 px-4 text-gray-300">{machine.ip_address || "-"}</td>
-                    <td className="py-3 px-4">
-                      <span className="inline-flex px-2 py-1 rounded-full border border-gray-600 text-gray-300 text-xs">
-                        {machine.status || "unknown"}
-                      </span>
-                    </td>
-                    <td className="py-3 px-4 text-gray-300">
-                      {machine.linked_printer ? (
-                        <div>
-                          <div className="text-white font-medium">
-                            {machine.linked_printer.name}
-                          </div>
-                          <div className="text-xs text-gray-500">
-                            {machine.linked_printer.code || `Printer #${machine.linked_printer_id}`}
-                          </div>
-                        </div>
-                      ) : (
-                        <span className="text-gray-500">Not linked</span>
-                      )}
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      {machine.linked_printer_id ? (
-                        <button
-                          type="button"
-                          onClick={() => handleUnlink(machine)}
-                          disabled={linking}
-                          className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
-                        >
-                          Unlink
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={() => openLinkDialog(machine)}
-                          disabled={linking}
-                          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
-                        >
-                          Link Printer
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
+      <BambuddyLegalNotice />
 
-      <section className="bg-gray-900/40 border border-gray-700/70 rounded-lg p-5">
-        <h2 className="text-sm font-semibold text-gray-200">AGPL Service Notice</h2>
-        <p className="text-sm text-gray-400 mt-2">
-          Bambuddy runs as a separate AGPL service. FilaOps PRO communicates with it through HTTP APIs.
-        </p>
-        <a
-          href="https://github.com/maziggy/bambuddy"
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
-        >
-          Bambuddy source and license
-        </a>
-      </section>
-
-      {selectedMachine && (
-        <div className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4">
-          <form
-            onSubmit={handleLink}
-            className="w-full max-w-lg bg-gray-900 border border-gray-700 rounded-lg p-6 space-y-5 shadow-xl"
-          >
-            <div>
-              <h2 className="text-lg font-semibold text-white">Link Printer</h2>
-              <p className="text-sm text-gray-400 mt-1">
-                Link {selectedMachine.name} to one existing FilaOps printer.
-              </p>
-            </div>
-
-            {printers.length === 0 ? (
-              <div className="bg-gray-800/60 border border-gray-700 rounded-md p-4">
-                <p className="text-sm text-gray-300">
-                  Create a FilaOps printer before linking Bambuddy machines.
-                </p>
-                <Link
-                  to="/admin/printers"
-                  className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
-                >
-                  Create printer first
-                </Link>
-              </div>
-            ) : (
-              <label className="block">
-                <span className="text-sm font-medium text-gray-300">
-                  FilaOps printer
-                </span>
-                <select
-                  value={selectedPrinterId}
-                  onChange={(event) => setSelectedPrinterId(event.target.value)}
-                  className="mt-1 w-full bg-gray-950 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  required
-                >
-                  <option value="">Select a printer</option>
-                  {printers.map((printer) => (
-                    <option key={printer.id} value={printer.id}>
-                      {printer.name} {printer.code ? `(${printer.code})` : ""}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={closeLinkDialog}
-                disabled={linking}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-sm font-medium"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={linking || printers.length === 0 || !selectedPrinterId}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
-              >
-                {linking ? "Linking..." : "Link Printer"}
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
+      <LinkPrinterModal
+        linking={linking}
+        machine={selectedMachine}
+        printers={printers}
+        selectedPrinterId={selectedPrinterId}
+        onClose={closeLinkDialog}
+        onPrinterChange={setSelectedPrinterId}
+        onSubmit={handleLink}
+      />
     </div>
   );
-}
-
-function StatusBadge({ health, connected }) {
-  const normalized = connected ? health || "unknown" : "disconnected";
-  const variants = {
-    healthy: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
-    ok: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
-    disconnected: "bg-gray-500/15 text-gray-300 border-gray-500/30",
-    error: "bg-red-500/15 text-red-300 border-red-500/30",
-    unhealthy: "bg-red-500/15 text-red-300 border-red-500/30",
-  };
-  return (
-    <span
-      role="status"
-      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border whitespace-nowrap ${
-        variants[normalized] || "bg-amber-500/15 text-amber-300 border-amber-500/30"
-      }`}
-    >
-      {connected ? normalized : "not connected"}
-    </span>
-  );
-}
-
-function InfoItem({ label, value }) {
-  return (
-    <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-3">
-      <dt className="text-xs uppercase tracking-wide text-gray-500">{label}</dt>
-      <dd className="mt-1 text-gray-200 break-words">{value}</dd>
-    </div>
-  );
-}
-
-function formatDate(value) {
-  if (!value) return "Never";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
 }

--- a/frontend/src/pages/admin/AdminBambuddy.jsx
+++ b/frontend/src/pages/admin/AdminBambuddy.jsx
@@ -1,0 +1,517 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useToast } from "../../components/Toast";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
+import { useApi } from "../../hooks/useApi";
+
+const DEFAULT_BAMBUDDY_URL = "http://127.0.0.1:8080";
+
+export default function AdminBambuddy() {
+  const api = useApi();
+  const toast = useToast();
+  const { isPro, loading: featuresLoading } = useFeatureFlags();
+  const [status, setStatus] = useState(null);
+  const [machines, setMachines] = useState([]);
+  const [form, setForm] = useState({
+    base_url: DEFAULT_BAMBUDDY_URL,
+    api_key: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [printers, setPrinters] = useState([]);
+  const [selectedMachine, setSelectedMachine] = useState(null);
+  const [selectedPrinterId, setSelectedPrinterId] = useState("");
+  const [linking, setLinking] = useState(false);
+  const [machineError, setMachineError] = useState("");
+
+  const connected = Boolean(status?.connected);
+  const openUrl = useMemo(
+    () => status?.base_url || form.base_url || DEFAULT_BAMBUDDY_URL,
+    [form.base_url, status?.base_url],
+  );
+
+  const loadMachines = useCallback(async () => {
+    if (!connected) {
+      setMachines([]);
+      return;
+    }
+    try {
+      setMachineError("");
+      const data = await api.get("/api/v1/pro/printer-providers/bambuddy/machines");
+      setMachines(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setMachines([]);
+      setMachineError(err.message);
+    }
+  }, [api, connected]);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const data = await api.get("/api/v1/pro/integrations/bambuddy/status");
+      setStatus(data);
+      if (data?.base_url) {
+        setForm((prev) => ({ ...prev, base_url: data.base_url }));
+      }
+    } catch (err) {
+      setStatus({ connected: false, health: "error" });
+      toast.error(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, toast]);
+
+  const loadPrinters = useCallback(async () => {
+    try {
+      const data = await api.get("/api/v1/printers?active_only=true&page_size=200");
+      setPrinters(Array.isArray(data?.items) ? data.items : []);
+    } catch (err) {
+      setPrinters([]);
+      toast.error(err.message);
+    }
+  }, [api, toast]);
+
+  useEffect(() => {
+    if (featuresLoading || !isPro) return;
+    loadStatus();
+    loadPrinters();
+  }, [featuresLoading, isPro, loadPrinters, loadStatus]);
+
+  useEffect(() => {
+    loadMachines();
+  }, [loadMachines]);
+
+  const handleConnect = async (event) => {
+    event.preventDefault();
+    setConnecting(true);
+    try {
+      const data = await api.post("/api/v1/pro/integrations/bambuddy/connect", {
+        base_url: form.base_url.trim(),
+        api_key: form.api_key.trim(),
+      });
+      setStatus(data);
+      setForm((prev) => ({ ...prev, api_key: "" }));
+      toast.success("Bambuddy connected");
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleSync = async () => {
+    setSyncing(true);
+    try {
+      const result = await api.post("/api/v1/pro/integrations/bambuddy/sync", {});
+      await loadStatus();
+      await loadMachines();
+      toast.success(`Synced ${result.synced || 0} Bambuddy records`);
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const openLinkDialog = (machine) => {
+    setSelectedMachine(machine);
+    setSelectedPrinterId("");
+  };
+
+  const closeLinkDialog = () => {
+    if (linking) return;
+    setSelectedMachine(null);
+    setSelectedPrinterId("");
+  };
+
+  const handleLink = async (event) => {
+    event.preventDefault();
+    if (!selectedMachine || !selectedPrinterId) return;
+    setLinking(true);
+    try {
+      await api.post(
+        `/api/v1/pro/printer-providers/bambuddy/printers/${encodeURIComponent(
+          selectedMachine.external_id,
+        )}/link`,
+        { filaops_printer_id: Number(selectedPrinterId) },
+      );
+      await loadMachines();
+      setSelectedMachine(null);
+      setSelectedPrinterId("");
+      toast.success("Bambuddy machine linked");
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  const handleUnlink = async (machine) => {
+    setLinking(true);
+    try {
+      await api.del(
+        `/api/v1/pro/printer-providers/bambuddy/printers/${encodeURIComponent(
+          machine.external_id,
+        )}/link`,
+      );
+      await loadMachines();
+      toast.success("Bambuddy machine unlinked");
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setLinking(false);
+    }
+  };
+
+  if (featuresLoading || loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+      </div>
+    );
+  }
+
+  if (!isPro) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
+        <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white">PRO required</h2>
+          <p className="text-sm text-gray-400 mt-2">
+            Bambuddy printer orchestration is available with FilaOps PRO.
+          </p>
+          <Link
+            to="/admin/license"
+            className="inline-flex mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium"
+          >
+            Open License
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
+          <p className="text-gray-400 mt-1">
+            Connect FilaOps PRO to the managed Bambuddy service for Bambu printer operations.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => window.open(openUrl, "_blank", "noopener,noreferrer")}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+          >
+            Open Bambuddy
+          </button>
+          <button
+            type="button"
+            onClick={loadStatus}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <section className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_360px] gap-6">
+        <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-white">Connector Status</h2>
+              <p className="text-sm text-gray-400 mt-1">
+                {connected
+                  ? "FilaOps is connected to Bambuddy."
+                  : "FilaOps is not connected to Bambuddy."}
+              </p>
+            </div>
+            <StatusBadge health={status?.health} connected={connected} />
+          </div>
+
+          <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <InfoItem label="Service URL" value={status?.base_url || "Not set"} />
+            <InfoItem label="Health" value={status?.health || "Disconnected"} />
+            <InfoItem label="Version" value={status?.version || "Unknown"} />
+            <InfoItem label="Last Sync" value={formatDate(status?.last_sync)} />
+          </dl>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleSync}
+              disabled={!connected || syncing}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+            >
+              {syncing ? "Syncing..." : "Sync Printers"}
+            </button>
+            <Link
+              to="/admin/printers"
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+            >
+              View FilaOps Printers
+            </Link>
+          </div>
+        </div>
+
+        <form
+          onSubmit={handleConnect}
+          className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
+        >
+          <div>
+            <h2 className="text-lg font-semibold text-white">Connection</h2>
+            <p className="text-sm text-gray-400 mt-1">
+              Use the API key generated in Bambuddy.
+            </p>
+          </div>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-300">Bambuddy URL</span>
+            <input
+              type="url"
+              value={form.base_url}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, base_url: event.target.value }))
+              }
+              className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder={DEFAULT_BAMBUDDY_URL}
+              required
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-300">API Key</span>
+            <input
+              type="password"
+              value={form.api_key}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, api_key: event.target.value }))
+              }
+              className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              autoComplete="off"
+              required
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={connecting}
+            className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+          >
+            {connecting ? "Connecting..." : connected ? "Update Connection" : "Connect"}
+          </button>
+        </form>
+      </section>
+
+      <section className="bg-gray-800/40 border border-gray-700 rounded-lg overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-700 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Bambuddy Machines</h2>
+            <p className="text-sm text-gray-400">
+              Synced printers appear here before they are dispatched through FilaOps jobs.
+            </p>
+          </div>
+          <span className="text-sm text-gray-400">{machines.length} machine(s)</span>
+        </div>
+
+        {machineError ? (
+          <div className="p-6 text-sm text-red-300 bg-red-500/10 border-t border-red-500/20">
+            {machineError}
+          </div>
+        ) : machines.length === 0 ? (
+          <div className="p-8 text-center text-gray-400">
+            {connected
+              ? "No Bambuddy printers returned yet."
+              : "Connect Bambuddy to list managed printers."}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-900/60 text-gray-400">
+                <tr>
+                  <th className="py-3 px-4 text-left font-medium">Machine</th>
+                  <th className="py-3 px-4 text-left font-medium">Model</th>
+                  <th className="py-3 px-4 text-left font-medium">IP Address</th>
+                  <th className="py-3 px-4 text-left font-medium">Status</th>
+                  <th className="py-3 px-4 text-left font-medium">FilaOps Printer</th>
+                  <th className="py-3 px-4 text-right font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700">
+                {machines.map((machine) => (
+                  <tr key={machine.external_id} className="hover:bg-gray-700/30">
+                    <td className="py-3 px-4 text-white font-medium">
+                      {machine.name}
+                      <div className="text-xs text-gray-500">{machine.external_id}</div>
+                    </td>
+                    <td className="py-3 px-4 text-gray-300">{machine.model || "-"}</td>
+                    <td className="py-3 px-4 text-gray-300">{machine.ip_address || "-"}</td>
+                    <td className="py-3 px-4">
+                      <span className="inline-flex px-2 py-1 rounded-full border border-gray-600 text-gray-300 text-xs">
+                        {machine.status || "unknown"}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4 text-gray-300">
+                      {machine.linked_printer ? (
+                        <div>
+                          <div className="text-white font-medium">
+                            {machine.linked_printer.name}
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            {machine.linked_printer.code || `Printer #${machine.linked_printer_id}`}
+                          </div>
+                        </div>
+                      ) : (
+                        <span className="text-gray-500">Not linked</span>
+                      )}
+                    </td>
+                    <td className="py-3 px-4 text-right">
+                      {machine.linked_printer_id ? (
+                        <button
+                          type="button"
+                          onClick={() => handleUnlink(machine)}
+                          disabled={linking}
+                          className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
+                        >
+                          Unlink
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => openLinkDialog(machine)}
+                          disabled={linking}
+                          className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
+                        >
+                          Link Printer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className="bg-gray-900/40 border border-gray-700/70 rounded-lg p-5">
+        <h2 className="text-sm font-semibold text-gray-200">AGPL Service Notice</h2>
+        <p className="text-sm text-gray-400 mt-2">
+          Bambuddy runs as a separate AGPL service. FilaOps PRO communicates with it through HTTP APIs.
+        </p>
+        <a
+          href="https://github.com/maziggy/bambuddy"
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
+        >
+          Bambuddy source and license
+        </a>
+      </section>
+
+      {selectedMachine && (
+        <div className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4">
+          <form
+            onSubmit={handleLink}
+            className="w-full max-w-lg bg-gray-900 border border-gray-700 rounded-lg p-6 space-y-5 shadow-xl"
+          >
+            <div>
+              <h2 className="text-lg font-semibold text-white">Link Printer</h2>
+              <p className="text-sm text-gray-400 mt-1">
+                Link {selectedMachine.name} to one existing FilaOps printer.
+              </p>
+            </div>
+
+            {printers.length === 0 ? (
+              <div className="bg-gray-800/60 border border-gray-700 rounded-md p-4">
+                <p className="text-sm text-gray-300">
+                  Create a FilaOps printer before linking Bambuddy machines.
+                </p>
+                <Link
+                  to="/admin/printers"
+                  className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
+                >
+                  Create printer first
+                </Link>
+              </div>
+            ) : (
+              <label className="block">
+                <span className="text-sm font-medium text-gray-300">
+                  FilaOps printer
+                </span>
+                <select
+                  value={selectedPrinterId}
+                  onChange={(event) => setSelectedPrinterId(event.target.value)}
+                  className="mt-1 w-full bg-gray-950 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  required
+                >
+                  <option value="">Select a printer</option>
+                  {printers.map((printer) => (
+                    <option key={printer.id} value={printer.id}>
+                      {printer.name} {printer.code ? `(${printer.code})` : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeLinkDialog}
+                disabled={linking}
+                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-sm font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={linking || printers.length === 0 || !selectedPrinterId}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+              >
+                {linking ? "Linking..." : "Link Printer"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ health, connected }) {
+  const normalized = connected ? health || "unknown" : "disconnected";
+  const variants = {
+    healthy: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+    ok: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+    disconnected: "bg-gray-500/15 text-gray-300 border-gray-500/30",
+    error: "bg-red-500/15 text-red-300 border-red-500/30",
+    unhealthy: "bg-red-500/15 text-red-300 border-red-500/30",
+  };
+  return (
+    <span
+      role="status"
+      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border whitespace-nowrap ${
+        variants[normalized] || "bg-amber-500/15 text-amber-300 border-amber-500/30"
+      }`}
+    >
+      {connected ? normalized : "not connected"}
+    </span>
+  );
+}
+
+function InfoItem({ label, value }) {
+  return (
+    <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-3">
+      <dt className="text-xs uppercase tracking-wide text-gray-500">{label}</dt>
+      <dd className="mt-1 text-gray-200 break-words">{value}</dd>
+    </div>
+  );
+}
+
+function formatDate(value) {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}

--- a/frontend/src/pages/admin/AdminIntegrations.jsx
+++ b/frontend/src/pages/admin/AdminIntegrations.jsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import AiSettingsSection from "../../components/settings/AiSettingsSection";
 
 /**
@@ -19,7 +21,10 @@ import AiSettingsSection from "../../components/settings/AiSettingsSection";
  */
 export default function AdminIntegrations() {
   const api = useApi();
+  const { isPro, hasFeature, loading: featuresLoading } = useFeatureFlags();
   const [aiStatus, setAiStatus] = useState("loading");
+  const [bambuddyStatus, setBambuddyStatus] = useState("loading");
+  const bambuddyAvailable = !featuresLoading && isPro && hasFeature("bambu_integration");
 
   const refreshAiStatus = useCallback(async () => {
     try {
@@ -42,9 +47,24 @@ export default function AdminIntegrations() {
     }
   }, [api]);
 
+  const refreshBambuddyStatus = useCallback(async () => {
+    if (!bambuddyAvailable) {
+      setBambuddyStatus("locked");
+      return;
+    }
+    try {
+      const data = await api.get("/api/v1/pro/integrations/bambuddy/status");
+      setBambuddyStatus(data?.connected ? "configured" : "not_configured");
+    } catch (err) {
+      console.error("Failed to fetch Bambuddy integration status:", err);
+      setBambuddyStatus("error");
+    }
+  }, [api, bambuddyAvailable]);
+
   useEffect(() => {
     refreshAiStatus();
-  }, [refreshAiStatus]);
+    refreshBambuddyStatus();
+  }, [refreshAiStatus, refreshBambuddyStatus]);
 
   return (
     <div className="space-y-6">
@@ -57,6 +77,44 @@ export default function AdminIntegrations() {
         testId="integration-card-ai"
       >
         <AiSettingsSection />
+      </IntegrationCard>
+
+      <IntegrationCard
+        title="Bambuddy"
+        description={
+          bambuddyAvailable
+            ? "Connect the managed Bambuddy service to FilaOps printer operations."
+            : "Bambu printer support is included with FilaOps PRO."
+        }
+        status={bambuddyStatus}
+        testId="integration-card-bambuddy"
+      >
+        {bambuddyAvailable ? (
+          <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-gray-400">
+              Configure the Bambuddy URL, API key, printer sync, and machine view.
+            </p>
+            <Link
+              to="/admin/bambuddy"
+              className="inline-flex justify-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium whitespace-nowrap"
+            >
+              Open Bambuddy
+            </Link>
+          </div>
+        ) : (
+          <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-gray-400">
+              Activate PRO to start Bambuddy, connect its API key, and link Bambu
+              machines to existing FilaOps printers.
+            </p>
+            <Link
+              to="/admin/license"
+              className="inline-flex justify-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium whitespace-nowrap"
+            >
+              Upgrade to PRO
+            </Link>
+          </div>
+        )}
       </IntegrationCard>
 
       <IntegrationCard
@@ -159,6 +217,10 @@ function StatusBadge({ status }) {
     loading: {
       label: "Loading…",
       classes: "bg-gray-500/15 text-gray-400 border-gray-500/30",
+    },
+    locked: {
+      label: "PRO feature",
+      classes: "bg-blue-500/15 text-blue-300 border-blue-500/30",
     },
   };
   const v = variants[status] || variants.not_configured;

--- a/frontend/src/pages/admin/__tests__/AdminBambuddy.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminBambuddy.test.jsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    get: vi.fn(),
+    post: vi.fn(),
+    del: vi.fn(),
+    isPro: true,
+  },
+}))
+
+vi.mock('../../../hooks/useApi', () => {
+  const api = {
+    get: mocks.get,
+    post: mocks.post,
+    patch: vi.fn(),
+    del: mocks.del,
+  }
+  return { useApi: () => api }
+})
+
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    tier: mocks.isPro ? 'professional' : 'community',
+    features: mocks.isPro ? ['bambu_integration'] : [],
+    hasFeature: (feature) => mocks.isPro && feature === 'bambu_integration',
+    isPro: mocks.isPro,
+    isEnterprise: false,
+    loading: false,
+  }),
+}))
+
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+import AdminBambuddy from '../AdminBambuddy'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminBambuddy />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mocks.get.mockReset()
+  mocks.post.mockReset()
+  mocks.del.mockReset()
+  mocks.isPro = true
+})
+
+describe('AdminBambuddy', () => {
+  it('lists Bambuddy machines with linked FilaOps printer state', async () => {
+    mocks.get.mockImplementation((path) => {
+      if (path === '/api/v1/pro/integrations/bambuddy/status') {
+        return Promise.resolve({
+          connected: true,
+          base_url: 'http://127.0.0.1:8080',
+          health: 'healthy',
+        })
+      }
+      if (path === '/api/v1/pro/printer-providers/bambuddy/machines') {
+        return Promise.resolve([
+          {
+            provider: 'bambuddy',
+            external_id: '7',
+            name: 'A1 Farm 07',
+            model: 'A1',
+            ip_address: '192.168.1.77',
+            status: 'idle',
+            linked_printer_id: 12,
+            linked_printer: {
+              id: 12,
+              code: 'PRN-A1-07',
+              name: 'FilaOps A1 07',
+            },
+          },
+        ])
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+
+    renderPage()
+
+    const row = await screen.findByText('A1 Farm 07')
+    const table = row.closest('table')
+    expect(within(table).getByText('PRN-A1-07')).toBeInTheDocument()
+    expect(within(table).getByText('FilaOps A1 07')).toBeInTheDocument()
+    expect(within(table).getByRole('button', { name: /unlink/i })).toBeInTheDocument()
+  })
+
+  it('links an unlinked Bambuddy machine to an existing active FilaOps printer', async () => {
+    const user = userEvent.setup()
+    let linked = false
+    mocks.get.mockImplementation((path) => {
+      if (path === '/api/v1/pro/integrations/bambuddy/status') {
+        return Promise.resolve({ connected: true, base_url: 'http://127.0.0.1:8080' })
+      }
+      if (path === '/api/v1/pro/printer-providers/bambuddy/machines') {
+        return Promise.resolve([
+          {
+            provider: 'bambuddy',
+            external_id: '7',
+            name: 'A1 Farm 07',
+            model: 'A1',
+            ip_address: '192.168.1.77',
+            status: 'idle',
+            linked_printer_id: linked ? 12 : null,
+            linked_printer: linked
+              ? { id: 12, code: 'PRN-A1-07', name: 'FilaOps A1 07' }
+              : null,
+          },
+        ])
+      }
+      if (path === '/api/v1/printers?active_only=true&page_size=200') {
+        return Promise.resolve({
+          items: [{ id: 12, code: 'PRN-A1-07', name: 'FilaOps A1 07', model: 'A1' }],
+        })
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+    mocks.post.mockImplementation((path) => {
+      if (path === '/api/v1/pro/printer-providers/bambuddy/printers/7/link') {
+        linked = true
+        return Promise.resolve({ external_printer_id: '7', filaops_printer_id: 12 })
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+
+    renderPage()
+
+    await user.click(await screen.findByRole('button', { name: /link printer/i }))
+    await user.selectOptions(await screen.findByLabelText(/filaops printer/i), '12')
+    const linkButtons = screen.getAllByRole('button', { name: /link printer/i })
+    await user.click(linkButtons[linkButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        '/api/v1/pro/printer-providers/bambuddy/printers/7/link',
+        { filaops_printer_id: 12 },
+      )
+    })
+  })
+
+  it('shows create-printer action when there are no existing FilaOps printers to link', async () => {
+    const user = userEvent.setup()
+    mocks.get.mockImplementation((path) => {
+      if (path === '/api/v1/pro/integrations/bambuddy/status') {
+        return Promise.resolve({ connected: true, base_url: 'http://127.0.0.1:8080' })
+      }
+      if (path === '/api/v1/pro/printer-providers/bambuddy/machines') {
+        return Promise.resolve([
+          {
+            provider: 'bambuddy',
+            external_id: '7',
+            name: 'A1 Farm 07',
+            status: 'idle',
+            linked_printer_id: null,
+            linked_printer: null,
+          },
+        ])
+      }
+      if (path === '/api/v1/printers?active_only=true&page_size=200') {
+        return Promise.resolve({ items: [] })
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+
+    renderPage()
+
+    await user.click(await screen.findByRole('button', { name: /link printer/i }))
+
+    expect(
+      await screen.findByText(/Create a FilaOps printer before linking/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /create printer/i })).toHaveAttribute(
+      'href',
+      '/admin/printers',
+    )
+  })
+})

--- a/frontend/src/pages/admin/__tests__/AdminBambuddy.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminBambuddy.test.jsx
@@ -8,9 +8,18 @@ const { mocks } = vi.hoisted(() => ({
     get: vi.fn(),
     post: vi.fn(),
     del: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    toast: null,
     isPro: true,
+    features: ['bambu_integration'],
   },
 }))
+
+mocks.toast = {
+  success: mocks.toastSuccess,
+  error: mocks.toastError,
+}
 
 vi.mock('../../../hooks/useApi', () => {
   const api = {
@@ -25,8 +34,8 @@ vi.mock('../../../hooks/useApi', () => {
 vi.mock('../../../hooks/useFeatureFlags', () => ({
   useFeatureFlags: () => ({
     tier: mocks.isPro ? 'professional' : 'community',
-    features: mocks.isPro ? ['bambu_integration'] : [],
-    hasFeature: (feature) => mocks.isPro && feature === 'bambu_integration',
+    features: mocks.features,
+    hasFeature: (feature) => mocks.isPro && mocks.features.includes(feature),
     isPro: mocks.isPro,
     isEnterprise: false,
     loading: false,
@@ -34,10 +43,7 @@ vi.mock('../../../hooks/useFeatureFlags', () => ({
 }))
 
 vi.mock('../../../components/Toast', () => ({
-  useToast: () => ({
-    success: vi.fn(),
-    error: vi.fn(),
-  }),
+  useToast: () => mocks.toast,
 }))
 
 import AdminBambuddy from '../AdminBambuddy'
@@ -54,10 +60,22 @@ beforeEach(() => {
   mocks.get.mockReset()
   mocks.post.mockReset()
   mocks.del.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.toastError.mockReset()
   mocks.isPro = true
+  mocks.features = ['bambu_integration']
 })
 
 describe('AdminBambuddy', () => {
+  it('locks the page for PRO installs without the Bambuddy feature', async () => {
+    mocks.features = []
+
+    renderPage()
+
+    expect(await screen.findByText(/Bambuddy not enabled/i)).toBeInTheDocument()
+    expect(mocks.get).not.toHaveBeenCalledWith('/api/v1/pro/integrations/bambuddy/status')
+  })
+
   it('lists Bambuddy machines with linked FilaOps printer state', async () => {
     mocks.get.mockImplementation((path) => {
       if (path === '/api/v1/pro/integrations/bambuddy/status') {
@@ -138,6 +156,7 @@ describe('AdminBambuddy', () => {
     renderPage()
 
     await user.click(await screen.findByRole('button', { name: /link printer/i }))
+    expect(screen.getByRole('dialog', { name: /link printer/i })).toBeInTheDocument()
     await user.selectOptions(await screen.findByLabelText(/filaops printer/i), '12')
     const linkButtons = screen.getAllByRole('button', { name: /link printer/i })
     await user.click(linkButtons[linkButtons.length - 1])
@@ -185,5 +204,34 @@ describe('AdminBambuddy', () => {
       'href',
       '/admin/printers',
     )
+  })
+
+  it('does not keep the Bambuddy credential in the form after a failed connect', async () => {
+    const user = userEvent.setup()
+    const typedCredential = ['temporary', 'connector', 'credential'].join('-')
+    mocks.get.mockImplementation((path) => {
+      if (path === '/api/v1/pro/integrations/bambuddy/status') {
+        return Promise.resolve({ connected: false, base_url: 'http://127.0.0.1:8080' })
+      }
+      if (path === '/api/v1/printers?active_only=true&page_size=200') {
+        return Promise.resolve({ items: [] })
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+    mocks.post.mockRejectedValue(new Error('bad credential'))
+
+    renderPage()
+
+    const input = await screen.findByLabelText(/api key/i)
+    await user.type(input, typedCredential)
+    await user.click(screen.getByRole('button', { name: /^connect$/i }))
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        '/api/v1/pro/integrations/bambuddy/connect',
+        { base_url: 'http://127.0.0.1:8080', api_key: typedCredential },
+      )
+      expect(input).toHaveValue('')
+    })
   })
 })

--- a/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminIntegrations.test.jsx
@@ -1,9 +1,12 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     get: vi.fn(),
+    isPro: true,
+    features: ['bambu_integration'],
   },
 }))
 
@@ -21,16 +24,37 @@ vi.mock('../../../components/settings/AiSettingsSection', () => ({
   ),
 }))
 
+vi.mock('../../../hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({
+    tier: mocks.isPro ? 'professional' : 'community',
+    features: mocks.features,
+    hasFeature: (feature) => mocks.features.includes(feature),
+    isPro: mocks.isPro,
+    isEnterprise: false,
+    loading: false,
+  }),
+}))
+
 import AdminIntegrations, { IntegrationCard } from '../AdminIntegrations'
+
+function renderIntegrations() {
+  return render(
+    <MemoryRouter>
+      <AdminIntegrations />
+    </MemoryRouter>,
+  )
+}
 
 beforeEach(() => {
   mocks.get.mockReset()
+  mocks.isPro = true
+  mocks.features = ['bambu_integration']
 })
 
 describe('AdminIntegrations', () => {
   it('renders header and all three integration cards', async () => {
     mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     await waitFor(() => {
       expect(screen.getByText(/Integrations & Connections/i)).toBeInTheDocument()
@@ -43,7 +67,7 @@ describe('AdminIntegrations', () => {
 
   it('AI card embeds the AiSettingsSection', async () => {
     mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     expect(
@@ -57,7 +81,7 @@ describe('AdminIntegrations', () => {
       ai_api_key_set: true,
       ai_status: 'configured',
     })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     await waitFor(() => {
@@ -71,7 +95,7 @@ describe('AdminIntegrations', () => {
       ai_api_key_set: false,
       ai_status: 'not_configured',
     })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     await waitFor(() => {
@@ -85,7 +109,7 @@ describe('AdminIntegrations', () => {
       ai_api_key_set: true,
       ai_status: 'error',
     })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     await waitFor(() => {
@@ -98,7 +122,7 @@ describe('AdminIntegrations', () => {
     // log stays clean — we still assert the error was logged below.
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mocks.get.mockRejectedValue(new Error('boom'))
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const aiCard = await screen.findByTestId('integration-card-ai')
     await waitFor(() => {
@@ -111,7 +135,7 @@ describe('AdminIntegrations', () => {
 
   it('Shopify card renders coming-soon placeholder with feature bullets', async () => {
     mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const shopifyCard = await screen.findByTestId('integration-card-shopify')
     expect(within(shopifyCard).getByText('Shopify')).toBeInTheDocument()
@@ -126,7 +150,7 @@ describe('AdminIntegrations', () => {
 
   it('QuickBooks card renders coming-soon placeholder with feature bullets', async () => {
     mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     const qboCard = await screen.findByTestId('integration-card-qbo')
     expect(within(qboCard).getByText('QuickBooks Online')).toBeInTheDocument()
@@ -140,15 +164,52 @@ describe('AdminIntegrations', () => {
   })
 
   it('only fires one GET on mount (no fetch storm from re-renders)', async () => {
+    mocks.isPro = false
+    mocks.features = []
     mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
-    render(<AdminIntegrations />)
+    renderIntegrations()
 
     await waitFor(() => {
       expect(screen.getByTestId('integration-card-ai')).toBeInTheDocument()
     })
-    // Exactly one initial fetch — useEffect with stable useCallback dep
+    // Community users should not call PRO-only Bambuddy endpoints.
     expect(mocks.get).toHaveBeenCalledTimes(1)
     expect(mocks.get).toHaveBeenCalledWith('/api/v1/settings/ai')
+  })
+
+  it('renders Bambuddy as a locked PRO card for Community without calling PRO APIs', async () => {
+    mocks.isPro = false
+    mocks.features = []
+    mocks.get.mockResolvedValue({ ai_provider: null, ai_api_key_set: false })
+
+    renderIntegrations()
+
+    const bambuddyCard = await screen.findByTestId('integration-card-bambuddy')
+    expect(within(bambuddyCard).getByText('PRO feature')).toBeInTheDocument()
+    expect(
+      within(bambuddyCard).getByText(/Bambu printer support is included with FilaOps PRO/i),
+    ).toBeInTheDocument()
+    expect(mocks.get).not.toHaveBeenCalledWith('/api/v1/pro/integrations/bambuddy/status')
+  })
+
+  it('checks Bambuddy status only for PRO users with bambu_integration', async () => {
+    mocks.get.mockImplementation((path) => {
+      if (path === '/api/v1/settings/ai') {
+        return Promise.resolve({ ai_provider: null, ai_api_key_set: false })
+      }
+      if (path === '/api/v1/pro/integrations/bambuddy/status') {
+        return Promise.resolve({ connected: true })
+      }
+      return Promise.reject(new Error(`unexpected path ${path}`))
+    })
+
+    renderIntegrations()
+
+    const bambuddyCard = await screen.findByTestId('integration-card-bambuddy')
+    await waitFor(() => {
+      expect(within(bambuddyCard).getByText('Configured')).toBeInTheDocument()
+    })
+    expect(mocks.get).toHaveBeenCalledWith('/api/v1/pro/integrations/bambuddy/status')
   })
 })
 

--- a/frontend/src/pages/admin/bambuddy/AccessLock.jsx
+++ b/frontend/src/pages/admin/bambuddy/AccessLock.jsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+
+export function BambuddyAccessLock({ isPro }) {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
+      <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-white">
+          {isPro ? "Bambuddy not enabled" : "PRO required"}
+        </h2>
+        <p className="text-sm text-gray-400 mt-2">
+          {isPro
+            ? "This PRO license does not include the Bambu integration feature."
+            : "Bambuddy printer orchestration is available with FilaOps PRO."}
+        </p>
+        <Link
+          to="/admin/license"
+          className="inline-flex mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm font-medium"
+        >
+          Open License
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/ConnectionForm.jsx
+++ b/frontend/src/pages/admin/bambuddy/ConnectionForm.jsx
@@ -1,0 +1,52 @@
+import { DEFAULT_BAMBUDDY_URL } from "./utils";
+
+export function BambuddyConnectionForm({
+  baseUrl,
+  connected,
+  connecting,
+  inputRef,
+  onBaseUrlChange,
+  onSubmit,
+}) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-4"
+    >
+      <div>
+        <h2 className="text-lg font-semibold text-white">Connection</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Use the API key generated in Bambuddy. Clear the field before sharing your screen.
+        </p>
+      </div>
+      <label className="block">
+        <span className="text-sm font-medium text-gray-300">Bambuddy URL</span>
+        <input
+          type="url"
+          value={baseUrl}
+          onChange={(event) => onBaseUrlChange(event.target.value)}
+          className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder={DEFAULT_BAMBUDDY_URL}
+          required
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm font-medium text-gray-300">API Key</span>
+        <input
+          ref={inputRef}
+          type="password"
+          className="mt-1 w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          autoComplete="off"
+          required
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={connecting}
+        className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+      >
+        {connecting ? "Connecting..." : connected ? "Update Connection" : "Connect"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/Header.jsx
+++ b/frontend/src/pages/admin/bambuddy/Header.jsx
@@ -1,0 +1,28 @@
+export function BambuddyHeader({ openUrl, onRefresh }) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Bambuddy</h1>
+        <p className="text-gray-400 mt-1">
+          Connect FilaOps PRO to the managed Bambuddy service for Bambu printer operations.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => window.open(openUrl, "_blank", "noopener,noreferrer")}
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+        >
+          Open Bambuddy
+        </button>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/LegalNotice.jsx
+++ b/frontend/src/pages/admin/bambuddy/LegalNotice.jsx
@@ -1,0 +1,18 @@
+export function BambuddyLegalNotice() {
+  return (
+    <section className="bg-gray-900/40 border border-gray-700/70 rounded-lg p-5">
+      <h2 className="text-sm font-semibold text-gray-200">AGPL Service Notice</h2>
+      <p className="text-sm text-gray-400 mt-2">
+        Bambuddy runs as a separate AGPL service. FilaOps PRO communicates with it through HTTP APIs.
+      </p>
+      <a
+        href="https://github.com/maziggy/bambuddy"
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
+      >
+        Bambuddy source and license
+      </a>
+    </section>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/LinkPrinterModal.jsx
+++ b/frontend/src/pages/admin/bambuddy/LinkPrinterModal.jsx
@@ -1,0 +1,82 @@
+import { Link } from "react-router-dom";
+import Modal from "../../../components/Modal";
+
+export function LinkPrinterModal({
+  linking,
+  machine,
+  printers,
+  selectedPrinterId,
+  onClose,
+  onPrinterChange,
+  onSubmit,
+}) {
+  return (
+    <Modal
+      isOpen={Boolean(machine)}
+      onClose={onClose}
+      title="Link Printer"
+      className="w-full max-w-lg"
+      disableClose={linking}
+    >
+      {machine && (
+        <form onSubmit={onSubmit} className="p-6 space-y-5">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Link Printer</h2>
+            <p className="text-sm text-gray-400 mt-1">
+              Link {machine.name} to one existing FilaOps printer.
+            </p>
+          </div>
+
+          {printers.length === 0 ? (
+            <div className="bg-gray-800/60 border border-gray-700 rounded-md p-4">
+              <p className="text-sm text-gray-300">
+                Create a FilaOps printer before linking Bambuddy machines.
+              </p>
+              <Link
+                to="/admin/printers"
+                className="inline-flex mt-3 text-sm text-blue-400 hover:text-blue-300"
+              >
+                Create printer first
+              </Link>
+            </div>
+          ) : (
+            <label className="block">
+              <span className="text-sm font-medium text-gray-300">FilaOps printer</span>
+              <select
+                value={selectedPrinterId}
+                onChange={(event) => onPrinterChange(event.target.value)}
+                className="mt-1 w-full bg-gray-950 border border-gray-700 rounded-md px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              >
+                <option value="">Select a printer</option>
+                {printers.map((printer) => (
+                  <option key={printer.id} value={printer.id}>
+                    {printer.name} {printer.code ? `(${printer.code})` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={linking}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={linking || printers.length === 0 || !selectedPrinterId}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+            >
+              {linking ? "Linking..." : "Link Printer"}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/MachinesTable.jsx
+++ b/frontend/src/pages/admin/bambuddy/MachinesTable.jsx
@@ -1,0 +1,104 @@
+export function BambuddyMachinesTable({
+  connected,
+  linking,
+  machineError,
+  machines,
+  onLink,
+  onUnlink,
+  unlinkingId,
+}) {
+  const mutationInProgress = linking || Boolean(unlinkingId);
+
+  return (
+    <section className="bg-gray-800/40 border border-gray-700 rounded-lg overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-700 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Bambuddy Machines</h2>
+          <p className="text-sm text-gray-400">
+            Synced printers appear here before they are dispatched through FilaOps jobs.
+          </p>
+        </div>
+        <span className="text-sm text-gray-400">{machines.length} machine(s)</span>
+      </div>
+
+      {machineError ? (
+        <div className="p-6 text-sm text-red-300 bg-red-500/10 border-t border-red-500/20">
+          {machineError}
+        </div>
+      ) : machines.length === 0 ? (
+        <div className="p-8 text-center text-gray-400">
+          {connected
+            ? "No Bambuddy printers returned yet."
+            : "Connect Bambuddy to list managed printers."}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-900/60 text-gray-400">
+              <tr>
+                <th className="py-3 px-4 text-left font-medium">Machine</th>
+                <th className="py-3 px-4 text-left font-medium">Model</th>
+                <th className="py-3 px-4 text-left font-medium">IP Address</th>
+                <th className="py-3 px-4 text-left font-medium">Status</th>
+                <th className="py-3 px-4 text-left font-medium">FilaOps Printer</th>
+                <th className="py-3 px-4 text-right font-medium">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700">
+              {machines.map((machine) => (
+                <tr key={machine.external_id} className="hover:bg-gray-700/30">
+                  <td className="py-3 px-4 text-white font-medium">
+                    {machine.name}
+                    <div className="text-xs text-gray-500">{machine.external_id}</div>
+                  </td>
+                  <td className="py-3 px-4 text-gray-300">{machine.model || "-"}</td>
+                  <td className="py-3 px-4 text-gray-300">{machine.ip_address || "-"}</td>
+                  <td className="py-3 px-4">
+                    <span className="inline-flex px-2 py-1 rounded-full border border-gray-600 text-gray-300 text-xs">
+                      {machine.status || "unknown"}
+                    </span>
+                  </td>
+                  <td className="py-3 px-4 text-gray-300">
+                    {machine.linked_printer ? (
+                      <div>
+                        <div className="text-white font-medium">
+                          {machine.linked_printer.name}
+                        </div>
+                        <div className="text-xs text-gray-500">
+                          {machine.linked_printer.code || `Printer #${machine.linked_printer_id}`}
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="text-gray-500">Not linked</span>
+                    )}
+                  </td>
+                  <td className="py-3 px-4 text-right">
+                    {machine.linked_printer_id ? (
+                      <button
+                        type="button"
+                        onClick={() => onUnlink(machine)}
+                        disabled={mutationInProgress}
+                        className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
+                      >
+                        {unlinkingId === machine.external_id ? "Unlinking..." : "Unlink"}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => onLink(machine)}
+                        disabled={mutationInProgress}
+                        className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded-md text-xs font-medium"
+                      >
+                        Link Printer
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/StatusPanel.jsx
+++ b/frontend/src/pages/admin/bambuddy/StatusPanel.jsx
@@ -1,0 +1,74 @@
+import { Link } from "react-router-dom";
+import { formatDate } from "./utils";
+
+export function BambuddyStatusPanel({ connected, status, syncing, onSync }) {
+  return (
+    <div className="bg-gray-800/40 border border-gray-700 rounded-lg p-6 space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Connector Status</h2>
+          <p className="text-sm text-gray-400 mt-1">
+            {connected
+              ? "FilaOps is connected to Bambuddy."
+              : "FilaOps is not connected to Bambuddy."}
+          </p>
+        </div>
+        <StatusBadge health={status?.health} connected={connected} />
+      </div>
+
+      <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+        <InfoItem label="Service URL" value={status?.base_url || "Not set"} />
+        <InfoItem label="Health" value={status?.health || "Disconnected"} />
+        <InfoItem label="Version" value={status?.version || "Unknown"} />
+        <InfoItem label="Last Sync" value={formatDate(status?.last_sync)} />
+      </dl>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onSync}
+          disabled={!connected || syncing}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-700 disabled:text-gray-400 text-white rounded-md text-sm font-medium"
+        >
+          {syncing ? "Syncing..." : "Sync Printers"}
+        </button>
+        <Link
+          to="/admin/printers"
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-md text-sm font-medium"
+        >
+          View FilaOps Printers
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ health, connected }) {
+  const normalized = connected ? health || "unknown" : "disconnected";
+  const variants = {
+    healthy: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+    ok: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+    disconnected: "bg-gray-500/15 text-gray-300 border-gray-500/30",
+    error: "bg-red-500/15 text-red-300 border-red-500/30",
+    unhealthy: "bg-red-500/15 text-red-300 border-red-500/30",
+  };
+  return (
+    <span
+      role="status"
+      className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border whitespace-nowrap ${
+        variants[normalized] || "bg-amber-500/15 text-amber-300 border-amber-500/30"
+      }`}
+    >
+      {connected ? normalized : "not connected"}
+    </span>
+  );
+}
+
+function InfoItem({ label, value }) {
+  return (
+    <div className="bg-gray-900/40 border border-gray-700/60 rounded-md p-3">
+      <dt className="text-xs uppercase tracking-wide text-gray-500">{label}</dt>
+      <dd className="mt-1 text-gray-200 break-words">{value}</dd>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/bambuddy/index.js
+++ b/frontend/src/pages/admin/bambuddy/index.js
@@ -1,0 +1,7 @@
+export { BambuddyAccessLock } from "./AccessLock";
+export { BambuddyConnectionForm } from "./ConnectionForm";
+export { BambuddyHeader } from "./Header";
+export { BambuddyLegalNotice } from "./LegalNotice";
+export { BambuddyMachinesTable } from "./MachinesTable";
+export { BambuddyStatusPanel } from "./StatusPanel";
+export { LinkPrinterModal } from "./LinkPrinterModal";

--- a/frontend/src/pages/admin/bambuddy/utils.js
+++ b/frontend/src/pages/admin/bambuddy/utils.js
@@ -1,0 +1,15 @@
+export const DEFAULT_BAMBUDDY_URL = "http://127.0.0.1:8080";
+
+export function formatDate(value) {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+export function getSyncMessage(result) {
+  if (typeof result?.synced === "number") {
+    return `Synced ${result.synced} Bambuddy records`;
+  }
+  return "Bambuddy sync complete";
+}


### PR DESCRIPTION
## Summary
- Adds the PRO-gated Bambuddy admin page and route.
- Adds the Community locked card in Integrations without calling PRO APIs.
- Adds machine linking/unlinking UI for existing active FilaOps printers.

## Test Plan
- npm run test:unit -- AdminBambuddy.test.jsx AdminIntegrations.test.jsx
- npm run build

Note: verification ran in C:\repos\filaops\frontend where dependencies are installed; the clean PR worktree does not have node_modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bambuddy PRO integration: admin page, machine discovery, status panel, connect/sync flow, and machine-to-printer linking via modal
  * Admin sidebar and integrations overview show a gated Bambuddy entry and settings card
  * Breadcrumbs and access-lock UI for Bambuddy routes; legal notice and connection form added

* **Bug Fixes**
  * Improved handling and messaging for Bambuddy vs core server outages

* **Tests**
  * Expanded test coverage for Bambuddy flows and feature-flag behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->