### PR TITLE
feat: require packaging physical metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Item create/edit now exposes optional weight and dimensions for shipping, with packaging items requiring all physical fields.
 - Manual quotes now support Core-owned file attachments with staff upload, download, list, and delete actions.
 - Public online quoter endpoints are now explicitly gated by `ENABLE_PUBLIC_QUOTER`, leaving Core manual quote creation independent of PRO.
 - Quotes now expose a Core-owned read-only archive response with retained file and material snapshots for downgrade/retrieval workflows.

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -708,6 +708,44 @@ def generate_item_sku(db: Session, item_type: str) -> str:
     return f"{item_type_prefix}-{new_num:03d}"
 
 
+PACKAGING_PHYSICAL_FIELDS = ("weight_oz", "length_in", "width_in", "height_in")
+PACKAGING_PHYSICAL_DETAIL = (
+    "Packaging items require weight_oz, length_in, width_in, and height_in."
+)
+
+
+def _item_type_value(item_type: object) -> str:
+    if hasattr(item_type, "value"):
+        return item_type.value
+    return str(item_type)
+
+
+def _physical_value_present(value: object) -> bool:
+    return value is not None and value != ""
+
+
+def _validate_packaging_physical_metadata(
+    data: dict,
+    *,
+    existing_item: Product | None = None,
+) -> None:
+    item_type = data.get(
+        "item_type",
+        existing_item.item_type if existing_item is not None else "finished_good",
+    )
+    if _item_type_value(item_type) != "packaging":
+        return
+
+    missing = []
+    for field in PACKAGING_PHYSICAL_FIELDS:
+        value = data[field] if field in data else getattr(existing_item, field, None)
+        if not _physical_value_present(value):
+            missing.append(field)
+
+    if missing:
+        raise HTTPException(status_code=400, detail=PACKAGING_PHYSICAL_DETAIL)
+
+
 def create_item(db: Session, *, data: dict) -> Product:
     """
     Create a new item (product).
@@ -719,6 +757,8 @@ def create_item(db: Session, *, data: dict) -> Product:
     item_type = data.get("item_type", "finished_good")
     if hasattr(item_type, "value"):
         item_type = item_type.value
+
+    _validate_packaging_physical_metadata({**data, "item_type": item_type})
 
     if not sku or sku.strip() == "":
         data["sku"] = generate_item_sku(db, item_type)
@@ -829,6 +869,8 @@ def update_item(db: Session, item_id: int, *, data: dict) -> Product:
     for enum_field in ["item_type", "procurement_type", "cost_method", "stocking_policy"]:
         if enum_field in data and data[enum_field] and hasattr(data[enum_field], "value"):
             data[enum_field] = data[enum_field].value
+
+    _validate_packaging_physical_metadata(data, existing_item=item)
 
     if "is_active" in data:
         data["active"] = data.pop("is_active")
@@ -1273,6 +1315,10 @@ def bulk_update_items(
                 if hasattr(item_type_value, "value"):
                     item_type_value = item_type_value.value
                 if item_type_value in valid_item_types:
+                    _validate_packaging_physical_metadata(
+                        {"item_type": item_type_value},
+                        existing_item=item,
+                    )
                     item.item_type = item_type_value
                 else:
                     raise ValueError(f"Invalid item_type: {item_type_value}")

--- a/backend/tests/api/v1/test_items.py
+++ b/backend/tests/api/v1/test_items.py
@@ -286,12 +286,54 @@ class TestCreateItem:
         payload = {
             "name": "Auto SKU Packaging",
             "item_type": "packaging",
+            "weight_oz": "3.20",
+            "length_in": "12.00",
+            "width_in": "9.00",
+            "height_in": "4.00",
         }
         resp = client.post(BASE_URL, json=payload)
         assert resp.status_code == 201
         body = resp.json()
         assert body["item_type"] == "packaging"
         assert body["sku"].startswith("PKG-")
+
+    def test_create_packaging_requires_physical_metadata(self, client):
+        payload = {
+            "name": "Box Missing Physical Metadata",
+            "item_type": "packaging",
+        }
+        resp = client.post(BASE_URL, json=payload)
+        assert resp.status_code == 400
+        assert "Packaging items require" in resp.json()["detail"]
+
+    def test_create_packaging_with_physical_metadata_succeeds(self, client):
+        payload = {
+            "name": "12x9x4 Corrugated Box",
+            "item_type": "packaging",
+            "weight_oz": "3.20",
+            "length_in": "12.00",
+            "width_in": "9.00",
+            "height_in": "4.00",
+        }
+        resp = client.post(BASE_URL, json=payload)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["item_type"] == "packaging"
+        assert body["weight_oz"] == "3.20"
+        assert body["length_in"] == "12.00"
+        assert body["width_in"] == "9.00"
+        assert body["height_in"] == "4.00"
+
+    def test_create_non_packaging_can_omit_physical_metadata(self, client):
+        payload = {
+            "name": "Physical Metadata Optional Component",
+            "item_type": "component",
+        }
+        resp = client.post(BASE_URL, json=payload)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["item_type"] == "component"
+        assert body["weight_oz"] is None
 
     def test_create_service_auto_sku_prefix(self, client):
         payload = {
@@ -537,6 +579,42 @@ class TestUpdateItem:
         assert body["name"] == "Renamed"
         # Original selling_price should be preserved
         assert float(body["selling_price"]) == pytest.approx(50.00, abs=0.01)
+
+    def test_update_to_packaging_requires_physical_metadata(self, client, make_product):
+        product = make_product(name="Supply Without Physical Data", item_type="supply")
+        resp = client.patch(f"{BASE_URL}/{product.id}", json={"item_type": "packaging"})
+        assert resp.status_code == 400
+        assert "Packaging items require" in resp.json()["detail"]
+
+    def test_update_to_packaging_with_physical_metadata_succeeds(self, client, make_product):
+        product = make_product(name="Supply With Physical Data", item_type="supply")
+        resp = client.patch(
+            f"{BASE_URL}/{product.id}",
+            json={
+                "item_type": "packaging",
+                "weight_oz": "2.50",
+                "length_in": "10.00",
+                "width_in": "8.00",
+                "height_in": "6.00",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["item_type"] == "packaging"
+        assert body["weight_oz"] == "2.50"
+
+    def test_update_packaging_cannot_clear_physical_metadata(self, client, make_product):
+        product = make_product(
+            name="Packaging With Physical Data",
+            item_type="packaging",
+            weight_oz=Decimal("2.50"),
+            length_in=Decimal("10.00"),
+            width_in=Decimal("8.00"),
+            height_in=Decimal("6.00"),
+        )
+        resp = client.patch(f"{BASE_URL}/{product.id}", json={"weight_oz": None})
+        assert resp.status_code == 400
+        assert "Packaging items require" in resp.json()["detail"]
 
 
 # =============================================================================
@@ -811,7 +889,14 @@ class TestBulkUpdate:
         assert resp.json()["updated_count"] == 1
 
     def test_bulk_update_packaging_item_type(self, client, make_product):
-        p1 = make_product(name="Bulk Packaging", item_type="supply")
+        p1 = make_product(
+            name="Bulk Packaging",
+            item_type="supply",
+            weight_oz=Decimal("2.50"),
+            length_in=Decimal("10.00"),
+            width_in=Decimal("8.00"),
+            height_in=Decimal("6.00"),
+        )
         payload = {
             "item_ids": [p1.id],
             "item_type": "packaging",
@@ -821,6 +906,19 @@ class TestBulkUpdate:
         body = resp.json()
         assert body["updated_count"] == 1
         assert body["error_count"] == 0
+
+    def test_bulk_update_packaging_item_type_requires_physical_metadata(self, client, make_product):
+        p1 = make_product(name="Bulk Packaging Missing Metadata", item_type="supply")
+        payload = {
+            "item_ids": [p1.id],
+            "item_type": "packaging",
+        }
+        resp = client.post(f"{BASE_URL}/bulk-update", json=payload)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["updated_count"] == 0
+        assert body["error_count"] == 1
+        assert "Packaging items require" in body["errors"][0]["error"]
 
     def test_bulk_update_deactivate(self, client, make_product):
         p1 = make_product(name="Bulk Deactivate")

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -411,12 +411,38 @@ class TestCreateItem:
         assert item.weight_oz == Decimal("1.25")
 
     def test_create_packaging_item_requires_physical_metadata(self, db):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(HTTPException) as exc_info:
             item_service.create_item(db, data={
                 "name": "Small Mailer Missing Metadata",
                 "item_type": "packaging",
             })
-        assert "Packaging items require" in str(exc_info.value)
+        assert exc_info.value.status_code == 400
+        assert "Packaging items require" in exc_info.value.detail
+
+    @pytest.mark.parametrize(
+        "physical_data",
+        [
+            {"weight_oz": Decimal("1.25")},
+            {
+                "weight_oz": Decimal("1.25"),
+                "length_in": Decimal("10.00"),
+                "width_in": Decimal("7.00"),
+            },
+        ],
+    )
+    def test_create_packaging_item_requires_complete_physical_metadata(
+        self,
+        db,
+        physical_data,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            item_service.create_item(db, data={
+                "name": "Small Mailer Partial Metadata",
+                "item_type": "packaging",
+                **physical_data,
+            })
+        assert exc_info.value.status_code == 400
+        assert "Packaging items require" in exc_info.value.detail
 
     def test_enum_values_converted(self, db):
         """Enum-like objects with .value attr are converted to strings."""

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -19,6 +19,8 @@ from decimal import Decimal
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from fastapi import HTTPException
+
 from app.services import item_service
 from app.models.product import Product
 from app.models.item_category import ItemCategory
@@ -155,7 +157,7 @@ class TestCreateCategory:
 
     def test_duplicate_code_raises_400(self, db):
         item_service.create_category(db, code="DUP-CAT", name="First")
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(HTTPException) as exc_info:
             item_service.create_category(db, code="DUP-CAT", name="Second")
         assert exc_info.value.status_code == 400
 
@@ -397,11 +399,24 @@ class TestCreateItem:
         item = item_service.create_item(db, data={
             "name": "Small Mailer",
             "item_type": "packaging",
+            "weight_oz": Decimal("1.25"),
+            "length_in": Decimal("10.00"),
+            "width_in": Decimal("7.00"),
+            "height_in": Decimal("0.50"),
         })
         assert item.item_type == "packaging"
         assert item.sku.startswith("PKG-")
         assert item.unit == "EA"
         assert item.purchase_uom == "EA"
+        assert item.weight_oz == Decimal("1.25")
+
+    def test_create_packaging_item_requires_physical_metadata(self, db):
+        with pytest.raises(Exception) as exc_info:
+            item_service.create_item(db, data={
+                "name": "Small Mailer Missing Metadata",
+                "item_type": "packaging",
+            })
+        assert "Packaging items require" in str(exc_info.value)
 
     def test_enum_values_converted(self, db):
         """Enum-like objects with .value attr are converted to strings."""
@@ -949,7 +964,13 @@ class TestBulkUpdateItems:
         assert result["error_count"] == 1
 
     def test_bulk_update_allows_packaging_item_type(self, db, make_product):
-        p = make_product(item_type="supply")
+        p = make_product(
+            item_type="supply",
+            weight_oz=Decimal("1.25"),
+            length_in=Decimal("10.00"),
+            width_in=Decimal("7.00"),
+            height_in=Decimal("0.50"),
+        )
         db.commit()
 
         result = item_service.bulk_update_items(
@@ -960,6 +981,18 @@ class TestBulkUpdateItems:
         assert result["error_count"] == 0
         db.refresh(p)
         assert p.item_type == "packaging"
+
+    def test_bulk_update_packaging_item_type_requires_physical_metadata(self, db, make_product):
+        p = make_product(item_type="supply")
+        db.commit()
+
+        result = item_service.bulk_update_items(
+            db, item_ids=[p.id], item_type="packaging"
+        )
+
+        assert result["updated_count"] == 0
+        assert result["error_count"] == 1
+        assert "Packaging items require" in result["errors"][0]["error"]
 
     def test_category_id_zero_clears_category(self, db, make_product):
         cat = _make_category(db, "BULK-CLR", "Clear Category")

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -9,6 +9,7 @@ import { API_URL } from "../config/api";
 import {
   validateRequired,
   validatePrice,
+  validateNumber,
   validateSKU,
   validateForm,
   hasErrors,
@@ -27,6 +28,16 @@ const STOCKING_POLICIES = [
   { value: "on_demand", label: "On-Demand (MRP-driven)" },
   { value: "stocked", label: "Stocked (Reorder Point)" },
 ];
+
+const PHYSICAL_FIELDS = [
+  { name: "weight_oz", label: "Weight (oz)" },
+  { name: "length_in", label: "Length (in)" },
+  { name: "width_in", label: "Width (in)" },
+  { name: "height_in", label: "Height (in)" },
+];
+
+const optionalNumber = (value) =>
+  value === "" || value === null || value === undefined ? null : parseFloat(value);
 
 export default function ItemForm({
   isOpen,
@@ -54,6 +65,10 @@ export default function ItemForm({
     standard_cost: editingItem?.standard_cost || "",
     selling_price: editingItem?.selling_price || "",
     reorder_point: editingItem?.reorder_point || "",
+    weight_oz: editingItem?.weight_oz || "",
+    length_in: editingItem?.length_in || "",
+    width_in: editingItem?.width_in || "",
+    height_in: editingItem?.height_in || "",
     image_url: editingItem?.image_url || "",
   });
 
@@ -115,6 +130,10 @@ export default function ItemForm({
           standard_cost: editingItem.standard_cost || "",
           selling_price: editingItem.selling_price || "",
           reorder_point: editingItem.reorder_point || "",
+          weight_oz: editingItem.weight_oz || "",
+          length_in: editingItem.length_in || "",
+          width_in: editingItem.width_in || "",
+          height_in: editingItem.height_in || "",
           image_url: editingItem.image_url || "",
         });
       } else {
@@ -131,6 +150,10 @@ export default function ItemForm({
           standard_cost: "",
           selling_price: "",
           reorder_point: "",
+          weight_oz: "",
+          length_in: "",
+          width_in: "",
+          height_in: "",
           image_url: "",
         });
       }
@@ -151,6 +174,7 @@ export default function ItemForm({
   }, [formData.item_type, editingItem]);
 
   const validateFormData = () => {
+    const isPackaging = formData.item_type === "packaging";
     const validationRules = {
       name: [(v) => validateRequired(v, "Item name")],
       unit: [(v) => validateRequired(v, "Unit of measure")],
@@ -174,6 +198,15 @@ export default function ItemForm({
       validationRules.selling_price = [
         (v) => validatePrice(v, "Selling price"),
       ];
+    }
+
+    for (const field of PHYSICAL_FIELDS) {
+      if (isPackaging || (formData[field.name] !== "" && formData[field.name] !== null)) {
+        validationRules[field.name] = [
+          ...(isPackaging ? [(v) => validateRequired(v, field.label)] : []),
+          (v) => validateNumber(v, field.label, { min: 0 }),
+        ];
+      }
     }
 
     return validateForm(formData, validationRules);
@@ -208,6 +241,10 @@ export default function ItemForm({
         selling_price: formData.selling_price
           ? parseFloat(formData.selling_price)
           : null,
+        weight_oz: optionalNumber(formData.weight_oz),
+        length_in: optionalNumber(formData.length_in),
+        width_in: optionalNumber(formData.width_in),
+        height_in: optionalNumber(formData.height_in),
         reorder_point: formData.stocking_policy === "stocked" && formData.reorder_point
           ? parseFloat(formData.reorder_point)
           : null,
@@ -646,6 +683,57 @@ export default function ItemForm({
                   </option>
                 ))}
               </select>
+            </div>
+
+            {/* Physical / Shipping */}
+            <div className="border border-gray-700 rounded-lg p-4">
+              <h3 className="text-sm font-semibold text-gray-200 mb-3">
+                Physical / Shipping
+              </h3>
+              <div className="grid grid-cols-2 gap-4">
+                {PHYSICAL_FIELDS.map((field) => (
+                  <div key={field.name}>
+                    <label
+                      htmlFor={`item-${field.name.replace("_", "-")}`}
+                      className="block text-sm font-medium text-gray-300 mb-1"
+                    >
+                      {field.label}
+                      {formData.item_type === "packaging" && <RequiredIndicator />}
+                    </label>
+                    <input
+                      id={`item-${field.name.replace("_", "-")}`}
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={formData[field.name]}
+                      onChange={(e) =>
+                        setFormData({ ...formData, [field.name]: e.target.value })
+                      }
+                      aria-invalid={!!errors[field.name]}
+                      aria-describedby={
+                        errors[field.name]
+                          ? `item-${field.name.replace("_", "-")}-error`
+                          : undefined
+                      }
+                      className={`w-full px-4 py-2 bg-gray-800 border rounded-lg text-white placeholder-gray-500 focus:outline-none ${
+                        errors[field.name]
+                          ? "border-red-500 focus:border-red-500"
+                          : "border-gray-700 focus:border-blue-500"
+                      }`}
+                      placeholder="0.00"
+                    />
+                    {errors[field.name] && (
+                      <p
+                        id={`item-${field.name.replace("_", "-")}-error`}
+                        role="alert"
+                        className="text-red-400 text-sm mt-1"
+                      >
+                        {errors[field.name]}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
 
             {/* Pricing */}

--- a/frontend/src/components/ItemForm.jsx
+++ b/frontend/src/components/ItemForm.jsx
@@ -39,6 +39,25 @@ const PHYSICAL_FIELDS = [
 const optionalNumber = (value) =>
   value === "" || value === null || value === undefined ? null : parseFloat(value);
 
+const buildFormState = (item) => ({
+  sku: item?.sku || "",
+  name: item?.name || "",
+  description: item?.description || "",
+  item_type: item?.item_type || "finished_good",
+  procurement_type: item?.procurement_type || "make",
+  stocking_policy: item?.stocking_policy || "on_demand",
+  category_id: item?.category_id || null,
+  unit: item?.unit || "EA",
+  standard_cost: item?.standard_cost || "",
+  selling_price: item?.selling_price || "",
+  reorder_point: item?.reorder_point || "",
+  weight_oz: item?.weight_oz || "",
+  length_in: item?.length_in || "",
+  width_in: item?.width_in || "",
+  height_in: item?.height_in || "",
+  image_url: item?.image_url || "",
+});
+
 export default function ItemForm({
   isOpen,
   onClose,
@@ -53,24 +72,7 @@ export default function ItemForm({
   const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef(null);
 
-  const [formData, setFormData] = useState({
-    sku: editingItem?.sku || "",
-    name: editingItem?.name || "",
-    description: editingItem?.description || "",
-    item_type: editingItem?.item_type || "finished_good",
-    procurement_type: editingItem?.procurement_type || "make",
-    stocking_policy: editingItem?.stocking_policy || "on_demand",
-    category_id: editingItem?.category_id || null,
-    unit: editingItem?.unit || "EA",
-    standard_cost: editingItem?.standard_cost || "",
-    selling_price: editingItem?.selling_price || "",
-    reorder_point: editingItem?.reorder_point || "",
-    weight_oz: editingItem?.weight_oz || "",
-    length_in: editingItem?.length_in || "",
-    width_in: editingItem?.width_in || "",
-    height_in: editingItem?.height_in || "",
-    image_url: editingItem?.image_url || "",
-  });
+  const [formData, setFormData] = useState(() => buildFormState(editingItem));
 
   const fetchCategories = useCallback(async () => {
     try {
@@ -117,46 +119,7 @@ export default function ItemForm({
     if (isOpen) {
       fetchCategories();
       fetchUomClasses();
-      if (editingItem) {
-        setFormData({
-          sku: editingItem.sku || "",
-          name: editingItem.name || "",
-          description: editingItem.description || "",
-          item_type: editingItem.item_type || "finished_good",
-          procurement_type: editingItem.procurement_type || "make",
-          stocking_policy: editingItem.stocking_policy || "on_demand",
-          category_id: editingItem.category_id || null,
-          unit: editingItem.unit || "EA",
-          standard_cost: editingItem.standard_cost || "",
-          selling_price: editingItem.selling_price || "",
-          reorder_point: editingItem.reorder_point || "",
-          weight_oz: editingItem.weight_oz || "",
-          length_in: editingItem.length_in || "",
-          width_in: editingItem.width_in || "",
-          height_in: editingItem.height_in || "",
-          image_url: editingItem.image_url || "",
-        });
-      } else {
-        // Reset form for new item
-        setFormData({
-          sku: "",
-          name: "",
-          description: "",
-          item_type: "finished_good",
-          procurement_type: "make",
-          stocking_policy: "on_demand",
-          category_id: null,
-          unit: "EA",
-          standard_cost: "",
-          selling_price: "",
-          reorder_point: "",
-          weight_oz: "",
-          length_in: "",
-          width_in: "",
-          height_in: "",
-          image_url: "",
-        });
-      }
+      setFormData(buildFormState(editingItem));
       setError(null);
       setErrors({});
     }

--- a/frontend/src/components/__tests__/ItemForm.test.jsx
+++ b/frontend/src/components/__tests__/ItemForm.test.jsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ItemForm from '../ItemForm'
+
+vi.mock('../Modal', () => ({
+  default: ({ isOpen, children }) => (isOpen ? <div role="dialog">{children}</div> : null),
+}))
+
+const fetchOk = (body) => ({
+  ok: true,
+  json: async () => body,
+})
+
+const postBody = () => {
+  const call = globalThis.fetch.mock.calls.find(
+    ([url, options]) => String(url).includes('/api/v1/items') && options?.method === 'POST'
+  )
+  if (!call) {
+    throw new Error('No POST /api/v1/items request was made')
+  }
+  return JSON.parse(call[1].body)
+}
+
+const renderForm = (props = {}) =>
+  render(
+    <ItemForm
+      isOpen
+      onClose={vi.fn()}
+      onSuccess={vi.fn()}
+      {...props}
+    />
+  )
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn((url, options = {}) => {
+    if (options.method === 'POST') {
+      return Promise.resolve(fetchOk({
+        id: 1,
+        name: '12x9x4 Corrugated Box',
+        item_type: 'packaging',
+        weight_oz: '3.20',
+        length_in: '12.00',
+        width_in: '9.00',
+        height_in: '4.00',
+      }))
+    }
+    if (String(url).includes('/api/v1/admin/uom/classes')) {
+      return Promise.resolve(fetchOk([]))
+    }
+    if (String(url).includes('/api/v1/items/categories')) {
+      return Promise.resolve(fetchOk([]))
+    }
+    return Promise.resolve(fetchOk({}))
+  })
+})
+
+describe('ItemForm packaging physical metadata', () => {
+  it('requires weight and dimensions before saving packaging items', async () => {
+    renderForm()
+
+    fireEvent.change(screen.getByLabelText(/Name/), {
+      target: { value: '12x9x4 Corrugated Box' },
+    })
+    fireEvent.change(screen.getByLabelText(/Item Type/), {
+      target: { value: 'packaging' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create Item' }))
+
+    expect(await screen.findByText('Weight (oz) is required')).toBeInTheDocument()
+    expect(screen.getByText('Length (in) is required')).toBeInTheDocument()
+    expect(screen.getByText('Width (in) is required')).toBeInTheDocument()
+    expect(screen.getByText('Height (in) is required')).toBeInTheDocument()
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/items'),
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('sends packaging weight and dimensions when all fields are filled', async () => {
+    const onSuccess = vi.fn()
+    renderForm({ onSuccess })
+
+    fireEvent.change(screen.getByLabelText(/Name/), {
+      target: { value: '12x9x4 Corrugated Box' },
+    })
+    fireEvent.change(screen.getByLabelText(/Item Type/), {
+      target: { value: 'packaging' },
+    })
+    fireEvent.change(screen.getByLabelText(/Weight \(oz\)/), {
+      target: { value: '3.2' },
+    })
+    fireEvent.change(screen.getByLabelText(/Length \(in\)/), {
+      target: { value: '12' },
+    })
+    fireEvent.change(screen.getByLabelText(/Width \(in\)/), {
+      target: { value: '9' },
+    })
+    fireEvent.change(screen.getByLabelText(/Height \(in\)/), {
+      target: { value: '4' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Item' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled())
+    expect(postBody()).toMatchObject({
+      item_type: 'packaging',
+      weight_oz: 3.2,
+      length_in: 12,
+      width_in: 9,
+      height_in: 4,
+    })
+  })
+})

--- a/frontend/src/components/__tests__/ItemForm.test.jsx
+++ b/frontend/src/components/__tests__/ItemForm.test.jsx
@@ -66,10 +66,10 @@ describe('ItemForm packaging physical metadata', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Create Item' }))
 
-    expect(await screen.findByText('Weight (oz) is required')).toBeInTheDocument()
-    expect(screen.getByText('Length (in) is required')).toBeInTheDocument()
-    expect(screen.getByText('Width (in) is required')).toBeInTheDocument()
-    expect(screen.getByText('Height (in) is required')).toBeInTheDocument()
+    expect(await screen.findAllByText('Weight (oz) is required')).toHaveLength(2)
+    expect(screen.getAllByText('Length (in) is required')).toHaveLength(2)
+    expect(screen.getAllByText('Width (in) is required')).toHaveLength(2)
+    expect(screen.getAllByText('Height (in) is required')).toHaveLength(2)
     expect(globalThis.fetch).not.toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/items'),
       expect.objectContaining({ method: 'POST' })


### PR DESCRIPTION
## Summary
- adds Core validation requiring packaging items to have weight and dimensions on create, PATCH, and bulk type conversion
- exposes optional item weight/dimensions in the item create/edit form, required only for packaging
- adds backend API coverage and focused ItemForm unit coverage

## Tests
- npm run test:unit -- src/components/__tests__/ItemForm.test.jsx
- VM disposable CI DB: pytest -q tests/api/v1/test_items.py::TestCreateItem::test_create_packaging_requires_physical_metadata tests/api/v1/test_items.py::TestCreateItem::test_create_packaging_with_physical_metadata_succeeds tests/api/v1/test_items.py::TestCreateItem::test_create_non_packaging_can_omit_physical_metadata tests/api/v1/test_items.py::TestUpdateItem::test_update_to_packaging_requires_physical_metadata tests/api/v1/test_items.py::TestUpdateItem::test_update_to_packaging_with_physical_metadata_succeeds tests/api/v1/test_items.py::TestUpdateItem::test_update_packaging_cannot_clear_physical_metadata tests/api/v1/test_items.py::TestBulkUpdate::test_bulk_update_packaging_item_type tests/api/v1/test_items.py::TestBulkUpdate::test_bulk_update_packaging_item_type_requires_physical_metadata
- python -m compileall backend/app/services/item_service.py
- python -m ruff check backend/app/services/item_service.py

## Notes
- Local focused ruff on backend/tests/api/v1/test_items.py reports pre-existing unused local variables in older tests; not cleaned up in this PR.
- npm ci reports 2 moderate dependency vulnerabilities already present in frontend lockfile; not changed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items can include optional shipping weight and physical dimensions (weight in ounces; length/width/height in inches).
  * Packaging items are now required to provide all physical dimension fields when created or edited.
  * Validation enforces complete physical metadata for packaging items and surfaces clear error messages on failure.

* **Tests**
  * API and form tests updated to cover the new packaging validation and UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blb3D/filaops/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->