### PR TITLE
fix: exclude shipping from dashboard revenue

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -79,6 +79,17 @@ ACCOUNTS = {
 }
 
 
+def _order_revenue_amount(order: SalesOrder) -> Decimal:
+    """Return recognized order revenue, excluding tax and shipping."""
+    if order.total_price is not None:
+        return order.total_price
+
+    total = order.grand_total if order.grand_total is not None else Decimal("0")
+    tax = order.tax_amount if order.tax_amount is not None else Decimal("0")
+    shipping = order.shipping_cost if order.shipping_cost is not None else Decimal("0")
+    return max(total - tax - shipping, Decimal("0"))
+
+
 @router.get("/inventory-by-account", response_model=InventoryByAccountResponse)
 async def get_inventory_by_account(
     db: Session = Depends(get_db),
@@ -569,8 +580,8 @@ async def get_accounting_dashboard(
         SalesOrder.status.in_(["shipped", "completed"])
     ).all()
 
-    # Revenue excludes tax (tax is a liability, not revenue)
-    mtd_revenue = sum(float((o.grand_total or o.total_price or 0) - (o.tax_amount or 0)) for o in mtd_orders)
+    # Revenue excludes tax and shipping (liabilities/operating expenses, not revenue)
+    mtd_revenue = sum(float(_order_revenue_amount(o)) for o in mtd_orders)
     mtd_tax = sum(float(o.tax_amount or 0) for o in mtd_orders)
     mtd_orders_count = len(mtd_orders)
 
@@ -580,8 +591,8 @@ async def get_accounting_dashboard(
         SalesOrder.status.in_(["shipped", "completed"])
     ).all()
 
-    # Revenue excludes tax (tax is a liability, not revenue)
-    ytd_revenue = sum(float((o.grand_total or o.total_price or 0) - (o.tax_amount or 0)) for o in ytd_orders)
+    # Revenue excludes tax and shipping (liabilities/operating expenses, not revenue)
+    ytd_revenue = sum(float(_order_revenue_amount(o)) for o in ytd_orders)
     ytd_tax = sum(float(o.tax_amount or 0) for o in ytd_orders)
     ytd_orders_count = len(ytd_orders)
 

--- a/backend/tests/api/v1/test_admin_accounting.py
+++ b/backend/tests/api/v1/test_admin_accounting.py
@@ -15,10 +15,9 @@ Tests the admin-scoped accounting view endpoints at /api/v1/admin/accounting/:
 These endpoints are view-only (GET) and sit under the /api/v1/admin/ router.
 Only /export/sales requires explicit staff auth; others rely on router-level access.
 """
-import pytest
 import uuid
 from decimal import Decimal
-from datetime import datetime, timezone, timedelta, date
+from datetime import datetime, timezone
 
 BASE = "/api/v1/admin/accounting"
 
@@ -882,9 +881,31 @@ class TestDashboardWithData:
         # Revenue MTD should be at least 50
         assert data["revenue"]["mtd"] >= 50.0
 
+    def test_dashboard_revenue_excludes_shipping(self, client, db, make_sales_order):
+        """Dashboard revenue should use order subtotal and keep shipping out of revenue."""
+        before = client.get(f"{BASE}/dashboard").json()["revenue"]
+
+        now = datetime.now(timezone.utc)
+        so = make_sales_order(
+            quantity=1,
+            unit_price=Decimal("100.00"),
+            status="shipped",
+        )
+        so.shipped_at = now
+        so.total_price = Decimal("100.00")
+        so.tax_amount = Decimal("8.00")
+        so.shipping_cost = Decimal("12.00")
+        so.grand_total = Decimal("120.00")
+        db.commit()
+
+        after = client.get(f"{BASE}/dashboard").json()["revenue"]
+
+        assert round(after["mtd"] - before["mtd"], 2) == 100.00
+        assert round(after["ytd"] - before["ytd"], 2) == 100.00
+
     def test_outstanding_payments_tracked(self, client, db, make_sales_order):
         """Orders with pending payment should show in outstanding."""
-        so = make_sales_order(
+        make_sales_order(
             quantity=1,
             unit_price=Decimal("75.00"),
             status="confirmed",


### PR DESCRIPTION
## Summary
- keep accounting dashboard revenue aligned with order subtotal semantics
- exclude customer shipping from MTD/YTD revenue while preserving tax exclusion
- add a regression test for shipped orders with subtotal, tax, and shipping
- remove small lint drift in the touched accounting test file

## Validation
- RED: `python -m pytest backend/tests/api/v1/test_admin_accounting.py::TestDashboardWithData::test_dashboard_revenue_excludes_shipping -q` failed with dashboard revenue delta `112.0` instead of `100.0`
- GREEN: `python -m pytest backend/tests/api/v1/test_admin_accounting.py::TestDashboardWithData::test_dashboard_revenue_excludes_shipping -q`
- `python -m pytest backend/tests/api/v1/test_admin_accounting.py -q` — 91 passed, existing Pydantic deprecation warnings
- `python -m compileall backend/app/api/v1/endpoints/admin/accounting.py backend/tests/api/v1/test_admin_accounting.py`
- `python -m ruff check backend/app/api/v1/endpoints/admin/accounting.py backend/tests/api/v1/test_admin_accounting.py`
- `git diff --check`

## Notes
- Test runs used `DB_NAME=filaops_test` with `DATABASE_URL` cleared, avoiding production DB access.
- Local test startup still attempted PRO license validation egress to `https://license.blb3dprinting.com/api/v1/validate`; recorded as Aeonyx observation #151 and left out of scope for this PR.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-20260606-001