### PR TITLE
fix: preserve invoice service line descriptions

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -150,7 +150,7 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
                 product = db.query(Product).filter(Product.id == ol.product_id).first()
 
             sku = product.sku if product else ""
-            description = product.name if product else "Item"
+            description = ol.description or (product.name if product else "Item")
             base_price = product.selling_price if product else ol.unit_price
             line_total = ol.quantity * ol.unit_price
 

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -167,6 +167,34 @@ class TestCreateInvoice:
         assert invoice.bill_to_city == "Billingtown"
         assert invoice.payment_terms == "net30"
 
+    def test_create_invoice_preserves_service_line_description(self, db, make_sales_order):
+        from app.models.sales_order import SalesOrderLine
+        from app.services.invoice_service import create_invoice
+
+        so = make_sales_order(
+            product_id=None,
+            product_name="Manual Order",
+            quantity=1,
+            unit_price=Decimal("250.00"),
+            status="confirmed",
+        )
+        db.add(SalesOrderLine(
+            sales_order_id=so.id,
+            line_type="service",
+            description="Engineering Fee",
+            quantity=Decimal("1.00"),
+            unit_price=Decimal("250.00"),
+            total=Decimal("250.00"),
+        ))
+        db.flush()
+
+        invoice = create_invoice(db, so.id)
+
+        assert len(invoice.lines) == 1
+        assert invoice.lines[0].description == "Engineering Fee"
+        assert invoice.lines[0].product_id is None
+        assert invoice.lines[0].line_total == Decimal("250.00")
+
     def test_duplicate_invoice_returns_400(self, db, make_product, make_sales_order):
         from fastapi import HTTPException
         from app.services.invoice_service import create_invoice


### PR DESCRIPTION
## Summary
- Preserve `SalesOrderLine.description` when generating invoice lines
- Keeps one-time service/fee lines like engineering fees readable on invoices instead of falling back to `Item`
- Keeps existing product-name fallback when no order-line description exists

## Validation
- Red check: `python -m pytest backend/tests/test_invoice_service.py::TestCreateInvoice::test_create_invoice_preserves_service_line_description -q` failed with `Item` vs `Engineering Fee`
- Green check: targeted test passed after fix
- `python -m pytest backend/tests/test_invoice_service.py -q` (28 passed)
- `python -m compileall backend/app/services/invoice_service.py backend/tests/test_invoice_service.py`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-invoice-line-descriptions-20260605-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice line item descriptions now correctly prioritize custom descriptions from sales orders, falling back to product names when unavailable, improving accuracy for service line items.

* **Tests**
  * Added test coverage for invoice service line description preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->