### PR TITLE
fix: preserve invoice order line totals

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -152,7 +152,7 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
             sku = product.sku if product else ""
             description = ol.description or (product.name if product else "Item")
             base_price = product.selling_price if product else ol.unit_price
-            line_total = ol.quantity * ol.unit_price
+            line_total = ol.total if ol.total is not None else ol.quantity * ol.unit_price
 
             invoice_lines.append(InvoiceLine(
                 product_id=ol.product_id,

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -195,6 +195,34 @@ class TestCreateInvoice:
         assert invoice.lines[0].product_id is None
         assert invoice.lines[0].line_total == Decimal("250.00")
 
+    def test_create_invoice_uses_adjusted_order_line_total(self, db, make_sales_order):
+        from app.models.sales_order import SalesOrderLine
+        from app.services.invoice_service import create_invoice
+
+        so = make_sales_order(
+            product_id=None,
+            product_name="Manual Order",
+            quantity=1,
+            unit_price=Decimal("90.00"),
+            status="confirmed",
+        )
+        db.add(SalesOrderLine(
+            sales_order_id=so.id,
+            line_type="service",
+            description="Discounted Engineering",
+            quantity=Decimal("2.00"),
+            unit_price=Decimal("50.00"),
+            discount=Decimal("10.00"),
+            total=Decimal("90.00"),
+        ))
+        db.flush()
+
+        invoice = create_invoice(db, so.id)
+
+        assert invoice.lines[0].line_total == Decimal("90.00")
+        assert invoice.subtotal == Decimal("90.00")
+        assert invoice.total == Decimal("90.00")
+
     def test_duplicate_invoice_returns_400(self, db, make_product, make_sales_order):
         from fastapi import HTTPException
         from app.services.invoice_service import create_invoice


### PR DESCRIPTION
## Summary
- Preserve saved `SalesOrderLine.total` when creating invoice lines
- Prevent adjusted/discounted order lines from being overstated by recomputing `quantity * unit_price`
- Keep the legacy calculation as a fallback for rows without a saved total

## Validation
- Red check: `python -m pytest backend/tests/test_invoice_service.py::TestCreateInvoice::test_create_invoice_uses_adjusted_order_line_total -q` failed with `100.00` vs `90.00`
- Green check: targeted test passed after fix
- `python -m pytest backend/tests/test_invoice_service.py -q` (29 passed)
- `python -m compileall backend/app/services/invoice_service.py backend/tests/test_invoice_service.py`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-invoice-line-totals-20260606-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected invoice line total calculations to properly account for discounted and adjusted amounts, ensuring all manual adjustments from sales orders are accurately reflected in invoice totals.

* **Tests**
  * Added test coverage for invoice line total calculations with discounts and manual adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->