### PR TITLE
[codex] Preserve quote conversion order totals

### DIFF
--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -946,9 +946,14 @@ def convert_quote_to_sales_order(
     shipping_cost = quote.shipping_cost or Decimal("0.00")
     subtotal = quote.subtotal
     if subtotal is None:
-        subtotal = (quote.total_price or Decimal("0.00")) - tax_amount - shipping_cost
-        if subtotal < Decimal("0.00"):
-            subtotal = quote.total_price or Decimal("0.00")
+        quote_total = quote.total_price or Decimal("0.00")
+        inferred_subtotal = quote_total - tax_amount - shipping_cost
+        if inferred_subtotal < Decimal("0.00"):
+            subtotal = quote_total
+            tax_amount = Decimal("0.00")
+            shipping_cost = Decimal("0.00")
+        else:
+            subtotal = inferred_subtotal
     grand_total = subtotal + tax_amount + shipping_cost
 
     # Create sales order

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -942,6 +942,15 @@ def convert_quote_to_sales_order(
     # Generate order number
     order_number = generate_order_number(db)
 
+    tax_amount = quote.tax_amount or Decimal("0.00")
+    shipping_cost = quote.shipping_cost or Decimal("0.00")
+    subtotal = quote.subtotal
+    if subtotal is None:
+        subtotal = (quote.total_price or Decimal("0.00")) - tax_amount - shipping_cost
+        if subtotal < Decimal("0.00"):
+            subtotal = quote.total_price or Decimal("0.00")
+    grand_total = subtotal + tax_amount + shipping_cost
+
     # Create sales order
     sales_order = SalesOrder(
         user_id=user_id,
@@ -953,13 +962,16 @@ def convert_quote_to_sales_order(
         color=quote.color,
         finish=quote.finish,
         unit_price=quote.unit_price,
-        total_price=quote.total_price,
-        tax_amount=Decimal('0.00'),
-        shipping_cost=Decimal('0.00'),
-        grand_total=quote.total_price,
+        total_price=subtotal,
+        tax_amount=tax_amount,
+        tax_rate=quote.tax_rate,
+        tax_name=quote.tax_name,
+        is_taxable=quote.tax_rate is not None,
+        shipping_cost=shipping_cost,
+        grand_total=grand_total,
         status="pending",
         payment_status="pending",
-        rush_level=quote.rush_level,
+        rush_level=quote.rush_level or "standard",
         shipping_address_line1=shipping_address_line1,
         shipping_address_line2=shipping_address_line2,
         shipping_city=shipping_city,
@@ -976,6 +988,7 @@ def convert_quote_to_sales_order(
     db.flush()
 
     # Update quote
+    quote.status = "converted"
     quote.sales_order_id = sales_order.id
     quote.converted_at = datetime.now(timezone.utc)
 
@@ -992,6 +1005,13 @@ def convert_quote_to_sales_order(
 
     # Generate production order with retry for code collisions
     estimated_time_minutes = int(quote.print_time_hours * 60) if quote.print_time_hours else None
+    priority_map = {
+        "standard": 3,
+        "rush": 2,
+        "super_rush": 2,
+        "urgent": 1,
+    }
+    priority = priority_map.get(quote.rush_level or "standard", 3)
 
     max_retries = 3
     for attempt in range(max_retries):
@@ -1007,7 +1027,7 @@ def convert_quote_to_sales_order(
                 sales_order_id=sales_order.id,
                 quantity_ordered=quote.quantity,
                 status="scheduled",
-                priority="normal" if quote.rush_level == "standard" else "high",
+                priority=priority,
                 estimated_time_minutes=estimated_time_minutes,
                 notes=f"Auto-created from Sales Order {order_number}. Quote: {quote.quote_number}",
                 created_by=str(user_id),

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1903,17 +1903,18 @@ class TestConvertQuoteToSalesOrder:
         assert exc_info.value.status_code == 400
         assert "product" in exc_info.value.detail.lower()
 
-    @pytest.mark.skip(
-        reason="Known bug: convert_quote_to_sales_order passes priority='normal' "
-        "(string) to ProductionOrder.priority (Integer column), causing DataError. "
-        "All validation paths are covered by the error-case tests above."
-    )
     def test_converts_valid_quote(self, db, make_product):
-        """Successfully converts an accepted quote to a sales order."""
+        """Successfully converts an accepted quote and preserves quote totals."""
         product = make_product(selling_price=Decimal("25.00"), has_bom=False)
         quote = self._make_quote(
             db, status="accepted", product_id=product.id,
-            total_price=Decimal("25.00"), unit_price=Decimal("25.00"),
+            subtotal=Decimal("25.00"),
+            total_price=Decimal("35.00"),
+            unit_price=Decimal("25.00"),
+            tax_rate=Decimal("0.0800"),
+            tax_amount=Decimal("2.00"),
+            tax_name="County Tax",
+            shipping_cost=Decimal("8.00"),
             quantity=1,
         )
 
@@ -1929,7 +1930,15 @@ class TestConvertQuoteToSalesOrder:
         assert order.order_type == "quote_based"
         assert order.status == "pending"
         assert order.total_price == Decimal("25.00")
+        assert order.tax_rate == Decimal("0.0800")
+        assert order.tax_amount == Decimal("2.00")
+        assert order.tax_name == "County Tax"
+        assert order.shipping_cost == Decimal("8.00")
+        assert order.grand_total == Decimal("35.00")
         assert order.shipping_address_line1 == "123 Main St"
+        db.refresh(quote)
+        assert quote.status == "converted"
+        assert quote.sales_order_id == order.id
 
 
 # =============================================================================

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1940,6 +1940,34 @@ class TestConvertQuoteToSalesOrder:
         assert quote.status == "converted"
         assert quote.sales_order_id == order.id
 
+    def test_conversion_fallback_does_not_double_count_inconsistent_legacy_totals(self, db, make_product):
+        """Keeps converted totals balanced when legacy quote components exceed total."""
+        product = make_product(selling_price=Decimal("5.00"), has_bom=False)
+        quote = self._make_quote(
+            db, status="accepted", product_id=product.id,
+            subtotal=None,
+            total_price=Decimal("5.00"),
+            unit_price=Decimal("5.00"),
+            tax_rate=Decimal("0.0800"),
+            tax_amount=Decimal("2.00"),
+            tax_name="County Tax",
+            shipping_cost=Decimal("8.00"),
+            quantity=1,
+        )
+
+        order = sales_order_service.convert_quote_to_sales_order(
+            db, quote_id=quote.id, user_id=1,
+            shipping_address_line1="123 Main St",
+            shipping_city="Springfield",
+            shipping_state="IL",
+            shipping_zip="62701",
+        )
+
+        assert order.total_price == Decimal("5.00")
+        assert order.tax_amount == Decimal("0.00")
+        assert order.shipping_cost == Decimal("0.00")
+        assert order.grand_total == Decimal("5.00")
+
 
 # =============================================================================
 # get_required_orders_for_sales_order


### PR DESCRIPTION
## Summary
- Re-enable the valid accepted-quote conversion test in `sales_order_service`.
- Preserve quote subtotal, tax amount/rate/name, shipping, and grand total when converting through `/sales-orders/convert/{quote_id}`.
- Mark the quote as converted and map rush level to the integer production-order priority scale.

## Root Cause
This conversion path still wrote `"normal"`/`"high"` into `ProductionOrder.priority`, which is an integer column, so valid conversions could fail with a database `DataError`. It also flattened `Quote.total_price` into `SalesOrder.total_price` while zeroing tax and shipping, so converted order economics diverged from the staff quote conversion path.

## Validation
- `python -m pytest backend/tests/services/test_sales_order_service.py::TestConvertQuoteToSalesOrder::test_converts_valid_quote -q`
- `python -m pytest backend/tests/services/test_sales_order_service.py -q` (`154 passed`)
- `python -m pytest backend/tests/api/v1/test_sales_orders.py -q` (`115 passed`)
- `python -m ruff check backend/app/services/sales_order_service.py backend/tests/services/test_sales_order_service.py`
- `git diff --check`

AI-assisted-by: Codex
Agent-Session: codex-quote-cash-next-20260606-003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sales order financials now derive correctly from quotes, populating tax rate, tax amount, shipping cost, subtotal, and grand total
  * Production order priorities are correctly assigned from quote rush levels
  * Quotes are marked converted and linked to their created sales orders for accurate tracking

* **Tests**
  * Enabled and expanded conversion test coverage, plus a new test ensuring legacy-total fallback does not double-count totals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->