### PR TITLE
feat: pass portal quote add-on ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Item create/edit now exposes optional weight and dimensions for shipping, with packaging items requiring all physical fields.
+- Public portal quote creation now passes selected component add-on ids through to the optional quote automation provider.
 - Manual quotes now support Core-owned file attachments with staff upload, download, list, and delete actions.
 - Public online quoter endpoints are now explicitly gated by `ENABLE_PUBLIC_QUOTER`, leaving Core manual quote creation independent of PRO.
 - Quotes now expose a Core-owned read-only archive response with retained file and material snapshots for downgrade/retrieval workflows.

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -376,6 +376,22 @@ def _safe_log_value(value: Any, max_length: int = 160) -> str:
     return safe[:max_length]
 
 
+def _normalize_portal_component_addon_ids(values: Optional[List[str]]) -> List[str]:
+    """Normalize optional public add-on ids without interpreting private costs."""
+    if values is None:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        for item in str(raw_value or "").split(","):
+            addon_id = item.strip()
+            if addon_id and addon_id not in seen:
+                seen.add(addon_id)
+                normalized.append(addon_id)
+    return normalized
+
+
 def _set_portal_quote_manual_review(quote: Quote, reason: str) -> None:
     quote.status = "pending"
     quote.approval_method = "manual"
@@ -580,6 +596,7 @@ async def create_portal_quote(
     quality: str = Form("standard"),
     infill: str = Form("20%"),
     quantity: int = Form(1, ge=1, le=10000),
+    component_addon_ids: Optional[List[str]] = Form(None),
     customer_notes: Optional[str] = Form(None),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -626,19 +643,25 @@ async def create_portal_quote(
         file_hash=stored_file["file_hash"],
     ))
 
+    automation_options: dict[str, Any] = {
+        "material_id": material,
+        "color": color,
+        "quality": quality,
+        "infill": infill,
+        "quantity": quantity,
+        "customer_notes": customer_notes,
+    }
+    if component_addon_ids is not None:
+        automation_options["component_addon_ids"] = (
+            _normalize_portal_component_addon_ids(component_addon_ids)
+        )
+
     extra = await _maybe_enrich_portal_quote(
         request,
         db=db,
         quote=quote,
         stored_file=stored_file,
-        options={
-            "material_id": material,
-            "color": color,
-            "quality": quality,
-            "infill": infill,
-            "quantity": quantity,
-            "customer_notes": customer_notes,
-        },
+        options=automation_options,
     )
     if customer_notes and not quote.requires_review_reason:
         quote.requires_review_reason = "Customer notes require manual review"

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -688,6 +688,52 @@ class TestPortalQuoteContract:
         expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
         assert expires_at.tzinfo is None or expires_at.tzinfo.utcoffset(expires_at) is not None
 
+    def test_portal_create_passes_component_addon_ids_to_provider(self, client):
+        captured_options = {}
+
+        def provider(**kwargs):
+            captured_options.update(kwargs["options"])
+            quote = kwargs["quote"]
+            quote.material_grams = Decimal("27.20")
+            quote.print_time_hours = Decimal("0.75")
+            quote.unit_price = Decimal("19.43")
+            quote.subtotal = Decimal("19.43")
+            quote.total_price = Decimal("19.43")
+            quote.status = "approved"
+            quote.approval_method = "auto"
+            quote.auto_approved = True
+            quote.auto_approve_eligible = True
+            quote.requires_review_reason = None
+            return {
+                "breakdown": {
+                    "component_addons": [
+                        {"id": "led-kit", "label": "LED Lamp Kit"},
+                    ],
+                },
+            }
+
+        provider_state = self._install_auto_quote_provider(client)
+        client.app.state.quote_automation_provider = provider
+        try:
+            response = client.post(
+                f"{BASE_URL}/portal",
+                data={
+                    "material": "pla-basic",
+                    "color": "yellow",
+                    "quality": "standard",
+                    "infill": "20%",
+                    "quantity": "1",
+                    "component_addon_ids": ["led-kit", "gift-box"],
+                },
+                files={"file": ("lamp.stl", b"solid test\nendsolid test\n", "model/stl")},
+            )
+        finally:
+            self._clear_auto_quote_provider(client, provider_state)
+
+        assert response.status_code == 201, response.text
+        assert captured_options["component_addon_ids"] == ["led-kit", "gift-box"]
+        assert response.json()["breakdown"]["component_addons"][0]["id"] == "led-kit"
+
     @pytest.mark.parametrize(
         ("filename", "content_type"),
         [


### PR DESCRIPTION
## Summary
- accept repeated `component_addon_ids` fields on Core public portal quote creation
- normalize add-on ids and pass them through to the optional `quote_automation_provider`
- omit the option entirely when older clients do not send the field so PRO defaults still apply

## Scope notes
- Core remains standalone and does not price or interpret component add-ons
- no PRO imports, schema changes, packaging, shipping, payment, or order conversion changes

## Tests
- `git diff --cached --check`
- `python -m py_compile backend/app/api/v1/endpoints/quotes.py`
- Attempted `python -m pytest backend/tests/api/v1/test_quotes.py::TestPortalQuoteContract::test_portal_create_passes_component_addon_ids_to_provider -q`; local run was blocked before test execution by Postgres auth for `postgres:postgres@localhost/filaops_test`. External Core CI should run the DB-backed pytest gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public portal quote creation now supports optional component add-on selection. Selected add-ons are included when requesting automated quotes, enabling more tailored pricing and breakdowns.
* **Tests**
  * Added a contract test to verify component add-on selections are passed through and reflected in quote responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->