### PR TITLE
fix: support direct order fee lines

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -383,8 +383,8 @@ async def get_order_cost_breakdown(
     # Total COGS (production costs only per GAAP)
     total_cogs = material_cost + labor_cost + packaging_cost
 
-    # Revenue and margin (excluding tax per GAAP)
-    revenue = (order.grand_total or order.total_price or Decimal("0")) - (order.tax_amount or Decimal("0"))
+    # Revenue and margin (subtotal only; tax is liability, shipping is operating expense)
+    revenue = order.total_price or Decimal("0")
     gross_profit = revenue - total_cogs
     margin_pct = (gross_profit / revenue * 100) if revenue > 0 else Decimal("0")
 

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -94,6 +94,10 @@ def build_sales_order_response(order: SalesOrder, db: Session) -> SalesOrderResp
 
             lines.append(SalesOrderLineResponse(
                 id=line.id,
+                line_type=getattr(line, "line_type", None) or (
+                    "material" if line.material_inventory_id else "product"
+                ),
+                description=getattr(line, "description", None),
                 product_id=line.product_id,
                 material_inventory_id=line.material_inventory_id,
                 product_sku=product_sku,
@@ -249,6 +253,8 @@ async def create_sales_order(
     """
     lines = [
         {
+            "line_type": line.line_type,
+            "description": line.description,
             "product_id": line.product_id,
             "material_inventory_id": line.material_inventory_id,
             "quantity": line.quantity,
@@ -837,7 +843,12 @@ async def edit_order_lines(
         raise HTTPException(status_code=403, detail="Admin access required")
 
     line_updates = [
-        {"line_id": ln.line_id, "new_quantity": ln.new_quantity, "reason": ln.reason}
+        {
+            "line_id": ln.line_id,
+            "new_quantity": ln.new_quantity,
+            "new_unit_price": ln.new_unit_price,
+            "reason": ln.reason,
+        }
         for ln in edit_request.lines
     ]
 

--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -201,6 +201,8 @@ class SalesOrderLine(Base):
     sales_order_id = Column(Integer, ForeignKey("sales_orders.id", ondelete="CASCADE"), nullable=False, index=True)
     product_id = Column(Integer, ForeignKey("products.id"), nullable=True, index=True)
     material_inventory_id = Column(Integer, ForeignKey("material_inventory.id"), nullable=True, index=True)
+    line_type = Column(String(20), nullable=False, default="product", index=True)
+    description = Column(String(255), nullable=True)
 
     # Line Details (matching actual database schema)
     quantity = Column(Numeric(10, 2), nullable=False)
@@ -229,11 +231,22 @@ class SalesOrderLine(Base):
     # line_number, product_sku, product_name, or created_at columns.
     # These are computed in the API layer when building responses.
 
-    # Exactly one of product_id or material_inventory_id must be set
+    def __init__(self, **kwargs):
+        if kwargs.get("line_type") is None:
+            if kwargs.get("material_inventory_id") is not None:
+                kwargs["line_type"] = "material"
+            elif kwargs.get("product_id") is None:
+                kwargs["line_type"] = "service"
+            else:
+                kwargs["line_type"] = "product"
+        super().__init__(**kwargs)
+
+    # Product/material lines require their inventory FK; service lines have neither FK.
     __table_args__ = (
         CheckConstraint(
-            "(product_id IS NOT NULL AND material_inventory_id IS NULL) OR "
-            "(product_id IS NULL AND material_inventory_id IS NOT NULL)",
+            "(line_type = 'product' AND product_id IS NOT NULL AND material_inventory_id IS NULL) OR "
+            "(line_type = 'material' AND product_id IS NULL AND material_inventory_id IS NOT NULL) OR "
+            "(line_type = 'service' AND product_id IS NULL AND material_inventory_id IS NULL)",
             name="ck_sol_product_or_material",
         ),
     )

--- a/backend/app/schemas/sales_order.py
+++ b/backend/app/schemas/sales_order.py
@@ -16,24 +16,54 @@ from app.schemas.fulfillment_status import FulfillmentStatusSummary
 class SalesOrderLineCreate(BaseModel):
     """Line item for manual order creation.
 
-    Exactly one of product_id or material_inventory_id must be provided.
+    Product/material lines reference inventory records; service lines are
+    one-time charges with a description and no inventory FK.
     """
+    line_type: Optional[str] = Field(None, description="Line type: product, material, or service")
     product_id: Optional[int] = Field(None, description="Product ID (for finished goods)")
     material_inventory_id: Optional[int] = Field(None, description="Material inventory ID (for raw material / filament)")
+    description: Optional[str] = Field(None, max_length=255, description="Description for one-time service/fee lines")
     quantity: Decimal = Field(..., gt=0, le=10000, description="Quantity — integer for products, fractional for materials (e.g. 0.5 kg)")
     unit_price: Optional[Decimal] = Field(None, ge=0, description="Unit price (uses product/material price if not specified)")
     notes: Optional[str] = Field(None, max_length=500)
 
     @model_validator(mode="after")
-    def exactly_one_item_ref(self) -> "SalesOrderLineCreate":
+    def validate_line_reference(self) -> "SalesOrderLineCreate":
+        normalized_type = (self.line_type or "").strip().lower()
         has_product = self.product_id is not None
         has_material = self.material_inventory_id is not None
-        if has_product == has_material:  # both True or both False
+
+        if not normalized_type:
+            if has_product:
+                normalized_type = "product"
+            elif has_material:
+                normalized_type = "material"
+        if normalized_type not in {"product", "material", "service"}:
+            raise ValueError("line_type must be product, material, or service")
+
+        if normalized_type == "service":
+            if has_product or has_material:
+                raise ValueError("Service lines must not reference product_id or material_inventory_id")
+            if not self.description or not self.description.strip():
+                raise ValueError("Service lines require a description")
+            if self.unit_price is None:
+                raise ValueError("Service lines require a unit_price")
+        elif normalized_type == "product":
+            if not has_product or has_material:
+                raise ValueError("Product lines require product_id and no material_inventory_id")
+            if self.quantity != self.quantity.to_integral_value():
+                raise ValueError("Product line quantity must be a whole number")
+        else:
+            if has_product or not has_material:
+                raise ValueError("Material lines require material_inventory_id and no product_id")
+
+        if not normalized_type:
             raise ValueError(
-                "Exactly one of product_id or material_inventory_id must be provided"
+                "Each line must specify product_id, material_inventory_id, or line_type='service'"
             )
-        if has_product and self.quantity != self.quantity.to_integral_value():
-            raise ValueError("Product line quantity must be a whole number")
+        self.line_type = normalized_type
+        if self.description:
+            self.description = self.description.strip()
         return self
 
 
@@ -119,14 +149,21 @@ class SalesOrderCancel(BaseModel):
 
 
 class SalesOrderLineUpdate(BaseModel):
-    """Update a single line item quantity"""
+    """Update a single line item quantity and/or unit price"""
     line_id: int = Field(..., description="ID of the line to update")
-    new_quantity: Decimal = Field(..., gt=0, le=10000, description="New quantity (must be >= shipped quantity)")
+    new_quantity: Optional[Decimal] = Field(None, gt=0, le=10000, description="New quantity (must be >= shipped quantity)")
+    new_unit_price: Optional[Decimal] = Field(None, ge=0, le=100000, description="New unit price for this line")
     reason: str = Field(..., min_length=1, max_length=500, description="Reason for the change")
+
+    @model_validator(mode="after")
+    def at_least_one_change(self) -> "SalesOrderLineUpdate":
+        if self.new_quantity is None and self.new_unit_price is None:
+            raise ValueError("At least one of new_quantity or new_unit_price must be provided")
+        return self
 
 
 class SalesOrderEditLines(BaseModel):
-    """Edit one or more line quantities on a sales order"""
+    """Edit one or more line quantities/prices on a sales order"""
     lines: List[SalesOrderLineUpdate] = Field(..., min_length=1)
 
 
@@ -186,6 +223,8 @@ class SalesOrderListResponse(SalesOrderBase):
 class SalesOrderLineResponse(BaseModel):
     """Sales order line item response"""
     id: int
+    line_type: str = "product"
+    description: Optional[str] = None
     product_id: Optional[int] = None
     material_inventory_id: Optional[int] = None
     product_sku: Optional[str] = None

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -532,10 +532,11 @@ def create_sales_order(
     """
     Create a manual sales order (line_item type).
 
-    Each line must contain exactly one of ``product_id`` or
-    ``material_inventory_id``.  Product lines use the catalog selling
-    price; material lines require an explicit ``unit_price`` (or fall
-    back to the material's ``cost_per_kg``).
+    Each line must contain a ``product_id``, a ``material_inventory_id``, or
+    ``line_type='service'``.  Product lines default to the catalog selling price
+    but may be overridden for manual/walk-in adjustments; material lines require
+    an explicit ``unit_price`` (or fall back to the material's ``cost_per_kg``);
+    service lines are one-time non-inventory charges with a description.
 
     Args:
         customer_id: Optional customer user ID
@@ -567,22 +568,101 @@ def create_sales_order(
     line_names: list[str] = []
 
     for line in lines:
+        line_type = (line.get("line_type") or "").strip().lower()
         has_product = line.get("product_id") is not None
         has_material = line.get("material_inventory_id") is not None
+
+        if not line_type:
+            if has_product:
+                line_type = "product"
+            elif has_material:
+                line_type = "material"
+
+        if line_type == "service":
+            if has_product or has_material:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Service lines must not specify product_id or material_inventory_id",
+                )
+            description = (line.get("description") or "").strip()
+            if not description:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Service lines require a description",
+                )
+            explicit_price = line.get("unit_price")
+            if explicit_price is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Service line '{description}' requires a unit_price",
+                )
+            unit_price = Decimal(str(explicit_price))
+            if unit_price < 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Service line '{description}' unit price must be >= 0",
+                )
+
+            line_total = unit_price * line["quantity"]
+
+            validated_lines.append({
+                "line_type": "service",
+                "description": description,
+                "product": None,
+                "material": None,
+                "product_id": None,
+                "material_inventory_id": None,
+                "quantity": line["quantity"],
+                "unit_price": unit_price,
+                "line_total": line_total,
+                "discountable": False,
+                "notes": line.get("notes"),
+            })
+            line_names.append(description)
+
+            total_price += line_total
+            total_quantity += line["quantity"]
+            continue
+
+        if line_type not in {"product", "material"}:
+            raise HTTPException(
+                status_code=400,
+                detail="line_type must be product, material, or service",
+            )
 
         if has_product == has_material:
             raise HTTPException(
                 status_code=400,
-                detail="Each line must specify exactly one of product_id or material_inventory_id",
+                detail="Each line must specify product_id, material_inventory_id, or line_type='service'",
+            )
+
+        if has_product and line_type != "product":
+            raise HTTPException(
+                status_code=400,
+                detail="Product-backed lines must use line_type='product'",
+            )
+        if has_material and line_type != "material":
+            raise HTTPException(
+                status_code=400,
+                detail="Material-backed lines must use line_type='material'",
             )
 
         if has_product:
             # --- Product line (existing path) ---
             product = validate_product_for_order(db, line["product_id"])
 
-            # SECURITY: Always use product's catalog price
-            unit_price = product.selling_price or Decimal("0")
-            if unit_price <= 0:
+            explicit_price = line.get("unit_price")
+            if explicit_price is not None:
+                unit_price = Decimal(str(explicit_price))
+            else:
+                unit_price = product.selling_price or Decimal("0")
+
+            if unit_price < 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Product '{product.sku}' unit price must be >= 0",
+                )
+            if explicit_price is None and unit_price <= 0:
                 raise HTTPException(
                     status_code=400,
                     detail=f"Product '{product.sku}' has no selling price configured",
@@ -591,6 +671,8 @@ def create_sales_order(
             line_total = unit_price * line["quantity"]
 
             validated_lines.append({
+                "line_type": "product",
+                "description": None,
                 "product": product,
                 "material": None,
                 "product_id": product.id,
@@ -598,6 +680,7 @@ def create_sales_order(
                 "quantity": line["quantity"],
                 "unit_price": unit_price,
                 "line_total": line_total,
+                "discountable": True,
                 "notes": line.get("notes"),
             })
             line_names.append(product.name)
@@ -630,6 +713,8 @@ def create_sales_order(
             line_total = unit_price * line["quantity"]
 
             validated_lines.append({
+                "line_type": "material",
+                "description": None,
                 "product": None,
                 "material": material,
                 "product_id": None,
@@ -637,6 +722,7 @@ def create_sales_order(
                 "quantity": line["quantity"],
                 "unit_price": unit_price,
                 "line_total": line_total,
+                "discountable": True,
                 "notes": line.get("notes"),
             })
             line_names.append(material.display_name)
@@ -653,6 +739,9 @@ def create_sales_order(
         # Apply discount to each line
         total_price = Decimal("0")
         for vl in validated_lines:
+            if not vl.get("discountable", True):
+                total_price += vl["line_total"]
+                continue
             original_price = vl["unit_price"]
             discounted_price = (
                 original_price * (Decimal("1") - discount_percent / Decimal("100"))
@@ -691,7 +780,7 @@ def create_sales_order(
     elif first_line["material"] and first_line["material"].material_type:
         material_type = first_line["material"].material_type.base_material
     else:
-        material_type = "Material"
+        material_type = "Service"
 
     # Use customer_id if provided, otherwise current user
     user_id = customer_id if customer_id else created_by_user_id
@@ -745,6 +834,8 @@ def create_sales_order(
     for line_data in validated_lines:
         order_line = SalesOrderLine(
             sales_order_id=sales_order.id,
+            line_type=line_data["line_type"],
+            description=line_data["description"],
             product_id=line_data["product_id"],
             material_inventory_id=line_data["material_inventory_id"],
             quantity=line_data["quantity"],
@@ -1282,11 +1373,11 @@ def edit_sales_order_lines(
     line_updates: list[dict],
     user_id: int,
 ) -> SalesOrder:
-    """Edit line quantities on a sales order.
+    """Edit line quantities and/or unit prices on a sales order.
 
     Args:
         order_id: Order to edit
-        line_updates: List of {line_id, new_quantity, reason}
+        line_updates: List of {line_id, new_quantity?, new_unit_price?, reason}
         user_id: Admin user making the change
 
     Returns:
@@ -1316,7 +1407,18 @@ def edit_sales_order_lines(
                 detail=f"Line {update['line_id']} not found on order {order.order_number}"
             )
 
-        new_qty = Decimal(str(update["new_quantity"]))
+        old_qty = line.quantity
+        old_unit_price = line.unit_price
+        new_qty = (
+            Decimal(str(update["new_quantity"]))
+            if update.get("new_quantity") is not None
+            else old_qty
+        )
+        new_unit_price = (
+            Decimal(str(update["new_unit_price"]))
+            if update.get("new_unit_price") is not None
+            else old_unit_price
+        )
         shipped = line.shipped_quantity or Decimal("0")
 
         if new_qty < shipped:
@@ -1325,15 +1427,23 @@ def edit_sales_order_lines(
                 detail=f"Cannot reduce line {line.id} below shipped quantity ({shipped})"
             )
 
-        old_qty = line.quantity
+        if new_unit_price < 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Line {line.id} unit price must be >= 0"
+            )
+
+        quantity_changed = new_qty != old_qty
+        price_changed = new_unit_price != old_unit_price
 
         # Preserve original quantity on first edit only
-        if line.original_quantity is None:
+        if quantity_changed and line.original_quantity is None:
             line.original_quantity = old_qty
 
         line.quantity = new_qty
+        line.unit_price = new_unit_price
         discount = line.discount or Decimal("0")
-        line.total = (new_qty * line.unit_price - discount).quantize(Decimal("0.01"))
+        line.total = (new_qty * new_unit_price - discount).quantize(Decimal("0.01"))
 
         # Resolve product name for the event
         product_name = "Line"
@@ -1341,21 +1451,35 @@ def edit_sales_order_lines(
             product = db.query(Product).filter(Product.id == line.product_id).first()
             if product:
                 product_name = product.name
+        elif line.material_inventory_id:
+            material = db.query(MaterialInventory).filter(
+                MaterialInventory.id == line.material_inventory_id
+            ).first()
+            if material:
+                product_name = material.display_name
+
+        change_messages = []
+        if quantity_changed:
+            change_messages.append(f"quantity changed from {old_qty} to {new_qty}")
+        if price_changed:
+            change_messages.append(f"unit price changed from {old_unit_price} to {new_unit_price}")
+        change_description = "; ".join(change_messages) or "line reviewed without changes"
 
         record_order_event(
             db=db,
             order_id=order_id,
             event_type="line_edited",
-            title=f"{product_name} quantity changed",
-            description=f"Quantity changed from {old_qty} to {new_qty}. Reason: {update['reason']}",
+            title=f"{product_name} line changed",
+            description=f"{change_description}. Reason: {update['reason']}",
             old_value=str(old_qty),
             new_value=str(new_qty),
             user_id=user_id,
         )
 
         logger.info(
-            "SO %s line %d qty %s → %s (reason: %s)",
-            order.order_number, line.id, old_qty, new_qty, update["reason"],
+            "SO %s line %d qty %s -> %s price %s -> %s (reason: %s)",
+            order.order_number, line.id, old_qty, new_qty,
+            old_unit_price, new_unit_price, update["reason"],
         )
 
     _recalculate_order_totals(db, order)

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -1421,6 +1421,12 @@ def edit_sales_order_lines(
         )
         shipped = line.shipped_quantity or Decimal("0")
 
+        if line.product_id and new_qty != new_qty.to_integral_value():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Line {line.id} quantity must be a whole number for product-backed lines"
+            )
+
         if new_qty < shipped:
             raise HTTPException(
                 status_code=400,
@@ -1442,8 +1448,7 @@ def edit_sales_order_lines(
 
         line.quantity = new_qty
         line.unit_price = new_unit_price
-        discount = line.discount or Decimal("0")
-        line.total = (new_qty * new_unit_price - discount).quantize(Decimal("0.01"))
+        line.total = (new_qty * new_unit_price).quantize(Decimal("0.01"))
 
         # Resolve product name for the event
         product_name = "Line"

--- a/backend/migrations/versions/085_add_service_sales_order_lines.py
+++ b/backend/migrations/versions/085_add_service_sales_order_lines.py
@@ -30,6 +30,11 @@ def _column_exists(table_name: str, column_name: str) -> bool:
     return column_name in {column["name"] for column in inspector.get_columns(table_name)}
 
 
+def _index_exists(table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
 def _constraint_exists(table_name: str, constraint_name: str) -> bool:
     inspector = sa.inspect(op.get_bind())
     return constraint_name in {
@@ -49,6 +54,8 @@ def upgrade() -> None:
                 server_default="product",
             ),
         )
+
+    if not _index_exists("sales_order_lines", "ix_sales_order_lines_line_type"):
         op.create_index(
             "ix_sales_order_lines_line_type",
             "sales_order_lines",
@@ -115,5 +122,6 @@ def downgrade() -> None:
     if _column_exists("sales_order_lines", "description"):
         op.drop_column("sales_order_lines", "description")
     if _column_exists("sales_order_lines", "line_type"):
-        op.drop_index("ix_sales_order_lines_line_type", table_name="sales_order_lines")
+        if _index_exists("sales_order_lines", "ix_sales_order_lines_line_type"):
+            op.drop_index("ix_sales_order_lines_line_type", table_name="sales_order_lines")
         op.drop_column("sales_order_lines", "line_type")

--- a/backend/migrations/versions/085_add_service_sales_order_lines.py
+++ b/backend/migrations/versions/085_add_service_sales_order_lines.py
@@ -1,0 +1,119 @@
+"""Allow service and fee sales order lines.
+
+Revision ID: 085
+Revises: 084
+Create Date: 2026-06-05
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "085"
+down_revision = "084"
+branch_labels = None
+depends_on = None
+
+
+CHECK_EXPR = (
+    "(line_type = 'product' AND product_id IS NOT NULL AND material_inventory_id IS NULL) OR "
+    "(line_type = 'material' AND product_id IS NULL AND material_inventory_id IS NOT NULL) OR "
+    "(line_type = 'service' AND product_id IS NULL AND material_inventory_id IS NULL)"
+)
+OLD_CHECK_EXPR = (
+    "(product_id IS NOT NULL AND material_inventory_id IS NULL) OR "
+    "(product_id IS NULL AND material_inventory_id IS NOT NULL)"
+)
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return constraint_name in {
+        constraint["name"]
+        for constraint in inspector.get_check_constraints(table_name)
+    }
+
+
+def upgrade() -> None:
+    if not _column_exists("sales_order_lines", "line_type"):
+        op.add_column(
+            "sales_order_lines",
+            sa.Column(
+                "line_type",
+                sa.String(length=20),
+                nullable=False,
+                server_default="product",
+            ),
+        )
+        op.create_index(
+            "ix_sales_order_lines_line_type",
+            "sales_order_lines",
+            ["line_type"],
+        )
+
+    if not _column_exists("sales_order_lines", "description"):
+        op.add_column(
+            "sales_order_lines",
+            sa.Column("description", sa.String(length=255), nullable=True),
+        )
+
+    op.execute(
+        "UPDATE sales_order_lines "
+        "SET line_type = 'material' "
+        "WHERE product_id IS NULL AND material_inventory_id IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE sales_order_lines "
+        "SET line_type = 'product' "
+        "WHERE product_id IS NOT NULL AND material_inventory_id IS NULL"
+    )
+
+    if _constraint_exists("sales_order_lines", "ck_sol_product_or_material"):
+        op.drop_constraint(
+            "ck_sol_product_or_material",
+            "sales_order_lines",
+            type_="check",
+        )
+    op.create_check_constraint(
+        "ck_sol_product_or_material",
+        "sales_order_lines",
+        CHECK_EXPR,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    has_service_lines = bind.execute(
+        sa.text(
+            "SELECT 1 FROM sales_order_lines "
+            "WHERE line_type = 'service' "
+            "LIMIT 1"
+        )
+    ).first()
+    if has_service_lines:
+        raise RuntimeError(
+            "Cannot downgrade: sales_order_lines with line_type='service' exist. "
+            "Delete or convert those rows before downgrading past revision 085."
+        )
+
+    if _constraint_exists("sales_order_lines", "ck_sol_product_or_material"):
+        op.drop_constraint(
+            "ck_sol_product_or_material",
+            "sales_order_lines",
+            type_="check",
+        )
+    op.create_check_constraint(
+        "ck_sol_product_or_material",
+        "sales_order_lines",
+        OLD_CHECK_EXPR,
+    )
+
+    if _column_exists("sales_order_lines", "description"):
+        op.drop_column("sales_order_lines", "description")
+    if _column_exists("sales_order_lines", "line_type"):
+        op.drop_index("ix_sales_order_lines_line_type", table_name="sales_order_lines")
+        op.drop_column("sales_order_lines", "line_type")

--- a/backend/tests/api/v1/test_admin_accounting.py
+++ b/backend/tests/api/v1/test_admin_accounting.py
@@ -225,6 +225,23 @@ class TestOrderCostBreakdown:
         # Revenue = grand_total - tax_amount = 108 - 8 = 100
         assert data["revenue"] == 100.0
 
+    def test_revenue_excludes_shipping(self, client, db, make_sales_order):
+        """Revenue should use order subtotal and keep shipping separate."""
+        so = make_sales_order(
+            quantity=1,
+            unit_price=Decimal("100.00"),
+            tax_amount=Decimal("8.00"),
+        )
+        so.shipping_cost = Decimal("12.00")
+        so.grand_total = Decimal("120.00")
+        db.commit()
+
+        resp = client.get(f"{BASE}/order-cost-breakdown/{so.id}")
+        data = resp.json()
+
+        assert data["revenue"] == 100.0
+        assert data["shipping_expense"] == 12.0
+
 
 # =============================================================================
 # TEST: COGS Summary

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -301,20 +301,20 @@ class TestCreateSalesOrder:
         assert data["status"] == "pending"
         assert data["order_type"] == "line_item"
 
-    def test_create_order_uses_catalog_price(self, client, db, make_product):
-        """Security: backend should use product.selling_price, not frontend-supplied price."""
+    def test_create_order_accepts_manual_line_price(self, client, db, make_product):
+        """Manual/admin order creation can override product catalog price per line."""
         product = make_product(selling_price=Decimal("25.00"))
         db.flush()
 
         response = client.post(BASE_URL, json={
             "lines": [
-                {"product_id": product.id, "quantity": 1, "unit_price": 1.00}
+                {"product_id": product.id, "quantity": 1, "unit_price": 30.00}
             ],
         })
         assert response.status_code == 201
         data = response.json()
-        # Should use catalog price ($25), not submitted price ($1)
-        assert Decimal(str(data["total_price"])) == Decimal("25.00")
+        assert Decimal(str(data["total_price"])) == Decimal("30.00")
+        assert Decimal(str(data["lines"][0]["unit_price"])) == Decimal("30.00")
 
     def test_create_order_missing_lines_fails(self, client):
         response = client.post(BASE_URL, json={

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -96,6 +96,22 @@ def setup_database():
             "ADD COLUMN IF NOT EXISTS material_inventory_id INTEGER "
             "REFERENCES material_inventory(id)"
         ))
+        conn.execute(text(
+            "ALTER TABLE sales_order_lines "
+            "ADD COLUMN IF NOT EXISTS line_type VARCHAR(20) NOT NULL DEFAULT 'product'"
+        ))
+        conn.execute(text(
+            "ALTER TABLE sales_order_lines "
+            "ADD COLUMN IF NOT EXISTS description VARCHAR(255)"
+        ))
+        conn.execute(text(
+            "UPDATE sales_order_lines SET line_type = 'material' "
+            "WHERE product_id IS NULL AND material_inventory_id IS NOT NULL"
+        ))
+        conn.execute(text(
+            "UPDATE sales_order_lines SET line_type = 'product' "
+            "WHERE product_id IS NOT NULL AND material_inventory_id IS NULL"
+        ))
         # Migration 065: widen cost columns
         for col in ("standard_cost", "average_cost", "last_cost"):
             conn.execute(text(
@@ -124,7 +140,6 @@ def setup_database():
             "ALTER TABLE routing_operation_materials "
             "ADD COLUMN IF NOT EXISTS is_variable BOOLEAN NOT NULL DEFAULT FALSE"
         ))
-        # Add CHECK constraint if it doesn't already exist
         conn.execute(text("""
             DO $$
             BEGIN
@@ -134,8 +149,31 @@ def setup_database():
                 ) THEN
                     ALTER TABLE sales_order_lines ADD CONSTRAINT ck_sol_product_or_material
                     CHECK (
-                        (product_id IS NOT NULL AND material_inventory_id IS NULL) OR
-                        (product_id IS NULL AND material_inventory_id IS NOT NULL)
+                        (line_type = 'product' AND product_id IS NOT NULL AND material_inventory_id IS NULL) OR
+                        (line_type = 'material' AND product_id IS NULL AND material_inventory_id IS NOT NULL) OR
+                        (line_type = 'service' AND product_id IS NULL AND material_inventory_id IS NULL)
+                    );
+                END IF;
+            END
+            $$;
+        """))
+        conn.execute(text("""
+            DO $$
+            DECLARE
+                constraint_expr TEXT;
+            BEGIN
+                SELECT pg_get_constraintdef(oid)
+                INTO constraint_expr
+                FROM pg_constraint
+                WHERE conname = 'ck_sol_product_or_material';
+
+                IF constraint_expr IS NOT NULL AND constraint_expr NOT LIKE '%line_type%' THEN
+                    ALTER TABLE sales_order_lines DROP CONSTRAINT ck_sol_product_or_material;
+                    ALTER TABLE sales_order_lines ADD CONSTRAINT ck_sol_product_or_material
+                    CHECK (
+                        (line_type = 'product' AND product_id IS NOT NULL AND material_inventory_id IS NULL) OR
+                        (line_type = 'material' AND product_id IS NULL AND material_inventory_id IS NOT NULL) OR
+                        (line_type = 'service' AND product_id IS NULL AND material_inventory_id IS NULL)
                     );
                 END IF;
             END

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -112,6 +112,10 @@ def setup_database():
             "UPDATE sales_order_lines SET line_type = 'product' "
             "WHERE product_id IS NOT NULL AND material_inventory_id IS NULL"
         ))
+        conn.execute(text(
+            "UPDATE sales_order_lines SET line_type = 'service' "
+            "WHERE product_id IS NULL AND material_inventory_id IS NULL"
+        ))
         # Migration 065: widen cost columns
         for col in ("standard_cost", "average_cost", "last_cost"):
             conn.execute(text(

--- a/backend/tests/services/test_sales_order_line_edit.py
+++ b/backend/tests/services/test_sales_order_line_edit.py
@@ -115,6 +115,61 @@ class TestEditSalesOrderLines:
         assert updated.total_price == Decimal("1040.00")
         assert updated.grand_total == Decimal("1040.00")
 
+    def test_updates_unit_price_and_recalculates(self, db, make_product):
+        """Changing a line unit price updates the line and order totals."""
+        user = _make_user(db)
+        product = make_product(selling_price=Decimal("10.00"))
+        order = _make_order(db, user.id, quantity=3, unit_price=Decimal("10.00"))
+        line = _make_line(db, order.id, product.id, quantity=3, unit_price=Decimal("10.00"))
+        db.commit()
+
+        updated = sales_order_service.edit_sales_order_lines(
+            db,
+            order_id=order.id,
+            line_updates=[
+                {
+                    "line_id": line.id,
+                    "new_quantity": Decimal("3"),
+                    "new_unit_price": Decimal("12.50"),
+                    "reason": "Manual line price adjustment",
+                }
+            ],
+            user_id=user.id,
+        )
+
+        db.refresh(line)
+        assert line.quantity == Decimal("3")
+        assert line.unit_price == Decimal("12.50")
+        assert line.total == Decimal("37.50")
+        assert updated.total_price == Decimal("37.50")
+        assert updated.grand_total == Decimal("37.50")
+
+    def test_rejects_negative_unit_price_edit(self, db, make_product):
+        """Line price edits must not create negative order values."""
+        user = _make_user(db)
+        product = make_product(selling_price=Decimal("10.00"))
+        order = _make_order(db, user.id, quantity=1)
+        line = _make_line(db, order.id, product.id, quantity=1)
+        db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.edit_sales_order_lines(
+                db,
+                order_id=order.id,
+                line_updates=[
+                    {
+                        "line_id": line.id,
+                        "new_quantity": Decimal("1"),
+                        "new_unit_price": Decimal("-1.00"),
+                        "reason": "Invalid price",
+                    }
+                ],
+                user_id=user.id,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "unit price" in exc_info.value.detail.lower()
+
     def test_stores_original_quantity_on_first_edit(self, db, make_product):
         """original_quantity is set on first edit and not overwritten on subsequent edits."""
         user = _make_user(db)

--- a/backend/tests/services/test_sales_order_line_edit.py
+++ b/backend/tests/services/test_sales_order_line_edit.py
@@ -144,6 +144,60 @@ class TestEditSalesOrderLines:
         assert updated.total_price == Decimal("37.50")
         assert updated.grand_total == Decimal("37.50")
 
+    def test_unit_price_edit_does_not_reapply_line_discount(self, db, make_product):
+        """Line discount stores audit data; it is not subtracted again during edits."""
+        user = _make_user(db)
+        product = make_product(selling_price=Decimal("10.00"))
+        order = _make_order(db, user.id, quantity=3, unit_price=Decimal("10.00"))
+        line = _make_line(db, order.id, product.id, quantity=3, unit_price=Decimal("10.00"))
+        line.discount = Decimal("5.00")
+        db.commit()
+
+        updated = sales_order_service.edit_sales_order_lines(
+            db,
+            order_id=order.id,
+            line_updates=[
+                {
+                    "line_id": line.id,
+                    "new_quantity": Decimal("3"),
+                    "new_unit_price": Decimal("12.50"),
+                    "reason": "Manual line price adjustment",
+                }
+            ],
+            user_id=user.id,
+        )
+
+        db.refresh(line)
+        assert line.discount == Decimal("5.00")
+        assert line.total == Decimal("37.50")
+        assert updated.total_price == Decimal("37.50")
+        assert updated.grand_total == Decimal("37.50")
+
+    def test_rejects_fractional_product_quantity_edit(self, db, make_product):
+        """Product-backed sales order lines must remain whole-number quantities."""
+        user = _make_user(db)
+        product = make_product(selling_price=Decimal("10.00"))
+        order = _make_order(db, user.id, quantity=3, unit_price=Decimal("10.00"))
+        line = _make_line(db, order.id, product.id, quantity=3, unit_price=Decimal("10.00"))
+        db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.edit_sales_order_lines(
+                db,
+                order_id=order.id,
+                line_updates=[
+                    {
+                        "line_id": line.id,
+                        "new_quantity": Decimal("1.5"),
+                        "reason": "Invalid fractional product quantity",
+                    }
+                ],
+                user_id=user.id,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "whole number" in exc_info.value.detail.lower()
+
     def test_rejects_negative_unit_price_edit(self, db, make_product):
         """Line price edits must not create negative order values."""
         user = _make_user(db)

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -380,6 +380,81 @@ class TestCreateSalesOrder:
         assert order.quantity == 2
         assert order.grand_total == Decimal("50.00")
 
+    def test_creates_product_line_with_manual_unit_price(self, db, make_product):
+        """Manual walk-in orders can override catalog price per line."""
+        product = make_product(selling_price=Decimal("25.00"))
+        _set_company_tax(db, tax_enabled=False)
+
+        order = sales_order_service.create_sales_order(
+            db,
+            customer_id=None,
+            lines=[{"product_id": product.id, "quantity": 2, "unit_price": Decimal("30.00")}],
+            created_by_user_id=1,
+        )
+
+        db.flush()
+        line = db.query(SalesOrderLine).filter(SalesOrderLine.sales_order_id == order.id).one()
+
+        assert line.unit_price == Decimal("30.00")
+        assert line.total == Decimal("60.00")
+        assert order.total_price == Decimal("60.00")
+        assert order.grand_total == Decimal("60.00")
+
+    def test_creates_one_time_service_fee_line(self, db, make_product):
+        """Manual orders can include non-inventory one-time service or engineering fees."""
+        product = make_product(selling_price=Decimal("25.00"))
+        _set_company_tax(db, tax_enabled=False)
+
+        order = sales_order_service.create_sales_order(
+            db,
+            customer_id=None,
+            lines=[
+                {"product_id": product.id, "quantity": 1},
+                {
+                    "line_type": "service",
+                    "description": "Engineering fee",
+                    "quantity": Decimal("1"),
+                    "unit_price": Decimal("75.00"),
+                },
+            ],
+            created_by_user_id=1,
+        )
+
+        db.flush()
+        lines = db.query(SalesOrderLine).filter(
+            SalesOrderLine.sales_order_id == order.id
+        ).order_by(SalesOrderLine.id).all()
+
+        assert order.product_name == "2 items"
+        assert order.total_price == Decimal("100.00")
+        assert order.grand_total == Decimal("100.00")
+        assert lines[1].product_id is None
+        assert lines[1].material_inventory_id is None
+        assert lines[1].line_type == "service"
+        assert lines[1].description == "Engineering fee"
+        assert lines[1].unit_price == Decimal("75.00")
+
+    def test_rejects_service_fee_without_description(self, db):
+        """One-time fee lines need a description for receipts and accounting review."""
+        _set_company_tax(db, tax_enabled=False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.create_sales_order(
+                db,
+                customer_id=None,
+                lines=[
+                    {
+                        "line_type": "service",
+                        "quantity": Decimal("1"),
+                        "unit_price": Decimal("75.00"),
+                    }
+                ],
+                created_by_user_id=1,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "description" in exc_info.value.detail.lower()
+
     def test_creates_order_with_multiple_lines(self, db, make_product):
         """Creates order with multiple line items and correct totals."""
         p1 = make_product(selling_price=Decimal("10.00"))

--- a/frontend/src/components/SalesOrderWizard.jsx
+++ b/frontend/src/components/SalesOrderWizard.jsx
@@ -616,7 +616,26 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     }
   };
 
-  // Remove line item (works for both product and material lines)
+  // Add one-time service/fee line item
+  const addServiceLineItem = ({ description, quantity, unit_price }) => {
+    const key = `service-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    setLineItems([
+      ...lineItems,
+      {
+        line_type: "service",
+        product_id: null,
+        material_inventory_id: null,
+        product: null,
+        material: null,
+        description: description.trim(),
+        quantity: quantity || 1,
+        unit_price: unit_price || 0,
+        _key: key,
+      },
+    ]);
+  };
+
+  // Remove line item (works for product, material, and service lines)
   const removeLineItem = (key) => {
     setLineItems(lineItems.filter((li) => li._key !== key));
   };
@@ -637,6 +656,15 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     setLineItems(
       lineItems.map((li) =>
         li._key === key ? { ...li, unit_price: price } : li
+      )
+    );
+  };
+
+  // Update one-time service/fee line description
+  const updateLineDescription = (key, description) => {
+    setLineItems(
+      lineItems.map((li) =>
+        li._key === key ? { ...li, description } : li
       )
     );
   };
@@ -993,10 +1021,20 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       for (const item of lineItems) {
         const qtyError = validateQuantity(item.quantity, "Quantity");
         if (qtyError) {
-          const itemName = item.line_type === "material"
-            ? item.material?.name
-            : item.product?.name || item.name;
+          const itemName = item.line_type === "service"
+            ? item.description || "Service line"
+            : item.line_type === "material"
+              ? item.material?.name
+              : item.product?.name || item.name;
           setError(`${itemName}: ${qtyError}`);
+          return false;
+        }
+        if (item.line_type === "service" && !item.description?.trim()) {
+          setError("Service and fee lines require a description");
+          return false;
+        }
+        if (item.unit_price < 0) {
+          setError("Line item prices must be zero or greater");
           return false;
         }
       }
@@ -1026,14 +1064,24 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       const payload = {
         customer_id: orderData.customer_id || null,
         lines: lineItems.map((li) => {
+          if (li.line_type === "service") {
+            return {
+              line_type: "service",
+              description: li.description,
+              quantity: li.quantity,
+              unit_price: li.unit_price,
+            };
+          }
           if (li.line_type === "material") {
             return {
+              line_type: "material",
               material_inventory_id: li.material_inventory_id,
               quantity: li.quantity,
               unit_price: li.unit_price,
             };
           }
           return {
+            line_type: "product",
             product_id: li.product_id,
             quantity: li.quantity,
             unit_price: li.unit_price,
@@ -1226,9 +1274,11 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
               lineItems={lineItems}
               addLineItem={addLineItem}
               addMaterialLineItem={addMaterialLineItem}
+              addServiceLineItem={addServiceLineItem}
               removeLineItem={removeLineItem}
               updateLineQuantity={updateLineQuantity}
               updateLinePrice={updateLinePrice}
+              updateLineDescription={updateLineDescription}
               orderTotal={orderTotal}
               startNewItem={startNewItem}
               materialInventory={materialInventory}

--- a/frontend/src/components/sales-order/ProductSelectionStep.jsx
+++ b/frontend/src/components/sales-order/ProductSelectionStep.jsx
@@ -4,6 +4,7 @@ import ItemCreationWizard from "./ItemCreationWizard";
 const TABS = [
   { id: "products", label: "Finished Goods" },
   { id: "materials", label: "Raw Materials" },
+  { id: "fees", label: "Fees" },
 ];
 
 export default function ProductSelectionStep({
@@ -13,9 +14,11 @@ export default function ProductSelectionStep({
   lineItems,
   addLineItem,
   addMaterialLineItem,
+  addServiceLineItem,
   removeLineItem,
   updateLineQuantity,
   updateLinePrice,
+  updateLineDescription,
   orderTotal,
   startNewItem,
   materialInventory = [],
@@ -27,6 +30,24 @@ export default function ProductSelectionStep({
   itemWizardProps,
 }) {
   const [activeTab, setActiveTab] = useState("products");
+  const [feeDescription, setFeeDescription] = useState("");
+  const [feeQuantity, setFeeQuantity] = useState(1);
+  const [feePrice, setFeePrice] = useState("");
+
+  const handleAddServiceLine = () => {
+    const description = feeDescription.trim();
+    const unitPrice = parseFloat(feePrice);
+    if (!description || Number.isNaN(unitPrice) || unitPrice < 0) return;
+
+    addServiceLineItem({
+      description,
+      quantity: Math.max(1, parseFloat(feeQuantity) || 1),
+      unit_price: unitPrice,
+    });
+    setFeeDescription("");
+    setFeeQuantity(1);
+    setFeePrice("");
+  };
 
   if (showItemWizard) {
     return (
@@ -259,6 +280,65 @@ export default function ProductSelectionStep({
         </>
       )}
 
+      {/* Fees Tab */}
+      {activeTab === "fees" && (
+        <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+          <div className="grid grid-cols-[1fr_96px_140px_auto] gap-3 items-end">
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">
+                Description
+              </label>
+              <input
+                type="text"
+                value={feeDescription}
+                onChange={(e) => setFeeDescription(e.target.value)}
+                placeholder="Engineering fee"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">
+                Qty
+              </label>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                value={feeQuantity}
+                onChange={(e) => setFeeQuantity(parseFloat(e.target.value) || 1)}
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white text-right"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">
+                Unit Price
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={feePrice}
+                onChange={(e) => setFeePrice(e.target.value)}
+                placeholder="75.00"
+                className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white text-right"
+              />
+            </div>
+            <button
+              onClick={handleAddServiceLine}
+              disabled={
+                !feeDescription.trim() ||
+                feePrice === "" ||
+                Number.isNaN(parseFloat(feePrice)) ||
+                parseFloat(feePrice) < 0
+              }
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Selected Line Items */}
       {lineItems.length > 0 && (
         <div className="space-y-2">
@@ -278,17 +358,33 @@ export default function ProductSelectionStep({
                         RAW
                       </span>
                     )}
-                    <div className="text-white font-medium">
+                    {li.line_type === "service" && (
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 border border-cyan-500/30 rounded">
+                        FEE
+                      </span>
+                    )}
+                    {li.line_type === "service" ? (
+                      <input
+                        type="text"
+                        value={li.description || ""}
+                        onChange={(e) => updateLineDescription(li._key, e.target.value)}
+                        className="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-white"
+                      />
+                    ) : (
+                      <div className="text-white font-medium">
+                        {li.line_type === "material"
+                          ? li.material?.name
+                          : li.product?.name}
+                      </div>
+                    )}
+                  </div>
+                  {li.line_type !== "service" && (
+                    <div className="text-gray-500 text-xs font-mono">
                       {li.line_type === "material"
-                        ? li.material?.name
-                        : li.product?.name}
+                        ? li.material?.sku
+                        : li.product?.sku}
                     </div>
-                  </div>
-                  <div className="text-gray-500 text-xs font-mono">
-                    {li.line_type === "material"
-                      ? li.material?.sku
-                      : li.product?.sku}
-                  </div>
+                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   <label className="text-gray-400 text-sm">

--- a/frontend/src/components/sales-order/ReviewStep.jsx
+++ b/frontend/src/components/sales-order/ReviewStep.jsx
@@ -90,10 +90,15 @@ export default function ReviewStep({
           <tbody>
             {lineItems.map((li) => {
               const isMaterial = li.line_type === "material";
-              const name = isMaterial
+              const isService = li.line_type === "service";
+              const name = isService
+                ? li.description
+                : isMaterial
                 ? li.material?.name
                 : li.product?.name;
-              const sku = isMaterial
+              const sku = isService
+                ? "One-time line"
+                : isMaterial
                 ? li.material?.sku
                 : li.product?.sku;
 
@@ -107,6 +112,11 @@ export default function ReviewStep({
                       {isMaterial && (
                         <span className="px-1.5 py-0.5 text-[10px] font-semibold bg-orange-500/20 text-orange-400 border border-orange-500/30 rounded">
                           RAW
+                        </span>
+                      )}
+                      {isService && (
+                        <span className="px-1.5 py-0.5 text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 border border-cyan-500/30 rounded">
+                          FEE
                         </span>
                       )}
                       <div>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -41,7 +41,9 @@ export default function OrderDetail() {
     if (!order?.lines || order.lines.length === 0) {
       return productionOrders.some((po) => po.product_id === order?.product_id);
     }
-    const lineProductIds = order.lines.map((line) => line.product_id);
+    const lineProductIds = order.lines
+      .filter((line) => line.product_id)
+      .map((line) => line.product_id);
     const woProductIds = productionOrders
       .filter((po) => po.sales_order_line_id)
       .map((po) => po.product_id);
@@ -70,6 +72,7 @@ export default function OrderDetail() {
   // Line editing state
   const [editingLineId, setEditingLineId] = useState(null);
   const [editQty, setEditQty] = useState("");
+  const [editPrice, setEditPrice] = useState("");
   const [editReason, setEditReason] = useState("");
   const [savingLineEdit, setSavingLineEdit] = useState(false);
   const [removingLineId, setRemovingLineId] = useState(null);
@@ -428,15 +431,21 @@ export default function OrderDetail() {
   };
 
   const handleSaveLineEdit = async (lineId) => {
-    if (!editQty || !editReason.trim()) return;
+    if ((editQty === "" && editPrice === "") || !editReason.trim()) return;
     setSavingLineEdit(true);
     try {
       await api.patch(`/api/v1/sales-orders/${orderId}/lines`, {
-        lines: [{ line_id: lineId, new_quantity: parseFloat(editQty), reason: editReason }],
+        lines: [{
+          line_id: lineId,
+          new_quantity: editQty !== "" ? parseFloat(editQty) : undefined,
+          new_unit_price: editPrice !== "" ? parseFloat(editPrice) : undefined,
+          reason: editReason,
+        }],
       });
-      toast.success("Line quantity updated");
+      toast.success("Line updated");
       setEditingLineId(null);
       setEditQty("");
+      setEditPrice("");
       setEditReason("");
       fetchOrder();
     } catch (err) {
@@ -447,7 +456,7 @@ export default function OrderDetail() {
   };
 
   const handleRemoveLine = async (line) => {
-    const label = line.product_name || line.material_name || `Line ${line.id}`;
+    const label = line.product_name || line.material_name || line.description || `Line ${line.id}`;
     if (!window.confirm(`Remove "${label}" from this order? This cannot be undone.`)) return;
     setRemovingLineId(line.id);
     try {
@@ -873,13 +882,15 @@ export default function OrderDetail() {
               {order.lines.map((line, idx) => {
                 const isEditing = editingLineId === line.id;
                 const shipped = parseFloat(line.shipped_quantity || 0);
+                const lineLabel = line.product_name || line.material_name || line.description || "One-time line";
+                const lineCode = line.product_sku || line.material_sku || line.sku || (line.line_type === "service" ? "FEE" : "\u2014");
                 return (
                   <tr key={line.id || idx}>
                     <td className="py-2 px-3 text-white">
-                      {line.product_name || line.material_name || "N/A"}
+                      {lineLabel}
                     </td>
                     <td className="py-2 px-3 text-gray-400 font-mono text-xs">
-                      {line.product_sku || line.sku || "\u2014"}
+                      {lineCode}
                     </td>
                     <td className="py-2 px-3 text-right text-white">
                       {isEditing ? (
@@ -905,7 +916,18 @@ export default function OrderDetail() {
                       {shipped > 0 ? shipped : "\u2014"}
                     </td>
                     <td className="py-2 px-3 text-right text-gray-300">
-                      ${parseFloat(line.unit_price || 0).toFixed(2)}
+                      {isEditing ? (
+                        <input
+                          type="number"
+                          value={editPrice}
+                          onChange={(e) => setEditPrice(e.target.value)}
+                          min="0"
+                          step="0.01"
+                          className="w-24 bg-gray-800 border border-blue-500 rounded px-2 py-1 text-right text-white text-sm"
+                        />
+                      ) : (
+                        `$${parseFloat(line.unit_price || 0).toFixed(2)}`
+                      )}
                     </td>
                     <td className="py-2 px-3 text-right text-green-400 font-medium">
                       ${parseFloat(line.total || 0).toFixed(2)}
@@ -916,14 +938,14 @@ export default function OrderDetail() {
                           <div className="flex gap-1 justify-center">
                             <button
                               onClick={() => handleSaveLineEdit(line.id)}
-                              disabled={savingLineEdit || !editQty || !editReason.trim()}
+                              disabled={savingLineEdit || (editQty === "" && editPrice === "") || !editReason.trim()}
                               className="text-green-400 hover:text-green-300 disabled:opacity-50 text-xs"
                               title="Save"
                             >
                               {savingLineEdit ? "..." : "\u2713"}
                             </button>
                             <button
-                              onClick={() => { setEditingLineId(null); setEditQty(""); setEditReason(""); }}
+                              onClick={() => { setEditingLineId(null); setEditQty(""); setEditPrice(""); setEditReason(""); }}
                               className="text-gray-400 hover:text-white text-xs"
                               title="Cancel"
                             >
@@ -933,9 +955,14 @@ export default function OrderDetail() {
                         ) : (
                           <div className="flex gap-2 justify-center">
                             <button
-                              onClick={() => { setEditingLineId(line.id); setEditQty(String(line.quantity)); setEditReason(""); }}
+                              onClick={() => {
+                                setEditingLineId(line.id);
+                                setEditQty(String(line.quantity));
+                                setEditPrice(String(line.unit_price || 0));
+                                setEditReason("");
+                              }}
                               className="text-gray-500 hover:text-blue-400 text-xs"
-                              title="Edit quantity"
+                              title="Edit line"
                             >
                               Edit
                             </button>


### PR DESCRIPTION
## Summary
- allow direct/manual sales orders to use explicit per-line pricing for product lines
- add non-inventory `service` sales order lines for one-time fees such as engineering or service charges
- expose service/fee lines in the create-order wizard and review screen, and allow line unit price edits from order detail
- keep service fees in order revenue/payment totals while avoiding inventory/WO treatment
- fix order cost breakdown revenue so shipping is not counted as revenue

## Accounting impact
- Service/engineering fees are stored as normal sales order lines and roll into `order.total_price`, `grand_total`, payment outstanding, and customer/order totals.
- They are not inventory-backed and do not create COGS.
- Shipping remains separate as an operating expense in the order cost breakdown instead of inflating revenue/gross margin.

## Verification
- `python -m compileall backend/app/models/sales_order.py backend/app/schemas/sales_order.py backend/app/api/v1/endpoints/sales_orders.py backend/app/services/sales_order_service.py backend/app/api/v1/endpoints/admin/accounting.py backend/migrations/versions/085_add_service_sales_order_lines.py backend/tests/conftest.py backend/tests/services/test_sales_order_service.py backend/tests/services/test_sales_order_line_edit.py backend/tests/api/v1/test_admin_accounting.py`
- backend schema smoke test for `SalesOrderLineCreate(line_type="service")` and `SalesOrderLineUpdate(new_unit_price=...)`
- `npm ci`
- `npm run build`

## Known local limitations
- Focused backend pytest attempts are blocked locally by `filaops_test` Postgres auth failure for user `postgres`; CircleCI should be the backend authority.
- Full frontend lint is blocked by existing repo-wide React compiler lint failures in files outside this change and pre-existing failures in `SalesOrderWizard.jsx`/`OrderDetail.jsx`; production build passes.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-direct-order-lines-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add one-time service/fee line items with description and per-line pricing.
  * Allow editing a line’s unit price (in addition to quantity) when modifying orders; frontend supports adding/editing service lines.

* **Bug Fixes**
  * Adjusted gross-margin revenue to exclude tax; shipping is reported separately.

* **Tests**
  * Added tests covering service lines, manual per-line pricing, and unit-price edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->