### PR TITLE
fix: count customer-linked orders in customer stats

### DIFF
--- a/backend/app/services/customer_service.py
+++ b/backend/app/services/customer_service.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import sqlalchemy as sa
 from fastapi import HTTPException
-from sqlalchemy import Integer, cast, desc, func
+from sqlalchemy import Integer, and_, cast, desc, func, or_
 from sqlalchemy.orm import Session
 
 from app.core.security import hash_password
@@ -43,17 +43,20 @@ def _build_full_name(customer: User) -> Optional[str]:
 
 def _get_customer_stats(db: Session, customer_id: int) -> dict:
     """Fetch order count, quote count, and total spent for a customer."""
+    order_customer_filter = _sales_order_customer_filter(customer_id)
+    quote_customer_filter = _quote_customer_filter(customer_id)
+
     order_count = db.query(func.count(SalesOrder.id)).filter(
-        SalesOrder.user_id == customer_id,
+        order_customer_filter,
         SalesOrder.status != "cancelled",
     ).scalar() or 0
 
     quote_count = db.query(func.count(Quote.id)).filter(
-        Quote.user_id == customer_id,
+        quote_customer_filter,
     ).scalar() or 0
 
     total_spent = db.query(func.sum(SalesOrder.grand_total)).filter(
-        SalesOrder.user_id == customer_id,
+        order_customer_filter,
         SalesOrder.status != "cancelled",
     ).scalar() or 0
 
@@ -62,6 +65,22 @@ def _get_customer_stats(db: Session, customer_id: int) -> dict:
         "quote_count": quote_count,
         "total_spent": float(total_spent),
     }
+
+
+def _sales_order_customer_filter(customer_id: int):
+    """Match orders for a customer, preferring explicit customer_id over legacy user_id."""
+    return or_(
+        SalesOrder.customer_id == customer_id,
+        and_(SalesOrder.customer_id.is_(None), SalesOrder.user_id == customer_id),
+    )
+
+
+def _quote_customer_filter(customer_id: int):
+    """Match quotes for a customer, preferring explicit customer_id over legacy user_id."""
+    return or_(
+        Quote.customer_id == customer_id,
+        and_(Quote.customer_id.is_(None), Quote.user_id == customer_id),
+    )
 
 
 def _get_customer_or_404(db: Session, customer_id: int) -> User:
@@ -230,12 +249,13 @@ def list_customers(
 
     result = []
     for customer in customers:
+        order_customer_filter = _sales_order_customer_filter(customer.id)
         order_stats = db.query(
             func.count(SalesOrder.id).label("order_count"),
             func.sum(SalesOrder.grand_total).label("total_spent"),
             func.max(SalesOrder.created_at).label("last_order"),
         ).filter(
-            SalesOrder.user_id == customer.id,
+            order_customer_filter,
             SalesOrder.status != "cancelled",
         ).first()
 
@@ -448,7 +468,7 @@ def delete_customer(db: Session, customer_id: int, admin_id: int) -> dict:
     customer = _get_customer_or_404(db, customer_id)
 
     order_count = db.query(func.count(SalesOrder.id)).filter(
-        SalesOrder.user_id == customer_id,
+        _sales_order_customer_filter(customer_id),
     ).scalar() or 0
 
     customer_number = customer.customer_number
@@ -502,7 +522,7 @@ def get_customer_orders(
 
     orders = (
         db.query(SalesOrder)
-        .filter(SalesOrder.user_id == customer_id)
+        .filter(_sales_order_customer_filter(customer_id))
         .order_by(desc(SalesOrder.created_at))
         .limit(limit)
         .all()

--- a/backend/tests/api/v1/test_customers.py
+++ b/backend/tests/api/v1/test_customers.py
@@ -16,6 +16,7 @@ Covers:
 """
 import io
 import uuid
+from decimal import Decimal
 
 import pytest
 
@@ -333,6 +334,25 @@ class TestListCustomers:
         assert len(match) >= 1
         assert match[0]["full_name"] == "Jane Smith"
 
+    def test_list_counts_orders_linked_by_customer_id(self, client, db, make_sales_order):
+        """Customer list stats include staff-owned orders linked by customer_id."""
+        customer = _create_customer(client, first_name="LinkedStats")
+        customer_id = customer["id"]
+        order = make_sales_order(
+            user_id=1,
+            customer_id=customer_id,
+            status="confirmed",
+        )
+        order.grand_total = Decimal("87.65")
+        order.total_price = Decimal("87.65")
+        db.flush()
+
+        response = client.get(BASE_URL, params={"search": customer["email"]})
+        assert response.status_code == 200
+        match = next(c for c in response.json() if c["id"] == customer_id)
+        assert match["order_count"] == 1
+        assert match["total_spent"] == 87.65
+
 
 # =============================================================================
 # GET /api/v1/admin/customers/search?q=... - Quick search
@@ -447,6 +467,51 @@ class TestGetCustomer:
         assert data["order_count"] == 0
         assert data["quote_count"] == 0
         assert data["total_spent"] == 0.0
+
+    def test_get_customer_counts_orders_linked_by_customer_id(self, client, db, make_sales_order):
+        """Staff-owned orders linked via customer_id count toward customer stats."""
+        customer = _create_customer(client)
+        customer_id = customer["id"]
+        order = make_sales_order(
+            user_id=1,
+            customer_id=customer_id,
+            status="confirmed",
+        )
+        order.grand_total = Decimal("123.45")
+        order.total_price = Decimal("123.45")
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{customer_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["order_count"] == 1
+        assert data["total_spent"] == 123.45
+
+    def test_get_customer_counts_quotes_linked_by_customer_id(self, client, db):
+        """Staff-owned quotes linked via customer_id count toward customer stats."""
+        from app.models.quote import Quote
+
+        customer = _create_customer(client)
+        quote = Quote(
+            user_id=1,
+            customer_id=customer["id"],
+            quote_number=f"Q-CUST-{uuid.uuid4().hex[:8]}",
+            product_name="Customer Linked Quote",
+            quantity=1,
+            material_type="PLA",
+            unit_price=Decimal("10.00"),
+            subtotal=Decimal("10.00"),
+            total_price=Decimal("10.00"),
+            status="pending",
+            file_format="manual",
+            file_size_bytes=0,
+        )
+        db.add(quote)
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{customer['id']}")
+        assert response.status_code == 200
+        assert response.json()["quote_count"] == 1
 
     def test_get_customer_includes_addresses(self, client):
         """Get customer includes full billing and shipping address fields."""
@@ -658,6 +723,17 @@ class TestCustomerOrders:
         assert "status" in order
         assert "grand_total" in order
         assert "created_at" in order
+
+    def test_orders_returns_orders_linked_by_customer_id(self, client, make_sales_order):
+        """Order history includes staff-owned orders linked by customer_id."""
+        customer = _create_customer(client)
+        customer_id = customer["id"]
+        so = make_sales_order(user_id=1, customer_id=customer_id, status="confirmed")
+
+        response = client.get(f"{BASE_URL}/{customer_id}/orders")
+        assert response.status_code == 200
+        data = response.json()
+        assert any(order["id"] == so.id for order in data)
 
     def test_orders_not_found(self, client):
         """Orders for non-existent customer returns 404."""


### PR DESCRIPTION
## Summary
- Count orders and quotes linked through `customer_id` in customer detail/list stats, while preserving legacy `user_id` fallback for older records.
- Include `customer_id`-linked orders in the customer order history endpoint.
- Add regression coverage for staff-owned orders/quotes attached to a CRM customer.

## Test Plan
- [x] `python -m compileall backend/app/services/customer_service.py backend/tests/api/v1/test_customers.py`
- [x] `git diff --check`
- [ ] `python -m pytest backend/tests/api/v1/test_customers.py -q` (attempted locally; blocked by local Postgres `filaops_test` credential mismatch, leaving CircleCI to run DB-backed tests)

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-customer-totals-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how orders and quotes are attributed to customer accounts, ensuring order counts and total spending amounts are accurate across customer dashboards and reports
  * Enhanced customer order history to properly display all orders linked to customer accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->