### PR TITLE
fix: allow editing order shipping charges

### DIFF
--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -780,6 +780,7 @@ async def update_shipping_address(
         shipping_state=update.shipping_state,
         shipping_zip=update.shipping_zip,
         shipping_country=update.shipping_country,
+        shipping_cost=update.shipping_cost,
     )
 
     db.commit()

--- a/backend/app/schemas/fulfillment_status.py
+++ b/backend/app/schemas/fulfillment_status.py
@@ -22,7 +22,7 @@ class LineStatus(BaseModel):
     """Status of a single order line."""
     line_id: int
     line_number: int
-    product_id: int
+    product_id: Optional[int] = None
     product_sku: str
     product_name: str
     quantity_ordered: float

--- a/backend/app/schemas/order_event.py
+++ b/backend/app/schemas/order_event.py
@@ -22,6 +22,7 @@ class EventType(str, Enum):
     SHIPPED = "shipped"
     DELIVERED = "delivered"
     ADDRESS_UPDATED = "address_updated"
+    SHIPPING_CHARGE_UPDATED = "shipping_charge_updated"
     CANCELLED = "cancelled"
     ON_HOLD = "on_hold"
     RESUMED = "resumed"

--- a/backend/app/schemas/sales_order.py
+++ b/backend/app/schemas/sales_order.py
@@ -141,6 +141,7 @@ class SalesOrderUpdateAddress(BaseModel):
     shipping_state: Optional[str] = Field(None, max_length=50)
     shipping_zip: Optional[str] = Field(None, max_length=20)
     shipping_country: Optional[str] = Field(None, max_length=100)
+    shipping_cost: Optional[Decimal] = Field(None, ge=0)
 
 
 class SalesOrderCancel(BaseModel):

--- a/backend/app/services/fulfillment_status.py
+++ b/backend/app/services/fulfillment_status.py
@@ -52,22 +52,25 @@ def get_fulfillment_status(db: Session, order_id: int) -> Optional[FulfillmentSt
         allocated = float(line.allocated_quantity or 0)
         shipped = float(line.shipped_quantity or 0)
         remaining = quantity_ordered - shipped
-        shortage = max(0, remaining - allocated)
-        is_ready = allocated >= remaining
+        product_id, product_sku, product_name = _line_product_identity(line)
+
+        if line.line_type == "service":
+            allocated = remaining
+            shortage = 0
+            is_ready = True
+        else:
+            shortage = max(0, remaining - allocated)
+            is_ready = allocated >= remaining
 
         if is_ready:
             lines_ready += 1
         else:
             lines_blocked += 1
 
-        # Get product info
-        product_sku = line.product.sku if line.product else "UNKNOWN"
-        product_name = line.product.name if line.product else "Unknown Product"
-
         lines_status.append(LineStatus(
             line_id=line.id,
             line_number=idx,
-            product_id=line.product_id,
+            product_id=product_id,
             product_sku=product_sku,
             product_name=product_name,
             quantity_ordered=quantity_ordered,
@@ -134,7 +137,9 @@ def _estimate_completion_date(db: Session, order: SalesOrder, lines_status: list
     Returns None if no incoming supply found for blocked items.
     """
     blocked_product_ids = [
-        line.product_id for line in lines_status if not line.is_ready
+        line.product_id
+        for line in lines_status
+        if not line.is_ready and line.product_id is not None
     ]
 
     if not blocked_product_ids:
@@ -165,14 +170,12 @@ def _build_shipped_status(db: Session, order: SalesOrder) -> FulfillmentStatus:
     for idx, line in enumerate(order.lines, start=1):
         quantity_ordered = float(line.quantity or 0)
         shipped = float(line.shipped_quantity or 0)
-
-        product_sku = line.product.sku if line.product else "UNKNOWN"
-        product_name = line.product.name if line.product else "Unknown Product"
+        product_id, product_sku, product_name = _line_product_identity(line)
 
         lines_status.append(LineStatus(
             line_id=line.id,
             line_number=idx,
-            product_id=line.product_id,
+            product_id=product_id,
             product_sku=product_sku,
             product_name=product_name,
             quantity_ordered=quantity_ordered,
@@ -216,14 +219,12 @@ def _build_cancelled_status(db: Session, order: SalesOrder) -> FulfillmentStatus
 
     for idx, line in enumerate(order.lines, start=1):
         quantity_ordered = float(line.quantity or 0)
-
-        product_sku = line.product.sku if line.product else "UNKNOWN"
-        product_name = line.product.name if line.product else "Unknown Product"
+        product_id, product_sku, product_name = _line_product_identity(line)
 
         lines_status.append(LineStatus(
             line_id=line.id,
             line_number=idx,
-            product_id=line.product_id,
+            product_id=product_id,
             product_sku=product_sku,
             product_name=product_name,
             quantity_ordered=quantity_ordered,
@@ -259,3 +260,21 @@ def _build_cancelled_status(db: Session, order: SalesOrder) -> FulfillmentStatus
         ),
         lines=lines_status
     )
+
+
+def _line_product_identity(line) -> tuple[Optional[int], str, str]:
+    """Return display identity for product, material, and service order lines."""
+    if line.line_type == "service":
+        return None, "SERVICE", line.description or "Service / Fee"
+
+    if line.line_type == "material":
+        material = line.material_inventory
+        if material:
+            return material.product_id, material.sku, material.display_name
+        return None, "MATERIAL", line.description or "Material"
+
+    product = line.product
+    if product:
+        return line.product_id, product.sku, product.name
+
+    return line.product_id, "UNKNOWN", line.description or "Unknown Product"

--- a/backend/app/services/fulfillment_status.py
+++ b/backend/app/services/fulfillment_status.py
@@ -55,7 +55,6 @@ def get_fulfillment_status(db: Session, order_id: int) -> Optional[FulfillmentSt
         product_id, product_sku, product_name = _line_product_identity(line)
 
         if line.line_type == "service":
-            allocated = remaining
             shortage = 0
             is_ready = True
         else:

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -1256,6 +1256,13 @@ def update_shipping_info(
     return order
 
 
+def _decimal_or_zero(value) -> Decimal:
+    """Normalize SQLAlchemy numeric values for total recalculation."""
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
 def update_shipping_address(
     db: Session,
     order_id: int,
@@ -1266,10 +1273,12 @@ def update_shipping_address(
     shipping_state: Optional[str] = None,
     shipping_zip: Optional[str] = None,
     shipping_country: Optional[str] = None,
+    shipping_cost: Optional[Decimal] = None,
 ) -> SalesOrder:
-    """Update shipping address for an order."""
+    """Update shipping address and customer-facing shipping charge for an order."""
     order = get_sales_order(db, order_id)
     address_changed = False
+    shipping_cost_changed = False
 
     if shipping_address_line1 is not None:
         order.shipping_address_line1 = shipping_address_line1
@@ -1289,8 +1298,19 @@ def update_shipping_address(
     if shipping_country is not None:
         order.shipping_country = shipping_country
         address_changed = True
+    if shipping_cost is not None:
+        new_shipping_cost = Decimal(str(shipping_cost)).quantize(Decimal("0.01"))
+        if new_shipping_cost < Decimal("0"):
+            raise HTTPException(status_code=400, detail="Shipping cost must be greater than or equal to 0")
+
+        old_shipping_cost = _decimal_or_zero(order.shipping_cost)
+        shipping_cost_changed = old_shipping_cost != new_shipping_cost
+        order.shipping_cost = new_shipping_cost
 
     order.updated_at = datetime.now(timezone.utc)
+
+    if address_changed or shipping_cost_changed:
+        _recalculate_order_totals(db, order)
 
     if address_changed:
         record_order_event(
@@ -1298,6 +1318,16 @@ def update_shipping_address(
             order_id=order_id,
             event_type="address_updated",
             title="Shipping address updated",
+            user_id=user_id,
+        )
+    if shipping_cost_changed:
+        record_order_event(
+            db=db,
+            order_id=order_id,
+            event_type="shipping_charge_updated",
+            title="Shipping charge updated",
+            old_value=str(old_shipping_cost),
+            new_value=str(new_shipping_cost),
             user_id=user_id,
         )
 
@@ -1389,16 +1419,16 @@ def _recalculate_order_totals(db: Session, order: SalesOrder) -> None:
         SalesOrderLine.sales_order_id == order.id
     ).all()
 
-    if not lines:
-        return
+    if lines:
+        line_total = sum((_decimal_or_zero(ln.total) for ln in lines), Decimal("0"))
+        line_qty = sum((_decimal_or_zero(ln.quantity) for ln in lines), Decimal("0"))
 
-    line_total = sum((ln.total or Decimal("0")) for ln in lines)
-    line_qty = sum((ln.quantity or Decimal("0")) for ln in lines)
+        order.total_price = line_total
+        order.quantity = int(line_qty)
+    else:
+        line_total = _decimal_or_zero(order.total_price)
 
-    order.total_price = line_total
-    order.quantity = int(line_qty)
-
-    shipping = order.shipping_cost or Decimal("0")
+    shipping = _decimal_or_zero(order.shipping_cost)
     # Recalculate tax if order is taxable
     if order.is_taxable and order.tax_rate is not None:
         company_settings = db.query(CompanySettings).filter(CompanySettings.id == 1).first()
@@ -1411,9 +1441,9 @@ def _recalculate_order_totals(db: Session, order: SalesOrder) -> None:
         )
         order.tax_amount = tax_result.tax_amount
     else:
-        order.tax_amount = order.tax_amount or Decimal("0")
+        order.tax_amount = _decimal_or_zero(order.tax_amount)
 
-    tax = order.tax_amount or Decimal("0")
+    tax = _decimal_or_zero(order.tax_amount)
     order.grand_total = (line_total + tax + shipping).quantize(Decimal("0.01"))
 
     # For quote-based single-line orders, sync the header unit_price

--- a/backend/tests/services/test_fulfillment_status.py
+++ b/backend/tests/services/test_fulfillment_status.py
@@ -1,0 +1,55 @@
+"""Tests for fulfillment status calculation."""
+from decimal import Decimal
+
+from app.models.sales_order import SalesOrderLine
+from app.schemas.fulfillment_status import FulfillmentState
+from app.services.fulfillment_status import get_fulfillment_status
+
+
+class TestFulfillmentStatusService:
+    def test_service_line_does_not_block_fulfillment(self, db, make_product, make_sales_order):
+        product = make_product(name="Fulfillable Widget")
+        order = make_sales_order(
+            product_id=None,
+            product_name="Manual order",
+            quantity=2,
+            unit_price=Decimal("17.50"),
+            status="pending",
+        )
+
+        db.add_all([
+            SalesOrderLine(
+                sales_order_id=order.id,
+                line_type="product",
+                product_id=product.id,
+                quantity=Decimal("1.00"),
+                unit_price=Decimal("25.00"),
+                total=Decimal("25.00"),
+                allocated_quantity=Decimal("1.00"),
+                shipped_quantity=Decimal("0.00"),
+            ),
+            SalesOrderLine(
+                sales_order_id=order.id,
+                line_type="service",
+                description="Design Fee",
+                quantity=Decimal("1.00"),
+                unit_price=Decimal("10.00"),
+                total=Decimal("10.00"),
+                allocated_quantity=Decimal("0.00"),
+                shipped_quantity=Decimal("0.00"),
+            ),
+        ])
+        db.flush()
+
+        status = get_fulfillment_status(db, order.id)
+
+        assert status is not None
+        assert status.summary.state == FulfillmentState.READY_TO_SHIP
+        assert status.summary.lines_total == 2
+        assert status.summary.lines_ready == 2
+
+        fee_line = next(line for line in status.lines if line.product_name == "Design Fee")
+        assert fee_line.product_id is None
+        assert fee_line.product_sku == "SERVICE"
+        assert fee_line.is_ready is True
+        assert fee_line.shortage == 0

--- a/backend/tests/services/test_fulfillment_status.py
+++ b/backend/tests/services/test_fulfillment_status.py
@@ -51,5 +51,6 @@ class TestFulfillmentStatusService:
         fee_line = next(line for line in status.lines if line.product_name == "Design Fee")
         assert fee_line.product_id is None
         assert fee_line.product_sku == "SERVICE"
+        assert fee_line.quantity_allocated == 0
         assert fee_line.is_ready is True
         assert fee_line.shortage == 0

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -26,6 +26,7 @@ from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.production_order import ProductionOrder
 from app.models.order_event import OrderEvent
 from app.models.company_settings import CompanySettings
+from app.schemas.order_event import OrderEventCreate
 from app.services import sales_order_service
 
 
@@ -1078,6 +1079,10 @@ class TestUpdateShippingAddress:
             OrderEvent.event_type == "shipping_charge_updated",
         ).all()
         assert len(events) == 1
+        assert OrderEventCreate(
+            event_type="shipping_charge_updated",
+            title="Shipping charge updated",
+        ).event_type.value == "shipping_charge_updated"
 
 
 # =============================================================================

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1037,6 +1037,48 @@ class TestUpdateShippingAddress:
         assert result.shipping_address_line1 == "Original St"
         assert result.shipping_city == "New City"
 
+    def test_shipping_cost_update_recalculates_taxable_order_total(self, db, make_sales_order, make_product):
+        """Updating order shipping cost after creation updates tax and grand total."""
+        product = make_product(selling_price=Decimal("100.00"))
+        order = make_sales_order(
+            status="pending",
+            order_type="line_item",
+            quantity=1,
+            unit_price=Decimal("100.00"),
+            tax_rate=Decimal("0.07"),
+            tax_amount=Decimal("7.00"),
+            is_taxable=True,
+            shipping_cost=Decimal("0.00"),
+            shipping_state="OH",
+        )
+        _make_order_line(
+            db,
+            order.id,
+            product.id,
+            quantity=1,
+            unit_price=Decimal("100.00"),
+        )
+
+        result = sales_order_service.update_shipping_address(
+            db,
+            order.id,
+            user_id=1,
+            shipping_state="IN",
+            shipping_cost=Decimal("10.00"),
+        )
+        db.flush()
+
+        assert result.total_price == Decimal("100.00")
+        assert result.shipping_cost == Decimal("10.00")
+        assert result.tax_amount == Decimal("7.70")
+        assert result.grand_total == Decimal("117.70")
+
+        events = db.query(OrderEvent).filter(
+            OrderEvent.sales_order_id == order.id,
+            OrderEvent.event_type == "shipping_charge_updated",
+        ).all()
+        assert len(events) == 1
+
 
 # =============================================================================
 # edit_sales_order_lines

--- a/frontend/src/components/orders/ShippingAddressSection.jsx
+++ b/frontend/src/components/orders/ShippingAddressSection.jsx
@@ -12,6 +12,8 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
   const [editingAddress, setEditingAddress] = useState(false);
   const [savingAddress, setSavingAddress] = useState(false);
   const [addressForm, setAddressForm] = useState({});
+  const shippingCharge = Number.parseFloat(order.shipping_cost || 0);
+  const grandTotal = Number.parseFloat(order.grand_total ?? order.total_price ?? 0);
 
   const handleEditAddress = () => {
     setAddressForm({
@@ -21,6 +23,7 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
       shipping_state: order.shipping_state || "",
       shipping_zip: order.shipping_zip || "",
       shipping_country: order.shipping_country || "USA",
+      shipping_cost: order.shipping_cost || "0.00",
     });
     setEditingAddress(true);
   };
@@ -28,13 +31,18 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
   const handleSaveAddress = async () => {
     setSavingAddress(true);
     try {
+      const parsedShippingCost = Number.parseFloat(addressForm.shipping_cost);
+      const payload = {
+        ...addressForm,
+        shipping_cost: Number.isNaN(parsedShippingCost) ? 0 : parsedShippingCost,
+      };
       const res = await fetch(
         `${API_URL}/api/v1/sales-orders/${order.id}/address`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
-          body: JSON.stringify(addressForm),
+          body: JSON.stringify(payload),
         }
       );
 
@@ -70,6 +78,24 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
       {editingAddress ? (
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
+            <div className="col-span-2 md:col-span-1">
+              <label className="block text-sm text-gray-400 mb-1">
+                Shipping Charge
+              </label>
+              <input
+                type="number"
+                value={addressForm.shipping_cost}
+                onChange={(e) =>
+                  setAddressForm({
+                    ...addressForm,
+                    shipping_cost: e.target.value,
+                  })
+                }
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                min="0"
+                step="0.01"
+              />
+            </div>
             <div className="col-span-2">
               <label className="block text-sm text-gray-400 mb-1">
                 Address Line 1
@@ -184,7 +210,21 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
           </div>
         </div>
       ) : (
-        <div>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <div className="text-sm text-gray-400">Shipping Charge</div>
+              <div className="text-white font-medium">
+                ${Number.isNaN(shippingCharge) ? "0.00" : shippingCharge.toFixed(2)}
+              </div>
+            </div>
+            <div>
+              <div className="text-sm text-gray-400">Order Total</div>
+              <div className="text-white font-medium">
+                ${Number.isNaN(grandTotal) ? "0.00" : grandTotal.toFixed(2)}
+              </div>
+            </div>
+          </div>
           {order.shipping_address_line1 ? (
             <div className="text-white">
               <div>{order.shipping_address_line1}</div>


### PR DESCRIPTION
## Summary
- Add optional `shipping_cost` support to the sales order address update request.
- Recalculate order subtotal/tax/grand total when shipping charge or destination state changes.
- Show and edit the shipping charge from the Order Detail shipping card, including the refreshed order total.

## Why
Manual/walk-in/phone orders can be created without a quote, but staff could not update the customer-facing shipping charge after order creation. That made ordinary invoice-and-ship workflows awkward and encouraged fake line items for shipping.

## Validation
- `python -m pytest backend/tests/services/test_sales_order_service.py::TestUpdateShippingAddress backend/tests/services/test_sales_order_service.py::TestEditSalesOrderLines -q` with `DB_NAME=filaops_test` and `DATABASE_URL` unset: 6 passed
- `npm ci` in `frontend/`
- `npm run build` in `frontend/`: passed
- `npx eslint src/components/orders/ShippingAddressSection.jsx`: passed
- `git diff --check`: passed

## Notes
- `npm run lint -- src/components/orders/ShippingAddressSection.jsx` still executes `eslint .` first and reports pre-existing unrelated frontend lint debt; tracked as Cortex observation 156.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-008-20260607-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enter and update shipping charges when editing shipping addresses; shipping charge and recalculated order total shown in the shipping address section
  * Order totals automatically recalc when shipping charge or address changes; a shipping-charge update event is recorded

* **Bug Fixes**
  * Service-type order lines no longer block fulfillment and are treated as ready even without product identity
  * Fulfillment status now safely handles missing product identifiers

* **Tests**
  * Added tests for shipping-charge updates and service-line fulfillment behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->