### PR TITLE
feat: add packaging item type

### DIFF
--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -15,7 +15,8 @@ class Product(Base):
     Unified item model for all inventory-tracked items:
     - finished_good: Products sold to customers
     - component: Parts used in BOMs (e.g., inserts, hardware)
-    - supply: Consumables (e.g., filament, packaging)
+    - packaging: Boxes, mailers, cartons, and shipping supplies
+    - supply: General consumables
     - service: Non-physical items (e.g., machine time)
     """
     __tablename__ = "products"
@@ -44,7 +45,7 @@ class Product(Base):
                              comment='Conversion: 1 purchase_uom = X unit. E.g., 1000 for KG->G')
 
     # Item classification
-    item_type = Column(String(20), default='finished_good', nullable=False)  # finished_good, component, supply, service
+    item_type = Column(String(20), default='finished_good', nullable=False)  # finished_good, component, packaging, supply, service, material
     procurement_type = Column(String(20), default='buy', nullable=False)  # 'make', 'buy', 'make_or_buy'
     category_id = Column(Integer, ForeignKey("item_categories.id"), nullable=True)
 

--- a/backend/app/schemas/item.py
+++ b/backend/app/schemas/item.py
@@ -4,7 +4,8 @@ Item and Category Pydantic Schemas
 Supports unified item management for:
 - Finished goods (products sold to customers)
 - Components (parts used in BOMs)
-- Supplies (consumables like filament, packaging)
+- Packaging (boxes, mailers, cartons, and shipping supplies)
+- Supplies (general consumables like tape, gloves, tools)
 - Services (non-physical items like machine time)
 """
 from pydantic import BaseModel, Field, field_validator
@@ -22,7 +23,8 @@ class ItemType(str, Enum):
     """Types of items in the system"""
     FINISHED_GOOD = "finished_good"  # Sellable products
     COMPONENT = "component"          # Parts used in assembly
-    SUPPLY = "supply"                # Consumables and supplies
+    PACKAGING = "packaging"          # Boxes, mailers, cartons, and shipping supplies
+    SUPPLY = "supply"                # General consumables and supplies
     SERVICE = "service"              # Non-physical services
     MATERIAL = "material"            # Raw materials (filament, sheet stock, etc.) - auto-configures UOM
 
@@ -343,7 +345,7 @@ class ItemBulkUpdateRequest(BaseModel):
     """Bulk update multiple items"""
     item_ids: List[int]
     category_id: Optional[int] = Field(None, description="Category ID (use 0 to clear category)")
-    item_type: Optional[str] = Field(None, description="Item type: finished_good, component, supply, service")
+    item_type: Optional[str] = Field(None, description="Item type: finished_good, component, packaging, supply, service, material")
     procurement_type: Optional[str] = Field(None, description="Procurement type: make, buy, make_or_buy")
     is_active: Optional[bool] = None
 

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -192,12 +192,12 @@ def get_inventory_valuation(db: Session, *, as_of_date: date | None = None) -> d
 
     # Define category mappings
     # item_type -> (category_name, gl_account_code)
-    # Valid item_types: finished_good, component, supply, service (see Product model)
-    # Note: WIP (1210) and Packaging (1230) GL accounts exist for journal entries
-    # but have no corresponding item_type — they track cost flow, not inventory categories
+    # Valid inventory item_types: finished_good, component, packaging, supply.
+    # WIP (1210) exists for journal entries, but has no corresponding item_type.
     category_map = {
         "supply": ("Raw Materials", "1200"),
         "component": ("Components", "1200"),
+        "packaging": ("Packaging", "1230"),
         "finished_good": ("Finished Goods", "1220"),
     }
 
@@ -638,6 +638,7 @@ def get_accounting_summary(db: Session) -> dict:
     category_map = {
         "supply": "Raw Materials",
         "component": "Components",
+        "packaging": "Packaging",
         "finished_good": "Finished Goods",
     }
 

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -1722,6 +1722,30 @@ def _strip_html(text: str) -> str:
     return text
 
 
+def _normalize_import_item_type(value: str | None, default: str) -> str:
+    """Normalize item type names from CSV exports and shop-owner shorthand."""
+    item_type_raw = (value or "").strip().lower()
+    if not item_type_raw:
+        return default
+
+    item_type_map = {
+        "simple": "finished_good",
+        "variable": "finished_good",
+        "finished_good": "finished_good",
+        "component": "component",
+        "packaging": "packaging",
+        "box": "packaging",
+        "mailers": "packaging",
+        "mailer": "packaging",
+        "supply": "supply",
+        "service": "service",
+        "material": "material",
+        "filament": "material",
+        "raw_material": "material",
+    }
+    return item_type_map.get(item_type_raw, default)
+
+
 def import_items_from_csv(
     db: Session,
     *,
@@ -1826,23 +1850,8 @@ def import_items_from_csv(
                     or row.get("Type", "")
                 ).strip()
                 if item_type_raw:
-                    item_type_map = {
-                        "simple": "finished_good",
-                        "variable": "finished_good",
-                        "finished_good": "finished_good",
-                        "component": "component",
-                        "packaging": "packaging",
-                        "box": "packaging",
-                        "mailers": "packaging",
-                        "mailer": "packaging",
-                        "supply": "supply",
-                        "service": "service",
-                        "material": "material",
-                        "filament": "material",
-                        "raw_material": "material",
-                    }
-                    existing.item_type = item_type_map.get(
-                        item_type_raw.lower(), existing.item_type
+                    existing.item_type = _normalize_import_item_type(
+                        item_type_raw, existing.item_type
                     )
 
                 # Update category
@@ -1924,8 +1933,12 @@ def import_items_from_csv(
                 item_type_str = (
                     row.get("item_type", "")
                     or row.get("Item Type", "")
+                    or row.get("Type", "")
                     or ""
                 ).strip() or default_item_type
+                item_type_str = _normalize_import_item_type(
+                    item_type_str, default_item_type
+                )
 
                 # Get reorder point
                 reorder_point = None

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -1910,25 +1910,6 @@ def import_items_from_csv(
                     db, row, default_category_id
                 )
 
-                # Get unit from CSV
-                unit_value = _get_csv_column_value(row, _UNIT_COLUMNS).upper()
-                purchase_uom_value = _get_csv_column_value(
-                    row, _PURCHASE_UOM_COLUMNS
-                ).upper()
-
-                # Auto-detect UOMs based on SKU/category if not provided
-                if not purchase_uom_value or not unit_value:
-                    recommended_purchase, recommended_unit, is_material = (
-                        get_recommended_uoms(db, sku=sku, category_id=final_category_id)
-                    )
-                    if not purchase_uom_value:
-                        purchase_uom_value = recommended_purchase
-                    if not unit_value and is_material:
-                        unit_value = recommended_unit
-
-                final_unit = unit_value or "EA"
-                final_purchase_uom = purchase_uom_value or final_unit
-
                 # Get item type
                 item_type_str = (
                     row.get("item_type", "")
@@ -1939,6 +1920,37 @@ def import_items_from_csv(
                 item_type_str = _normalize_import_item_type(
                     item_type_str, default_item_type
                 )
+
+                # Get unit from CSV
+                unit_value = _get_csv_column_value(row, _UNIT_COLUMNS).upper()
+                purchase_uom_value = _get_csv_column_value(
+                    row, _PURCHASE_UOM_COLUMNS
+                ).upper()
+                purchase_factor = None
+                is_raw_material = False
+
+                # Auto-detect UOMs based on item type, SKU, and category if not provided.
+                if not purchase_uom_value or not unit_value:
+                    (
+                        recommended_purchase,
+                        recommended_unit,
+                        is_raw_material,
+                        purchase_factor,
+                    ) = get_recommended_uoms(
+                        db,
+                        sku=sku,
+                        category_id=final_category_id,
+                        item_type=item_type_str,
+                    )
+                    if not purchase_uom_value:
+                        purchase_uom_value = recommended_purchase
+                    if not unit_value and is_raw_material:
+                        unit_value = recommended_unit
+
+                final_unit = unit_value or "EA"
+                final_purchase_uom = purchase_uom_value or final_unit
+                if purchase_factor is None:
+                    purchase_factor = 1
 
                 # Get reorder point
                 reorder_point = None
@@ -1961,6 +1973,8 @@ def import_items_from_csv(
                     category_id=final_category_id,
                     standard_cost=standard_cost,
                     selling_price=selling_price,
+                    purchase_factor=purchase_factor,
+                    is_raw_material=is_raw_material,
                     reorder_point=reorder_point,
                     upc=upc,
                     active=True,

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -646,6 +646,7 @@ def get_item_stats(db: Session) -> dict:
         "total": total,
         "finished_goods": by_type.get("finished_good", 0),
         "components": by_type.get("component", 0),
+        "packaging": by_type.get("packaging", 0),
         "supplies": by_type.get("supply", 0),
         "materials": by_type.get("material", 0),
         "needs_reorder": reorder_count,
@@ -683,6 +684,7 @@ def generate_item_sku(db: Session, item_type: str) -> str:
     item_type_prefix = {
         "finished_good": "FG",
         "component": "COMP",
+        "packaging": "PKG",
         "supply": "SUP",
         "service": "SRV",
         "material": get_default_material_sku_prefix(),
@@ -1250,7 +1252,7 @@ def bulk_update_items(
     updated = 0
     errors = []
 
-    valid_item_types = ["finished_good", "component", "supply", "service", "material"]
+    valid_item_types = ["finished_good", "component", "packaging", "supply", "service", "material"]
     valid_proc_types = ["make", "buy", "make_or_buy"]
 
     for item_id in item_ids:
@@ -1829,6 +1831,10 @@ def import_items_from_csv(
                         "variable": "finished_good",
                         "finished_good": "finished_good",
                         "component": "component",
+                        "packaging": "packaging",
+                        "box": "packaging",
+                        "mailers": "packaging",
+                        "mailer": "packaging",
                         "supply": "supply",
                         "service": "service",
                         "material": "material",

--- a/backend/tests/api/v1/test_items.py
+++ b/backend/tests/api/v1/test_items.py
@@ -148,6 +148,15 @@ class TestListItems:
         for item in body["items"]:
             assert item["item_type"] == "component"
 
+    def test_list_filter_by_packaging_item_type(self, client, make_product):
+        make_product(item_type="packaging", name="Packaging Filter Test")
+        resp = client.get(BASE_URL, params={"item_type": "packaging"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] >= 1
+        for item in body["items"]:
+            assert item["item_type"] == "packaging"
+
     def test_list_filter_by_procurement_type(self, client, make_product):
         make_product(procurement_type="make", name="Make Filter Test")
         resp = client.get(BASE_URL, params={"procurement_type": "make"})
@@ -272,6 +281,17 @@ class TestCreateItem:
         resp = client.post(BASE_URL, json=payload)
         assert resp.status_code == 201
         assert resp.json()["sku"].startswith("SUP-")
+
+    def test_create_packaging_auto_sku_prefix(self, client):
+        payload = {
+            "name": "Auto SKU Packaging",
+            "item_type": "packaging",
+        }
+        resp = client.post(BASE_URL, json=payload)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["item_type"] == "packaging"
+        assert body["sku"].startswith("PKG-")
 
     def test_create_service_auto_sku_prefix(self, client):
         payload = {
@@ -789,6 +809,18 @@ class TestBulkUpdate:
         resp = client.post(f"{BASE_URL}/bulk-update", json=payload)
         assert resp.status_code == 200
         assert resp.json()["updated_count"] == 1
+
+    def test_bulk_update_packaging_item_type(self, client, make_product):
+        p1 = make_product(name="Bulk Packaging", item_type="supply")
+        payload = {
+            "item_ids": [p1.id],
+            "item_type": "packaging",
+        }
+        resp = client.post(f"{BASE_URL}/bulk-update", json=payload)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["updated_count"] == 1
+        assert body["error_count"] == 0
 
     def test_bulk_update_deactivate(self, client, make_product):
         p1 = make_product(name="Bulk Deactivate")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -246,6 +246,7 @@ def setup_database():
             ("5000", "Cost of Goods Sold", "expense", True, None),
             ("5010", "Shipping Supplies", "expense", True, None),
             ("5020", "Scrap Expense (Production)", "expense", True, None),
+            ("5030", "Inventory Adjustment", "expense", True, None),
             ("5100", "Material Cost", "expense", True, None),
             ("5200", "Scrap Expense", "expense", True, None),
             ("5500", "Inventory Adjustment", "expense", True, None),

--- a/backend/tests/services/test_accounting_service.py
+++ b/backend/tests/services/test_accounting_service.py
@@ -324,6 +324,29 @@ class TestGetInventoryValuation:
         # No GL entries means GL balance is lower, creating a variance
         assert fg_cat["variance"] >= Decimal("0")
 
+    def test_packaging_inventory_maps_to_packaging_gl_category(self, db, make_product):
+        product = make_product(
+            item_type="packaging",
+            cost_method="standard",
+            standard_cost=Decimal("1.25"),
+        )
+        inv = Inventory(
+            product_id=product.id,
+            location_id=1,
+            on_hand_quantity=Decimal("10"),
+        )
+        db.add(inv)
+        db.flush()
+
+        result = accounting_service.get_inventory_valuation(db)
+
+        packaging_cat = next(
+            (c for c in result["categories"] if c["category"] == "Packaging"), None,
+        )
+        assert packaging_cat is not None
+        assert packaging_cat["gl_account_code"] == "1230"
+        assert packaging_cat["inventory_value"] >= Decimal("12.50")
+
     def test_valuation_categories_match_gl_accounts(self, db):
         """Each category maps to its expected GL account code."""
         result = accounting_service.get_inventory_valuation(db)
@@ -841,6 +864,30 @@ class TestGetAccountingSummary:
         assert fg_cat is not None
         assert fg_cat["value"] >= Decimal("150")
         assert fg_cat["item_count"] >= 1
+
+    def test_inventory_by_category_includes_packaging(self, db, make_product):
+        product = make_product(
+            item_type="packaging",
+            cost_method="standard",
+            standard_cost=Decimal("2.00"),
+        )
+        inv = Inventory(
+            product_id=product.id,
+            location_id=1,
+            on_hand_quantity=Decimal("4"),
+        )
+        db.add(inv)
+        db.flush()
+
+        result = accounting_service.get_accounting_summary(db)
+
+        packaging_cat = next(
+            (c for c in result["inventory_by_category"] if c["category"] == "Packaging"),
+            None,
+        )
+        assert packaging_cat is not None
+        assert packaging_cat["value"] >= Decimal("8.00")
+        assert packaging_cat["item_count"] >= 1
 
 
 # ===========================================================================

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -312,6 +312,10 @@ class TestGenerateItemSku:
         sku = item_service.generate_item_sku(db, "supply")
         assert sku.startswith("SUP-")
 
+    def test_packaging_prefix(self, db):
+        sku = item_service.generate_item_sku(db, "packaging")
+        assert sku.startswith("PKG-")
+
     def test_material_prefix(self, db):
         sku = item_service.generate_item_sku(db, "material")
         assert sku.startswith("MAT-")
@@ -389,6 +393,16 @@ class TestCreateItem:
         })
         assert item.sku.startswith("COMP-")
 
+    def test_create_packaging_item(self, db):
+        item = item_service.create_item(db, data={
+            "name": "Small Mailer",
+            "item_type": "packaging",
+        })
+        assert item.item_type == "packaging"
+        assert item.sku.startswith("PKG-")
+        assert item.unit == "EA"
+        assert item.purchase_uom == "EA"
+
     def test_enum_values_converted(self, db):
         """Enum-like objects with .value attr are converted to strings."""
         class FakeEnum:
@@ -417,6 +431,30 @@ class TestCreateItem:
             "category_id": cat.id,
         })
         assert item.category_id == cat.id
+
+
+class TestPackagingItemType:
+    """Packaging participates in item stats and CSV import."""
+
+    def test_get_item_stats_counts_packaging(self, db, make_product):
+        make_product(sku="PKG-STATS-001", name="Stats Box", item_type="packaging")
+        db.commit()
+
+        stats = item_service.get_item_stats(db)
+
+        assert stats["packaging"] >= 1
+
+    def test_import_csv_maps_packaging_item_type(self, db):
+        csv_data = (
+            "sku,name,item_type,unit\n"
+            "PKG-CSV-001,CSV Corrugated Box,packaging,EA\n"
+        ).encode("utf-8")
+
+        result = item_service.import_items_from_csv(db, file_content=csv_data)
+
+        assert result["created"] == 1
+        item = db.query(Product).filter(Product.sku == "PKG-CSV-001").one()
+        assert item.item_type == "packaging"
 
 
 class TestGetItem:
@@ -897,6 +935,19 @@ class TestBulkUpdateItems:
             db, item_ids=[p.id], item_type="not_a_valid_type"
         )
         assert result["error_count"] == 1
+
+    def test_bulk_update_allows_packaging_item_type(self, db, make_product):
+        p = make_product(item_type="supply")
+        db.commit()
+
+        result = item_service.bulk_update_items(
+            db, item_ids=[p.id], item_type="packaging"
+        )
+
+        assert result["updated_count"] == 1
+        assert result["error_count"] == 0
+        db.refresh(p)
+        assert p.item_type == "packaging"
 
     def test_category_id_zero_clears_category(self, db, make_product):
         cat = _make_category(db, "BULK-CLR", "Clear Category")

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -456,6 +456,18 @@ class TestPackagingItemType:
         item = db.query(Product).filter(Product.sku == "PKG-CSV-001").one()
         assert item.item_type == "packaging"
 
+    def test_import_csv_maps_packaging_alias_on_create(self, db):
+        csv_data = (
+            "sku,name,Type,unit\n"
+            "PKG-CSV-ALIAS-001,CSV Box Alias,box,EA\n"
+        ).encode("utf-8")
+
+        result = item_service.import_items_from_csv(db, file_content=csv_data)
+
+        assert result["created"] == 1
+        item = db.query(Product).filter(Product.sku == "PKG-CSV-ALIAS-001").one()
+        assert item.item_type == "packaging"
+
 
 class TestGetItem:
     """Test get_item and get_item_by_sku."""

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -14,16 +14,8 @@ import {
   hasErrors,
 } from "../utils/validation";
 import { FormErrorSummary, RequiredIndicator } from "./ErrorMessage";
+import { ITEM_TYPES } from "./item-wizard/constants";
 import Modal from "./Modal";
-
-const ITEM_TYPES = [
-  { value: "finished_good", label: "Finished Good" },
-  { value: "component", label: "Component" },
-  { value: "packaging", label: "Packaging" },
-  { value: "supply", label: "Supply" },
-  { value: "service", label: "Service" },
-  { value: "material", label: "Material (Filament)" },
-];
 
 const PROCUREMENT_TYPES = [
   { value: "make", label: "Make (Manufactured)" },

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -19,6 +19,7 @@ import Modal from "./Modal";
 const ITEM_TYPES = [
   { value: "finished_good", label: "Finished Good" },
   { value: "component", label: "Component" },
+  { value: "packaging", label: "Packaging" },
   { value: "supply", label: "Supply" },
   { value: "service", label: "Service" },
   { value: "material", label: "Material (Filament)" },

--- a/frontend/src/components/ItemWizard.jsx
+++ b/frontend/src/components/ItemWizard.jsx
@@ -93,6 +93,7 @@ export default function ItemWizard({ isOpen, onClose, onSuccess, editingItem = n
     if (item.name && !item.sku && !editingItem) {
       const prefix = item.item_type === "finished_good" ? "FG" :
                      item.item_type === "component" ? "CP" :
+                     item.item_type === "packaging" ? "PKG" :
                      item.item_type === "supply" ? "SP" : "SV";
       const timestamp = Date.now().toString(36).toUpperCase();
       setItem(prev => ({ ...prev, sku: `${prefix}-${timestamp}` }));

--- a/frontend/src/components/item-wizard/constants.js
+++ b/frontend/src/components/item-wizard/constants.js
@@ -8,6 +8,7 @@
 export const ITEM_TYPES = [
   { value: "finished_good", label: "Finished Good", color: "blue", defaultProcurement: "make" },
   { value: "component", label: "Component", color: "purple", defaultProcurement: "buy" },
+  { value: "packaging", label: "Packaging", color: "teal", defaultProcurement: "buy" },
   { value: "supply", label: "Supply", color: "orange", defaultProcurement: "buy" },
   { value: "service", label: "Service", color: "green", defaultProcurement: "buy" },
   { value: "material", label: "Material (Filament)", color: "yellow", defaultProcurement: "buy" },

--- a/frontend/src/components/items/BulkUpdateModal.jsx
+++ b/frontend/src/components/items/BulkUpdateModal.jsx
@@ -8,6 +8,7 @@ const ITEM_TYPES = [
   { value: "finished_good", label: "Finished Good" },
   { value: "component", label: "Component" },
   { value: "material", label: "Material" },
+  { value: "packaging", label: "Packaging" },
   { value: "supply", label: "Supply" },
   { value: "service", label: "Service" },
 ];

--- a/frontend/src/components/items/ItemsFilterBar.jsx
+++ b/frontend/src/components/items/ItemsFilterBar.jsx
@@ -6,6 +6,7 @@ const ITEM_TYPES = [
   { value: "component", label: "Component", color: "purple" },
   { value: "material", label: "Material", color: "orange" },
   { value: "filament", label: "Filament (Legacy)", color: "orange" },
+  { value: "packaging", label: "Packaging", color: "teal" },
   { value: "supply", label: "Supply", color: "yellow" },
   { value: "service", label: "Service", color: "green" },
 ];

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -9,6 +9,7 @@ const ITEM_TYPES = [
   { value: "component", label: "Component", color: "purple" },
   { value: "material", label: "Material", color: "orange" },
   { value: "filament", label: "Filament (Legacy)", color: "orange" },
+  { value: "packaging", label: "Packaging", color: "teal" },
   { value: "supply", label: "Supply", color: "yellow" },
   { value: "service", label: "Service", color: "green" },
 ];
@@ -23,6 +24,7 @@ const getItemTypeStyle = (type, hasFilament = false) => {
     blue: "bg-blue-500/20 text-blue-400",
     purple: "bg-purple-500/20 text-purple-400",
     orange: "bg-orange-500/20 text-orange-400",
+    teal: "bg-teal-500/20 text-teal-400",
     yellow: "bg-yellow-500/20 text-yellow-400",
     green: "bg-green-500/20 text-green-400",
   }[found.color];

--- a/frontend/src/components/items/__tests__/ItemsTable.test.jsx
+++ b/frontend/src/components/items/__tests__/ItemsTable.test.jsx
@@ -249,3 +249,28 @@ describe('ItemsTable — variant inventory rollup (Workstream A)', () => {
     ).toBeInTheDocument()
   })
 })
+
+describe('ItemsTable — item type labels', () => {
+  it('renders packaging items with the Packaging label', () => {
+    render(
+      <MockLocaleProvider currency="USD" locale="en-US">
+        <ItemsTable
+          {...baseProps}
+          items={[
+            {
+              ...item,
+              id: 300,
+              sku: 'PKG-BOX-001',
+              name: 'Shipping Box',
+              item_type: 'packaging',
+              material_type_id: null,
+              unit: 'EA',
+            },
+          ]}
+        />
+      </MockLocaleProvider>
+    )
+
+    expect(screen.getByText('Packaging')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/purchasing/QuickCreateItemModal.jsx
+++ b/frontend/src/components/purchasing/QuickCreateItemModal.jsx
@@ -157,6 +157,7 @@ export default function QuickCreateItemModal({ onClose, onCreated, initialName =
                   className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white"
                 >
                   <option value="supply">Supply</option>
+                  <option value="packaging">Packaging</option>
                   <option value="material">Material (Filament)</option>
                   <option value="component">Component</option>
                   <option value="finished_good">Finished Good</option>


### PR DESCRIPTION
## Summary
Adds `packaging` as a first-class Core item type so boxes, mailers, cartons, and shipping supplies can be managed separately from generic supplies. This is PR C1 from the PRO Quoter GTM pricing/components/packaging/shipping plan.

## Related Issues
None linked. Supports the PRO Quoter GTM packaging and shipping groundwork.

## Changes
- Backend item contracts now include `packaging` without removing existing item types.
- Item services support packaging SKU prefixes, stats, filtering, bulk update, CSV import normalization, and accounting inventory category valuation against GL 1230.
- Frontend item creation/edit, wizard, item table/filter, bulk update, and purchasing quick-create surfaces expose Packaging.
- Tests cover packaging create/list/bulk update, service SKU/stats/import behavior, accounting category mapping, and table rendering.

## Tests
- [x] `python -m py_compile app/schemas/item.py app/services/item_service.py app/services/accounting_service.py app/models/product.py`
- [x] Backend schema/import smoke for `ItemType.PACKAGING`, `ItemCreate`, bulk update parsing, and CSV alias normalization
- [x] `npm run test:unit -- ItemsTable.test.jsx --run`
- [x] `npm run build`
- [x] `git diff --check`
- [ ] Targeted backend pytest: blocked locally because local `filaops_test` PostgreSQL rejects `postgres/postgres` password auth. Same blocker was observed on the clean baseline before this PR.
- [ ] GitHub Actions: blocked by GitHub account billing lock. Check annotations say the jobs were not started because the account is locked due to a billing issue.

## Notes
- `npm run lint` reports 235 pre-existing frontend issues across unrelated files; this PR does not add those hook/no-undef patterns.
- C2 should add optional physical metadata fields and require dimensions/weight for packaging items.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-core-packaging-c1-20260530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Packaging" as a new inventory item type available in all item management forms, filters, and dropdowns.
  * Packaging items automatically receive SKU prefixes starting with "PKG-" upon creation.
  * Updated inventory accounting to include packaging items in valuations and category summaries.
  * CSV import now recognizes packaging-related values and maps them to the packaging item type.

* **Tests**
  * Added comprehensive test coverage for packaging item type functionality across API, services, and UI components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->