### PR TITLE
[codex] Include shipping in manual order review totals

### DIFF
--- a/frontend/src/components/sales-order/ReviewStep.jsx
+++ b/frontend/src/components/sales-order/ReviewStep.jsx
@@ -3,6 +3,23 @@
  * Displays order summary: customer info, shipping, line items with totals, tax, and notes.
  * Supports both product and raw material line items.
  */
+const STATE_ALIASES = {
+  INDIANA: "IN",
+};
+
+const SHIPPING_TAXABLE_STATES = new Set(["IN"]);
+
+const normalizeState = (value) => {
+  if (!value) return null;
+  const normalized = value.trim().toUpperCase();
+  return STATE_ALIASES[normalized] || normalized;
+};
+
+const isShippingTaxable = ({ shipToState, sellerState }) => {
+  const state = normalizeState(shipToState) || normalizeState(sellerState);
+  return SHIPPING_TAXABLE_STATES.has(state);
+};
+
 export default function ReviewStep({
   selectedCustomer,
   orderData,
@@ -11,6 +28,22 @@ export default function ReviewStep({
   taxSettings,
   customerDiscount = null,
 }) {
+  const subtotal = Number.isFinite(orderTotal) ? orderTotal : 0;
+  const parsedShippingCost = parseFloat(orderData.shipping_cost);
+  const shippingCost = Number.isNaN(parsedShippingCost)
+    ? 0
+    : Math.max(0, parsedShippingCost);
+  const taxRate = taxSettings.tax_enabled && taxSettings.tax_rate > 0
+    ? taxSettings.tax_rate
+    : 0;
+  const shippingTaxable = shippingCost > 0 && isShippingTaxable({
+    shipToState: orderData.shipping_state,
+    sellerState: taxSettings.company_state,
+  });
+  const taxableBase = subtotal + (shippingTaxable ? shippingCost : 0);
+  const taxAmount = taxRate > 0 ? taxableBase * taxRate : 0;
+  const grandTotal = subtotal + shippingCost + taxAmount;
+
   return (
     <div className="space-y-6">
       <h3 className="text-lg font-semibold text-white">Review Order</h3>
@@ -149,19 +182,32 @@ export default function ReviewStep({
                 Subtotal
               </td>
               <td className="py-3 px-4 text-right text-white font-medium">
-                ${orderTotal.toFixed(2)}
+                ${subtotal.toFixed(2)}
               </td>
             </tr>
-            {taxSettings.tax_enabled && taxSettings.tax_rate > 0 && (
+            {shippingCost > 0 && (
               <tr>
                 <td
                   colSpan={3}
                   className="py-3 px-4 text-right text-gray-400"
                 >
-                  {taxSettings.tax_name} ({(taxSettings.tax_rate * 100).toFixed(2)}%)
+                  Shipping
                 </td>
                 <td className="py-3 px-4 text-right text-white font-medium">
-                  ${(orderTotal * taxSettings.tax_rate).toFixed(2)}
+                  ${shippingCost.toFixed(2)}
+                </td>
+              </tr>
+            )}
+            {taxRate > 0 && (
+              <tr>
+                <td
+                  colSpan={3}
+                  className="py-3 px-4 text-right text-gray-400"
+                >
+                  {taxSettings.tax_name} ({(taxRate * 100).toFixed(2)}%)
+                </td>
+                <td className="py-3 px-4 text-right text-white font-medium">
+                  ${taxAmount.toFixed(2)}
                 </td>
               </tr>
             )}
@@ -173,10 +219,7 @@ export default function ReviewStep({
                 Grand Total
               </td>
               <td className="py-3 px-4 text-right text-green-400 font-bold text-lg">
-                ${(taxSettings.tax_enabled && taxSettings.tax_rate > 0
-                  ? orderTotal * (1 + taxSettings.tax_rate)
-                  : orderTotal
-                ).toFixed(2)}
+                ${grandTotal.toFixed(2)}
               </td>
             </tr>
           </tfoot>

--- a/frontend/src/components/sales-order/ReviewStep.jsx
+++ b/frontend/src/components/sales-order/ReviewStep.jsx
@@ -15,9 +15,9 @@ const normalizeState = (value) => {
   return STATE_ALIASES[normalized] || normalized;
 };
 
-const isShippingTaxable = ({ shipToState, sellerState }) => {
-  const state = normalizeState(shipToState) || normalizeState(sellerState);
-  return SHIPPING_TAXABLE_STATES.has(state);
+const isShippingTaxable = (shipToState) => {
+  const state = normalizeState(shipToState);
+  return state ? SHIPPING_TAXABLE_STATES.has(state) : false;
 };
 
 export default function ReviewStep({
@@ -36,10 +36,7 @@ export default function ReviewStep({
   const taxRate = taxSettings.tax_enabled && taxSettings.tax_rate > 0
     ? taxSettings.tax_rate
     : 0;
-  const shippingTaxable = shippingCost > 0 && isShippingTaxable({
-    shipToState: orderData.shipping_state,
-    sellerState: taxSettings.company_state,
-  });
+  const shippingTaxable = shippingCost > 0 && isShippingTaxable(orderData.shipping_state);
   const taxableBase = subtotal + (shippingTaxable ? shippingCost : 0);
   const taxAmount = taxRate > 0 ? taxableBase * taxRate : 0;
   const grandTotal = subtotal + shippingCost + taxAmount;

--- a/frontend/src/components/sales-order/__tests__/ReviewStep.test.jsx
+++ b/frontend/src/components/sales-order/__tests__/ReviewStep.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ReviewStep from "../ReviewStep";
+
+const lineItems = [
+  {
+    _key: "product-1",
+    line_type: "product",
+    product: { name: "Bracket", sku: "BRACKET-001" },
+    quantity: 2,
+    unit_price: 50,
+  },
+];
+
+const renderReview = ({
+  shippingState = "IN",
+  companyState = "IN",
+} = {}) => render(
+  <ReviewStep
+    selectedCustomer={null}
+    orderData={{
+      shipping_address_line1: "",
+      shipping_city: "",
+      shipping_state: shippingState,
+      shipping_zip: "",
+      shipping_cost: "10.00",
+      customer_notes: "",
+    }}
+    lineItems={lineItems}
+    orderTotal={100}
+    taxSettings={{
+      tax_enabled: true,
+      tax_rate: 0.07,
+      tax_name: "Sales Tax",
+      company_state: companyState,
+    }}
+  />,
+);
+
+describe("ReviewStep order totals", () => {
+  it("includes shipping in the displayed grand total and taxable base when shipping is taxable", () => {
+    renderReview();
+
+    expect(screen.getByText("Shipping")).toBeTruthy();
+    expect(screen.getByText("$10.00")).toBeTruthy();
+    expect(screen.getByText("$7.70")).toBeTruthy();
+    expect(screen.getByText("$117.70")).toBeTruthy();
+  });
+
+  it("keeps shipping out of the tax preview when destination state is not shipping-taxable", () => {
+    renderReview({ shippingState: "OH", companyState: "IN" });
+
+    expect(screen.getByText("$10.00")).toBeTruthy();
+    expect(screen.getByText("$7.00")).toBeTruthy();
+    expect(screen.getByText("$117.00")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/sales-order/__tests__/ReviewStep.test.jsx
+++ b/frontend/src/components/sales-order/__tests__/ReviewStep.test.jsx
@@ -12,10 +12,7 @@ const lineItems = [
   },
 ];
 
-const renderReview = ({
-  shippingState = "IN",
-  companyState = "IN",
-} = {}) => render(
+const renderReview = ({ shippingState = "IN" } = {}) => render(
   <ReviewStep
     selectedCustomer={null}
     orderData={{
@@ -32,7 +29,6 @@ const renderReview = ({
       tax_enabled: true,
       tax_rate: 0.07,
       tax_name: "Sales Tax",
-      company_state: companyState,
     }}
   />,
 );
@@ -48,7 +44,15 @@ describe("ReviewStep order totals", () => {
   });
 
   it("keeps shipping out of the tax preview when destination state is not shipping-taxable", () => {
-    renderReview({ shippingState: "OH", companyState: "IN" });
+    renderReview({ shippingState: "OH" });
+
+    expect(screen.getByText("$10.00")).toBeTruthy();
+    expect(screen.getByText("$7.00")).toBeTruthy();
+    expect(screen.getByText("$117.00")).toBeTruthy();
+  });
+
+  it("keeps shipping out of the tax preview when destination state is missing", () => {
+    renderReview({ shippingState: "" });
 
     expect(screen.getByText("$10.00")).toBeTruthy();
     expect(screen.getByText("$7.00")).toBeTruthy();


### PR DESCRIPTION
## Summary
- Show manual order shipping charges in the review-step totals before submit.
- Include shipping in the displayed grand total and in the tax preview when the entered destination state is shipping-taxable under Core's current built-in rule.
- Add focused ReviewStep coverage for taxable and non-taxable shipping destinations.

## Validation
- `npm ci`
- `npx vitest run --config vitest.unit.config.js src/components/sales-order/__tests__/ReviewStep.test.jsx`
- `npx eslint src/components/sales-order/ReviewStep.jsx src/components/sales-order/__tests__/ReviewStep.test.jsx`
- `npm run build`
- `git diff --check`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-006-20260607-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tax calculation logic to properly account for state-based shipping taxability rules, ensuring accurate order totals in the sales order review step.
  * Improved monetary totals derivation through input normalization for more reliable calculations.

* **Tests**
  * Added comprehensive test coverage for order total and tax preview calculations with various state and shipping configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->