### PR TITLE
fix: sideload pro wheel in relay installs

### DIFF
--- a/backend/app/api/v1/endpoints/admin/pro_install.py
+++ b/backend/app/api/v1/endpoints/admin/pro_install.py
@@ -1,12 +1,11 @@
 """
 PRO Installer API Endpoints (PR-04)
 
-Orchestrates the post-activation download + pip install of the FilaOps PRO
-wheel from the license server. After PR-02 the customer has a license.json
-on disk; this module is what turns that into an actually-installed PRO
-package, surfacing progress through a polled status endpoint so the admin UI
-can show download/install progress without the customer ever touching a
-terminal.
+Orchestrates the post-activation download + install of the FilaOps PRO wheel
+from the license server. After PR-02 the customer has a license.json on disk;
+this module is what turns that into an actually-installed PRO package,
+surfacing progress through a polled status endpoint so the admin UI can show
+download/install progress without the customer ever touching a terminal.
 
 Sacred Rule: this module MUST NOT ``import filaops_pro``. Detection of an
 already-installed PRO uses ``importlib.util.find_spec``, which only walks
@@ -16,8 +15,10 @@ stays free of PRO references whether or not the wheel is present.
 Patterns reused:
   - Background task + module-level status dict:
       app/api/v1/endpoints/admin/system.py:_update_status
-  - subprocess pip install against sys.executable:
+  - subprocess pip install for standard Python deployments:
       app/api/v1/endpoints/settings.py:install_anthropic_package
+  - Relay/AppImage sideload target:
+      FILAOPS_PRO_SITE_PACKAGES injected by the desktop runtime
   - httpx + admin-auth conventions:
       app/api/v1/endpoints/system_license.py
 
@@ -40,10 +41,13 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Optional
@@ -132,6 +136,71 @@ def _extract_version_from_filename(wheel_path: Path) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def _relay_site_packages_dir() -> Optional[Path]:
+    """Return Relay/AppImage PRO sideload target when configured.
+
+    Relay injects this directory onto ``sys.path`` before Core imports. In
+    bundled desktop builds ``sys.executable`` points at the backend executable,
+    so ``sys.executable -m pip`` fails with "unknown subcommand: -m".
+    """
+    configured = os.getenv("FILAOPS_PRO_SITE_PACKAGES")
+    if not configured:
+        return None
+    return Path(configured)
+
+
+def _remove_existing_sideload(site_packages: Path) -> None:
+    """Remove prior sideloaded filaops-pro files before extracting a new wheel."""
+    for path in [
+        site_packages / "filaops_pro",
+        *site_packages.glob("filaops_pro-*.dist-info"),
+        *site_packages.glob("filaops_pro-*.data"),
+    ]:
+        if not path.exists():
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def _safe_extract_wheel(wheel_path: Path, dest_dir: Path) -> None:
+    """Extract a verified wheel zip into ``dest_dir`` without path escapes."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    root = dest_dir.resolve()
+    with zipfile.ZipFile(wheel_path) as zf:
+        for member in zf.infolist():
+            target = (dest_dir / member.filename).resolve()
+            if root != target and root not in target.parents:
+                raise InstallError(
+                    f"Wheel contains an unsafe path: {member.filename!r}"
+                )
+        zf.extractall(dest_dir)
+
+
+def _install_verified_wheel(wheel_path: Path) -> str:
+    """Install the already-hash-verified PRO wheel.
+
+    Returns ``"sideload"`` for Relay/AppImage installs or ``"pip"`` for
+    standard Python deployments.
+    """
+    site_packages = _relay_site_packages_dir()
+    if site_packages is not None:
+        _remove_existing_sideload(site_packages)
+        _safe_extract_wheel(wheel_path, site_packages)
+        return "sideload"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", str(wheel_path), "--no-deps"],
+        capture_output=True,
+        text=True,
+        timeout=_PIP_INSTALL_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        raise InstallError(f"pip install failed: {result.stderr[:500]}")
+    return "pip"
+
+
 async def _download_wheel(
     *,
     license_server_url: str,
@@ -194,7 +263,7 @@ async def _download_wheel(
 
 
 async def _do_pro_install() -> None:
-    """Background install pipeline: download -> verify -> pip install -> done.
+    """Background install pipeline: download -> verify -> install -> done.
 
     Mutates ``_install_status`` so the polling endpoint can surface progress.
     Every exception is converted into the error state — Core must keep
@@ -252,14 +321,7 @@ async def _do_pro_install() -> None:
         # Phase 3: Install
         _install_status["state"] = "installing"
         _install_status["progress"] = "Installing PRO package..."
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", str(wheel_path), "--no-deps"],
-            capture_output=True,
-            text=True,
-            timeout=_PIP_INSTALL_TIMEOUT_SECONDS,
-        )
-        if result.returncode != 0:
-            raise InstallError(f"pip install failed: {result.stderr[:500]}")
+        install_method = _install_verified_wheel(wheel_path)
 
         # Phase 4: Done
         _install_status["state"] = "restart_required"
@@ -269,9 +331,10 @@ async def _do_pro_install() -> None:
         _install_status["installed_version"] = _extract_version_from_filename(wheel_path)
         _install_status["completed_at"] = _now_iso()
         logger.info(
-            "PRO installed successfully (version=%s, wheel=%s)",
+            "PRO installed successfully (version=%s, wheel=%s, method=%s)",
             _install_status["installed_version"],
             wheel_path.name,
+            install_method,
         )
 
     except InstallError as exc:

--- a/backend/tests/endpoints/test_pro_install.py
+++ b/backend/tests/endpoints/test_pro_install.py
@@ -24,8 +24,10 @@ stub so pip never actually executes.
 from __future__ import annotations
 
 import hashlib
+import io
 import subprocess
 import uuid
+import zipfile
 from typing import Optional
 
 import httpx
@@ -88,6 +90,7 @@ def _license_env(monkeypatch, tmp_path):
     monkeypatch.setattr(
         settings, "LICENSE_SERVER_URL", "http://license-test.local", raising=False
     )
+    monkeypatch.delenv("FILAOPS_PRO_SITE_PACKAGES", raising=False)
     yield tmp_path
 
 
@@ -253,6 +256,40 @@ def _ok_wheel_response(*, sha256: str = WHEEL_SHA256) -> _MockResponse:
     )
 
 
+def _wheel_zip_response() -> _MockResponse:
+    """Return a tiny valid wheel-shaped zip for sideload extraction tests."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("filaops_pro/__init__.py", "__version__ = '1.2.3'\n")
+        zf.writestr("filaops_pro-1.2.3.dist-info/METADATA", "Name: filaops-pro\n")
+        zf.writestr("filaops_pro-1.2.3.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+    data = buf.getvalue()
+    return _MockResponse(
+        200,
+        content=data,
+        headers={
+            "X-Wheel-SHA256": hashlib.sha256(data).hexdigest(),
+            "Content-Disposition": f'attachment; filename="{WHEEL_FILENAME}"',
+        },
+    )
+
+
+def _unsafe_wheel_zip_response() -> _MockResponse:
+    """Return a wheel zip with a member path that attempts to escape."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../escape.py", "raise RuntimeError('escaped')\n")
+    data = buf.getvalue()
+    return _MockResponse(
+        200,
+        content=data,
+        headers={
+            "X-Wheel-SHA256": hashlib.sha256(data).hexdigest(),
+            "Content-Disposition": f'attachment; filename="{WHEEL_FILENAME}"',
+        },
+    )
+
+
 # =============================================================================
 # POST /install — input / state validation
 # =============================================================================
@@ -398,6 +435,80 @@ def test_install_invokes_pip_with_no_deps_and_current_python(
     # Wheel path is the last positional before the flag
     wheel_arg = args[4]
     assert wheel_arg.endswith(WHEEL_FILENAME)
+
+
+def test_install_sideloads_wheel_when_relay_site_packages_is_configured(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    monkeypatch,
+    tmp_path,
+):
+    """Relay/AppImage installs extract into FILAOPS_PRO_SITE_PACKAGES.
+
+    In bundled desktop builds ``sys.executable`` is the backend executable, not
+    a Python interpreter. Calling ``sys.executable -m pip`` there fails with
+    "unknown subcommand: -m", so the installer must sideload the verified
+    wheel into the path the Relay backend already injects onto ``sys.path``.
+    """
+    site_packages = tmp_path / "pro-site-packages"
+    monkeypatch.setenv("FILAOPS_PRO_SITE_PACKAGES", str(site_packages))
+    mock_license_server(_wheel_zip_response())
+
+    pip_calls: list = []
+
+    def fake_run(args, **kwargs):
+        pip_calls.append(args)
+        raise AssertionError("pip must not be invoked for Relay sideload installs")
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 200
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "restart_required"
+    assert body["installed_version"] == "1.2.3"
+    assert pip_calls == []
+    assert (site_packages / "filaops_pro" / "__init__.py").exists()
+    assert (site_packages / "filaops_pro-1.2.3.dist-info" / "METADATA").exists()
+
+
+def test_install_rejects_sideload_wheel_with_unsafe_member_path(
+    client,
+    with_license,
+    mock_pro_not_installed,
+    mock_license_server,
+    monkeypatch,
+    tmp_path,
+):
+    """Sideload extraction must reject zip members that escape the target."""
+    site_packages = tmp_path / "pro-site-packages"
+    monkeypatch.setenv("FILAOPS_PRO_SITE_PACKAGES", str(site_packages))
+    mock_license_server(_unsafe_wheel_zip_response())
+
+    pip_calls: list = []
+
+    def fake_run(args, **kwargs):
+        pip_calls.append(args)
+        raise AssertionError("pip must not be invoked for Relay sideload installs")
+
+    import app.api.v1.endpoints.admin.pro_install as mod
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    resp = client.post(INSTALL_URL)
+    assert resp.status_code == 200
+
+    body = client.get(STATUS_URL).json()
+    assert body["state"] == "error"
+    assert "unsafe path" in body["error"].lower()
+    assert pip_calls == []
+    assert not (tmp_path / "escape.py").exists()
+    assert not (site_packages / "filaops_pro").exists()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- fix PRO package installation for Relay/AppImage builds by sideloading the verified wheel into `FILAOPS_PRO_SITE_PACKAGES`
- keep the existing `sys.executable -m pip install --no-deps` path for normal Python/server deployments
- add a regression test proving Relay sideload installs do not invoke pip

## Root Cause
The dogfood AppImage runs Core from a bundled backend executable. In that runtime, `sys.executable` is not a Python interpreter, so `sys.executable -m pip install ...` fails with `unknown subcommand: -m`.

## Verification
- `git diff --check`
- `python -m py_compile backend/app/api/v1/endpoints/admin/pro_install.py backend/tests/endpoints/test_pro_install.py`
- `powershell -ExecutionPolicy Bypass -File scripts/ci/check-pro-code.ps1`
- attempted `python -m pytest tests/endpoints/test_pro_install.py -q`; local setup could not authenticate to Postgres `filaops_test` with default `postgres/postgres`, so no endpoint tests ran locally. External CI should run the database-backed tests.

## Notes
This keeps Core independent of PRO imports. The wheel is still downloaded and hash-verified before either install path runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Relay/AppImage sideload installation mode for desktop runtimes as an alternative to pip; installation method is now reported in logs.
  * Sideload behavior is governed by a configurable environment setting.

* **Bug Fixes / Security**
  * Installer rejects wheel packages that contain unsafe member paths to prevent path traversal during extraction.

* **Tests**
  * Added tests covering safe sideload extraction and rejection of unsafe wheel payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->