### PR TITLE
fix: send license key header for PRO wheel install

### DIFF
--- a/backend/app/api/v1/endpoints/admin/pro_install.py
+++ b/backend/app/api/v1/endpoints/admin/pro_install.py
@@ -21,10 +21,11 @@ Patterns reused:
   - httpx + admin-auth conventions:
       app/api/v1/endpoints/system_license.py
 
-License-server endpoint contract (per the deployed PR-04 server impl,
-documented in `tests/test_wheel_download.py` on the license-server side):
-  GET /api/v1/download/wheel?license_key=<key>
-  Headers: X-API-Key: <server-to-server credential>
+License-server endpoint contract:
+  GET /api/v1/download/wheel
+  Headers:
+    X-API-Key: <server-to-server credential>
+    X-License-Key: <customer license key>
   Response: wheel binary (application/octet-stream)
   Response headers: X-Wheel-SHA256 (hex digest)
 
@@ -149,12 +150,14 @@ async def _download_wheel(
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
     url = f"{license_server_url}/api/v1/download/wheel"
-    headers = {"X-API-Key": api_key}
-    params = {"license_key": license_key}
+    headers = {
+        "X-API-Key": api_key,
+        "X-License-Key": license_key,
+    }
 
     async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT_SECONDS) as client:
         try:
-            resp = await client.get(url, headers=headers, params=params)
+            resp = await client.get(url, headers=headers)
         except httpx.TimeoutException as exc:
             raise InstallError("License server did not respond in time.") from exc
         except httpx.RequestError as exc:

--- a/backend/tests/endpoints/test_pro_install.py
+++ b/backend/tests/endpoints/test_pro_install.py
@@ -8,7 +8,7 @@ Covers POST /api/v1/admin/system/pro/install + GET .../install/status:
   task runs (FastAPI BackgroundTasks executes inline in TestClient, so the
   pipeline finishes before the next request)
 - License-server contract: GET to ``/api/v1/download/wheel`` with
-  ``X-API-Key`` header + ``license_key`` query param
+  ``X-API-Key`` and ``X-License-Key`` headers
 - Error pipeline: download network error, download timeout, server 4xx,
   hash mismatch, pip non-zero exit, pip timeout — all leave Core running
   and surface as ``state=error`` (retryable)
@@ -363,7 +363,7 @@ def test_install_calls_license_server_with_correct_credentials(
     mock_license_server,
     mock_pip_success,
 ):
-    """Contract test: ``X-API-Key`` header + ``license_key`` query param."""
+    """Contract test: API credential and customer license are sent as headers."""
     mock_license_server(_ok_wheel_response())
     client.post(INSTALL_URL)
 
@@ -372,7 +372,8 @@ def test_install_calls_license_server_with_correct_credentials(
     call = calls[0]
     assert call["url"] == "http://license-test.local/api/v1/download/wheel"
     assert call["headers"]["X-API-Key"] == "test-api-key"
-    assert call["params"]["license_key"] == VALID_KEY
+    assert call["headers"]["X-License-Key"] == VALID_KEY
+    assert not call["params"]
 
 
 def test_install_invokes_pip_with_no_deps_and_current_python(


### PR DESCRIPTION
## Summary
- Update Core PRO wheel installer to send the customer license key in `X-License-Key`.
- Keep the server-to-server credential in `X-API-Key` and stop sending the license key as a query parameter.
- Update the PRO installer contract test to match the deployed license-server behavior seen during dogfood.

## Related Issues
- Follow-up from clean main dogfood deployment test.

## Changes
- `backend/app/api/v1/endpoints/admin/pro_install.py`: uses `X-API-Key` + `X-License-Key` headers for wheel download.
- `backend/tests/endpoints/test_pro_install.py`: asserts the header-based contract and no query params.

## Testing
- [ ] Manual browser validation (eyes and mouse)
- [x] API endpoint tested
- [x] Fresh database tested

Command:
`$env:DATABASE_URL="postgresql+psycopg://filaops:***@127.0.0.1:5433/filaops_test"; python -m pytest backend/tests/endpoints/test_pro_install.py -q`

Result: 27 passed, 111 existing Pydantic deprecation warnings.

## Checklist
- [x] No secrets or business data committed
- [x] No PRO code in core changes
- [x] Tested on Windows (if backend/seed changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication credential transmission method for license-server API integration
* **Tests**
  * Updated corresponding test assertions for authentication verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->