### PR TITLE
[codex] Honor quote tax rate updates

### DIFF
--- a/backend/app/api/v1/endpoints/quotes.py
+++ b/backend/app/api/v1/endpoints/quotes.py
@@ -118,6 +118,7 @@ class ManualQuoteUpdate(BaseModel):
 
     # Tax
     apply_tax: Optional[bool] = Field(None, description="Whether to apply tax")
+    tax_rate_id: Optional[int] = Field(None, description="Specific TaxRate id to apply")
 
     # Shipping cost
     shipping_cost: Optional[Decimal] = Field(None, ge=0, description="Shipping cost")
@@ -154,6 +155,7 @@ class QuoteListItem(BaseModel):
     subtotal: Optional[Decimal]
     tax_rate: Optional[Decimal]
     tax_amount: Optional[Decimal]
+    tax_name: Optional[str] = None
     shipping_cost: Optional[Decimal] = None
     total_price: Decimal
     discount_percent: Optional[Decimal] = None

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -427,19 +427,23 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
     # Handle lines update — replace all existing lines
     lines_data = update_data.pop("lines", None)
 
-    # Update fields (exclude apply_tax as it's not a model field)
+    # Update fields (exclude quote-calculation controls that are not model fields)
     apply_tax = update_data.pop("apply_tax", None)
+    tax_rate_id_updated = "tax_rate_id" in update_data
+    tax_rate_id = update_data.pop("tax_rate_id", None)
     shipping_cost_updated = "shipping_cost" in update_data
     shipping_state_updated = "shipping_state" in update_data
 
     for field, value in update_data.items():
         setattr(quote, field, value)
 
+    use_selected_tax_rate = tax_rate_id_updated and tax_rate_id is not None and apply_tax is not False
     should_recalculate = (
         lines_data is not None
         or request.unit_price is not None
         or request.quantity is not None
         or apply_tax is not None
+        or tax_rate_id_updated
         or shipping_cost_updated
         or shipping_state_updated
     )
@@ -510,8 +514,8 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
 
         # Resolve tax (respect apply_tax toggle during multi-line edit)
         shipping = quote.shipping_cost or Decimal("0")
-        if apply_tax is not None:
-            if apply_tax:
+        if use_selected_tax_rate or apply_tax is not None:
+            if use_selected_tax_rate or apply_tax:
                 tax_rate, _tax_amount, tax_name = _resolve_tax(db, subtotal, request, company_settings)
                 quote.tax_rate = tax_rate
                 quote.tax_amount = _calculate_quote_tax_amount(
@@ -551,8 +555,8 @@ def update_quote(db: Session, quote_id: int, request) -> Quote:
         shipping = quote.shipping_cost or Decimal("0")
 
         # Handle tax calculation
-        if apply_tax is not None:
-            if apply_tax:
+        if use_selected_tax_rate or apply_tax is not None:
+            if use_selected_tax_rate or apply_tax:
                 tax_rate, _tax_amount, tax_name = _resolve_tax(db, subtotal, request, company_settings)
                 quote.tax_rate = tax_rate
                 quote.tax_amount = _calculate_quote_tax_amount(
@@ -723,7 +727,7 @@ def convert_quote_to_order(db: Session, quote_id: int) -> dict:
         quote_id=quote.id,
         user_id=quote.user_id,
         order_type="line_item" if has_lines else "quote_based",
-        source="portal",
+        source="quote",
         product_id=quote.product_id if not has_lines else None,
         product_name=quote.product_name,
         quantity=quote.quantity,

--- a/backend/tests/api/v1/test_quotes.py
+++ b/backend/tests/api/v1/test_quotes.py
@@ -1642,6 +1642,31 @@ class TestUpdateQuote:
         # total should equal subtotal without tax
         assert Decimal(str(data["total_price"])) == Decimal(str(data["subtotal"]))
 
+    def test_update_named_tax_rate(self, client, db):
+        """Quote update should accept tax_rate_id from the quote form payload."""
+        from app.models.tax_rate import TaxRate
+
+        named_rate = TaxRate(
+            name="County Tax",
+            rate=Decimal("0.0650"),
+            is_default=False,
+            is_active=True,
+        )
+        db.add(named_rate)
+        db.flush()
+
+        quote = _create_quote(client, quantity=1, unit_price="100.00", apply_tax=False)
+        response = client.patch(f"{BASE_URL}/{quote['id']}", json={
+            "tax_rate_id": named_rate.id,
+        })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert Decimal(str(data["tax_rate"])) == Decimal("0.0650")
+        assert data["tax_name"] == "County Tax"
+        assert Decimal(str(data["tax_amount"])) == Decimal("6.50")
+        assert Decimal(str(data["total_price"])) == Decimal("106.50")
+
     def test_update_nonexistent_quote_returns_404(self, client):
         response = client.patch(f"{BASE_URL}/999999", json={
             "product_name": "Ghost",
@@ -1885,6 +1910,7 @@ class TestConvertQuote:
         assert so["quantity"] == 5
         assert so["customer_name"] == "Convert Customer"
         assert so["customer_email"] == "convert@test.com"
+        assert so["source"] == "quote"
 
     def test_convert_pending_quote_fails(self, client):
         """Only approved/accepted quotes can be converted."""

--- a/backend/tests/services/test_quote_service.py
+++ b/backend/tests/services/test_quote_service.py
@@ -477,6 +477,32 @@ class TestUpdateQuote:
         assert result.tax_amount == Decimal("5.00")
         assert result.total_price == Decimal("105.00")
 
+    def test_tax_rate_id_update_recalculates_single_item_quote(self, db):
+        named_rate = TaxRate(
+            name="County Tax",
+            rate=Decimal("0.0650"),
+            is_default=False,
+            is_active=True,
+        )
+        db.add(named_rate)
+        db.flush()
+        q = _make_quote(
+            db,
+            quote_number="Q-UPD-NAMED-TAX-01",
+            unit_price=Decimal("100.00"),
+            subtotal=Decimal("100.00"),
+            total_price=Decimal("100.00"),
+            quantity=1,
+        )
+
+        request = self._make_update_request(tax_rate_id=named_rate.id)
+        result = quote_service.update_quote(db, q.id, request)
+
+        assert result.tax_rate == Decimal("0.0650")
+        assert result.tax_name == "County Tax"
+        assert result.tax_amount == Decimal("6.50")
+        assert result.total_price == Decimal("106.50")
+
 
 # =============================================================================
 # update_quote_status
@@ -560,6 +586,9 @@ class TestConvertQuoteToOrder:
         db.refresh(q)
         assert q.status == "converted"
         assert q.sales_order_id == result["order_id"]
+
+        order = db.query(SalesOrder).filter(SalesOrder.id == result["order_id"]).first()
+        assert order.source == "quote"
 
     def test_accepted_status_also_converts(self, db):
         q = _make_quote(


### PR DESCRIPTION
## Summary
- Accept `tax_rate_id` on manual quote updates and use it to recalculate named tax rates.
- Include `tax_name` in quote API responses so named-rate snapshots are visible to clients.
- Mark admin quote conversions as `source="quote"` instead of `portal` so only real portal orders carry the portal source.

## Root Cause
The admin quote form was already sending `tax_rate_id`, but the update schema dropped it and `quote_service.update_quote` never treated it as a recalculation control. Separately, Core admin quote conversion reused the portal source value, which made staff-created quote orders look externally sourced.

## Validation
- `python -m pytest backend/tests/services/test_quote_service.py::TestUpdateQuote::test_tax_rate_id_update_recalculates_single_item_quote backend/tests/services/test_quote_service.py::TestConvertQuoteToOrder::test_happy_path backend/tests/api/v1/test_quotes.py::TestUpdateQuote::test_update_named_tax_rate backend/tests/api/v1/test_quotes.py::TestConvertQuote::test_convert_creates_sales_order_with_correct_data -q`
- `python -m pytest backend/tests/services/test_quote_service.py backend/tests/api/v1/test_quotes.py -q` (`219 passed`)
- `python -m ruff check backend/app/api/v1/endpoints/quotes.py backend/app/services/quote_service.py backend/tests/services/test_quote_service.py backend/tests/api/v1/test_quotes.py`

AI-assisted-by: Codex
Agent-Session: codex-quote-cash-next-20260606-002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now specify a tax rate when updating a quote.
  * Tax names are now displayed in quote listings.
  * Sales orders created from quotes are now properly identified as quote-sourced orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->