### PR TITLE
feat: serve local PRO surfaces

### DIFF
--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -135,3 +135,13 @@ def resolve_frontend_dist(override: str | None = None) -> Path | None:
     empty directory.
     """
     return _coerce_override(override)
+
+
+def resolve_surface_dist(override: str | None = None) -> Path | None:
+    """Customer-facing or PRO admin SPA dist directory, OR None if unset.
+
+    This mirrors ``resolve_frontend_dist`` but keeps the call sites readable
+    when Core is asked to serve additional local-first surfaces such as
+    Portal Admin, the B2B Portal, or the public Quoter.
+    """
+    return _coerce_override(override)

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -271,6 +271,27 @@ class Settings(BaseSettings):
             "frontend dist."
         ),
     )
+    PORTAL_ADMIN_DIST: str = Field(
+        default="",
+        description=(
+            "Portal Admin SPA dist directory. When set, FastAPI serves it at "
+            "/portal-admin for local-first PRO installs."
+        ),
+    )
+    PORTAL_DIST: str = Field(
+        default="",
+        description=(
+            "B2B Portal SPA dist directory. When set, FastAPI serves it at "
+            "/portal for local-first PRO installs."
+        ),
+    )
+    QUOTER_DIST: str = Field(
+        default="",
+        description=(
+            "Public Quoter SPA dist directory. When set, FastAPI serves it at "
+            "/quote for local-first PRO installs."
+        ),
+    )
     MAX_FILE_SIZE_MB: int = Field(default=100, description="Max upload size (MB)")
     ALLOWED_FILE_FORMATS: List[str] = Field(
         default=[".3mf", ".stl", ".obj", ".step", ".stp"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -660,13 +660,17 @@ class _SPAStaticFiles(StaticFiles):
             raise
 
 
-for mount_path, name, dist in SURFACE_DISTS:
-    async def surface_root(index_path: Path = dist):
-        return FileResponse(index_path / "index.html")
+def _surface_root_handler(index_path: Path):
+    async def surface_root():
+        return FileResponse(index_path)
 
+    return surface_root
+
+
+for mount_path, name, dist in SURFACE_DISTS:
     app.add_api_route(
         mount_path,
-        surface_root,
+        _surface_root_handler(dist / "index.html"),
         methods=["GET"],
         name=f"{name}_root",
         include_in_schema=False,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.core.limiter import apply_rate_limiting
 from app.core.paths import (
     resolve_frontend_dist,
     resolve_static_dir,
+    resolve_surface_dist,
     resolve_upload_products_dir,
 )
 from app.api.v1 import router as api_v1_router
@@ -434,6 +435,45 @@ if FRONTEND_DIST is not None:
     logger.info("Serving React SPA from %s", FRONTEND_DIST)
 
 
+def _validated_spa_dist(label: str, configured_path: str) -> Path | None:
+    dist = resolve_surface_dist(configured_path)
+    if dist is None:
+        return None
+    if not (dist / "index.html").is_file():
+        logger.error(
+            "%s is set to %s but no index.html found there; surface will "
+            "not be served. Check the path or unset it.",
+            label,
+            dist,
+        )
+        return None
+    logger.info("Serving %s from %s", label, dist)
+    return dist
+
+
+SURFACE_DISTS: tuple[tuple[str, str, Path], ...] = tuple(
+    (mount_path, name, dist)
+    for mount_path, name, dist in (
+        (
+            "/portal-admin",
+            "portal_admin_spa",
+            _validated_spa_dist("PORTAL_ADMIN_DIST", settings.PORTAL_ADMIN_DIST),
+        ),
+        (
+            "/portal",
+            "portal_spa",
+            _validated_spa_dist("PORTAL_DIST", settings.PORTAL_DIST),
+        ),
+        (
+            "/quote",
+            "quoter_spa",
+            _validated_spa_dist("QUOTER_DIST", settings.QUOTER_DIST),
+        ),
+    )
+    if dist is not None
+)
+
+
 @app.get("/")
 async def root():
     """API status JSON, or SPA index.html when FRONTEND_DIST is configured."""
@@ -560,65 +600,97 @@ load_plugin(app)
 #     so client-side routes (e.g. /admin/items) resolve once the React
 #     router boots in the browser.
 #
-# The fallback opens a fixed path (FRONTEND_DIST / "index.html") with
+# The fallback opens a fixed index.html path configured at startup with
 # no user input — that's why it's safe.
+class _SPAStaticFiles(StaticFiles):
+    def __init__(
+        self,
+        *,
+        directory: str,
+        index_path: Path,
+        reserved_first_segments: frozenset[str] = frozenset(),
+        **kwargs,
+    ):
+        super().__init__(directory=directory, **kwargs)
+        self.index_path = index_path
+        self.reserved_first_segments = reserved_first_segments
+
+    async def get_response(self, path: str, scope):
+        # `path` here is the os-normalised filesystem path produced by
+        # StaticFiles.get_path — on Windows it uses backslashes and
+        # `os.path.normpath` strips trailing slashes. Both behaviours
+        # are wrong for HTTP routing decisions, so we consult the raw
+        # URL path from the ASGI scope for prefix/trailing-slash checks.
+        url_path = scope.get("path", "").lstrip("/")
+        first_segment, sep, _ = url_path.partition("/")
+
+        if first_segment in self.reserved_first_segments:
+            # API / static paths that reach the SPA mount didn't match
+            # any upstream route. Three cases reach this branch:
+            #   1. `/api`        — bare prefix, no real endpoint to
+            #                      redirect to. Just 404.
+            #   2. `/api/v1/foo` — extra path, no trailing slash. The
+            #                      most likely cause is a router whose
+            #                      route is registered as `/`
+            #                      (canonical form ends with `/`).
+            #                      Mirror FastAPI's redirect_slashes so
+            #                      the client lands on the canonical
+            #                      URL instead of index.html.
+            #   3. `/api/v1/foo/` — already canonical, still unmatched.
+            #                       Genuine 404.
+            if sep and not url_path.endswith("/"):
+                from fastapi.responses import RedirectResponse
+
+                qs = scope.get("query_string", b"")
+                target = f"/{url_path}/"
+                if qs:
+                    target += "?" + qs.decode("latin-1")
+                return RedirectResponse(url=target, status_code=307)
+            # Cases 1 and 3 — raise HTTPException so the request exits
+            # this mount and re-enters the parent FastAPI app's
+            # exception handler chain, which renders 404 as JSON
+            # (Starlette's bare default would be a plain text body).
+            raise StarletteHTTPException(status_code=404)
+
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404:
+                return FileResponse(self.index_path)
+            raise
+
+
+for mount_path, name, dist in SURFACE_DISTS:
+    async def surface_root(index_path: Path = dist):
+        return FileResponse(index_path / "index.html")
+
+    app.add_api_route(
+        mount_path,
+        surface_root,
+        methods=["GET"],
+        name=f"{name}_root",
+        include_in_schema=False,
+    )
+    app.mount(
+        mount_path,
+        _SPAStaticFiles(
+            directory=str(dist),
+            index_path=dist / "index.html",
+            html=True,
+        ),
+        name=name,
+    )
+
+
 if FRONTEND_DIST is not None:
-
-    # First URL path segments the API / static layer owns. The SPA mount
-    # must never serve index.html for these — frontend code that expects
-    # JSON would otherwise receive HTML and silently mis-interpret it.
-    # We compare against the FIRST segment (not a prefix substring), so
-    # `apidocs/foo` does not collide with `api/foo`.
-    _RESERVED_FIRST_SEGMENTS = frozenset({"api", "static"})
-
-    class _SPAStaticFiles(StaticFiles):
-        async def get_response(self, path: str, scope):
-            # `path` here is the os-normalised filesystem path produced by
-            # StaticFiles.get_path — on Windows it uses backslashes and
-            # `os.path.normpath` strips trailing slashes. Both behaviours
-            # are wrong for HTTP routing decisions, so we consult the raw
-            # URL path from the ASGI scope for prefix/trailing-slash checks.
-            url_path = scope.get("path", "").lstrip("/")
-            first_segment, sep, _ = url_path.partition("/")
-
-            if first_segment in _RESERVED_FIRST_SEGMENTS:
-                # API / static paths that reach the SPA mount didn't match
-                # any upstream route. Three cases reach this branch:
-                #   1. `/api`        — bare prefix, no real endpoint to
-                #                      redirect to. Just 404.
-                #   2. `/api/v1/foo` — extra path, no trailing slash. The
-                #                      most likely cause is a router whose
-                #                      route is registered as `/`
-                #                      (canonical form ends with `/`).
-                #                      Mirror FastAPI's redirect_slashes so
-                #                      the client lands on the canonical
-                #                      URL instead of index.html.
-                #   3. `/api/v1/foo/` — already canonical, still unmatched.
-                #                       Genuine 404.
-                if sep and not url_path.endswith("/"):
-                    from fastapi.responses import RedirectResponse
-
-                    qs = scope.get("query_string", b"")
-                    target = f"/{url_path}/"
-                    if qs:
-                        target += "?" + qs.decode("latin-1")
-                    return RedirectResponse(url=target, status_code=307)
-                # Cases 1 and 3 — raise HTTPException so the request exits
-                # this mount and re-enters the parent FastAPI app's
-                # exception handler chain, which renders 404 as JSON
-                # (Starlette's bare default would be a plain text body).
-                raise StarletteHTTPException(status_code=404)
-
-            try:
-                return await super().get_response(path, scope)
-            except StarletteHTTPException as exc:
-                if exc.status_code == 404:
-                    return FileResponse(FRONTEND_DIST / "index.html")
-                raise
-
     app.mount(
         "/",
-        _SPAStaticFiles(directory=str(FRONTEND_DIST), html=True),
+        _SPAStaticFiles(
+            directory=str(FRONTEND_DIST),
+            index_path=FRONTEND_DIST / "index.html",
+            reserved_first_segments=frozenset({"api", "static"}),
+            html=True,
+        ),
         name="spa",
     )
 

--- a/backend/tests/core/test_paths.py
+++ b/backend/tests/core/test_paths.py
@@ -19,6 +19,7 @@ from app.core.paths import (
     BACKEND_DIR,
     resolve_frontend_dist,
     resolve_static_dir,
+    resolve_surface_dist,
     resolve_upload_po_docs_dir,
     resolve_upload_products_dir,
 )
@@ -135,3 +136,22 @@ def test_resolve_frontend_dist_returns_path_when_set():
 
 def test_resolve_frontend_dist_strips_whitespace():
     assert resolve_frontend_dist("  /srv/filaops/frontend  ") == Path("/srv/filaops/frontend")
+
+
+# ---------------------------------------------------------------------------
+# resolve_surface_dist
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_surface_dist_returns_none_when_unset():
+    assert resolve_surface_dist(None) is None
+    assert resolve_surface_dist("") is None
+    assert resolve_surface_dist("   ") is None
+
+
+def test_resolve_surface_dist_returns_path_when_set():
+    assert resolve_surface_dist("/srv/filaops/quoter") == Path("/srv/filaops/quoter")
+
+
+def test_resolve_surface_dist_strips_whitespace():
+    assert resolve_surface_dist("  /srv/filaops/portal  ") == Path("/srv/filaops/portal")

--- a/backend/tests/test_main_spa_mount.py
+++ b/backend/tests/test_main_spa_mount.py
@@ -258,6 +258,16 @@ def test_surface_roots_serve_own_spas_without_trailing_slash(multi_surface_app):
         assert "core-spa" not in resp.text, path
 
 
+def test_surface_root_ignores_index_path_query_param(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    resp = client.get("/quote?index_path=/tmp/other-index.html")
+
+    assert resp.status_code == 200
+    assert "quoter-spa" in resp.text
+    assert "core-spa" not in resp.text
+
+
 def test_b2b_portal_surface_serves_own_spa(multi_surface_app):
     client = TestClient(multi_surface_app)
 

--- a/backend/tests/test_main_spa_mount.py
+++ b/backend/tests/test_main_spa_mount.py
@@ -74,6 +74,47 @@ def spa_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
                 sys.modules[name] = prior
 
 
+@pytest.fixture()
+def multi_surface_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Reload app.main with Core, Portal Admin, Portal, and Quoter SPAs.
+
+    The local-first PRO install serves distinct SPAs from one Core process.
+    This fixture stages minimal dist folders for each surface so route tests
+    prove prefixed surfaces are mounted before the root Core SPA catch-all.
+    """
+
+    def make_dist(name: str, body: str) -> Path:
+        dist = tmp_path / name
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            f"<!doctype html><html><body>{body}</body></html>"
+        )
+        (dist / "assets" / "surface.js").write_text(f"// {body} asset")
+        return dist
+
+    core_dist = make_dist("core", "core-spa")
+    portal_admin_dist = make_dist("portal-admin", "portal-admin-spa")
+    portal_dist = make_dist("portal", "portal-spa")
+    quoter_dist = make_dist("quoter", "quoter-spa")
+
+    monkeypatch.setenv("FRONTEND_DIST", str(core_dist))
+    monkeypatch.setenv("PORTAL_ADMIN_DIST", str(portal_admin_dist))
+    monkeypatch.setenv("PORTAL_DIST", str(portal_dist))
+    monkeypatch.setenv("QUOTER_DIST", str(quoter_dist))
+
+    cached_names = ("app.main", "app.core.config", "app.core.settings")
+    priors = {name: sys.modules.pop(name, None) for name in cached_names}
+    try:
+        main = importlib.import_module("app.main")
+        yield main.app
+    finally:
+        for name in cached_names:
+            sys.modules.pop(name, None)
+        for name, prior in priors.items():
+            if prior is not None:
+                sys.modules[name] = prior
+
+
 def test_api_path_without_trailing_slash_redirects_to_canonical(spa_app):
     """The bug: `/api/v1/purchase-orders` (no slash) used to return 200 +
     index.html. After the fix it must 307 to `/api/v1/purchase-orders/`
@@ -190,3 +231,57 @@ def test_root_serves_index_html_when_spa_mounted(spa_app):
     resp = client.get("/")
     assert resp.status_code == 200
     assert "<!doctype html>" in resp.text.lower()
+
+
+def test_portal_admin_surface_serves_own_spa(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    resp = client.get("/portal-admin/admin/quote-config")
+
+    assert resp.status_code == 200
+    assert "portal-admin-spa" in resp.text
+    assert "core-spa" not in resp.text
+
+
+def test_surface_roots_serve_own_spas_without_trailing_slash(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    expected = {
+        "/portal-admin": "portal-admin-spa",
+        "/portal": "portal-spa",
+        "/quote": "quoter-spa",
+    }
+    for path, body in expected.items():
+        resp = client.get(path)
+        assert resp.status_code == 200, path
+        assert body in resp.text, path
+        assert "core-spa" not in resp.text, path
+
+
+def test_b2b_portal_surface_serves_own_spa(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    resp = client.get("/portal/catalog")
+
+    assert resp.status_code == 200
+    assert "portal-spa" in resp.text
+    assert "core-spa" not in resp.text
+
+
+def test_quoter_surface_serves_own_spa(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    resp = client.get("/quote/result/Q-123")
+
+    assert resp.status_code == 200
+    assert "quoter-spa" in resp.text
+    assert "core-spa" not in resp.text
+
+
+def test_surface_assets_serve_from_surface_dist(multi_surface_app):
+    client = TestClient(multi_surface_app)
+
+    resp = client.get("/quote/assets/surface.js")
+
+    assert resp.status_code == 200
+    assert "quoter-spa asset" in resp.text


### PR DESCRIPTION
## Summary
- add env-backed local SPA dist settings for Portal Admin, B2B Portal, and Quoter
- mount `/portal-admin`, `/portal`, and `/quote` before the root Core SPA fallback
- keep exact prefix routes from falling through to the Core admin shell

## Verification
- `python -m compileall backend\app\core\paths.py backend\app\core\settings.py backend\app\main.py backend\tests\core\test_paths.py backend\tests\test_main_spa_mount.py`
- direct TestClient smoke for `/`, `/portal-admin`, `/portal-admin/admin/quote-config`, `/portal`, `/portal/catalog`, `/quote`, `/quote/result/Q-123`, and `/quote/assets/surface.js`
- `python -m ruff check backend\app\core\paths.py backend\app\core\settings.py backend\app\main.py backend\tests\core\test_paths.py backend\tests\test_main_spa_mount.py`
- `git diff --check`

## Local pytest note
- `python -m pytest backend/tests/core/test_paths.py backend/tests/test_main_spa_mount.py -q` did not reach assertions locally because the shared Core test autouse fixture could not authenticate to local Postgres `filaops_test` as `postgres` on port 5432. CI/external CI should run this with the provisioned test DB.

Agent-Session: codex-20260602-core-local-surfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple independently-configured SPA surfaces (Portal Admin, Portal, Quoter) served at /portal-admin, /portal, and /quote.
  * Configurable distribution directories for each surface and improved routing to serve the correct surface HTML while properly handling assets and reserved paths.

* **Tests**
  * Added regression tests verifying multi-surface mounting, root-serving behavior, and asset serving per surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->