### PR TITLE
ci: avoid CircleCI heredoc parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           command: |
             cd backend
             . .venv/bin/activate
-            python - <<'PY'
+            python -c '
             import os
             import time
 
@@ -146,7 +146,7 @@ jobs:
                     last_error = exc
                     time.sleep(2)
             raise SystemExit(f"Postgres did not become ready: {last_error}")
-            PY
+            '
       - run:
           name: Run backend tests
           command: |


### PR DESCRIPTION
## Summary
- replace the `python - <<'PY'` heredoc in the CircleCI Postgres wait step with `python -c`
- avoid CircleCI config v2.1 parsing `<<` as an unclosed template tag

## Failure
CircleCI rejected the first Core main pipeline with:

```text
Error calling job: 'core-backend-tests'
Unclosed '<<' tag
('<<' must be escaped as '\<<' in config v2.1+)
```

## Validation
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.circleci/config.yml').read_text()); print('yaml ok')"`
- `rg "<<" .circleci/config.yml` returned no matches
- `git diff --check`
- local Bash smoke of the replacement quote shape reached Python import execution; local Git Bash lacks `psycopg`, but parsing/quoting succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve consistency and reliability of database readiness checks during the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->