### PR TITLE
feat: retain quote handoff snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Quotes and quote-based orders now retain Core-owned pricing, component, packaging, shipping, artifact, and slicer diagnostic snapshots for durable public-quoter handoff.
 - Item create/edit now exposes optional weight and dimensions for shipping, with packaging items requiring all physical fields.
 - Public portal quote creation now passes selected component add-on ids through to the optional quote automation provider.
 - Manual quotes now support Core-owned file attachments with staff upload, download, list, and delete actions.

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -4,6 +4,7 @@ Quote Management Endpoints - Community Edition
 Manual quote creation and management for small businesses.
 Supports creating quotes, updating status, and converting to sales orders.
 """
+import json
 from datetime import datetime, timezone, timedelta
 from inspect import isawaitable
 from typing import Any, List, Optional
@@ -23,11 +24,12 @@ from app.api.v1.endpoints.auth import get_current_user
 from app.services import quote_service
 from app.services import bom_service
 from app.services.file_storage import file_storage
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/quotes", tags=["Quotes"])
+PORTAL_SNAPSHOT_MAX_BYTES = 32 * 1024
 
 
 # ============================================================================
@@ -253,6 +255,32 @@ class PortalShippingSelection(BaseModel):
     shipping_snapshot: Optional[dict[str, Any]] = None
     artifact_snapshot: Optional[dict[str, Any]] = None
     slicer_diagnostics: Optional[dict[str, Any]] = None
+
+    @field_validator(
+        "pricing_snapshot",
+        "component_snapshot",
+        "packaging_snapshot",
+        "shipping_snapshot",
+        "artifact_snapshot",
+        "slicer_diagnostics",
+    )
+    @classmethod
+    def _limit_snapshot_size(cls, value: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if value is None:
+            return value
+        try:
+            encoded = json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Snapshot payload must be JSON serializable") from exc
+
+        if len(encoded.encode("utf-8")) > PORTAL_SNAPSHOT_MAX_BYTES:
+            raise ValueError("Snapshot payload must be 32KB or smaller")
+        return value
 
 
 class QuoteArchiveFile(BaseModel):

--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -247,6 +247,12 @@ class PortalShippingSelection(BaseModel):
     print_mode: Optional[str] = Field(None, max_length=20)
     adjusted_unit_price: Optional[Decimal] = Field(None, ge=0)
     multi_color_info: Optional[dict[str, Any]] = None
+    pricing_snapshot: Optional[dict[str, Any]] = None
+    component_snapshot: Optional[dict[str, Any]] = None
+    packaging_snapshot: Optional[dict[str, Any]] = None
+    shipping_snapshot: Optional[dict[str, Any]] = None
+    artifact_snapshot: Optional[dict[str, Any]] = None
+    slicer_diagnostics: Optional[dict[str, Any]] = None
 
 
 class QuoteArchiveFile(BaseModel):
@@ -490,6 +496,53 @@ def _apply_portal_shipping(quote: Quote, current_user: User, payload: PortalShip
         current_user.phone = payload.shipping_phone
 
 
+def _fallback_shipping_snapshot(
+    quote: Quote,
+    payload: PortalShippingSelection,
+) -> Optional[dict[str, Any]]:
+    if not any([
+        payload.shipping_rate_id,
+        payload.shipping_carrier,
+        payload.shipping_service,
+        payload.shipping_cost is not None,
+    ]):
+        return None
+
+    return {
+        "source": "portal_accept",
+        "rate_id": quote.shipping_rate_id,
+        "carrier": quote.shipping_carrier,
+        "service": quote.shipping_service,
+        "cost": str(quote.shipping_cost) if quote.shipping_cost is not None else None,
+        "ship_to": {
+            "name": quote.shipping_name,
+            "address_line1": quote.shipping_address_line1,
+            "address_line2": quote.shipping_address_line2,
+            "city": quote.shipping_city,
+            "state": quote.shipping_state,
+            "zip": quote.shipping_zip,
+            "country": quote.shipping_country,
+            "phone": quote.shipping_phone,
+        },
+    }
+
+
+def _apply_portal_snapshots(quote: Quote, payload: PortalShippingSelection) -> None:
+    if payload.pricing_snapshot is not None:
+        quote.pricing_snapshot = payload.pricing_snapshot
+    if payload.component_snapshot is not None:
+        quote.component_snapshot = payload.component_snapshot
+    if payload.packaging_snapshot is not None:
+        quote.packaging_snapshot = payload.packaging_snapshot
+    shipping_snapshot = payload.shipping_snapshot or _fallback_shipping_snapshot(quote, payload)
+    if shipping_snapshot is not None:
+        quote.shipping_snapshot = shipping_snapshot
+    if payload.artifact_snapshot is not None:
+        quote.artifact_snapshot = payload.artifact_snapshot
+    if payload.slicer_diagnostics is not None:
+        quote.slicer_diagnostics = payload.slicer_diagnostics
+
+
 def _apply_portal_print_selection(
     db: Session,
     quote: Quote,
@@ -685,6 +738,7 @@ async def accept_portal_quote(
     _require_public_quoter_enabled()
     quote = _portal_quote_or_404(db, quote_id, current_user)
     _apply_portal_shipping(quote, current_user, payload)
+    _apply_portal_snapshots(quote, payload)
     _apply_portal_print_selection(db, quote, payload)
 
     requires_review = bool(quote.requires_review_reason)

--- a/backend/app/models/quote.py
+++ b/backend/app/models/quote.py
@@ -6,7 +6,7 @@ Handles quote requests, file uploads, and approval workflow
 from datetime import datetime, timezone
 from sqlalchemy import (
     Column, Integer, String, Numeric, BigInteger, Boolean,
-    DateTime, Date, ForeignKey, LargeBinary, func, text
+    DateTime, Date, ForeignKey, JSON, LargeBinary, func, text
 )
 from sqlalchemy.orm import relationship
 
@@ -103,6 +103,14 @@ class Quote(Base):
     shipping_carrier = Column(String(50), nullable=True)   # USPS, UPS, FedEx
     shipping_service = Column(String(100), nullable=True)  # Priority, Ground, etc.
     shipping_cost = Column(Numeric(10, 2), nullable=True)  # Selected shipping cost
+
+    # Durable quote snapshots from customer-facing or automated quote flows.
+    pricing_snapshot = Column(JSON, nullable=True)
+    component_snapshot = Column(JSON, nullable=True)
+    packaging_snapshot = Column(JSON, nullable=True)
+    shipping_snapshot = Column(JSON, nullable=True)
+    artifact_snapshot = Column(JSON, nullable=True)
+    slicer_diagnostics = Column(JSON, nullable=True)
 
     # Conversion to Order
     sales_order_id = Column(Integer, nullable=True)

--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -3,7 +3,7 @@ Sales Order Model
 
 Represents customer orders converted from approved quotes
 """
-from sqlalchemy import Column, Integer, String, Numeric, DateTime, ForeignKey, Text, Boolean, CheckConstraint
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, ForeignKey, Text, Boolean, CheckConstraint, JSON
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
@@ -109,6 +109,14 @@ class SalesOrder(Base):
     carrier = Column(String(100), nullable=True)  # USPS, FedEx, UPS
     shipped_at = Column(DateTime, nullable=True)
     delivered_at = Column(DateTime, nullable=True)
+
+    # Durable snapshots copied from the accepted quote at conversion time.
+    pricing_snapshot = Column(JSON, nullable=True)
+    component_snapshot = Column(JSON, nullable=True)
+    packaging_snapshot = Column(JSON, nullable=True)
+    shipping_snapshot = Column(JSON, nullable=True)
+    artifact_snapshot = Column(JSON, nullable=True)
+    slicer_diagnostics = Column(JSON, nullable=True)
 
     # Notes
     customer_notes = Column(Text, nullable=True)

--- a/backend/app/services/quote_conversion_service.py
+++ b/backend/app/services/quote_conversion_service.py
@@ -203,6 +203,12 @@ def convert_portal_quote_to_order(
             shipping_state=shipping_state,
             shipping_zip=shipping_zip,
             shipping_country=shipping_country,
+            pricing_snapshot=quote.pricing_snapshot,
+            component_snapshot=quote.component_snapshot,
+            packaging_snapshot=quote.packaging_snapshot,
+            shipping_snapshot=quote.shipping_snapshot,
+            artifact_snapshot=quote.artifact_snapshot,
+            slicer_diagnostics=quote.slicer_diagnostics,
             customer_notes=quote.customer_notes,
             # Hybrid architecture fields
             order_type="quote_based",

--- a/backend/migrations/versions/084_quote_order_snapshots.py
+++ b/backend/migrations/versions/084_quote_order_snapshots.py
@@ -6,6 +6,7 @@ Create Date: 2026-06-01
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 
 revision = "084"
@@ -22,6 +23,7 @@ SNAPSHOT_COLUMNS = (
     "artifact_snapshot",
     "slicer_diagnostics",
 )
+SNAPSHOT_JSON_TYPE = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
 
 
 def _table_exists(table_name: str) -> bool:
@@ -40,7 +42,7 @@ def upgrade() -> None:
             continue
         for column_name in SNAPSHOT_COLUMNS:
             if not _column_exists(table_name, column_name):
-                op.add_column(table_name, sa.Column(column_name, sa.JSON(), nullable=True))
+                op.add_column(table_name, sa.Column(column_name, SNAPSHOT_JSON_TYPE, nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/084_quote_order_snapshots.py
+++ b/backend/migrations/versions/084_quote_order_snapshots.py
@@ -1,0 +1,52 @@
+"""Add durable quote and order handoff snapshots.
+
+Revision ID: 084
+Revises: 083
+Create Date: 2026-06-01
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "084"
+down_revision = "083"
+branch_labels = None
+depends_on = None
+
+
+SNAPSHOT_COLUMNS = (
+    "pricing_snapshot",
+    "component_snapshot",
+    "packaging_snapshot",
+    "shipping_snapshot",
+    "artifact_snapshot",
+    "slicer_diagnostics",
+)
+
+
+def _table_exists(table_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return table_name in set(inspector.get_table_names())
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    for table_name in ("quotes", "sales_orders"):
+        if not _table_exists(table_name):
+            continue
+        for column_name in SNAPSHOT_COLUMNS:
+            if not _column_exists(table_name, column_name):
+                op.add_column(table_name, sa.Column(column_name, sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    for table_name in ("sales_orders", "quotes"):
+        if not _table_exists(table_name):
+            continue
+        for column_name in reversed(SNAPSHOT_COLUMNS):
+            if _column_exists(table_name, column_name):
+                op.drop_column(table_name, column_name)

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -944,6 +944,108 @@ class TestPortalQuoteContract:
         finally:
             self._clear_auto_quote_provider(client, provider_state)
 
+    def test_portal_accept_persists_quote_handoff_snapshots(self, client, db):
+        from app.models.quote import Quote
+
+        provider_state = self._install_auto_quote_provider(client)
+        try:
+            create_response = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("lamp.3mf", b"PK\x03\x04fake-3mf", "model/3mf")},
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "pricing_snapshot": {
+                        "source": "core_backed",
+                        "material_cost": "7.65",
+                    },
+                    "component_snapshot": {
+                        "items": [{"sku": "COMP-LED", "quantity": 1}],
+                    },
+                    "packaging_snapshot": {
+                        "sku": "BOX-8",
+                        "dimensions_in": {"length": 8, "width": 8, "height": 8},
+                    },
+                    "shipping_snapshot": {
+                        "carrier": "USPS",
+                        "service": "Ground Advantage",
+                        "cost": "8.50",
+                        "package": {"sku": "BOX-8"},
+                    },
+                    "artifact_snapshot": {
+                        "files": [{"kind": "gcode", "file_id": "artifact-123"}],
+                    },
+                    "slicer_diagnostics": {
+                        "source": "real_slicer",
+                        "plates": 1,
+                    },
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.pricing_snapshot["source"] == "core_backed"
+            assert quote.component_snapshot["items"][0]["sku"] == "COMP-LED"
+            assert quote.packaging_snapshot["sku"] == "BOX-8"
+            assert quote.shipping_snapshot["package"]["sku"] == "BOX-8"
+            assert quote.artifact_snapshot["files"][0]["kind"] == "gcode"
+            assert quote.slicer_diagnostics["source"] == "real_slicer"
+        finally:
+            self._clear_auto_quote_provider(client, provider_state)
+
+    def test_portal_accept_derives_shipping_snapshot_when_not_supplied(self, client, db):
+        from app.models.quote import Quote
+
+        provider_state = self._install_auto_quote_provider(client)
+        try:
+            create_response = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            quote = db.get(Quote, created["quote_id"])
+            assert quote.shipping_snapshot["source"] == "portal_accept"
+            assert quote.shipping_snapshot["carrier"] == "USPS"
+            assert quote.shipping_snapshot["cost"] == "8.50"
+            assert quote.shipping_snapshot["ship_to"]["zip"] == "46204"
+        finally:
+            self._clear_auto_quote_provider(client, provider_state)
+
     def test_portal_accept_snapshots_multi_color_slots(self, client, db):
         from app.models.quote import Quote, QuoteMaterial
 

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -1046,6 +1046,39 @@ class TestPortalQuoteContract:
         finally:
             self._clear_auto_quote_provider(client, provider_state)
 
+    def test_portal_accept_rejects_oversized_handoff_snapshot(self, client):
+        provider_state = self._install_auto_quote_provider(client)
+        try:
+            create_response = client.post(
+                f"{BASE_URL}/portal",
+                data={"material": "PLA_BASIC", "color": "JADE_WHITE", "quantity": "1"},
+                files={"file": ("part.stl", b"solid test\nendsolid test\n", "model/stl")},
+            )
+            assert create_response.status_code == 201, create_response.text
+            created = create_response.json()
+
+            response = client.post(
+                f"{BASE_URL}/portal/{created['quote_id']}/accept",
+                json={
+                    "shipping_name": "Jane Customer",
+                    "shipping_address_line1": "123 Print St",
+                    "shipping_city": "Indianapolis",
+                    "shipping_state": "IN",
+                    "shipping_zip": "46204",
+                    "shipping_country": "US",
+                    "shipping_rate_id": "rate_test",
+                    "shipping_carrier": "USPS",
+                    "shipping_service": "Ground Advantage",
+                    "shipping_cost": "8.50",
+                    "pricing_snapshot": {"raw": "x" * (33 * 1024)},
+                },
+            )
+
+            assert response.status_code == 422
+            assert "32KB" in response.text
+        finally:
+            self._clear_auto_quote_provider(client, provider_state)
+
     def test_portal_accept_snapshots_multi_color_slots(self, client, db):
         from app.models.quote import Quote, QuoteMaterial
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -167,6 +167,19 @@ def setup_database():
             "ALTER TABLE sales_orders "
             "ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ"
         ))
+        # Migration 084: durable quote/order snapshots for public quote handoff
+        for table in ("quotes", "sales_orders"):
+            for col in (
+                "pricing_snapshot",
+                "component_snapshot",
+                "packaging_snapshot",
+                "shipping_snapshot",
+                "artifact_snapshot",
+                "slicer_diagnostics",
+            ):
+                conn.execute(text(
+                    f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col} JSON"
+                ))
         # Migration 074: close short and line editing
         conn.execute(text(
             "ALTER TABLE sales_orders "

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -178,7 +178,7 @@ def setup_database():
                 "slicer_diagnostics",
             ):
                 conn.execute(text(
-                    f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col} JSON"
+                    f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col} JSONB"
                 ))
         # Migration 074: close short and line editing
         conn.execute(text(

--- a/backend/tests/services/test_quote_conversion_service.py
+++ b/backend/tests/services/test_quote_conversion_service.py
@@ -1,7 +1,6 @@
 """Tests for quote_conversion_service.py — quote-to-order conversion workflow."""
-import pytest
 from decimal import Decimal
-from datetime import datetime, timedelta, timezone, date
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 from app.services.quote_conversion_service import (
@@ -12,9 +11,7 @@ from app.services.quote_conversion_service import (
     ShippingInfo,
     ConversionResult,
 )
-from app.models.quote import Quote
-from app.models.sales_order import SalesOrder
-from app.models.production_order import ProductionOrder
+from app.services import quote_conversion_service
 
 
 class TestGenerateSalesOrderNumber:
@@ -105,6 +102,47 @@ class TestConvertQuoteToOrder:
         result = convert_portal_quote_to_order(quote, db)
         assert result.success is False
         assert "already converted" in result.error_message.lower()
+
+    def test_copies_quote_handoff_snapshots_to_sales_order(
+        self, db, make_product, make_bom, monkeypatch
+    ):
+        product = make_product(
+            item_type="finished_good",
+            procurement_type="make",
+            selling_price=Decimal("50.00"),
+        )
+        make_bom(product_id=product.id)
+        quote = self._make_quote(
+            db,
+            status="approved",
+            product_id=product.id,
+            color="YEL",
+            material_grams=Decimal("120.00"),
+            subtotal=Decimal("50.00"),
+            pricing_snapshot={"source": "core_backed", "print_cost": "12.34"},
+            component_snapshot={"items": [{"sku": "COMP-LED", "quantity": 1}]},
+            packaging_snapshot={"sku": "BOX-8"},
+            shipping_snapshot={"carrier": "USPS", "cost": "8.50"},
+            artifact_snapshot={"files": [{"kind": "gcode"}]},
+            slicer_diagnostics={"source": "real_slicer"},
+        )
+
+        monkeypatch.setattr(
+            quote_conversion_service,
+            "validate_quote_for_bom",
+            lambda _quote, _db: (True, "Valid"),
+        )
+
+        result = convert_portal_quote_to_order(quote, db)
+
+        assert result.success is True, result.error_message
+        order = result.sales_order
+        assert order.pricing_snapshot == quote.pricing_snapshot
+        assert order.component_snapshot == quote.component_snapshot
+        assert order.packaging_snapshot == quote.packaging_snapshot
+        assert order.shipping_snapshot == quote.shipping_snapshot
+        assert order.artifact_snapshot == quote.artifact_snapshot
+        assert order.slicer_diagnostics == quote.slicer_diagnostics
 
 
 class TestConvertQuoteAfterPayment:


### PR DESCRIPTION
## Summary
- add Core-owned JSON snapshots for quote pricing, components, packaging, shipping, artifacts, and slicer diagnostics
- persist public portal handoff snapshots during quote accept, including a fallback shipping snapshot from existing scalar fields
- copy accepted quote snapshots onto quote-based sales orders during conversion

## Tests
- `$env:DB_PASSWORD='Admin'; python -m pytest backend/tests/api/v1/test_quotes.py backend/tests/services/test_quote_conversion_service.py -q`
- `python -m ruff check backend/app/models/quote.py backend/app/models/sales_order.py backend/app/api/v1/endpoints/quotes.py backend/app/services/quote_conversion_service.py backend/tests/api/v1/test_quotes.py backend/tests/services/test_quote_conversion_service.py backend/tests/conftest.py`
- `python -m compileall -q backend/app/models/quote.py backend/app/models/sales_order.py backend/app/api/v1/endpoints/quotes.py backend/app/services/quote_conversion_service.py backend/tests/api/v1/test_quotes.py backend/tests/services/test_quote_conversion_service.py backend/tests/conftest.py`
- `python -m alembic heads`
- `python -m alembic history -r 083:084`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quotes now persist diagnostic snapshots (pricing, components, packaging, shipping, artifacts, slicer diagnostics) for durable handoff to orders.
  * System derives a shipping snapshot automatically when not provided at quote acceptance.

* **Tests**
  * Added tests verifying snapshot persistence, shipping-snapshot derivation, and rejection of oversized snapshots.

* **Documentation**
  * Changelog updated to document snapshot retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->