### PR TITLE
[codex] Align manual quote shipping tax preview

### DIFF
--- a/frontend/src/components/quotes/QuoteFormModal.jsx
+++ b/frontend/src/components/quotes/QuoteFormModal.jsx
@@ -11,6 +11,23 @@ import { useNavigate } from "react-router-dom";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
 
+const STATE_ALIASES = {
+  INDIANA: "IN",
+};
+
+const SHIPPING_TAXABLE_STATES = new Set(["IN"]);
+
+const normalizeState = (value) => {
+  if (!value) return null;
+  const normalized = value.trim().toUpperCase();
+  return STATE_ALIASES[normalized] || normalized;
+};
+
+const isShippingTaxable = (state) => {
+  const normalized = normalizeState(state);
+  return normalized ? SHIPPING_TAXABLE_STATES.has(normalized) : false;
+};
+
 export default function QuoteFormModal({ quote, onSave, onClose }) {
   const navigate = useNavigate();
   const toast = useToast();
@@ -367,8 +384,9 @@ export default function QuoteFormModal({ quote, onSave, onClose }) {
     return sum + linePrice * (li.quantity || 1);
   }, 0);
   const taxRate = form.apply_tax && companySettings?.tax_rate_percent ? companySettings.tax_rate_percent / 100 : 0;
-  const taxAmount = subtotal * taxRate;
   const shippingCost = parseFloat(form.shipping_cost) || 0;
+  const taxableBase = subtotal + (isShippingTaxable(companySettings?.company_state) ? shippingCost : 0);
+  const taxAmount = taxRate > 0 ? taxableBase * taxRate : 0;
   const grandTotal = subtotal + taxAmount + shippingCost;
 
   return (

--- a/frontend/src/components/quotes/__tests__/QuoteFormModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteFormModal.test.jsx
@@ -33,6 +33,8 @@ const quote = {
   ],
 };
 
+let companySettingsResponse;
+
 const renderModal = (props = {}) => render(
   <ToastProvider>
     <QuoteFormModal
@@ -46,6 +48,7 @@ const renderModal = (props = {}) => render(
 
 describe("QuoteFormModal editing", () => {
   beforeEach(() => {
+    companySettingsResponse = { tax_enabled: false };
     vi.stubGlobal("fetch", vi.fn((url) => {
       const value = String(url);
       if (value.includes("/api/v1/items")) {
@@ -57,7 +60,7 @@ describe("QuoteFormModal editing", () => {
       if (value.includes("/api/v1/settings/company")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ tax_enabled: false }),
+          json: () => Promise.resolve(companySettingsResponse),
         });
       }
       if (value.includes("/api/v1/tax-rates")) {
@@ -95,6 +98,65 @@ describe("QuoteFormModal editing", () => {
           }),
         ],
       }));
+    });
+  });
+
+  it("submits one-time fee lines without a product id", async () => {
+    const onSave = vi.fn();
+    renderModal({ quote: null, onSave });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Fees" }));
+    fireEvent.change(screen.getByPlaceholderText("Engineering fee"), {
+      target: { value: "Engineering fee" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("75.00"), {
+      target: { value: "75.00" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Quote" }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        lines: [
+          expect.objectContaining({
+            product_id: null,
+            product_name: "Engineering fee",
+            quantity: 1,
+            unit_price: 75,
+          }),
+        ],
+      }));
+    });
+  });
+
+  it("includes taxable shipping in the quote tax preview", async () => {
+    companySettingsResponse = {
+      tax_enabled: true,
+      tax_rate_percent: 7,
+      tax_name: "Sales Tax",
+      company_state: "IN",
+    };
+    renderModal({
+      quote: {
+        ...quote,
+        tax_rate: "0.07",
+        shipping_cost: "10.00",
+        lines: [
+          {
+            ...quote.lines[0],
+            quantity: 2,
+            unit_price: "50.00",
+            total: "100.00",
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("$7.70")).toBeTruthy();
+      expect(screen.getByText("$117.70")).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Align the manual quote form total preview with Core's built-in taxable-shipping behavior by including shipping in the tax base for taxable company states.
- Add regression coverage that the manual quote Fees tab submits one-time fee lines as product-less quote lines.
- Add regression coverage for taxable shipping in the quote total preview.

## Validation
- `npm ci`
- `npx vitest run --config vitest.unit.config.js src/components/quotes/__tests__/QuoteFormModal.test.jsx`
- `npm run build`
- `git diff --check`

## Validation note
- `npx eslint src/components/quotes/QuoteFormModal.jsx src/components/quotes/__tests__/QuoteFormModal.test.jsx` is currently blocked by pre-existing React hook/compiler findings in `QuoteFormModal.jsx`; reported via Cortex observation 155. This PR does not expand that refactor.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-007-20260607-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated tax calculation logic to properly include shipping costs in the tax base for eligible states.

* **Tests**
  * Expanded test coverage for quote fees without product identifiers and shipping tax calculations based on state eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->