### PR TITLE
fix: support quote fee lines and order shipping

### DIFF
--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -236,12 +236,13 @@ def create_quote(db: Session, request, user_id: int) -> Quote:
         subtotal = Decimal("0")
         for line in request.lines:
             line_price = Decimal(str(line.unit_price)).quantize(Decimal("0.01"))
-            if discount_percent and discount_percent > 0:
+            if line.product_id and discount_percent and discount_percent > 0:
                 line_price = (line_price * (Decimal("1") - discount_percent / Decimal("100"))).quantize(Decimal("0.01"))
             subtotal += line_price * line.quantity
-        # Use first line's product for header-level backward compat
-        header_product_name = request.lines[0].product_name
-        header_product_id = request.lines[0].product_id
+        # Use the first product line for header-level backward compat, else first line.
+        header_line = next((line for line in request.lines if line.product_id), request.lines[0])
+        header_product_name = header_line.product_name
+        header_product_id = header_line.product_id
         header_quantity = sum(line.quantity for line in request.lines)
         header_unit_price = None  # Multi-line: no single unit price
     else:
@@ -315,7 +316,7 @@ def create_quote(db: Session, request, user_id: int) -> Quote:
         for idx, line_data in enumerate(request.lines, start=1):
             line_price = Decimal(str(line_data.unit_price)).quantize(Decimal("0.01"))
             line_discount = None
-            if discount_percent and discount_percent > 0:
+            if line_data.product_id and discount_percent and discount_percent > 0:
                 line_price = (line_price * (Decimal("1") - discount_percent / Decimal("100"))).quantize(Decimal("0.01"))
                 line_discount = discount_percent
             line = QuoteLine(
@@ -432,7 +433,7 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
             ld = line_data if isinstance(line_data, dict) else line_data.model_dump()
             line_price = Decimal(str(ld["unit_price"])).quantize(Decimal("0.01"))
             line_discount = None
-            if discount_percent and discount_percent > 0:
+            if ld.get("product_id") and discount_percent and discount_percent > 0:
                 line_price = (line_price * (Decimal("1") - discount_percent / Decimal("100"))).quantize(Decimal("0.01"))
                 line_discount = discount_percent
             line_total = (line_price * ld["quantity"]).quantize(Decimal("0.01"))
@@ -454,7 +455,14 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
             db.add(line)
 
         # Update header from lines
-        quote.product_name = lines_data[0]["product_name"] if isinstance(lines_data[0], dict) else lines_data[0].product_name
+        header_line = next(
+            (
+                line for line in lines_data
+                if (line.get("product_id") if isinstance(line, dict) else line.product_id)
+            ),
+            lines_data[0],
+        )
+        quote.product_name = header_line["product_name"] if isinstance(header_line, dict) else header_line.product_name
         quote.quantity = sum(ld["quantity"] if isinstance(ld, dict) else ld.quantity for ld in lines_data)
         quote.unit_price = None
         quote.subtotal = subtotal
@@ -657,7 +665,7 @@ def convert_quote_to_order(db: Session, quote_id: int) -> dict:
         quantity=quote.quantity,
         material_type=quote.material_type or "PLA",
         finish=quote.finish or "standard",
-        unit_price=quote.unit_price,
+        unit_price=quote.unit_price if quote.unit_price is not None else Decimal("0"),
         total_price=subtotal,
         tax_amount=tax,
         tax_rate=quote.tax_rate,
@@ -684,20 +692,15 @@ def convert_quote_to_order(db: Session, quote_id: int) -> dict:
 
     # Create SalesOrderLines for multi-line quotes
     if has_lines:
-        # Validate: ck_sol_product_or_material requires product_id to be set
-        missing = [ql.product_name for ql in quote.lines if not ql.product_id]
-        if missing:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Cannot convert: line(s) missing product link: {', '.join(missing)}. "
-                       "Edit the quote and select a product from the catalog for each line."
-            )
-
         for ql in quote.lines:
-            # unit_price is already net (discount applied), so discount=0
+            # unit_price is already net (discount applied), so discount=0.
+            # Product-less quote lines are one-time service/fee lines.
+            is_service_line = ql.product_id is None
             sol = SalesOrderLine(
                 sales_order_id=sales_order.id,
-                product_id=ql.product_id,
+                line_type="service" if is_service_line else "product",
+                product_id=None if is_service_line else ql.product_id,
+                description=ql.product_name if is_service_line else None,
                 quantity=ql.quantity,
                 unit_price=ql.unit_price,
                 discount=Decimal("0"),

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -24,7 +24,7 @@ from types import SimpleNamespace
 from fastapi import HTTPException
 
 from app.services import quote_service
-from app.models.quote import Quote
+from app.models.quote import Quote, QuoteLine
 from app.models.company_settings import CompanySettings
 from app.models.user import User
 from app.models.sales_order import SalesOrder
@@ -551,6 +551,60 @@ class TestConvertQuoteToOrder:
         assert order.tax_amount == Decimal("8.25")
         assert order.tax_rate == Decimal("0.0825")
         assert order.grand_total == Decimal("113.25")
+
+    def test_converts_product_and_fee_lines(self, db, make_product):
+        product = make_product(name="Standard Widget", selling_price=Decimal("20.00"))
+        q = _make_quote(
+            db,
+            quote_number="Q-CONV-FEE-01",
+            status="approved",
+            product_name="Standard Widget",
+            product_id=None,
+            quantity=2,
+            unit_price=None,
+            subtotal=Decimal("90.00"),
+            total_price=Decimal("95.00"),
+            shipping_cost=Decimal("5.00"),
+        )
+        db.add_all([
+            QuoteLine(
+                quote_id=q.id,
+                product_id=product.id,
+                line_number=1,
+                product_name="Standard Widget",
+                quantity=2,
+                unit_price=Decimal("20.00"),
+                total=Decimal("40.00"),
+            ),
+            QuoteLine(
+                quote_id=q.id,
+                product_id=None,
+                line_number=2,
+                product_name="Engineering fee",
+                quantity=1,
+                unit_price=Decimal("50.00"),
+                total=Decimal("50.00"),
+                notes="CAD cleanup",
+            ),
+        ])
+        db.flush()
+
+        result = quote_service.convert_quote_to_order(db, q.id)
+        order = db.query(SalesOrder).filter(SalesOrder.id == result["order_id"]).first()
+
+        assert order.total_price == Decimal("90.00")
+        assert order.shipping_cost == Decimal("5.00")
+        assert order.grand_total == Decimal("95.00")
+
+        product_line = next(line for line in order.lines if line.product_id == product.id)
+        fee_line = next(line for line in order.lines if line.line_type == "service")
+        assert product_line.line_type == "product"
+        assert product_line.total == Decimal("40.00")
+        assert fee_line.description == "Engineering fee"
+        assert fee_line.quantity == Decimal("1")
+        assert fee_line.unit_price == Decimal("50.00")
+        assert fee_line.total == Decimal("50.00")
+        assert fee_line.notes == "CAD cleanup"
 
 
 # =============================================================================

--- a/frontend/src/components/SalesOrderWizard.jsx
+++ b/frontend/src/components/SalesOrderWizard.jsx
@@ -1064,6 +1064,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     setError(null);
 
     try {
+      const parsedShippingCost = parseFloat(orderData.shipping_cost);
       const payload = {
         customer_id: orderData.customer_id || null,
         lines: lineItems.map((li) => {
@@ -1095,7 +1096,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
         shipping_city: orderData.shipping_city || null,
         shipping_state: orderData.shipping_state || null,
         shipping_zip: orderData.shipping_zip || null,
-        shipping_cost: orderData.shipping_cost ? parseFloat(orderData.shipping_cost) : 0,
+        shipping_cost: Number.isNaN(parsedShippingCost) ? 0 : parsedShippingCost,
         customer_notes: orderData.customer_notes || null,
       };
 

--- a/frontend/src/components/SalesOrderWizard.jsx
+++ b/frontend/src/components/SalesOrderWizard.jsx
@@ -86,6 +86,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
     shipping_city: "",
     shipping_state: "",
     shipping_zip: "",
+    shipping_cost: "",
     customer_notes: "",
   });
 
@@ -174,6 +175,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
             shipping_city: data.shipping_city || "",
             shipping_state: data.shipping_state || "",
             shipping_zip: data.shipping_zip || "",
+            shipping_cost: data.shipping_cost || "",
             customer_notes: data.customer_notes || "",
           });
           setLineItems(data.lineItems || []);
@@ -681,6 +683,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
         shipping_city: orderData.shipping_city,
         shipping_state: orderData.shipping_state,
         shipping_zip: orderData.shipping_zip,
+        shipping_cost: orderData.shipping_cost,
         customer_notes: orderData.customer_notes,
         lineItems: lineItems,
         currentStep: currentStep,
@@ -1092,6 +1095,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
         shipping_city: orderData.shipping_city || null,
         shipping_state: orderData.shipping_state || null,
         shipping_zip: orderData.shipping_zip || null,
+        shipping_cost: orderData.shipping_cost ? parseFloat(orderData.shipping_cost) : 0,
         customer_notes: orderData.customer_notes || null,
       };
 
@@ -1128,6 +1132,7 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
       shipping_city: "",
       shipping_state: "",
       shipping_zip: "",
+      shipping_cost: "",
       customer_notes: "",
     });
     setLineItems([]);
@@ -1241,28 +1246,56 @@ export default function SalesOrderWizard({ isOpen, onClose, onSuccess }) {
         <div className="flex-1 overflow-auto p-6">
           {/* Step 1: Customer */}
           {currentStep === 1 && (
-            <CustomerSelectionStep
-              customers={customers}
-              orderData={orderData}
-              setOrderData={setOrderData}
-              selectedCustomer={selectedCustomer}
-              onNavigateToNewCustomer={() => {
-                sessionStorage.setItem(
-                  "pendingOrderData",
-                  JSON.stringify({
-                    customer_id: orderData.customer_id,
-                    shipping_address_line1: orderData.shipping_address_line1,
-                    shipping_city: orderData.shipping_city,
-                    shipping_state: orderData.shipping_state,
-                    shipping_zip: orderData.shipping_zip,
-                    customer_notes: orderData.customer_notes,
-                    lineItems: lineItems,
-                    currentStep: currentStep,
-                  })
-                );
-                navigate("/admin/customers?action=new&returnTo=order");
-              }}
-            />
+            <div className="space-y-6">
+              <CustomerSelectionStep
+                customers={customers}
+                orderData={orderData}
+                setOrderData={setOrderData}
+                selectedCustomer={selectedCustomer}
+                onNavigateToNewCustomer={() => {
+                  sessionStorage.setItem(
+                    "pendingOrderData",
+                    JSON.stringify({
+                      customer_id: orderData.customer_id,
+                      shipping_address_line1: orderData.shipping_address_line1,
+                      shipping_city: orderData.shipping_city,
+                      shipping_state: orderData.shipping_state,
+                      shipping_zip: orderData.shipping_zip,
+                      shipping_cost: orderData.shipping_cost,
+                      customer_notes: orderData.customer_notes,
+                      lineItems: lineItems,
+                      currentStep: currentStep,
+                    })
+                  );
+                  navigate("/admin/customers?action=new&returnTo=order");
+                }}
+              />
+              <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
+                <h4 className="text-md font-medium text-white mb-3">
+                  Shipping Charge
+                </h4>
+                <label className="block text-sm text-gray-400 mb-1">
+                  Shipping Cost
+                </label>
+                <div className="relative w-44">
+                  <span className="absolute left-3 top-2 text-gray-400">$</span>
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={orderData.shipping_cost}
+                    onChange={(e) =>
+                      setOrderData({
+                        ...orderData,
+                        shipping_cost: e.target.value,
+                      })
+                    }
+                    placeholder="0.00"
+                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 pl-7 text-white"
+                  />
+                </div>
+              </div>
+            </div>
           )}
 
           {/* Step 2: Products */}

--- a/frontend/src/components/quotes/QuoteFormModal.jsx
+++ b/frontend/src/components/quotes/QuoteFormModal.jsx
@@ -241,6 +241,13 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
     );
   };
 
+  const handleTabKeyDown = (e) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      setActiveLineTab((current) => (current === "products" ? "fees" : "products"));
+    }
+  };
+
   const handleCustomerSelect = (e) => {
     const customerId = e.target.value ? parseInt(e.target.value) : null;
     if (customerId) {
@@ -266,8 +273,13 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
     }
 
     for (const li of lineItems) {
-      if (!li.product_name || li.unit_price === "" || li.unit_price === null || isNaN(Number(li.unit_price))) {
+      const unitPrice = Number(li.unit_price);
+      if (!li.product_name || li.unit_price === "" || li.unit_price === null || Number.isNaN(unitPrice)) {
         toast.error("Each line item needs a description and unit price");
+        return;
+      }
+      if (unitPrice < 0) {
+        toast.error("Line item unit prices cannot be negative");
         return;
       }
     }
@@ -346,10 +358,14 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
   };
 
   // Calculate totals
-  const subtotal = lineItems.reduce(
-    (sum, li) => sum + (parseFloat(li.unit_price) || 0) * (li.quantity || 1),
-    0
-  );
+  const discountPercent = parseFloat(customerDiscount) || 0;
+  const subtotal = lineItems.reduce((sum, li) => {
+    let linePrice = parseFloat(li.unit_price) || 0;
+    if (li.line_type === "product" && discountPercent > 0) {
+      linePrice *= 1 - discountPercent / 100;
+    }
+    return sum + linePrice * (li.quantity || 1);
+  }, 0);
   const taxRate = form.apply_tax && companySettings?.tax_rate_percent ? companySettings.tax_rate_percent / 100 : 0;
   const taxAmount = subtotal * taxRate;
   const shippingCost = parseFloat(form.shipping_cost) || 0;
@@ -392,10 +408,19 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                 </p>
               </div>
 
-              <div className="flex gap-1 bg-gray-800 p-1 rounded-lg">
+              <div
+                role="tablist"
+                aria-label="Quote line item type"
+                className="flex gap-1 bg-gray-800 p-1 rounded-lg"
+              >
                 <button
                   type="button"
+                  role="tab"
+                  id="products-tab"
+                  aria-selected={activeLineTab === "products"}
+                  aria-controls="products-panel"
                   onClick={() => setActiveLineTab("products")}
+                  onKeyDown={handleTabKeyDown}
                   className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                     activeLineTab === "products"
                       ? "bg-blue-600 text-white"
@@ -406,7 +431,12 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                 </button>
                 <button
                   type="button"
+                  role="tab"
+                  id="fees-tab"
+                  aria-selected={activeLineTab === "fees"}
+                  aria-controls="fees-panel"
                   onClick={() => setActiveLineTab("fees")}
+                  onKeyDown={handleTabKeyDown}
                   className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                     activeLineTab === "fees"
                       ? "bg-blue-600 text-white"
@@ -419,75 +449,85 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
 
               {/* Product Search */}
               {activeLineTab === "products" && (
-                <div className="relative">
-                  <input
-                    type="text"
-                    placeholder="Search products by SKU or name..."
-                    value={productSearch}
-                    onChange={(e) => setProductSearch(e.target.value)}
-                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white pl-10"
-                  />
-                  <svg
-                    className="w-5 h-5 absolute left-3 top-3.5 text-gray-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                <div
+                  role="tabpanel"
+                  id="products-panel"
+                  aria-labelledby="products-tab"
+                  className="space-y-3"
+                >
+                  <div className="relative">
+                    <input
+                      type="text"
+                      placeholder="Search products by SKU or name..."
+                      value={productSearch}
+                      onChange={(e) => setProductSearch(e.target.value)}
+                      className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white pl-10"
                     />
-                  </svg>
-                </div>
-              )}
+                    <svg
+                      className="w-5 h-5 absolute left-3 top-3.5 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                      />
+                    </svg>
+                  </div>
 
-              {/* Product Grid */}
-              {activeLineTab === "products" && (
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-3 max-h-[300px] overflow-auto">
-                  {loading ? (
-                    <div className="col-span-full flex justify-center py-8">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-                    </div>
-                  ) : filteredProducts.length === 0 ? (
-                    <div className="col-span-full text-center py-8 text-gray-500">
-                      {productSearch.trim()
-                        ? `No products found matching "${productSearch}"`
-                        : "No finished goods available."}
-                    </div>
-                  ) : (
-                    filteredProducts.map((product) => {
-                      const inCart = lineItems.some((li) => li.product_id === product.id);
-                      return (
-                        <button
-                          key={product.id}
-                          onClick={() => handleAddProduct(product)}
-                          className={`text-left p-4 bg-gray-800 border rounded-lg hover:border-blue-500 transition-colors ${
-                            inCart ? "border-blue-500 bg-blue-900/20" : "border-gray-700"
-                          }`}
-                        >
-                          <div className="text-white font-medium truncate">{product.name}</div>
-                          <div className="text-gray-500 text-xs font-mono mt-1">{product.sku}</div>
-                          <div className="flex justify-between items-center mt-2">
-                            <span className="text-green-400 font-medium">
-                              ${parseFloat(product.selling_price || 0).toFixed(2)}
-                            </span>
-                            {inCart && (
-                              <span className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">
-                                Added
+                  {/* Product Grid */}
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3 max-h-[300px] overflow-auto">
+                    {loading ? (
+                      <div className="col-span-full flex justify-center py-8">
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+                      </div>
+                    ) : filteredProducts.length === 0 ? (
+                      <div className="col-span-full text-center py-8 text-gray-500">
+                        {productSearch.trim()
+                          ? `No products found matching "${productSearch}"`
+                          : "No finished goods available."}
+                      </div>
+                    ) : (
+                      filteredProducts.map((product) => {
+                        const inCart = lineItems.some((li) => li.product_id === product.id);
+                        return (
+                          <button
+                            key={product.id}
+                            onClick={() => handleAddProduct(product)}
+                            className={`text-left p-4 bg-gray-800 border rounded-lg hover:border-blue-500 transition-colors ${
+                              inCart ? "border-blue-500 bg-blue-900/20" : "border-gray-700"
+                            }`}
+                          >
+                            <div className="text-white font-medium truncate">{product.name}</div>
+                            <div className="text-gray-500 text-xs font-mono mt-1">{product.sku}</div>
+                            <div className="flex justify-between items-center mt-2">
+                              <span className="text-green-400 font-medium">
+                                ${parseFloat(product.selling_price || 0).toFixed(2)}
                               </span>
-                            )}
-                          </div>
-                        </button>
-                      );
-                    })
-                  )}
+                              {inCart && (
+                                <span className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">
+                                  Added
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
                 </div>
               )}
 
               {activeLineTab === "fees" && (
-                <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+                <div
+                  role="tabpanel"
+                  id="fees-panel"
+                  aria-labelledby="fees-tab"
+                  className="bg-gray-800/50 border border-gray-700 rounded-lg p-4"
+                >
                   <div className="grid grid-cols-1 sm:grid-cols-[1fr_96px_140px_auto] gap-3 items-end">
                     <div>
                       <label className="block text-xs font-medium text-gray-400 mb-1">
@@ -849,12 +889,6 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                   <span className="text-gray-400">Subtotal ({lineItems.length} item{lineItems.length !== 1 ? "s" : ""}):</span>
                   <span className="text-white">${subtotal.toFixed(2)}</span>
                 </div>
-                {customerDiscount && (
-                  <div className="flex justify-between items-center text-sm">
-                    <span className="text-green-400">Customer Discount ({customerDiscount}%):</span>
-                    <span className="text-green-400">Applied to line prices</span>
-                  </div>
-                )}
                 {form.apply_tax && taxAmount > 0 && (
                   <div className="flex justify-between items-center text-sm">
                     <span className="text-gray-400">

--- a/frontend/src/components/quotes/QuoteFormModal.jsx
+++ b/frontend/src/components/quotes/QuoteFormModal.jsx
@@ -20,6 +20,10 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
   const [companySettings, setCompanySettings] = useState(null);
   const [taxRates, setTaxRates] = useState([]);
   const [productSearch, setProductSearch] = useState("");
+  const [activeLineTab, setActiveLineTab] = useState("products");
+  const [feeDescription, setFeeDescription] = useState("");
+  const [feeQuantity, setFeeQuantity] = useState(1);
+  const [feePrice, setFeePrice] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saveAsCustomer, setSaveAsCustomer] = useState(false);
@@ -28,6 +32,7 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
   const [lineItems, setLineItems] = useState(() => {
     if (quote?.lines?.length > 0) {
       return quote.lines.map((l) => ({
+        line_type: l.product_id ? "product" : "service",
         product_id: l.product_id,
         product_name: l.product_name,
         product_sku: "",
@@ -40,6 +45,7 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
     }
     if (quote?.product_name) {
       return [{
+        line_type: "product",
         product_id: quote.product_id,
         product_name: quote.product_name,
         product_sku: "",
@@ -188,6 +194,7 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
         ...prev,
         {
           product_id: product.id,
+          line_type: "product",
           product_name: product.name,
           product_sku: product.sku,
           quantity: 1,
@@ -198,6 +205,30 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
         },
       ];
     });
+  };
+
+  const handleAddFeeLine = () => {
+    const description = feeDescription.trim();
+    const unitPrice = parseFloat(feePrice);
+    if (!description || Number.isNaN(unitPrice) || unitPrice < 0) return;
+
+    setLineItems((prev) => [
+      ...prev,
+      {
+        line_type: "service",
+        product_id: null,
+        product_name: description,
+        product_sku: "",
+        quantity: Math.max(1, parseInt(feeQuantity, 10) || 1),
+        unit_price: unitPrice.toFixed(2),
+        material_type: "",
+        color: "",
+        notes: "",
+      },
+    ]);
+    setFeeDescription("");
+    setFeeQuantity(1);
+    setFeePrice("");
   };
 
   const handleRemoveLine = (index) => {
@@ -230,13 +261,13 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (lineItems.length === 0) {
-      toast.error("Add at least one product");
+      toast.error("Add at least one line item");
       return;
     }
 
     for (const li of lineItems) {
       if (!li.product_name || li.unit_price === "" || li.unit_price === null || isNaN(Number(li.unit_price))) {
-        toast.error("Each line item needs a product name and unit price");
+        toast.error("Each line item needs a description and unit price");
         return;
       }
     }
@@ -285,7 +316,7 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
     // Build payload with lines array
     const payload = {
       lines: lineItems.map((li) => ({
-        product_id: li.product_id || null,
+        product_id: li.line_type === "service" ? null : li.product_id || null,
         product_name: li.product_name,
         quantity: li.quantity,
         unit_price: parseFloat(li.unit_price),
@@ -351,7 +382,7 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
               <div>
                 <h4 className="text-white font-medium mb-2">Add Products</h4>
                 <p className="text-gray-400 text-sm mb-4">
-                  Select products for this quote, or{" "}
+                  Select products or add one-time fees for this quote, or{" "}
                   <button
                     onClick={() => navigate("/admin/items?action=new")}
                     className="text-blue-400 hover:underline"
@@ -361,70 +392,158 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                 </p>
               </div>
 
-              {/* Product Search */}
-              <div className="relative">
-                <input
-                  type="text"
-                  placeholder="Search products by SKU or name..."
-                  value={productSearch}
-                  onChange={(e) => setProductSearch(e.target.value)}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white pl-10"
-                />
-                <svg
-                  className="w-5 h-5 absolute left-3 top-3.5 text-gray-500"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+              <div className="flex gap-1 bg-gray-800 p-1 rounded-lg">
+                <button
+                  type="button"
+                  onClick={() => setActiveLineTab("products")}
+                  className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                    activeLineTab === "products"
+                      ? "bg-blue-600 text-white"
+                      : "text-gray-400 hover:text-white hover:bg-gray-700"
+                  }`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
-                </svg>
+                  Products
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveLineTab("fees")}
+                  className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                    activeLineTab === "fees"
+                      ? "bg-blue-600 text-white"
+                      : "text-gray-400 hover:text-white hover:bg-gray-700"
+                  }`}
+                >
+                  Fees
+                </button>
               </div>
 
+              {/* Product Search */}
+              {activeLineTab === "products" && (
+                <div className="relative">
+                  <input
+                    type="text"
+                    placeholder="Search products by SKU or name..."
+                    value={productSearch}
+                    onChange={(e) => setProductSearch(e.target.value)}
+                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white pl-10"
+                  />
+                  <svg
+                    className="w-5 h-5 absolute left-3 top-3.5 text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                </div>
+              )}
+
               {/* Product Grid */}
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 max-h-[300px] overflow-auto">
-                {loading ? (
-                  <div className="col-span-full flex justify-center py-8">
-                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-                  </div>
-                ) : filteredProducts.length === 0 ? (
-                  <div className="col-span-full text-center py-8 text-gray-500">
-                    {productSearch.trim()
-                      ? `No products found matching "${productSearch}"`
-                      : "No finished goods available."}
-                  </div>
-                ) : (
-                  filteredProducts.map((product) => {
-                    const inCart = lineItems.some((li) => li.product_id === product.id);
-                    return (
-                      <button
-                        key={product.id}
-                        onClick={() => handleAddProduct(product)}
-                        className={`text-left p-4 bg-gray-800 border rounded-lg hover:border-blue-500 transition-colors ${
-                          inCart ? "border-blue-500 bg-blue-900/20" : "border-gray-700"
-                        }`}
-                      >
-                        <div className="text-white font-medium truncate">{product.name}</div>
-                        <div className="text-gray-500 text-xs font-mono mt-1">{product.sku}</div>
-                        <div className="flex justify-between items-center mt-2">
-                          <span className="text-green-400 font-medium">
-                            ${parseFloat(product.selling_price || 0).toFixed(2)}
-                          </span>
-                          {inCart && (
-                            <span className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">
-                              Added
+              {activeLineTab === "products" && (
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-3 max-h-[300px] overflow-auto">
+                  {loading ? (
+                    <div className="col-span-full flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+                    </div>
+                  ) : filteredProducts.length === 0 ? (
+                    <div className="col-span-full text-center py-8 text-gray-500">
+                      {productSearch.trim()
+                        ? `No products found matching "${productSearch}"`
+                        : "No finished goods available."}
+                    </div>
+                  ) : (
+                    filteredProducts.map((product) => {
+                      const inCart = lineItems.some((li) => li.product_id === product.id);
+                      return (
+                        <button
+                          key={product.id}
+                          onClick={() => handleAddProduct(product)}
+                          className={`text-left p-4 bg-gray-800 border rounded-lg hover:border-blue-500 transition-colors ${
+                            inCart ? "border-blue-500 bg-blue-900/20" : "border-gray-700"
+                          }`}
+                        >
+                          <div className="text-white font-medium truncate">{product.name}</div>
+                          <div className="text-gray-500 text-xs font-mono mt-1">{product.sku}</div>
+                          <div className="flex justify-between items-center mt-2">
+                            <span className="text-green-400 font-medium">
+                              ${parseFloat(product.selling_price || 0).toFixed(2)}
                             </span>
-                          )}
-                        </div>
-                      </button>
-                    );
-                  })
-                )}
-              </div>
+                            {inCart && (
+                              <span className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">
+                                Added
+                              </span>
+                            )}
+                          </div>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              )}
+
+              {activeLineTab === "fees" && (
+                <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-[1fr_96px_140px_auto] gap-3 items-end">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-400 mb-1">
+                        Description
+                      </label>
+                      <input
+                        type="text"
+                        value={feeDescription}
+                        onChange={(e) => setFeeDescription(e.target.value)}
+                        placeholder="Engineering fee"
+                        className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-400 mb-1">
+                        Qty
+                      </label>
+                      <input
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={feeQuantity}
+                        onChange={(e) => setFeeQuantity(parseInt(e.target.value, 10) || 1)}
+                        className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white text-right"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-400 mb-1">
+                        Unit Price
+                      </label>
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={feePrice}
+                        onChange={(e) => setFeePrice(e.target.value)}
+                        placeholder="75.00"
+                        className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white text-right"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleAddFeeLine}
+                      disabled={
+                        !feeDescription.trim() ||
+                        feePrice === "" ||
+                        Number.isNaN(parseFloat(feePrice)) ||
+                        parseFloat(feePrice) < 0
+                      }
+                      className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {/* Selected Items Table */}
               {lineItems.length > 0 && (
@@ -436,8 +555,24 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                     {lineItems.map((li, idx) => (
                       <div key={idx} className="p-3 flex items-center gap-4">
                         <div className="flex-1 min-w-0">
-                          <div className="text-white font-medium truncate">{li.product_name}</div>
-                          {li.product_sku && (
+                          <div className="flex items-center gap-2">
+                            {li.line_type === "service" && (
+                              <span className="px-1.5 py-0.5 text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 border border-cyan-500/30 rounded">
+                                FEE
+                              </span>
+                            )}
+                            {li.line_type === "service" ? (
+                              <input
+                                type="text"
+                                value={li.product_name}
+                                onChange={(e) => handleUpdateLine(idx, "product_name", e.target.value)}
+                                className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1 text-white text-sm"
+                              />
+                            ) : (
+                              <div className="text-white font-medium truncate">{li.product_name}</div>
+                            )}
+                          </div>
+                          {li.line_type !== "service" && li.product_sku && (
                             <div className="text-gray-500 text-xs">{li.product_sku}</div>
                           )}
                         </div>
@@ -528,8 +663,13 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
                   <div className="space-y-1">
                     {lineItems.map((li, idx) => (
                       <div key={idx} className="flex justify-between text-sm">
-                        <span className="text-gray-300 truncate">
-                          {li.product_name} x{li.quantity}
+                        <span className="text-gray-300 truncate flex items-center gap-2">
+                          {li.line_type === "service" && (
+                            <span className="px-1.5 py-0.5 text-[10px] font-semibold bg-cyan-500/20 text-cyan-300 border border-cyan-500/30 rounded">
+                              FEE
+                            </span>
+                          )}
+                          <span>{li.product_name} x{li.quantity}</span>
                         </span>
                         <span className="text-gray-400">
                           ${((parseFloat(li.unit_price) || 0) * li.quantity).toFixed(2)}


### PR DESCRIPTION
## Summary
- allow manual quotes to include one-time fee/service lines alongside catalog products
- preserve those fee lines when converting an approved quote into a sales order
- add a shipping cost field to direct/manual order creation so phone or walk-in orders can include shipping without a quote

## Test Plan
- [x] python -m compileall backend/app/services/quote_service.py backend/tests/services/test_quote_service.py
- [x] python -m pytest backend/tests/services/test_quote_service.py -q
- [x] npm run build
- [x] git diff --check

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-fee-lines-order-shipping-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shipping charge field with persistent wizard state and submission support
  * Quote creation UI now supports one-time fee (service) lines with inputs and FEE badge
  * Quote-to-order conversion now preserves service/fee lines and their descriptions

* **Bug Fixes**
  * Customer discounts apply only to product lines; fee/service lines are excluded
  * Order line pricing defaults missing unit prices to zero

* **Tests**
  * Added test covering conversion of mixed product and fee lines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->