### PR TITLE
fix: invoice linked customer orders

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -118,10 +118,11 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
             detail=f"Invoice {existing.invoice_number} already exists for this order",
         )
 
-    # Get customer info from User record
+    # Get customer info from the linked customer record, falling back to legacy user_id.
     customer = None
-    if order.user_id:
-        customer = db.query(User).filter(User.id == order.user_id).first()
+    invoice_customer_id = order.customer_id or order.user_id
+    if invoice_customer_id:
+        customer = db.query(User).filter(User.id == invoice_customer_id).first()
 
     # Payment terms: use customer's payment_terms if the column exists
     # (migration 069 is on a separate branch), else default to "cod"
@@ -199,7 +200,7 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
     invoice = Invoice(
         invoice_number=invoice_number,
         sales_order_id=order.id,
-        customer_id=order.user_id,
+        customer_id=invoice_customer_id,
         customer_name=customer_name,
         customer_email=order.customer_email or (customer.email if customer else None),
         customer_company=customer.company_name if customer else None,

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -1,4 +1,5 @@
 """Tests for invoice service and API endpoints."""
+import uuid
 from datetime import date, timedelta
 from decimal import Decimal
 
@@ -122,6 +123,49 @@ class TestCreateInvoice:
         assert len(invoice.lines) == 1
         assert invoice.lines[0].quantity == 2
         assert invoice.lines[0].unit_price == Decimal("25.00")
+
+    def test_create_invoice_uses_linked_customer_for_staff_order(self, db, make_product, make_sales_order):
+        from app.models.user import User
+        from app.services.invoice_service import create_invoice
+
+        uid = uuid.uuid4().hex[:8]
+        customer = User(
+            email=f"invoice-customer-{uid}@example.com",
+            password_hash="test-hash",
+            first_name="Invoice",
+            last_name="Customer",
+            company_name="Invoice Customer Co",
+            account_type="customer",
+            payment_terms="net30",
+            billing_address_line1="123 Billing Way",
+            billing_city="Billingtown",
+            billing_state="IN",
+            billing_zip="46204",
+        )
+        db.add(customer)
+        db.flush()
+
+        product = make_product(selling_price=Decimal("25.00"))
+        so = make_sales_order(
+            user_id=1,
+            customer_id=customer.id,
+            customer_name="Order Snapshot Name",
+            customer_email="snapshot@example.com",
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("25.00"),
+            status="confirmed",
+        )
+
+        invoice = create_invoice(db, so.id)
+
+        assert invoice.customer_id == customer.id
+        assert invoice.customer_name == "Order Snapshot Name"
+        assert invoice.customer_email == "snapshot@example.com"
+        assert invoice.customer_company == "Invoice Customer Co"
+        assert invoice.bill_to_line1 == "123 Billing Way"
+        assert invoice.bill_to_city == "Billingtown"
+        assert invoice.payment_terms == "net30"
 
     def test_duplicate_invoice_returns_400(self, db, make_product, make_sales_order):
         from fastapi import HTTPException


### PR DESCRIPTION
## Summary
- Prefer `SalesOrder.customer_id` when generating invoices from staff-owned/manual orders
- Keep `SalesOrder.user_id` as the legacy fallback for older/user-owned orders
- Add regression coverage proving invoice customer, billing, and terms snapshot from the linked customer

## Validation
- `python -m pytest backend/tests/test_invoice_service.py::TestCreateInvoice::test_create_invoice_uses_linked_customer_for_staff_order -q` (failed before fix, passed after)
- `python -m pytest backend/tests/test_invoice_service.py -q` (27 passed)
- `python -m compileall backend/app/services/invoice_service.py backend/tests/test_invoice_service.py`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-to-cash-next-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invoice generation to use linked customer details (name, email, company, payment terms, and billing address) when available, instead of defaulting to the order creator's information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->