### PR TITLE
ci: add CircleCI core baseline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,197 @@
+version: 2.1
+
+executors:
+  python-311:
+    docker:
+      - image: cimg/python:3.11
+    working_directory: ~/project
+
+  python-311-postgres:
+    docker:
+      - image: cimg/python:3.11
+      - image: postgres:16
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: Admin
+          POSTGRES_DB: filaops
+    environment:
+      DB_HOST: localhost
+      DB_PORT: "5432"
+      DB_NAME: filaops
+      DB_USER: postgres
+      DB_PASSWORD: Admin
+      DATABASE_URL: postgresql+psycopg://postgres:Admin@localhost:5432/filaops
+      ENVIRONMENT: test
+      SECRET_KEY: ci-test-secret-key-not-for-production-use
+      DEBUG: "false"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+    working_directory: ~/project
+
+  node:
+    docker:
+      - image: cimg/node:lts
+    working_directory: ~/project
+
+commands:
+  fetch_main:
+    steps:
+      - run:
+          name: Fetch main for diff checks
+          command: git fetch origin main:refs/remotes/origin/main --depth=50
+
+  install_backend_dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-pip-backend-{{ checksum "backend/requirements.txt" }}
+      - run:
+          name: Install backend dependencies
+          command: |
+            cd backend
+            python -m venv .venv
+            . .venv/bin/activate
+            python -m pip install --upgrade pip
+            python -m pip install -r requirements.txt
+      - save_cache:
+          key: v1-pip-backend-{{ checksum "backend/requirements.txt" }}
+          paths:
+            - ~/.cache/pip
+
+  install_frontend_dependencies:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-npm-frontend-{{ checksum "frontend/package-lock.json" }}
+      - run:
+          name: Install frontend dependencies
+          command: cd frontend && npm ci
+      - save_cache:
+          key: v1-npm-frontend-{{ checksum "frontend/package-lock.json" }}
+          paths:
+            - ~/.npm
+
+jobs:
+  core-diff:
+    executor: python-311
+    steps:
+      - checkout
+      - fetch_main
+      - run:
+          name: Check whitespace and conflict markers
+          command: git diff --check origin/main...HEAD
+
+  core-pro-guard:
+    executor: python-311
+    steps:
+      - checkout
+      - fetch_main
+      - run:
+          name: Assert Core repo has no PRO code
+          command: |
+            set -euo pipefail
+            if [ -d backend/app/pro ]; then
+              echo "backend/app/pro found; PRO code must not be in the public Core repo."
+              exit 1
+            fi
+            if [ -d license-server ]; then
+              echo "license-server found; PRO code must not be in the public Core repo."
+              exit 1
+            fi
+            pro_files="$(git diff --name-only origin/main...HEAD | grep -E '^(backend/app/pro/|license-server/)' || true)"
+            if [ -n "$pro_files" ]; then
+              echo "Diff contains PRO-only paths:"
+              echo "$pro_files"
+              exit 1
+            fi
+            echo "No PRO code detected; public Core repo is clean."
+
+  core-backend-static:
+    executor: python-311
+    steps:
+      - checkout
+      - run:
+          name: Compile backend Python files
+          command: cd backend && python -m compileall -q app tests
+
+  core-backend-tests:
+    executor: python-311-postgres
+    steps:
+      - checkout
+      - install_backend_dependencies
+      - run:
+          name: Wait for Postgres
+          command: |
+            cd backend
+            . .venv/bin/activate
+            python - <<'PY'
+            import os
+            import time
+
+            import psycopg
+
+            deadline = time.time() + 60
+            last_error = None
+            while time.time() < deadline:
+                try:
+                    with psycopg.connect(
+                        host=os.environ["DB_HOST"],
+                        port=os.environ["DB_PORT"],
+                        dbname=os.environ["DB_NAME"],
+                        user=os.environ["DB_USER"],
+                        password=os.environ["DB_PASSWORD"],
+                    ):
+                        print("Postgres is ready")
+                        raise SystemExit(0)
+                except Exception as exc:  # pragma: no cover - CI bootstrap
+                    last_error = exc
+                    time.sleep(2)
+            raise SystemExit(f"Postgres did not become ready: {last_error}")
+            PY
+      - run:
+          name: Run backend tests
+          command: |
+            cd backend
+            . .venv/bin/activate
+            mkdir -p ../test-results/core-backend
+            python -m pytest -q --junitxml=../test-results/core-backend/pytest.xml
+      - store_test_results:
+          path: test-results/core-backend
+      - store_artifacts:
+          path: test-results/core-backend
+
+  core-frontend-build:
+    executor: node
+    steps:
+      - checkout
+      - install_frontend_dependencies
+      - run:
+          name: Build frontend
+          command: cd frontend && npm run build
+          environment:
+            VITE_API_URL: http://localhost:8001
+
+  core-frontend-unit:
+    executor: node
+    steps:
+      - checkout
+      - install_frontend_dependencies
+      - run:
+          name: Run frontend unit tests
+          command: |
+            cd frontend
+            mkdir -p ../test-results/core-frontend-unit
+            npm run test:unit -- --run --reporter=default --reporter=junit --outputFile=../test-results/core-frontend-unit/vitest.xml
+      - store_test_results:
+          path: test-results/core-frontend-unit
+      - store_artifacts:
+          path: test-results/core-frontend-unit
+
+workflows:
+  core-ci:
+    jobs:
+      - core-diff
+      - core-pro-guard
+      - core-backend-static
+      - core-backend-tests
+      - core-frontend-build
+      - core-frontend-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
     steps:
       - run:
           name: Fetch main for diff checks
-          command: git fetch origin main:refs/remotes/origin/main --depth=50
+          command: git fetch origin main:refs/remotes/origin/main
 
   install_backend_dependencies:
     steps:
@@ -89,15 +89,15 @@ jobs:
           name: Assert Core repo has no PRO code
           command: |
             set -euo pipefail
-            if [ -d backend/app/pro ]; then
+            if [ -e backend/app/pro ]; then
               echo "backend/app/pro found; PRO code must not be in the public Core repo."
               exit 1
             fi
-            if [ -d license-server ]; then
+            if [ -e license-server ]; then
               echo "license-server found; PRO code must not be in the public Core repo."
               exit 1
             fi
-            pro_files="$(git diff --name-only origin/main...HEAD | grep -E '^(backend/app/pro/|license-server/)' || true)"
+            pro_files="$(git diff --name-only origin/main...HEAD | grep -E '^(backend/app/pro($|/)|license-server($|/))' || true)"
             if [ -n "$pro_files" ]; then
               echo "Diff contains PRO-only paths:"
               echo "$pro_files"
@@ -192,6 +192,16 @@ workflows:
       - core-diff
       - core-pro-guard
       - core-backend-static
-      - core-backend-tests
-      - core-frontend-build
-      - core-frontend-unit
+      - core-backend-tests:
+          requires:
+            - core-diff
+            - core-pro-guard
+            - core-backend-static
+      - core-frontend-build:
+          requires:
+            - core-diff
+            - core-pro-guard
+      - core-frontend-unit:
+          requires:
+            - core-diff
+            - core-pro-guard

--- a/docs/operations/circleci.md
+++ b/docs/operations/circleci.md
@@ -1,0 +1,48 @@
+# CircleCI
+
+Date: 2026-06-04
+
+This repository uses CircleCI as the next primary CI entry point for Core
+source validation. GitHub Actions workflows remain `workflow_dispatch` only so
+they can be run manually without reintroducing automatic GitHub-hosted Actions
+usage.
+
+The starter CircleCI workflow intentionally has no deployment jobs, no
+production secrets, and no production database access. Backend tests use a
+disposable Postgres service container with explicit test environment values.
+
+## Current Cloud Jobs
+
+- `core-diff`: whitespace/conflict-marker diff check.
+- `core-pro-guard`: public Core boundary check; rejects PRO-only paths such as
+  `backend/app/pro/` and `license-server/`.
+- `core-backend-static`: Python compile check for `backend/app` and
+  `backend/tests`.
+- `core-backend-tests`: backend pytest against disposable Postgres with JUnit
+  stored under `test-results/core-backend`.
+- `core-frontend-build`: frontend `npm ci` and `npm run build`.
+- `core-frontend-unit`: frontend Vitest unit tests with JUnit stored under
+  `test-results/core-frontend-unit`.
+
+## Smarter Testing
+
+Start with the full-suite CircleCI baseline. Do not enable dynamic splitting or
+Test Impact Analysis for Core until this workflow has a green history on PRs and
+`main`.
+
+Recommended next steps:
+
+1. Require the CircleCI contexts only after at least one clean PR run.
+2. Keep the existing external CI statuses available as rollback until CircleCI
+   is the trusted gate.
+3. Pilot dynamic splitting on `core-backend-tests` only after backend JUnit
+   timings are stable.
+4. Treat Test Impact Analysis as advisory before it becomes a required Core
+   gate.
+
+## Rollback
+
+If CircleCI setup fails, continue using the external runner documented in
+`external-ci-statuses.md`. Reverting this setup should be a config-only PR that
+removes `.circleci/config.yml` while leaving manual GitHub Actions workflows
+unchanged.

--- a/docs/operations/external-ci-statuses.md
+++ b/docs/operations/external-ci-statuses.md
@@ -41,3 +41,7 @@ GitHub-hosted workflows in `.github/workflows/` are intentionally
 `workflow_dispatch` only. CodeQL can still be run manually from GitHub, or by an
 external security job that posts its own required status once that runner is
 available.
+
+CircleCI is being introduced as the replacement hosted CI surface for these
+Core checks. Until the CircleCI workflow has green history and branch rules are
+updated deliberately, keep the external CI runner available as rollback.


### PR DESCRIPTION
## Summary
- add a Core CircleCI workflow covering the existing external CI gate shape
- run backend tests against disposable Postgres with explicit test env values
- upload backend pytest and frontend Vitest JUnit results for CircleCI test insights
- document rollout, smarter-testing timing, and external-runner rollback

## Validation
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.circleci/config.yml').read_text()); print('yaml ok')"`
- `git diff --check`
- `cd backend && python -m compileall -q app tests`
- `cd frontend && npm run test:unit -- --run --reporter=default --reporter=junit --outputFile=../test-results/core-frontend-unit/vitest.xml`
- `cd frontend && npm run build` with `VITE_API_URL=http://localhost:8001`

## Rollout Note
Keep the existing `external-ci/core-*` statuses as the trusted required gate until this CircleCI workflow has green PR/main history. Then update the Core ruleset deliberately.

## Out of Scope
- no deploy jobs
- no production secrets
- no production database access
- no dynamic splitting or Test Impact Analysis yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced CircleCI as the primary CI pipeline, adding automated checks, backend compilation, and frontend/backend test execution with artifact and test-result publishing.

* **Documentation**
  * Added operational guidance for the new CircleCI workflow, rollout/rollback guidance, and notes on external CI status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->