### PR TITLE
docs: add shared agent policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,111 +1,11 @@
-# FilaOps Core — Open Source ERP
+# Claude Instructions
 
-> Primary safety is enforced by PreToolUse hooks and T-REX protocol. If a gate conflicts with behavioral instructions, the gate wins.
+Read and follow `../AGENT_POLICY.md`. It is the shared source of truth for this
+repository.
 
-## 🔴 SACRED RULE
+Claude-specific commit attribution:
 
-**"NO Core Changes from PRO. PRO Must Not Break Core."**
-
-- Never modify files in Core (`C:\repos\filaops`) from the ecosystem repo
-- Never add Core dependencies on any PRO / `filaops-ecosystem` package
-- Core must run identically with zero PRO code installed
-- PRO integrates via `register(app)`; keep coupling behind extension interfaces
-
-## Aeonyx Session Protocol
-
-**register → claim → recall → work → end**
-
-1. `rex_register_session(session_id, branch, task)` at start
-2. `rex_claim_files(session_id, branch, files)` before editing
-3. `mem_recall("<topic>")` before major work (gated — will block otherwise)
-4. During work: `mem_remember` for decisions/incidents/patterns, `cortex_observe` for pre-existing bugs
-5. `rex_end_session` or `rex_handoff` at end
-
-Don't store: routine file edits, blame attribution, "started working on X".
-Pre-existing issues: report via `cortex_observe`, investigate, fix if safe, or add `# TODO(pre-existing)`.
-
-## Layer 0 — Mechanical Gates (Enforced)
-
-Enforced by hooks and CI. If blocked, read the block message and comply — don't route around.
-
-- **0.1 Session Registration** — no edits until `rex_register_session`
-- **0.2 Memory Recall** — no edits until `mem_recall` runs
-- **0.3 File Claim** — no edits until file is claimed (one agent per file, TTL)
-- **0.4 Type Check** — `pytest tests/ -x -q`, `npx tsc --noEmit`, `npx vitest run` must pass; CI is authority
-- **0.5 Database Safety** — confirm `DATABASE_URL`, state it explicitly. This repo → `filaops`, never `filaops_prod`
-- **0.6 Lockfile** — `npm ci` / `pip install --require-hashes` only
-- **0.7 Dependency Addition** — human approval for any new manifest entry; see `filaops-supply-chain` skill
-- **0.8 Build Artifact Audit** — no `.map`, `.env`, `.key` in publish payload
-- **0.9 Network Egress Logging** — report unexpected outbound connections via `cortex_observe`
-
-## Layer 1 — Behavioral Guidelines
-
-### Pre-Work
-- **Step 0 Rule**: Before refactoring any file >300 LOC, remove dead code in a separate commit. One commit, one purpose.
-- **Phased Execution**: Max 5 files per phase. Verify and get approval before continuing.
-
-### Code Quality
-- **Senior Dev Override**: Ask "what would a perfectionist reject in code review?" Fix structural issues. Changes touching >5 files need a plan first.
-- **Sub-Agent Isolation**: For tasks across >5 independent files, split into parallel sub-agents — each registers own session, claims own files.
-
-### Context Management
-- **Decay Awareness**: After ~8-10 messages or focus change, re-read relevant files before editing.
-- **File Read Budget**: 2000 line cap. For files >500 LOC, chunk with offset/limit.
-- **Tool Result Blindness**: Outputs >50k chars get truncated. If grep returns suspiciously few hits, narrow scope.
-
-### Edit Safety
-- **Edit Integrity**: Re-read before editing, re-read after. Max 3 edits per file without verification.
-- **Explicit Reference Hunting**: You have grep, not an AST. When renaming, search: direct calls, type refs, string literals, dynamic imports, re-exports, tests/mocks.
-
-### Supply Chain & Observation
-See skills: `filaops-supply-chain` (dependency hygiene, registry trust, attribution, anomaly reporting) and `filaops-safety-philosophy` (why gates exist, threat landscape).
-
-AI attribution is required in commits, PR descriptions, and documentation:
 ```text
-feat: short description
-
 Co-authored-by: Claude <claude@anthropic.com>
 Agent-Session: [session-id]
 ```
-
-## Core vs PRO Architecture
-
-```text
-┌─────────────────────────────────┐
-│         FilaOps Core            │  ← This repo. Open source. Standalone.
-│   FastAPI + React + PostgreSQL  │
-└──────────────┬──────────────────┘
-               │ pip install filaops-pro
-               ▼
-┌─────────────────────────────────┐
-│       filaops-pro package       │  ← filaops-ecosystem repo. Private.
-│   register(app, license_key)    │
-└─────────────────────────────────┘
-```
-
-PRO imports FROM Core, never reverse. PRO adds new tables via FK to Core tables, never alters Core schema.
-
-### What IS Core (add here ✅)
-Inventory/MRP/production/sales/purchase orders · BOM · traceability (lots, serials) · UOM (costs $/KG, inventory grams — see `backend/app/core/uom_config.py`) · basic GL · i18n · dashboards · auth/RBAC · MQTT printer integration
-
-### What is PRO (never add here ❌)
-B2B Portal · quote engine · QuickBooks/Shopify integrations · advanced accounting · catalog access control · AI agents (Cortex) · FilaFarm automation · license management · anything subscription-gated
-
-## Repo Map
-
-| Repo | Purpose |
-|------|---------|
-| `C:\repos\filaops` | **THIS REPO** — Core, open source, public |
-| `C:\repos\filaops-ecosystem` | PRO monorepo, private |
-
-## Tech Stack
-
-Backend: FastAPI + SQLAlchemy + PostgreSQL + Alembic
-Frontend: React 19 + Vite + Tailwind
-Testing: pytest (backend), Vitest (frontend)
-
-**UOM Safety**: Costs stored $/KG, inventory in grams. Single source: `backend/app/core/uom_config.py`. Never hardcode conversions elsewhere.
-
-## Git Workflow
-
-Feature branches off `main`: `feature/description`, `fix/description`. PRs require passing CI. Commit prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Codex Instructions
+
+Read and follow `AGENT_POLICY.md`. It is the shared source of truth for this
+repository.
+
+Codex-specific commit attribution:
+
+```text
+Co-authored-by: Codex <codex@openai.com>
+Agent-Session: [session-id]
+```

--- a/AGENT_POLICY.md
+++ b/AGENT_POLICY.md
@@ -133,7 +133,7 @@ subscription-gated capabilities.
 
 - Backend: FastAPI, SQLAlchemy, PostgreSQL, Alembic
 - Frontend: React, Vite, Tailwind
-- Testing: pytest for backend, Vitest for frontend
+- Testing: pytest for backend, Vitest for frontend, Playwright for E2E
 
 UOM safety: costs are stored as dollars per kilogram and inventory is stored in
 grams. The single source is `backend/app/core/uom_config.py`. Do not hardcode
@@ -142,7 +142,8 @@ conversions elsewhere.
 ## Git Workflow
 
 - Use feature branches off `main`.
-- Preferred branch prefixes: `codex/`, `claude/`, `feat/`, `fix/`, `docs/`.
+- Preferred branch prefixes: `codex/`, `claude/`, `feature/`, `feat/`,
+  `fix/`, `docs/`.
 - Commit prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`.
 - Pull requests require passing CI and completed bot-review triage.
 - Delete merged feature branches unless explicitly retained.

--- a/AGENT_POLICY.md
+++ b/AGENT_POLICY.md
@@ -1,0 +1,151 @@
+# FilaOps Agent Policy
+
+This is the shared source of truth for AI agents working in this repository.
+Tool-specific files such as `AGENTS.md` and `.claude/CLAUDE.md` should stay
+small and point here instead of duplicating policy.
+
+If an automated hook, CI gate, or T-REX/Aeonyx gate conflicts with prose in
+this document, the mechanical gate wins.
+
+## Non-Negotiable Workflow
+
+Agents must follow the full PR loop for repository changes.
+
+1. Create or use a feature branch for all repo changes.
+2. Open a pull request before considering the work deliverable.
+3. Wait for CI and all bot reviews/checks to complete.
+4. Review and triage every bot review comment, review thread, annotation, and
+   failed check.
+5. Fix actionable findings. If a finding is not applicable, reply with the
+   rationale so the reviewer/check is explicitly released or documented.
+6. Push fixes and repeat the CI/review loop until the PR is clean or only
+   explicitly accepted residual risk remains.
+7. Re-check CI and bot reviews after the final push.
+8. Merge only after the PR is clean and the user has approved merge or the task
+   explicitly includes merge authority.
+9. After merge, delete the remote feature branch unless the user explicitly asks
+   to keep it.
+10. Clean up local worktrees and local branches created for the task once they
+    are no longer needed.
+
+Do not report a PR as done just because code was pushed. Done means reviewed,
+triaged, fixed, rechecked, and either merged/cleaned up or clearly waiting on a
+specific human decision.
+
+## Sacred Rule
+
+No Core changes from PRO. PRO must not break Core.
+
+- Never modify files in Core (`C:\repos\filaops`) from the ecosystem repo.
+- Never add Core dependencies on any PRO or `filaops-ecosystem` package.
+- Core must run identically with zero PRO code installed.
+- PRO integrates via `register(app)`; keep coupling behind extension
+  interfaces.
+
+## Canonical Repos And Worktrees
+
+`C:\repos\filaops` is the canonical local Core checkout.
+
+Agents may create task-scoped git worktrees such as
+`C:\repos\filaops-<topic>` for isolated PR work. A worktree is not a new
+product repo and must not be treated as the canonical Core checkout.
+
+Use `git worktree list` when there is any ambiguity.
+
+## Aeonyx Session Protocol
+
+Follow the session flow before editing:
+
+1. Register or identify the session when the tool is available.
+2. Recall relevant memory before major work.
+3. Claim files before editing.
+4. Work only inside claimed files.
+5. Remember decisions, incidents, and reusable patterns.
+6. Observe pre-existing issues instead of silently ignoring or casually fixing
+   unrelated problems.
+7. End or release the session when finished.
+
+Do not store routine file edits, blame attribution, or "started working on X"
+as memory.
+
+## Mechanical Gates
+
+Comply with hook and CI feedback instead of routing around it.
+
+- Session registration: no edits until session requirements are met.
+- Memory recall: no major work until relevant memory has been checked.
+- File claim: no edits until files are claimed.
+- Type/test checks: run the narrowest meaningful checks first, then broaden as
+  risk requires. CI is the authority.
+- Database safety: confirm `DATABASE_URL` before database work. For this repo,
+  local development should target `filaops`, never `filaops_prod`.
+- Lockfiles: use lockfile-respecting install commands. Do not churn lockfiles
+  accidentally.
+- Dependency additions: require human approval for any new manifest entry.
+- Build artifact audit: do not publish `.map`, `.env`, `.key`, secrets, or
+  generated local artifacts.
+- Network egress: report unexpected outbound connections.
+
+## Code Quality
+
+- Before refactoring any file over 300 lines, remove dead code in a separate
+  commit when practical.
+- Keep phases small. Changes touching more than five files need a plan first.
+- Ask what a strict reviewer would reject and address structural issues early.
+- For broad independent work, split tasks across isolated agents/sessions when
+  available.
+- Re-read relevant files after long context shifts or after 8-10 messages.
+- For files over 500 lines, read focused chunks instead of flooding context.
+- Re-read before editing and after editing.
+- When renaming or changing a contract, search direct calls, type references,
+  string literals, dynamic imports, re-exports, tests, and mocks.
+
+## Core Vs PRO Architecture
+
+```text
+FilaOps Core                         filaops-pro package
+Open-source standalone app           Private extension package
+FastAPI + React + PostgreSQL   <---  register(app, license_key)
+```
+
+PRO imports from Core, never the reverse. PRO may add its own tables with
+foreign keys to Core tables, but must not alter Core schema for PRO-only
+features.
+
+What belongs in Core:
+Inventory, MRP, production, sales, purchase orders, BOM, traceability, UOM,
+basic GL, i18n, dashboards, auth/RBAC, and base printer integration.
+
+What belongs in PRO:
+B2B Portal, quote engine, QuickBooks/Shopify integrations, advanced accounting,
+catalog access control, AI agents, FilaFarm automation, license management, and
+subscription-gated capabilities.
+
+## Repo Map
+
+| Repo | Purpose |
+| --- | --- |
+| `C:\repos\filaops` | Core, open source, public |
+| `C:\repos\filaops-ecosystem` | PRO monorepo, private |
+| `C:\repos\filaops-relay` | Desktop relay/installer/runtime shell |
+
+## Tech Stack
+
+- Backend: FastAPI, SQLAlchemy, PostgreSQL, Alembic
+- Frontend: React, Vite, Tailwind
+- Testing: pytest for backend, Vitest for frontend
+
+UOM safety: costs are stored as dollars per kilogram and inventory is stored in
+grams. The single source is `backend/app/core/uom_config.py`. Do not hardcode
+conversions elsewhere.
+
+## Git Workflow
+
+- Use feature branches off `main`.
+- Preferred branch prefixes: `codex/`, `claude/`, `feat/`, `fix/`, `docs/`.
+- Commit prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`.
+- Pull requests require passing CI and completed bot-review triage.
+- Delete merged feature branches unless explicitly retained.
+
+Commit attribution should identify the tool that made the commit. Use the
+tool-specific wrapper file for the correct attribution line.


### PR DESCRIPTION
## Summary
- add AGENT_POLICY.md as the shared source of truth for FilaOps AI agents
- convert Codex and Claude instruction files into small wrappers
- document mandatory PR, bot-review triage, merge, branch deletion, and worktree cleanup workflow

## Testing
- git diff --check

## Notes
- docs-only policy change; no runtime behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated and reorganized internal AI agent guidance into a single repository-wide policy and added an agent reference document.
* **Chores**
  * Replaced extensive per-repo instructions with a shorter agent-specific guidance block and standardized commit attribution text.

---

Note: No user-facing functionality changes; updates are internal documentation and policy only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->