### PR TITLE
fix: lock accepted quotes from edits

### DIFF
--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -22,6 +22,17 @@ from app.models.user import User
 logger = get_logger(__name__)
 
 
+LOCKED_QUOTE_STATUSES = {"accepted", "converted"}
+
+
+def _raise_if_quote_locked_for_modification(quote: Quote) -> None:
+    if quote.status in LOCKED_QUOTE_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot modify a {quote.status} quote"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Helper: Generate Quote Number
 # ---------------------------------------------------------------------------
@@ -354,12 +365,7 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
             detail=f"Quote {quote_id} not found"
         )
 
-    # Don't allow editing converted quotes
-    if quote.status == "converted":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot edit a converted quote"
-        )
+    _raise_if_quote_locked_for_modification(quote)
 
     # Validate customer_id if provided
     if request.customer_id is not None:
@@ -738,11 +744,7 @@ def delete_quote(db: Session, quote_id: int) -> str:
             detail=f"Quote {quote_id} not found"
         )
 
-    if quote.status == "converted":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot delete a converted quote"
-        )
+    _raise_if_quote_locked_for_modification(quote)
 
     quote_number = quote.quote_number
     db.delete(quote)

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -1664,6 +1664,33 @@ class TestUpdateQuote:
         assert response.status_code == 400
         assert "converted" in response.json()["detail"].lower()
 
+    def test_update_accepted_quote_fails(self, client):
+        """Cannot edit a quote after customer acceptance."""
+        quote = _create_quote(client)
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={"status": "approved"})
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={"status": "accepted"})
+
+        response = client.patch(f"{BASE_URL}/{quote['id']}", json={
+            "product_name": "Changed After Acceptance",
+        })
+        assert response.status_code == 400
+        assert "accepted" in response.json()["detail"].lower()
+
+    def test_update_approved_quote_succeeds_before_acceptance(self, client):
+        """Staff can revise an approved/sent quote until the customer accepts it."""
+        quote = _create_quote(client, apply_tax=False)
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={"status": "approved"})
+
+        response = client.patch(f"{BASE_URL}/{quote['id']}", json={
+            "product_name": "Revised Before Acceptance",
+            "quantity": 3,
+            "unit_price": "20.00",
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["product_name"] == "Revised Before Acceptance"
+        assert Decimal(str(data["subtotal"])) == Decimal("60.00")
+
     def test_update_invalid_customer_id_fails(self, client):
         quote = _create_quote(client)
         response = client.patch(f"{BASE_URL}/{quote['id']}", json={
@@ -1961,6 +1988,26 @@ class TestDeleteQuote:
         })
         response = client.delete(f"{BASE_URL}/{quote['id']}")
         assert response.status_code == 204
+
+    def test_delete_approved_quote_succeeds_before_acceptance(self, client):
+        quote = _create_quote(client)
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={
+            "status": "approved",
+        })
+        response = client.delete(f"{BASE_URL}/{quote['id']}")
+        assert response.status_code == 204
+
+    def test_delete_accepted_quote_fails(self, client):
+        quote = _create_quote(client)
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={
+            "status": "approved",
+        })
+        client.patch(f"{BASE_URL}/{quote['id']}/status", json={
+            "status": "accepted",
+        })
+        response = client.delete(f"{BASE_URL}/{quote['id']}")
+        assert response.status_code == 400
+        assert "accepted" in response.json()["detail"].lower()
 
     def test_delete_converted_quote_fails(self, client, db):
         from app.models.quote import Quote

--- a/frontend/src/components/quotes/QuoteDetailModal.jsx
+++ b/frontend/src/components/quotes/QuoteDetailModal.jsx
@@ -48,6 +48,7 @@ export default function QuoteDetailModal({
   const isExpired = new Date(q.expires_at) < new Date();
   const canConvert =
     (q.status === "approved" || q.status === "accepted") && !isExpired && !q.sales_order_id;
+  const canModify = q.status !== "accepted" && q.status !== "converted";
 
   const loadQuoteFiles = useCallback(async ({ signal } = {}) => {
     try {
@@ -675,7 +676,7 @@ export default function QuoteDetailModal({
                 Duplicate
               </button>
 
-              {q.status !== "converted" && (
+              {canModify && (
                 <>
                   <button
                     onClick={() => onEdit(q)}

--- a/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
@@ -231,4 +231,21 @@ describe("QuoteDetailModal attachments", () => {
     expect(onEdit).toHaveBeenCalledWith(detailQuote);
     expect(onDuplicate).toHaveBeenCalledWith(detailQuote);
   });
+
+  it("does not offer edit or delete actions after customer acceptance", async () => {
+    quoteFiles = [];
+    detailQuote = {
+      ...quote,
+      status: "accepted",
+    };
+
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Convert to Order" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/quotes/__tests__/QuoteFormModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteFormModal.test.jsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import QuoteFormModal from "../QuoteFormModal";
+import { ToastProvider } from "../../Toast";
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const quote = {
+  id: 42,
+  quote_number: "Q-2026-000042",
+  status: "pending",
+  customer_id: null,
+  customer_name: "Example Customer",
+  customer_email: "customer@example.com",
+  customer_notes: "",
+  admin_notes: "",
+  tax_rate: null,
+  shipping_cost: "0.00",
+  lines: [
+    {
+      id: 101,
+      product_id: 201,
+      product_name: "Bracket",
+      quantity: 2,
+      unit_price: "15.00",
+      total: "30.00",
+      material_type: "PETG",
+      color: "Black",
+      notes: "Original note",
+    },
+  ],
+};
+
+const renderModal = (props = {}) => render(
+  <ToastProvider>
+    <QuoteFormModal
+      quote={quote}
+      onSave={vi.fn()}
+      onClose={vi.fn()}
+      {...props}
+    />
+  </ToastProvider>,
+);
+
+describe("QuoteFormModal editing", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn((url) => {
+      const value = String(url);
+      if (value.includes("/api/v1/items")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (value.includes("/api/v1/admin/customers")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (value.includes("/api/v1/settings/company")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ tax_enabled: false }),
+        });
+      }
+      if (value.includes("/api/v1/tax-rates")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("submits edited line quantity and price for an existing manual quote", async () => {
+    const onSave = vi.fn();
+    renderModal({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Items" }));
+
+    const spinButtons = screen.getAllByRole("spinbutton");
+    fireEvent.change(spinButtons[0], { target: { value: "3" } });
+    fireEvent.change(spinButtons[1], { target: { value: "20.00" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update Quote" }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        lines: [
+          expect.objectContaining({
+            product_id: 201,
+            product_name: "Bracket",
+            quantity: 3,
+            unit_price: 20,
+          }),
+        ],
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Lock accepted quotes from edit/delete in the quote service while preserving edits/deletes for pending, approved, rejected, and cancelled quotes before acceptance
- Hide Edit/Delete actions for accepted quotes in the admin quote detail modal while still allowing conversion
- Add regressions for accepted quote locks, approved-before-acceptance changes, and manual quote line quantity/price submission

## Test plan
- [x] `npx vitest run --config vitest.unit.config.js src/components/quotes/__tests__/QuoteDetailModal.test.jsx src/components/quotes/__tests__/QuoteFormModal.test.jsx`
- [x] `python -m compileall backend/app/services/quote_service.py backend/tests/api/v1/test_quotes.py`
- [x] `git diff --check`
- [ ] `DEBUG=false python -m pytest backend/tests/api/v1/test_quotes.py -q -k "update_accepted_quote_fails or update_approved_quote_succeeds_before_acceptance or delete_approved_quote_succeeds_before_acceptance or delete_accepted_quote_fails"` blocked locally: Postgres `filaops_test` password authentication failed for user `postgres`; CircleCI should run with proper DB credentials.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-manual-quote-edit-delete-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quotes in "accepted" status can no longer be edited or deleted; only approved and earlier statuses remain modifiable.

* **Tests**
  * Added test coverage for quote modification restrictions and quote form editing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->