### PR TITLE
fix: ignore runtime config script in vite build

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="/config.js"></script>
+    <script src="/config.js" vite-ignore></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `vite-ignore` to the runtime-served `/config.js` script in `frontend/index.html`
- preserves the classic script tag so Docker/Relay can provide `config.js` at runtime
- unblocks `external-ci/core-frontend-build` under Vite 8

## Verification
- `git diff --check`
- `npm run build`
- `npm run test:unit -- --run`

## Notes
This fixes a pre-existing `main` build blocker surfaced while validating PR #630. The script is generated by `frontend/docker-entrypoint.sh` at runtime, so it should not be bundled or resolved during Vite build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize asset processing for configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->