### PR TITLE
fix: show customer paid and outstanding totals

### DIFF
--- a/backend/app/schemas/customer.py
+++ b/backend/app/schemas/customer.py
@@ -119,6 +119,8 @@ class CustomerListResponse(BaseModel):
     # Stats
     order_count: int = 0
     total_spent: float = 0.0
+    total_paid: float = 0.0
+    outstanding_balance: float = 0.0
     last_order_date: Optional[datetime] = None
 
     # PRO price level discount (None if PRO not installed)
@@ -153,6 +155,9 @@ class CustomerResponse(CustomerBase):
     order_count: int = 0
     quote_count: int = 0
     total_spent: float = 0.0
+    total_paid: float = 0.0
+    outstanding_balance: float = 0.0
+    last_order_date: Optional[datetime] = None
 
     # PRO price level discount (None if PRO not installed)
     discount_percent: Optional[float] = None

--- a/backend/app/services/customer_service.py
+++ b/backend/app/services/customer_service.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from app.core.security import hash_password
 from app.core.utils import escape_like
 from app.logging_config import get_logger
+from app.models.payment import Payment
 from app.models.quote import Quote
 from app.models.sales_order import SalesOrder
 from app.models.user import User
@@ -42,28 +43,42 @@ def _build_full_name(customer: User) -> Optional[str]:
 
 
 def _get_customer_stats(db: Session, customer_id: int) -> dict:
-    """Fetch order count, quote count, and total spent for a customer."""
+    """Fetch order, quote, booked, paid, and outstanding stats for a customer."""
     order_customer_filter = _sales_order_customer_filter(customer_id)
     quote_customer_filter = _quote_customer_filter(customer_id)
 
-    order_count = db.query(func.count(SalesOrder.id)).filter(
+    orders = db.query(SalesOrder).filter(
         order_customer_filter,
         SalesOrder.status != "cancelled",
-    ).scalar() or 0
+    ).all()
+
+    order_ids = [order.id for order in orders]
+    paid_by_order = _completed_payment_totals_by_order(db, order_ids)
+
+    total_spent = Decimal("0")
+    total_paid = Decimal("0")
+    outstanding_balance = Decimal("0")
+    last_order_date = None
+    for order in orders:
+        order_total = _sales_order_total(order)
+        paid = paid_by_order.get(order.id, Decimal("0"))
+        total_spent += order_total
+        total_paid += paid
+        outstanding_balance += max(order_total - paid, Decimal("0"))
+        if order.created_at and (last_order_date is None or order.created_at > last_order_date):
+            last_order_date = order.created_at
 
     quote_count = db.query(func.count(Quote.id)).filter(
         quote_customer_filter,
     ).scalar() or 0
 
-    total_spent = db.query(func.sum(SalesOrder.grand_total)).filter(
-        order_customer_filter,
-        SalesOrder.status != "cancelled",
-    ).scalar() or 0
-
     return {
-        "order_count": order_count,
+        "order_count": len(orders),
         "quote_count": quote_count,
         "total_spent": float(total_spent),
+        "total_paid": float(total_paid),
+        "outstanding_balance": float(outstanding_balance),
+        "last_order_date": last_order_date,
     }
 
 
@@ -81,6 +96,27 @@ def _quote_customer_filter(customer_id: int):
         Quote.customer_id == customer_id,
         and_(Quote.customer_id.is_(None), Quote.user_id == customer_id),
     )
+
+
+def _sales_order_total(order: SalesOrder) -> Decimal:
+    """Return the customer-facing order total, including tax, fees, and shipping."""
+    return order.grand_total or order.total_price or Decimal("0")
+
+
+def _completed_payment_totals_by_order(db: Session, order_ids: list[int]) -> dict[int, Decimal]:
+    """Return net completed payment totals keyed by sales order id."""
+    if not order_ids:
+        return {}
+
+    rows = db.query(
+        Payment.sales_order_id,
+        func.coalesce(func.sum(Payment.amount), 0).label("paid"),
+    ).filter(
+        Payment.sales_order_id.in_(order_ids),
+        Payment.status == "completed",
+    ).group_by(Payment.sales_order_id).all()
+
+    return {row.sales_order_id: row.paid for row in rows}
 
 
 def _get_customer_or_404(db: Session, customer_id: int) -> User:
@@ -168,6 +204,9 @@ def _customer_response(customer: User, stats: dict, db: Optional[Session] = None
         "order_count": stats["order_count"],
         "quote_count": stats["quote_count"],
         "total_spent": stats["total_spent"],
+        "total_paid": stats["total_paid"],
+        "outstanding_balance": stats["outstanding_balance"],
+        "last_order_date": stats.get("last_order_date"),
         "discount_percent": discount_percent,
     }
 
@@ -249,15 +288,7 @@ def list_customers(
 
     result = []
     for customer in customers:
-        order_customer_filter = _sales_order_customer_filter(customer.id)
-        order_stats = db.query(
-            func.count(SalesOrder.id).label("order_count"),
-            func.sum(SalesOrder.grand_total).label("total_spent"),
-            func.max(SalesOrder.created_at).label("last_order"),
-        ).filter(
-            order_customer_filter,
-            SalesOrder.status != "cancelled",
-        ).first()
+        stats = _get_customer_stats(db, customer.id)
 
         result.append({
             "id": customer.id,
@@ -274,9 +305,11 @@ def list_customers(
             "shipping_city": customer.shipping_city,
             "shipping_state": customer.shipping_state,
             "shipping_zip": customer.shipping_zip,
-            "order_count": order_stats.order_count or 0,
-            "total_spent": float(order_stats.total_spent or 0),
-            "last_order_date": order_stats.last_order,
+            "order_count": stats["order_count"],
+            "total_spent": stats["total_spent"],
+            "total_paid": stats["total_paid"],
+            "outstanding_balance": stats["outstanding_balance"],
+            "last_order_date": stats["last_order_date"],
             "created_at": customer.created_at,
         })
 
@@ -401,6 +434,9 @@ def create_customer(
         "order_count": 0,
         "quote_count": 0,
         "total_spent": 0.0,
+        "total_paid": 0.0,
+        "outstanding_balance": 0.0,
+        "last_order_date": None,
     }, db=db)
 
 
@@ -527,18 +563,23 @@ def get_customer_orders(
         .limit(limit)
         .all()
     )
+    paid_by_order = _completed_payment_totals_by_order(db, [order.id for order in orders])
 
-    return [
-        {
-            "id": o.id,
-            "order_number": o.order_number,
-            "status": o.status,
-            "grand_total": float(o.grand_total or 0),
-            "payment_status": o.payment_status,
-            "created_at": o.created_at,
-        }
-        for o in orders
-    ]
+    result = []
+    for order in orders:
+        order_total = _sales_order_total(order)
+        amount_paid = paid_by_order.get(order.id, Decimal("0"))
+        result.append({
+            "id": order.id,
+            "order_number": order.order_number,
+            "status": order.status,
+            "grand_total": float(order_total),
+            "amount_paid": float(amount_paid),
+            "balance_due": float(max(order_total - amount_paid, Decimal("0"))),
+            "payment_status": order.payment_status,
+            "created_at": order.created_at,
+        })
+    return result
 
 
 # =============================================================================

--- a/backend/app/services/customer_service.py
+++ b/backend/app/services/customer_service.py
@@ -44,41 +44,21 @@ def _build_full_name(customer: User) -> Optional[str]:
 
 def _get_customer_stats(db: Session, customer_id: int) -> dict:
     """Fetch order, quote, booked, paid, and outstanding stats for a customer."""
-    order_customer_filter = _sales_order_customer_filter(customer_id)
-    quote_customer_filter = _quote_customer_filter(customer_id)
+    return _get_customers_stats_batch(db, [customer_id]).get(
+        customer_id,
+        _empty_customer_stats(),
+    )
 
-    orders = db.query(SalesOrder).filter(
-        order_customer_filter,
-        SalesOrder.status != "cancelled",
-    ).all()
 
-    order_ids = [order.id for order in orders]
-    paid_by_order = _completed_payment_totals_by_order(db, order_ids)
-
-    total_spent = Decimal("0")
-    total_paid = Decimal("0")
-    outstanding_balance = Decimal("0")
-    last_order_date = None
-    for order in orders:
-        order_total = _sales_order_total(order)
-        paid = paid_by_order.get(order.id, Decimal("0"))
-        total_spent += order_total
-        total_paid += paid
-        outstanding_balance += max(order_total - paid, Decimal("0"))
-        if order.created_at and (last_order_date is None or order.created_at > last_order_date):
-            last_order_date = order.created_at
-
-    quote_count = db.query(func.count(Quote.id)).filter(
-        quote_customer_filter,
-    ).scalar() or 0
-
+def _empty_customer_stats() -> dict:
+    """Return the zero-value shape used by customer stats responses."""
     return {
-        "order_count": len(orders),
-        "quote_count": quote_count,
-        "total_spent": float(total_spent),
-        "total_paid": float(total_paid),
-        "outstanding_balance": float(outstanding_balance),
-        "last_order_date": last_order_date,
+        "order_count": 0,
+        "quote_count": 0,
+        "total_spent": 0.0,
+        "total_paid": 0.0,
+        "outstanding_balance": 0.0,
+        "last_order_date": None,
     }
 
 
@@ -100,7 +80,88 @@ def _quote_customer_filter(customer_id: int):
 
 def _sales_order_total(order: SalesOrder) -> Decimal:
     """Return the customer-facing order total, including tax, fees, and shipping."""
-    return order.grand_total or order.total_price or Decimal("0")
+    if order.grand_total is not None:
+        return order.grand_total
+    if order.total_price is not None:
+        return order.total_price
+    return Decimal("0")
+
+
+def _get_customers_stats_batch(db: Session, customer_ids: list[int]) -> dict[int, dict]:
+    """Fetch order, quote, booked, paid, and outstanding stats for customers."""
+    if not customer_ids:
+        return {}
+
+    customer_ids_set = set(customer_ids)
+    stats_by_customer = {customer_id: _empty_customer_stats() for customer_id in customer_ids_set}
+
+    orders = db.query(SalesOrder).filter(
+        or_(
+            SalesOrder.customer_id.in_(customer_ids_set),
+            and_(
+                SalesOrder.customer_id.is_(None),
+                SalesOrder.user_id.in_(customer_ids_set),
+            ),
+        ),
+        SalesOrder.status != "cancelled",
+    ).all()
+
+    paid_by_order = _completed_payment_totals_by_order(db, [order.id for order in orders])
+    totals_by_customer = {
+        customer_id: {
+            "total_spent": Decimal("0"),
+            "total_paid": Decimal("0"),
+            "outstanding_balance": Decimal("0"),
+        }
+        for customer_id in customer_ids_set
+    }
+
+    for order in orders:
+        customer_id = order.customer_id
+        if customer_id not in customer_ids_set and order.customer_id is None:
+            customer_id = order.user_id
+        if customer_id not in customer_ids_set:
+            continue
+
+        order_total = _sales_order_total(order)
+        paid = paid_by_order.get(order.id, Decimal("0"))
+        stats = stats_by_customer[customer_id]
+        totals = totals_by_customer[customer_id]
+
+        stats["order_count"] += 1
+        totals["total_spent"] += order_total
+        totals["total_paid"] += paid
+        totals["outstanding_balance"] += max(order_total - paid, Decimal("0"))
+        if order.created_at and (
+            stats["last_order_date"] is None or order.created_at > stats["last_order_date"]
+        ):
+            stats["last_order_date"] = order.created_at
+
+    quote_customer_id = func.coalesce(Quote.customer_id, Quote.user_id)
+    quote_rows = db.query(
+        quote_customer_id.label("customer_id"),
+        func.count(Quote.id).label("quote_count"),
+    ).filter(
+        or_(
+            Quote.customer_id.in_(customer_ids_set),
+            and_(
+                Quote.customer_id.is_(None),
+                Quote.user_id.in_(customer_ids_set),
+            ),
+        ),
+    ).group_by(quote_customer_id).all()
+
+    for row in quote_rows:
+        if row.customer_id in stats_by_customer:
+            stats_by_customer[row.customer_id]["quote_count"] = row.quote_count
+
+    for customer_id, totals in totals_by_customer.items():
+        stats = stats_by_customer[customer_id]
+        stats["total_spent"] = float(totals["total_spent"])
+        stats["total_paid"] = float(totals["total_paid"])
+        stats["outstanding_balance"] = float(totals["outstanding_balance"])
+
+    return stats_by_customer
 
 
 def _completed_payment_totals_by_order(db: Session, order_ids: list[int]) -> dict[int, Decimal]:
@@ -285,10 +346,14 @@ def list_customers(
 
     query = query.order_by(desc(User.created_at))
     customers = query.offset(skip).limit(limit).all()
+    stats_by_customer = _get_customers_stats_batch(
+        db,
+        [customer.id for customer in customers],
+    )
 
     result = []
     for customer in customers:
-        stats = _get_customer_stats(db, customer.id)
+        stats = stats_by_customer.get(customer.id, _empty_customer_stats())
 
         result.append({
             "id": customer.id,

--- a/backend/tests/api/v1/test_customers.py
+++ b/backend/tests/api/v1/test_customers.py
@@ -402,6 +402,60 @@ class TestListCustomers:
         assert match["total_paid"] == 40.0
         assert match["outstanding_balance"] == 80.0
 
+    def test_list_maps_payment_stats_to_each_customer(self, client, db, make_sales_order):
+        """Customer list batch stats are mapped back to the right customers."""
+        from app.models.payment import Payment
+
+        first_customer = _create_customer(client, first_name="BatchStatsA")
+        second_customer = _create_customer(client, first_name="BatchStatsB")
+        first_order = make_sales_order(
+            user_id=1,
+            customer_id=first_customer["id"],
+            status="confirmed",
+        )
+        first_order.grand_total = Decimal("120.00")
+        first_order.total_price = Decimal("120.00")
+        second_order = make_sales_order(
+            user_id=1,
+            customer_id=second_customer["id"],
+            status="confirmed",
+        )
+        second_order.grand_total = Decimal("80.00")
+        second_order.total_price = Decimal("80.00")
+        db.add_all([
+            Payment(
+                payment_number=f"PAY-{uuid.uuid4().hex[:8]}",
+                sales_order_id=first_order.id,
+                recorded_by_id=1,
+                amount=Decimal("50.00"),
+                payment_method="card",
+                payment_type="payment",
+                status="completed",
+            ),
+            Payment(
+                payment_number=f"PAY-{uuid.uuid4().hex[:8]}",
+                sales_order_id=second_order.id,
+                recorded_by_id=1,
+                amount=Decimal("80.00"),
+                payment_method="card",
+                payment_type="payment",
+                status="completed",
+            ),
+        ])
+        db.flush()
+
+        response = client.get(BASE_URL, params={"limit": 100})
+        assert response.status_code == 200
+        customers_by_id = {customer["id"]: customer for customer in response.json()}
+        first_stats = customers_by_id[first_customer["id"]]
+        second_stats = customers_by_id[second_customer["id"]]
+        assert first_stats["total_spent"] == 120.0
+        assert first_stats["total_paid"] == 50.0
+        assert first_stats["outstanding_balance"] == 70.0
+        assert second_stats["total_spent"] == 80.0
+        assert second_stats["total_paid"] == 80.0
+        assert second_stats["outstanding_balance"] == 0.0
+
 
 # =============================================================================
 # GET /api/v1/admin/customers/search?q=... - Quick search
@@ -539,6 +593,26 @@ class TestGetCustomer:
         data = response.json()
         assert data["order_count"] == 1
         assert data["total_spent"] == 123.45
+
+    def test_get_customer_preserves_zero_grand_total(self, client, db, make_sales_order):
+        """A zero grand_total is authoritative and does not fall back to total_price."""
+        customer = _create_customer(client)
+        customer_id = customer["id"]
+        order = make_sales_order(
+            user_id=1,
+            customer_id=customer_id,
+            status="confirmed",
+        )
+        order.grand_total = Decimal("0.00")
+        order.total_price = Decimal("99.99")
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{customer_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["order_count"] == 1
+        assert data["total_spent"] == 0.0
+        assert data["outstanding_balance"] == 0.0
 
     def test_get_customer_allocates_paid_and_outstanding(self, client, db, make_sales_order):
         """Customer detail separates booked order value from net paid cash."""

--- a/backend/tests/api/v1/test_customers.py
+++ b/backend/tests/api/v1/test_customers.py
@@ -16,6 +16,7 @@ Covers:
 """
 import io
 import uuid
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -118,6 +119,8 @@ class TestCreateCustomer:
         assert data["status"] == "active"
         assert data["order_count"] == 0
         assert data["total_spent"] == 0.0
+        assert data["total_paid"] == 0.0
+        assert data["outstanding_balance"] == 0.0
 
     def test_create_customer_full(self, client):
         """Create a customer with all fields populated."""
@@ -234,6 +237,8 @@ class TestListCustomers:
         assert "status" in item
         assert "order_count" in item
         assert "total_spent" in item
+        assert "total_paid" in item
+        assert "outstanding_balance" in item
         assert "created_at" in item
 
     def test_list_search_by_email(self, client):
@@ -353,6 +358,50 @@ class TestListCustomers:
         assert match["order_count"] == 1
         assert match["total_spent"] == 87.65
 
+    def test_list_allocates_paid_and_outstanding_by_customer_id(self, client, db, make_sales_order):
+        """Customer list stats include net paid cash and outstanding balance."""
+        from app.models.payment import Payment
+
+        customer = _create_customer(client, first_name="PaymentStats")
+        customer_id = customer["id"]
+        order = make_sales_order(
+            user_id=1,
+            customer_id=customer_id,
+            status="confirmed",
+        )
+        order.total_price = Decimal("100.00")
+        order.tax_amount = Decimal("10.00")
+        order.shipping_cost = Decimal("10.00")
+        order.grand_total = Decimal("120.00")
+        db.add_all([
+            Payment(
+                payment_number=f"PAY-{uuid.uuid4().hex[:8]}",
+                sales_order_id=order.id,
+                recorded_by_id=1,
+                amount=Decimal("50.00"),
+                payment_method="card",
+                payment_type="payment",
+                status="completed",
+            ),
+            Payment(
+                payment_number=f"PAY-{uuid.uuid4().hex[:8]}",
+                sales_order_id=order.id,
+                recorded_by_id=1,
+                amount=Decimal("-10.00"),
+                payment_method="card",
+                payment_type="refund",
+                status="completed",
+            ),
+        ])
+        db.flush()
+
+        response = client.get(BASE_URL, params={"search": customer["email"]})
+        assert response.status_code == 200
+        match = next(c for c in response.json() if c["id"] == customer_id)
+        assert match["total_spent"] == 120.0
+        assert match["total_paid"] == 40.0
+        assert match["outstanding_balance"] == 80.0
+
 
 # =============================================================================
 # GET /api/v1/admin/customers/search?q=... - Quick search
@@ -456,7 +505,7 @@ class TestGetCustomer:
         assert data["customer_number"] is not None
 
     def test_get_customer_includes_stats(self, client):
-        """Get customer response includes order_count, quote_count, total_spent."""
+        """Get customer response includes order, quote, booked, paid, and balance stats."""
         customer = _create_customer(client)
         response = client.get(f"{BASE_URL}/{customer['id']}")
         assert response.status_code == 200
@@ -464,9 +513,13 @@ class TestGetCustomer:
         assert "order_count" in data
         assert "quote_count" in data
         assert "total_spent" in data
+        assert "total_paid" in data
+        assert "outstanding_balance" in data
         assert data["order_count"] == 0
         assert data["quote_count"] == 0
         assert data["total_spent"] == 0.0
+        assert data["total_paid"] == 0.0
+        assert data["outstanding_balance"] == 0.0
 
     def test_get_customer_counts_orders_linked_by_customer_id(self, client, db, make_sales_order):
         """Staff-owned orders linked via customer_id count toward customer stats."""
@@ -487,6 +540,37 @@ class TestGetCustomer:
         assert data["order_count"] == 1
         assert data["total_spent"] == 123.45
 
+    def test_get_customer_allocates_paid_and_outstanding(self, client, db, make_sales_order):
+        """Customer detail separates booked order value from net paid cash."""
+        from app.models.payment import Payment
+
+        customer = _create_customer(client)
+        customer_id = customer["id"]
+        order = make_sales_order(
+            user_id=1,
+            customer_id=customer_id,
+            status="confirmed",
+        )
+        order.grand_total = Decimal("200.00")
+        order.total_price = Decimal("175.00")
+        db.add(Payment(
+            payment_number=f"PAY-{uuid.uuid4().hex[:8]}",
+            sales_order_id=order.id,
+            recorded_by_id=1,
+            amount=Decimal("75.00"),
+            payment_method="cash",
+            payment_type="payment",
+            status="completed",
+        ))
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{customer_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_spent"] == 200.0
+        assert data["total_paid"] == 75.0
+        assert data["outstanding_balance"] == 125.0
+
     def test_get_customer_counts_quotes_linked_by_customer_id(self, client, db):
         """Staff-owned quotes linked via customer_id count toward customer stats."""
         from app.models.quote import Quote
@@ -505,6 +589,7 @@ class TestGetCustomer:
             status="pending",
             file_format="manual",
             file_size_bytes=0,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
         )
         db.add(quote)
         db.flush()
@@ -722,6 +807,8 @@ class TestCustomerOrders:
         assert "order_number" in order
         assert "status" in order
         assert "grand_total" in order
+        assert "amount_paid" in order
+        assert "balance_due" in order
         assert "created_at" in order
 
     def test_orders_returns_orders_linked_by_customer_id(self, client, make_sales_order):

--- a/frontend/src/components/customers/CustomerDetailsModal.jsx
+++ b/frontend/src/components/customers/CustomerDetailsModal.jsx
@@ -359,7 +359,7 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
           {activeTab === "overview" && (
             <div className="space-y-6">
               {/* Stats */}
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
                 <div className="bg-gray-800/50 rounded-lg p-4">
                   <p className="text-gray-400 text-sm">Total Orders</p>
                   <p className="text-2xl font-bold text-white">
@@ -367,9 +367,21 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
                   </p>
                 </div>
                 <div className="bg-gray-800/50 rounded-lg p-4">
-                  <p className="text-gray-400 text-sm">Total Spent</p>
+                  <p className="text-gray-400 text-sm">Booked Orders</p>
                   <p className="text-2xl font-bold text-emerald-400">
                     {formatCurrency(customer.total_spent || 0)}
+                  </p>
+                </div>
+                <div className="bg-gray-800/50 rounded-lg p-4">
+                  <p className="text-gray-400 text-sm">Paid Cash</p>
+                  <p className="text-2xl font-bold text-blue-300">
+                    {formatCurrency(customer.total_paid || 0)}
+                  </p>
+                </div>
+                <div className="bg-gray-800/50 rounded-lg p-4">
+                  <p className="text-gray-400 text-sm">Outstanding</p>
+                  <p className="text-2xl font-bold text-amber-300">
+                    {formatCurrency(customer.outstanding_balance || 0)}
                   </p>
                 </div>
                 <div className="bg-gray-800/50 rounded-lg p-4">
@@ -522,6 +534,8 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
                         <th className="text-left py-2 px-3 text-gray-400">Date</th>
                         <th className="text-left py-2 px-3 text-gray-400">Status</th>
                         <th className="text-right py-2 px-3 text-gray-400">Total</th>
+                        <th className="text-right py-2 px-3 text-gray-400">Paid</th>
+                        <th className="text-right py-2 px-3 text-gray-400">Balance</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -540,6 +554,12 @@ export default function CustomerDetailsModal({ customer, onClose, onEdit }) {
                           </td>
                           <td className="py-2 px-3 text-right text-emerald-400">
                             ${parseFloat(order.grand_total || order.total || 0).toFixed(2)}
+                          </td>
+                          <td className="py-2 px-3 text-right text-blue-300">
+                            {formatCurrency(order.amount_paid || 0)}
+                          </td>
+                          <td className="py-2 px-3 text-right text-amber-300">
+                            {formatCurrency(order.balance_due || 0)}
                           </td>
                         </tr>
                       ))}

--- a/frontend/src/pages/admin/AdminCustomers.jsx
+++ b/frontend/src/pages/admin/AdminCustomers.jsx
@@ -78,8 +78,16 @@ export default function AdminCustomers() {
     total: customers.length,
     active: customers.filter((c) => c.status === "active").length,
     withOrders: customers.filter((c) => c.order_count > 0).length,
-    totalRevenue: customers.reduce(
+    bookedOrders: customers.reduce(
       (sum, c) => sum + (parseFloat(c.total_spent) || 0),
+      0
+    ),
+    paidCash: customers.reduce(
+      (sum, c) => sum + (parseFloat(c.total_paid) || 0),
+      0
+    ),
+    outstanding: customers.reduce(
+      (sum, c) => sum + (parseFloat(c.outstanding_balance) || 0),
       0
     ),
   };
@@ -173,15 +181,27 @@ export default function AdminCustomers() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-6 gap-4">
         <StatCard variant="simple" title="Total Customers" value={stats.total} color="neutral" />
         <StatCard variant="simple" title="Active" value={stats.active} color="success" />
         <StatCard variant="simple" title="With Orders" value={stats.withOrders} color="secondary" />
         <StatCard
           variant="simple"
-          title="Total Revenue"
-          value={formatCurrency(stats.totalRevenue)}
+          title="Booked Orders"
+          value={formatCurrency(stats.bookedOrders)}
           color="primary"
+        />
+        <StatCard
+          variant="simple"
+          title="Paid Cash"
+          value={formatCurrency(stats.paidCash)}
+          color="success"
+        />
+        <StatCard
+          variant="simple"
+          title="Outstanding"
+          value={formatCurrency(stats.outstanding)}
+          color="warning"
         />
       </div>
 
@@ -250,7 +270,13 @@ export default function AdminCustomers() {
                   Orders
                 </th>
                 <th className="text-right py-3 px-4 text-xs font-medium text-gray-400 uppercase">
-                  Total Spent
+                  Booked
+                </th>
+                <th className="text-right py-3 px-4 text-xs font-medium text-gray-400 uppercase">
+                  Paid
+                </th>
+                <th className="text-right py-3 px-4 text-xs font-medium text-gray-400 uppercase">
+                  Balance
                 </th>
                 <th className="text-center py-3 px-4 text-xs font-medium text-gray-400 uppercase">
                   Status
@@ -283,12 +309,13 @@ export default function AdminCustomers() {
                     {customer.order_count || 0}
                   </td>
                   <td className="py-3 px-4 text-right text-emerald-400">
-                    {customer.total_spent
-                      ? `$${parseFloat(customer.total_spent).toLocaleString(
-                          "en-US",
-                          { minimumFractionDigits: 2 }
-                        )}`
-                      : "$0.00"}
+                    {formatCurrency(customer.total_spent || 0)}
+                  </td>
+                  <td className="py-3 px-4 text-right text-blue-300">
+                    {formatCurrency(customer.total_paid || 0)}
+                  </td>
+                  <td className="py-3 px-4 text-right text-amber-300">
+                    {formatCurrency(customer.outstanding_balance || 0)}
                   </td>
                   <td className="py-3 px-4 text-center">
                     <span
@@ -320,7 +347,7 @@ export default function AdminCustomers() {
               ))}
               {filteredCustomers.length === 0 && (
                 <tr>
-                  <td colSpan={9} className="py-12 text-center text-gray-500">
+                  <td colSpan={11} className="py-12 text-center text-gray-500">
                     No customers found
                   </td>
                 </tr>
@@ -368,4 +395,3 @@ export default function AdminCustomers() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add customer `total_paid` and `outstanding_balance` totals based on completed payment records against linked sales orders
- keep existing `total_spent` as booked order value while separating paid cash and open balance in customer list/detail UI
- include amount paid and balance due on customer order history rows

## Test Plan
- [x] python -m compileall backend/app/services/customer_service.py backend/app/schemas/customer.py backend/tests/api/v1/test_customers.py
- [x] python -m pytest backend/tests/api/v1/test_customers.py -q
- [x] npm ci
- [x] npm run build
- [x] git diff --check

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-payment-totals-real-orders-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed customer financial metrics: Booked Orders, Paid Cash, and Outstanding balances in customer lists and detail views.
  * Orders now show payment breakdown per order with Amount Paid and Balance Due.
  * Updated dashboard/stats layouts and table columns to surface the new monetary metrics with consistent currency formatting.

* **Tests**
  * Added tests validating customer financial metrics and correct allocation of payments (including refunds) across customers and orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->