### PR TITLE
fix: stop treating invoice line discounts as percent

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -161,7 +161,6 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
                 quantity=ol.quantity,
                 unit_price=ol.unit_price,
                 base_price=base_price if base_price != ol.unit_price else None,
-                discount_percent=ol.discount if ol.discount else None,
                 line_total=line_total,
             ))
             subtotal += line_total

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -220,6 +220,7 @@ class TestCreateInvoice:
         invoice = create_invoice(db, so.id)
 
         assert invoice.lines[0].line_total == Decimal("90.00")
+        assert invoice.lines[0].discount_percent is None
         assert invoice.subtotal == Decimal("90.00")
         assert invoice.total == Decimal("90.00")
 


### PR DESCRIPTION
## Summary
- Stop copying `SalesOrderLine.discount` currency amounts into `InvoiceLine.discount_percent`.
- Keep invoice economics based on the saved `SalesOrderLine.total`, so adjusted order pricing remains intact.
- Add regression coverage that a `$10.00` order-line discount does not serialize as a `10%` invoice discount.

## Validation
- Red check: `python -m pytest backend/tests/test_invoice_service.py::TestCreateInvoice::test_create_invoice_uses_adjusted_order_line_total -q` failed before the fix with `Decimal('10.00') is None`.
- `DATABASE_URL` cleared, `DB_NAME=filaops_test`: `python -m pytest backend/tests/test_invoice_service.py -q` -> 29 passed, 111 existing Pydantic deprecation warnings.
- `python -m compileall backend/app/services/invoice_service.py backend/tests/test_invoice_service.py`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-invoice-line-discount-field-20260606-001