### PR TITLE
ci: disable automatic github actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,7 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    - cron: "30 6 * * 1" # Monday 6:30 UTC
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,6 @@
 name: Deploy Documentation
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'requirements-docs.txt'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/filaops-ci.yml
+++ b/.github/workflows/filaops-ci.yml
@@ -1,8 +1,7 @@
 name: FilaOps CI
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   backend:

--- a/.github/workflows/pro-guard.yml
+++ b/.github/workflows/pro-guard.yml
@@ -1,8 +1,7 @@
 name: PRO Code Guard
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   check-pro-code:

--- a/.github/workflows/review-council.yml
+++ b/.github/workflows/review-council.yml
@@ -1,8 +1,6 @@
 name: Review Council
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       agents:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: FilaOps CI/CD - Tests
 
 on:
-  push:
-    branches: [ main, develop, feat/* ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
   # Backend Tests

--- a/docs/operations/external-ci-statuses.md
+++ b/docs/operations/external-ci-statuses.md
@@ -1,0 +1,43 @@
+# External CI Statuses
+
+Core PR and main protection is enforced by external commit statuses instead of
+automatic GitHub Actions runs. This keeps the gate mechanical while avoiding
+GitHub-hosted Actions usage.
+
+Core branch protection is intended to require these status contexts for `main`:
+
+```text
+external-ci/core-diff
+external-ci/core-pro-guard
+external-ci/core-backend-static
+external-ci/core-backend-tests
+external-ci/core-frontend-build
+external-ci/core-frontend-unit
+```
+
+`external-ci/core-pro-guard` runs the same public-repo boundary check as
+`scripts/ci/check-pro-code.ps1`: Core must not contain `backend/app/pro/`,
+`license-server/`, or a PR diff touching those paths.
+
+The external runner lives in `Blb3D/filaops-ecosystem` under
+`scripts/ci/run-external-ci.ps1` and `scripts/ci/run-external-ci.sh`. Run it
+against a Core PR with:
+
+```powershell
+.\scripts\ci\run-external-ci.ps1 `
+  -Repository Blb3D/filaops `
+  -PrNumber <pr-number> `
+  -Profile core
+```
+
+```bash
+scripts/ci/run-external-ci.sh \
+  --repository Blb3D/filaops \
+  --pr-number <pr-number> \
+  --profile core
+```
+
+GitHub-hosted workflows in `.github/workflows/` are intentionally
+`workflow_dispatch` only. CodeQL can still be run manually from GitHub, or by an
+external security job that posts its own required status once that runner is
+available.

--- a/scripts/ci/check-pro-code.ps1
+++ b/scripts/ci/check-pro-code.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$BaseRef = "origin/main",
+    [string]$HeadRef = "HEAD"
+)
+
+$ErrorActionPreference = "Stop"
+
+$found = $false
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+
+function Report-ProHit {
+    param([string]$Message)
+    Write-Error $Message
+    $script:found = $true
+}
+
+$proDirs = @(
+    "backend/app/pro",
+    "license-server"
+)
+
+foreach ($dir in $proDirs) {
+    $path = Join-Path $repoRoot $dir
+    if (Test-Path -LiteralPath $path) {
+        Report-ProHit "$dir found; PRO code must not be in the public Core repo."
+    }
+}
+
+$mergeBase = git -C $repoRoot merge-base $BaseRef $HeadRef
+$changedFiles = git -C $repoRoot diff --name-only "$mergeBase..$HeadRef"
+
+$proFilePattern = '^(backend/app/pro/|license-server/)'
+$proFiles = $changedFiles | Where-Object { $_ -match $proFilePattern }
+
+if ($proFiles) {
+    Report-ProHit "Diff contains PRO-only paths:`n$($proFiles -join "`n")"
+}
+
+if ($found) {
+    exit 1
+}
+
+Write-Host "No PRO code detected; public Core repo is clean."

--- a/scripts/ci/check-pro-code.ps1
+++ b/scripts/ci/check-pro-code.ps1
@@ -8,10 +8,10 @@ $ErrorActionPreference = "Stop"
 $found = $false
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 
-function Report-ProHit {
+function Write-ProHit {
     param([string]$Message)
-    Write-Error $Message
     $script:found = $true
+    Write-Host "::error::$Message"
 }
 
 $proDirs = @(
@@ -22,7 +22,7 @@ $proDirs = @(
 foreach ($dir in $proDirs) {
     $path = Join-Path $repoRoot $dir
     if (Test-Path -LiteralPath $path) {
-        Report-ProHit "$dir found; PRO code must not be in the public Core repo."
+        Write-ProHit "$dir found; PRO code must not be in the public Core repo."
     }
 }
 
@@ -33,7 +33,7 @@ $proFilePattern = '^(backend/app/pro/|license-server/)'
 $proFiles = $changedFiles | Where-Object { $_ -match $proFilePattern }
 
 if ($proFiles) {
-    Report-ProHit "Diff contains PRO-only paths:`n$($proFiles -join "`n")"
+    Write-ProHit "Diff contains PRO-only paths:`n$($proFiles -join "`n")"
 }
 
 if ($found) {

--- a/scripts/ci/check-pro-code.ps1
+++ b/scripts/ci/check-pro-code.ps1
@@ -27,7 +27,16 @@ foreach ($dir in $proDirs) {
 }
 
 $mergeBase = git -C $repoRoot merge-base $BaseRef $HeadRef
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($mergeBase)) {
+    Write-ProHit "Failed to compute merge-base for refs '$BaseRef' and '$HeadRef'."
+    exit 1
+}
+
 $changedFiles = git -C $repoRoot diff --name-only "$mergeBase..$HeadRef"
+if ($LASTEXITCODE -ne 0) {
+    Write-ProHit "Failed to diff changed files for range '$mergeBase..$HeadRef'."
+    exit 1
+}
 
 $proFilePattern = '^(backend/app/pro/|license-server/)'
 $proFiles = $changedFiles | Where-Object { $_ -match $proFilePattern }


### PR DESCRIPTION
## Summary
- makes Core GitHub Actions workflows manual-only with `workflow_dispatch`
- stops push/PR/scheduled GitHub-hosted workflow runs from consuming paid Actions minutes
- adds a Core-side PRO guard helper for the external CI runner/status flow

## Why
Core PR enforcement already relies on external `external-ci/core-*` statuses. The remaining automatic GitHub Actions triggers still fire on PRs and `main` pushes, which can block or burn Actions minutes when billing is locked.

## Validation
- `git diff --check`
- `./scripts/ci/check-pro-code.ps1 -BaseRef origin/main -HeadRef HEAD`
- checked workflow trigger files for remaining `push`, `pull_request`, and `schedule` triggers

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-disable-gh-actions-main-worktree-20260601


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to run primarily via manual trigger for greater control over automation.
  * Added an automated check to block inadvertent inclusion of restricted/pro-only content before merge.

* **Documentation**
  * New operational guidance on external CI status requirements and how to run external security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->