### PR TITLE
fix: record invoice payments in ledger

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -17,6 +17,10 @@ from app.models.user import User
 from app.models.payment import Payment
 from app.models.sales_order import SalesOrder
 from app.models.order_event import OrderEvent
+from app.services.payment_service import (
+    generate_payment_number,
+    update_order_payment_status,
+)
 from app.schemas.payment import (
     PaymentCreate,
     RefundCreate,
@@ -29,52 +33,6 @@ from app.schemas.payment import (
 
 router = APIRouter(prefix="/payments", tags=["payments"])
 logger = logging.getLogger(__name__)
-
-
-# ============================================================================
-# Helper Functions
-# ============================================================================
-
-def generate_payment_number(db: Session) -> str:
-    """Generate next payment number: PAY-YYYY-NNNN"""
-    year = datetime.now(timezone.utc).year
-    prefix = f"PAY-{year}-"
-
-    last_payment = db.query(Payment).filter(
-        Payment.payment_number.like(f"{prefix}%")
-    ).order_by(desc(Payment.payment_number)).first()
-
-    if last_payment:
-        try:
-            seq = int(last_payment.payment_number.split("-")[2])
-            next_seq = seq + 1
-        except (IndexError, ValueError):
-            next_seq = 1
-    else:
-        next_seq = 1
-
-    return f"{prefix}{next_seq:04d}"
-
-
-def update_order_payment_status(db: Session, order: SalesOrder):
-    """Update order payment_status based on payments received"""
-    # Calculate totals
-    total_paid = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
-        Payment.sales_order_id == order.id,
-        Payment.status == "completed"
-    ).scalar() or Decimal("0")
-
-    order_total = order.grand_total or order.total_price or Decimal("0")
-
-    # Determine status
-    if total_paid <= 0:
-        order.payment_status = "pending"
-    elif total_paid >= order_total:
-        order.payment_status = "paid"
-        if not order.paid_at:
-            order.paid_at = datetime.now(timezone.utc)
-    else:
-        order.payment_status = "partial"
 
 
 def payment_to_response(payment: Payment) -> PaymentResponse:

--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -11,9 +11,14 @@ from sqlalchemy.orm import Session
 from app.logging_config import get_logger
 from app.models.company_settings import CompanySettings
 from app.models.invoice import Invoice, InvoiceLine
+from app.models.payment import Payment
 from app.models.product import Product
 from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.user import User
+from app.services.payment_service import (
+    generate_payment_number,
+    update_order_payment_status,
+)
 
 logger = get_logger(__name__)
 
@@ -258,6 +263,27 @@ def record_payment(
     invoice.amount_paid = new_paid
     invoice.payment_method = method
     invoice.payment_reference = reference
+
+    if invoice.sales_order_id:
+        order = (
+            db.query(SalesOrder)
+            .filter(SalesOrder.id == invoice.sales_order_id)
+            .first()
+        )
+        if order:
+            payment = Payment(
+                payment_number=generate_payment_number(db),
+                sales_order_id=order.id,
+                amount=amount,
+                payment_method=method,
+                payment_type="payment",
+                status="completed",
+                transaction_id=reference,
+                notes=f"Invoice {invoice.invoice_number}",
+            )
+            db.add(payment)
+            db.flush()
+            update_order_payment_status(db, order)
 
     if new_paid >= invoice.total:
         invoice.status = "paid"

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -1,0 +1,53 @@
+"""Shared payment ledger helpers."""
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import desc, func
+from sqlalchemy.orm import Session
+
+from app.models.payment import Payment
+from app.models.sales_order import SalesOrder
+
+
+def generate_payment_number(db: Session) -> str:
+    """Generate next payment number: PAY-YYYY-NNNN."""
+    year = datetime.now(timezone.utc).year
+    prefix = f"PAY-{year}-"
+
+    last_payment = db.query(Payment).filter(
+        Payment.payment_number.like(f"{prefix}%")
+    ).order_by(desc(Payment.payment_number)).first()
+
+    if last_payment:
+        try:
+            seq = int(last_payment.payment_number.split("-")[2])
+            next_seq = seq + 1
+        except (IndexError, ValueError):
+            next_seq = 1
+    else:
+        next_seq = 1
+
+    return f"{prefix}{next_seq:04d}"
+
+
+def update_order_payment_status(db: Session, order: SalesOrder) -> None:
+    """Update order payment_status based on completed ledger payments."""
+    total_paid = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
+        Payment.sales_order_id == order.id,
+        Payment.status == "completed",
+    ).scalar() or Decimal("0")
+
+    order_total = (
+        order.grand_total
+        if order.grand_total is not None
+        else (order.total_price or Decimal("0"))
+    )
+
+    if total_paid <= 0:
+        order.payment_status = "pending"
+    elif total_paid >= order_total:
+        order.payment_status = "paid"
+        if not order.paid_at:
+            order.paid_at = datetime.now(timezone.utc)
+    else:
+        order.payment_status = "partial"

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -2,32 +2,44 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import desc, func
+from sqlalchemy import Integer, cast, func, text
 from sqlalchemy.orm import Session
 
 from app.models.payment import Payment
 from app.models.sales_order import SalesOrder
 
+_PAYMENT_NUMBER_LOCK_NAMESPACE = 74001
+
 
 def generate_payment_number(db: Session) -> str:
-    """Generate next payment number: PAY-YYYY-NNNN."""
+    """Generate next payment number under a transaction-scoped DB lock."""
     year = datetime.now(timezone.utc).year
     prefix = f"PAY-{year}-"
 
-    last_payment = db.query(Payment).filter(
-        Payment.payment_number.like(f"{prefix}%")
-    ).order_by(desc(Payment.payment_number)).first()
+    db.execute(
+        text(
+            """
+            SELECT pg_advisory_xact_lock(
+                CAST(:namespace AS integer),
+                CAST(:year AS integer)
+            )
+            """
+        ),
+        {"namespace": _PAYMENT_NUMBER_LOCK_NAMESPACE, "year": year},
+    )
 
-    if last_payment:
-        try:
-            seq = int(last_payment.payment_number.split("-")[2])
-            next_seq = seq + 1
-        except (IndexError, ValueError):
-            next_seq = 1
-    else:
-        next_seq = 1
+    sequence_value = cast(func.replace(Payment.payment_number, prefix, ""), Integer)
+    max_seq = (
+        db.query(func.max(sequence_value))
+        .filter(
+            Payment.payment_number.like(f"{prefix}%"),
+            Payment.payment_number.op("~")(rf"^PAY-{year}-\d+$"),
+        )
+        .scalar()
+        or 0
+    )
 
-    return f"{prefix}{next_seq:04d}"
+    return f"{prefix}{max_seq + 1:04d}"
 
 
 def update_order_payment_status(db: Session, order: SalesOrder) -> None:

--- a/backend/tests/api/v1/test_payments.py
+++ b/backend/tests/api/v1/test_payments.py
@@ -54,6 +54,34 @@ def test_payment(client, test_order):
 # POST /api/v1/payments (Record Payment)
 # =============================================================================
 
+class TestGeneratePaymentNumber:
+
+    def test_uses_numeric_sequence_after_four_digits(self, db, test_order):
+        from datetime import datetime, timezone
+
+        from app.models.payment import Payment
+        from app.services.payment_service import generate_payment_number
+
+        year = datetime.now(timezone.utc).year
+        db.add_all([
+            Payment(
+                payment_number=f"PAY-{year}-9999",
+                sales_order_id=test_order.id,
+                amount=Decimal("1.00"),
+                payment_method="cash",
+            ),
+            Payment(
+                payment_number=f"PAY-{year}-10000",
+                sales_order_id=test_order.id,
+                amount=Decimal("1.00"),
+                payment_method="cash",
+            ),
+        ])
+        db.flush()
+
+        assert generate_payment_number(db) == f"PAY-{year}-10001"
+
+
 class TestRecordPayment:
 
     def test_record_payment_success(self, client, test_order):

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -264,6 +264,37 @@ class TestRecordPayment:
         assert updated.amount_paid == Decimal("20.00")
         assert updated.paid_at is not None
 
+    def test_record_payment_writes_sales_order_payment_ledger(
+        self, db, make_product, make_sales_order
+    ):
+        from app.models.payment import Payment
+        from app.services.invoice_service import create_invoice, record_payment
+
+        product = make_product(selling_price=Decimal("45.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("45.00"),
+            status="confirmed",
+            payment_status="pending",
+        )
+        invoice = create_invoice(db, so.id)
+
+        record_payment(
+            db, invoice.id, Decimal("45.00"), "card", reference="txn_invoice_123"
+        )
+        db.refresh(so)
+
+        payment = db.query(Payment).filter(Payment.sales_order_id == so.id).one()
+        assert payment.amount == Decimal("45.00")
+        assert payment.payment_method == "card"
+        assert payment.payment_type == "payment"
+        assert payment.status == "completed"
+        assert payment.transaction_id == "txn_invoice_123"
+        assert payment.payment_number.startswith("PAY-")
+        assert so.payment_status == "paid"
+        assert so.paid_at is not None
+
 
 class TestMarkSent:
     """Test mark_sent transition."""


### PR DESCRIPTION
## Summary
- Record invoice-entered payments into the `payments` ledger tied to the sales order.
- Update the sales order payment status from completed ledger payments after invoice payment entry.
- Extract shared payment-number and order-payment-status helpers for both `/payments` and invoice payment flows.

## Validation
- Red check: `python -m pytest backend/tests/test_invoice_service.py::TestRecordPayment::test_record_payment_writes_sales_order_payment_ledger -q` failed before the fix with `No row was found when one was required`.
- `DATABASE_URL` cleared, `DB_NAME=filaops_test`: `python -m pytest backend/tests/test_invoice_service.py backend/tests/api/v1/test_payments.py backend/tests/api/v1/test_admin_accounting.py -q` -> 151 passed, 111 existing Pydantic deprecation warnings.
- `python -m compileall backend/app/services/invoice_service.py backend/app/services/payment_service.py backend/app/api/v1/endpoints/payments.py backend/tests/test_invoice_service.py`
- `python -m ruff check backend/app/services/invoice_service.py backend/app/services/payment_service.py backend/app/api/v1/endpoints/payments.py backend/tests/test_invoice_service.py`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-invoice-accounting-next-20260606-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments recorded from invoices now create ledger entries linked to sales orders; consistent, year-prefixed payment IDs are generated automatically.
  * Sales order payment statuses update automatically (pending/partial/paid) when payments or refunds are recorded.

* **Refactor**
  * Payment generation and status logic moved into a shared payment service for centralized behavior.

* **Tests**
  * New tests cover payment sequencing and ledger-record creation with order status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->