### PR TITLE
feat: keep invoice workflow on orders

### DIFF
--- a/backend/app/api/v1/endpoints/invoices.py
+++ b/backend/app/api/v1/endpoints/invoices.py
@@ -48,13 +48,19 @@ def create_invoice(
 def list_invoices(
     status: Optional[str] = Query(None),
     search: Optional[str] = Query(None),
+    sales_order_id: Optional[int] = Query(None),
     limit: int = Query(100, le=500),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_staff_user),
 ):
     invoices = invoice_service.list_invoices(
-        db, status=status, customer_search=search, limit=limit, offset=offset,
+        db,
+        status=status,
+        customer_search=search,
+        sales_order_id=sales_order_id,
+        limit=limit,
+        offset=offset,
     )
     results = []
     for inv in invoices:

--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -302,14 +302,18 @@ def list_invoices(
     db: Session,
     status: Optional[str] = None,
     customer_search: Optional[str] = None,
+    sales_order_id: Optional[int] = None,
     limit: int = 100,
     offset: int = 0,
 ) -> list[Invoice]:
-    """List invoices with optional status and customer search filters.
+    """List invoices with optional status, customer, and order filters.
 
     Special status value 'overdue' returns sent invoices past their due date.
     """
     query = db.query(Invoice).order_by(desc(Invoice.created_at))
+
+    if sales_order_id is not None:
+        query = query.filter(Invoice.sales_order_id == sales_order_id)
 
     if status and status != "all":
         if status == "overdue":

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -352,6 +352,40 @@ class TestInvoiceAPI:
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
+    def test_list_invoices_filters_by_sales_order_id(
+        self, client, db, make_product, make_sales_order
+    ):
+        product = make_product(selling_price=Decimal("30.00"))
+        target_order = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("30.00"),
+            status="confirmed",
+        )
+        other_order = make_sales_order(
+            product_id=product.id,
+            quantity=2,
+            unit_price=Decimal("30.00"),
+            status="confirmed",
+        )
+
+        target_response = client.post(
+            "/api/v1/invoices", json={"sales_order_id": target_order.id}
+        )
+        other_response = client.post(
+            "/api/v1/invoices", json={"sales_order_id": other_order.id}
+        )
+        assert target_response.status_code == 200
+        assert other_response.status_code == 200
+
+        response = client.get(f"/api/v1/invoices?sales_order_id={target_order.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["sales_order_id"] == target_order.id
+        assert data[0]["invoice_number"] == target_response.json()["invoice_number"]
+
     def test_get_invoice_not_found(self, client):
         response = client.get("/api/v1/invoices/999999")
         assert response.status_code == 404

--- a/frontend/src/pages/admin/AdminInvoices.jsx
+++ b/frontend/src/pages/admin/AdminInvoices.jsx
@@ -31,6 +31,9 @@ const PAYMENT_METHODS = [
   { value: "other", label: "Other" },
 ];
 
+const getInvoiceBalanceDue = (invoice) =>
+  invoice?.balance_due ?? invoice?.amount_due ?? 0;
+
 export default function AdminInvoices() {
   const api = useApi();
   const toast = useToast();
@@ -39,6 +42,7 @@ export default function AdminInvoices() {
 
   const statusFilter = searchParams.get("status") || "";
   const searchQuery = searchParams.get("search") || "";
+  const invoiceIdParam = searchParams.get("invoice") || "";
 
   const [invoices, setInvoices] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -60,12 +64,6 @@ export default function AdminInvoices() {
 
   // Send invoice state
   const [sendingInvoice, setSendingInvoice] = useState(false);
-
-  useEffect(() => {
-    fetchInvoices();
-    fetchSummary();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter]);
 
   const fetchInvoices = async () => {
     setLoading(true);
@@ -93,6 +91,14 @@ export default function AdminInvoices() {
     }
   };
 
+  useEffect(() => {
+    void Promise.resolve().then(() => {
+      fetchInvoices();
+      fetchSummary();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
+
   const handleViewInvoice = async (invoice) => {
     setDetailLoading(true);
     try {
@@ -104,6 +110,27 @@ export default function AdminInvoices() {
       setDetailLoading(false);
     }
   };
+
+  useEffect(() => {
+    const invoiceId = Number(invoiceIdParam);
+    if (!invoiceId || selectedInvoice?.id === invoiceId) return;
+    let cancelled = false;
+
+    api.get(`/api/v1/invoices/${invoiceId}`)
+      .then((data) => {
+        if (!cancelled) setSelectedInvoice(data);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.error(err.message || "Failed to load invoice details");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [invoiceIdParam]);
 
   const handleSendInvoice = async () => {
     if (!selectedInvoice) return;
@@ -366,7 +393,7 @@ export default function AdminInvoices() {
                       {formatCurrency(invoice.amount_paid || 0)}
                     </td>
                     <td className="py-3 px-4 text-right text-white font-medium">
-                      {formatCurrency(invoice.balance_due || 0)}
+                      {formatCurrency(getInvoiceBalanceDue(invoice))}
                     </td>
                     <td className="py-3 px-4 text-center">
                       <span
@@ -582,8 +609,8 @@ export default function AdminInvoices() {
                       </div>
                       <div className="flex justify-between border-t border-gray-700 pt-2 font-semibold">
                         <span className="text-white">Balance Due</span>
-                        <span className={parseFloat(selectedInvoice.balance_due || 0) > 0 ? "text-red-400" : "text-green-400"}>
-                          {formatCurrency(selectedInvoice.balance_due || 0)}
+                        <span className={parseFloat(getInvoiceBalanceDue(selectedInvoice)) > 0 ? "text-red-400" : "text-green-400"}>
+                          {formatCurrency(getInvoiceBalanceDue(selectedInvoice))}
                         </span>
                       </div>
                     </div>
@@ -638,7 +665,7 @@ export default function AdminInvoices() {
                             onChange={(e) =>
                               setPaymentForm({ ...paymentForm, amount: e.target.value })
                             }
-                            placeholder={`${parseFloat(selectedInvoice.balance_due || 0).toFixed(2)}`}
+                            placeholder={`${parseFloat(getInvoiceBalanceDue(selectedInvoice)).toFixed(2)}`}
                             className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white placeholder-gray-500 text-sm"
                           />
                         </div>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -115,133 +115,7 @@ export default function OrderDetail() {
     refetch: refetchFulfillment,
   } = useFulfillmentStatus(orderId);
 
-  const fetchOrder = async () => {
-    setLoading(true);
-    setError(null);
-
-    try {
-      const data = await api.get(`/api/v1/sales-orders/${orderId}`);
-      setOrder(data);
-
-      // Explode BOM for material requirements
-      if (
-        data.order_type === "line_item" &&
-        data.lines &&
-        data.lines.length > 0
-      ) {
-        const firstLine = data.lines[0];
-        if (firstLine.product_id) {
-          // eslint-disable-next-line react-hooks/immutability
-          await explodeBOM(firstLine.product_id, firstLine.quantity);
-        }
-      } else if (data.product_id) {
-        await explodeBOM(data.product_id, data.quantity);
-      } else if (data.quote_id) {
-        try {
-          const quoteData = await api.get(`/api/v1/quotes/${data.quote_id}`);
-          if (quoteData.product_id) {
-            await explodeBOM(quoteData.product_id, data.quantity);
-          }
-        } catch {
-          // Quote fetch failure is non-critical
-        }
-      }
-    } catch (err) {
-      setError(err.message || "Failed to fetch order");
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchProductionOrders = async () => {
-    if (!orderId) return;
-    try {
-      const data = await api.get(
-        `/api/v1/production-orders?sales_order_id=${orderId}`
-      );
-      setProductionOrders(data.items || data || []);
-    } catch {
-      // Production orders fetch failure is non-critical
-    }
-  };
-
-  const fetchPaymentData = async () => {
-    if (!orderId) return;
-    try {
-      const summary = await api.get(
-        `/api/v1/payments/order/${orderId}/summary`
-      );
-      setPaymentSummary(summary);
-    } catch {
-      // Payment summary fetch failure is non-critical
-    }
-    try {
-      const data = await api.get(`/api/v1/payments?order_id=${orderId}`);
-      setPayments(data.items || []);
-    } catch {
-      // Payment list fetch failure is non-critical
-    }
-  };
-
-  const fetchOrderInvoice = async () => {
-    if (!orderId) return null;
-    setInvoiceLoading(true);
-    try {
-      const data = await api.get(
-        `/api/v1/invoices?sales_order_id=${orderId}&limit=1`
-      );
-      const invoices = data.items || data || [];
-      const invoice = invoices.length > 0 ? invoices[0] : null;
-      setOrderInvoice(invoice);
-      return invoice;
-    } catch {
-      setOrderInvoice(null);
-      return null;
-    } finally {
-      setInvoiceLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (orderId) {
-      void Promise.resolve().then(() => {
-        fetchOrder();
-        fetchProductionOrders();
-        fetchPaymentData();
-        fetchOrderInvoice();
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderId]);
-
-  const handlePaymentRecorded = () => {
-    setShowPaymentModal(false);
-    setIsRefund(false);
-    fetchPaymentData();
-    fetchOrder();
-    fetchOrderInvoice();
-    toast.success(isRefund ? "Refund recorded" : "Payment recorded");
-  };
-
-  const handleRefresh = async () => {
-    setRefreshing(true);
-    try {
-      await Promise.all([
-        fetchOrder(),
-        fetchProductionOrders(),
-        fetchPaymentData(),
-        fetchOrderInvoice(),
-      ]);
-      toast.success("Data refreshed");
-    } catch {
-      toast.error("Failed to refresh");
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
-  async function explodeBOM(productId, quantity) {
+  const explodeBOM = async (productId, quantity) => {
     setExploding(true);
     try {
       // PRIMARY: Use the new material-requirements endpoint (routing-first approach)
@@ -360,7 +234,152 @@ export default function OrderDetail() {
     } finally {
       setExploding(false);
     }
-  }
+  };
+
+  const fetchOrder = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.get(`/api/v1/sales-orders/${orderId}`);
+      setOrder(data);
+
+      // Explode BOM for material requirements
+      if (
+        data.order_type === "line_item" &&
+        data.lines &&
+        data.lines.length > 0
+      ) {
+        const firstLine = data.lines[0];
+        if (firstLine.product_id) {
+          await explodeBOM(firstLine.product_id, firstLine.quantity);
+        }
+      } else if (data.product_id) {
+        await explodeBOM(data.product_id, data.quantity);
+      } else if (data.quote_id) {
+        try {
+          const quoteData = await api.get(`/api/v1/quotes/${data.quote_id}`);
+          if (quoteData.product_id) {
+            await explodeBOM(quoteData.product_id, data.quantity);
+          }
+        } catch {
+          // Quote fetch failure is non-critical
+        }
+      }
+    } catch (err) {
+      setError(err.message || "Failed to fetch order");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchProductionOrders = async () => {
+    if (!orderId) return;
+    try {
+      const data = await api.get(
+        `/api/v1/production-orders?sales_order_id=${orderId}`
+      );
+      setProductionOrders(data.items || data || []);
+    } catch {
+      // Production orders fetch failure is non-critical
+    }
+  };
+
+  const fetchPaymentData = async () => {
+    if (!orderId) return;
+    try {
+      const summary = await api.get(
+        `/api/v1/payments/order/${orderId}/summary`
+      );
+      setPaymentSummary(summary);
+    } catch {
+      // Payment summary fetch failure is non-critical
+    }
+    try {
+      const data = await api.get(`/api/v1/payments?order_id=${orderId}`);
+      setPayments(data.items || []);
+    } catch {
+      // Payment list fetch failure is non-critical
+    }
+  };
+
+  const fetchOrderInvoice = async ({ shouldApply = () => true } = {}) => {
+    if (!orderId) return null;
+    if (shouldApply()) {
+      setInvoiceLoading(true);
+    }
+    try {
+      const data = await api.get(
+        `/api/v1/invoices?sales_order_id=${orderId}&limit=1`
+      );
+      const invoices = data.items || data || [];
+      const invoice = invoices.length > 0 ? invoices[0] : null;
+      if (shouldApply()) {
+        setOrderInvoice(invoice);
+      }
+      return invoice;
+    } catch {
+      if (shouldApply()) {
+        setOrderInvoice(null);
+      }
+      return null;
+    } finally {
+      if (shouldApply()) {
+        setInvoiceLoading(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!orderId) return undefined;
+    let cancelled = false;
+    const shouldApply = () => !cancelled;
+
+    void (async () => {
+      try {
+        await Promise.all([
+          fetchOrder(),
+          fetchProductionOrders(),
+          fetchPaymentData(),
+          fetchOrderInvoice({ shouldApply }),
+        ]);
+      } catch {
+        // Individual fetchers own user-visible error state.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderId]);
+
+  const handlePaymentRecorded = () => {
+    setShowPaymentModal(false);
+    setIsRefund(false);
+    fetchPaymentData();
+    fetchOrder();
+    fetchOrderInvoice();
+    toast.success(isRefund ? "Refund recorded" : "Payment recorded");
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        fetchOrder(),
+        fetchProductionOrders(),
+        fetchPaymentData(),
+        fetchOrderInvoice(),
+      ]);
+      toast.success("Data refreshed");
+    } catch {
+      toast.error("Failed to refresh");
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   const handleCreateProductionOrder = async () => {
     const hasProduct =

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -25,6 +25,11 @@ import PaymentsSection from "../../components/orders/PaymentsSection";
 import ShippingAddressSection from "../../components/orders/ShippingAddressSection";
 import { CancelOrderModal, DeleteOrderModal } from "../../components/orders/OrderModals";
 
+const getInvoiceBalanceDue = (invoice) =>
+  invoice?.balance_due ?? invoice?.amount_due ?? 0;
+
+const formatMoney = (value) => `$${parseFloat(value || 0).toFixed(2)}`;
+
 export default function OrderDetail() {
   const { orderId } = useParams();
   const navigate = useNavigate();
@@ -68,6 +73,9 @@ export default function OrderDetail() {
 
   // Invoice generation state
   const [generatingInvoice, setGeneratingInvoice] = useState(false);
+  const [orderInvoice, setOrderInvoice] = useState(null);
+  const [invoiceLoading, setInvoiceLoading] = useState(false);
+  const [sendingInvoice, setSendingInvoice] = useState(false);
 
   // Line editing state
   const [editingLineId, setEditingLineId] = useState(null);
@@ -107,15 +115,6 @@ export default function OrderDetail() {
     refetch: refetchFulfillment,
   } = useFulfillmentStatus(orderId);
 
-  useEffect(() => {
-    if (orderId) {
-      fetchOrder();
-      fetchProductionOrders();
-      fetchPaymentData();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderId]);
-
   const fetchOrder = async () => {
     setLoading(true);
     setError(null);
@@ -132,6 +131,7 @@ export default function OrderDetail() {
       ) {
         const firstLine = data.lines[0];
         if (firstLine.product_id) {
+          // eslint-disable-next-line react-hooks/immutability
           await explodeBOM(firstLine.product_id, firstLine.quantity);
         }
       } else if (data.product_id) {
@@ -184,11 +184,43 @@ export default function OrderDetail() {
     }
   };
 
+  const fetchOrderInvoice = async () => {
+    if (!orderId) return null;
+    setInvoiceLoading(true);
+    try {
+      const data = await api.get(
+        `/api/v1/invoices?sales_order_id=${orderId}&limit=1`
+      );
+      const invoices = data.items || data || [];
+      const invoice = invoices.length > 0 ? invoices[0] : null;
+      setOrderInvoice(invoice);
+      return invoice;
+    } catch {
+      setOrderInvoice(null);
+      return null;
+    } finally {
+      setInvoiceLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (orderId) {
+      void Promise.resolve().then(() => {
+        fetchOrder();
+        fetchProductionOrders();
+        fetchPaymentData();
+        fetchOrderInvoice();
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderId]);
+
   const handlePaymentRecorded = () => {
     setShowPaymentModal(false);
     setIsRefund(false);
     fetchPaymentData();
     fetchOrder();
+    fetchOrderInvoice();
     toast.success(isRefund ? "Refund recorded" : "Payment recorded");
   };
 
@@ -199,6 +231,7 @@ export default function OrderDetail() {
         fetchOrder(),
         fetchProductionOrders(),
         fetchPaymentData(),
+        fetchOrderInvoice(),
       ]);
       toast.success("Data refreshed");
     } catch {
@@ -208,7 +241,7 @@ export default function OrderDetail() {
     }
   };
 
-  const explodeBOM = async (productId, quantity) => {
+  async function explodeBOM(productId, quantity) {
     setExploding(true);
     try {
       // PRIMARY: Use the new material-requirements endpoint (routing-first approach)
@@ -327,7 +360,7 @@ export default function OrderDetail() {
     } finally {
       setExploding(false);
     }
-  };
+  }
 
   const handleCreateProductionOrder = async () => {
     const hasProduct =
@@ -537,13 +570,36 @@ export default function OrderDetail() {
       const invoice = await api.post("/api/v1/invoices", {
         sales_order_id: order.id,
       });
+      setOrderInvoice(invoice);
       toast.success(`Invoice ${invoice.invoice_number} created`);
-      navigate("/admin/invoices");
+      await Promise.all([fetchOrder(), fetchOrderInvoice(), fetchPaymentData()]);
     } catch (err) {
       toast.error(err.response?.data?.detail || err.message || "Failed to generate invoice");
     } finally {
       setGeneratingInvoice(false);
     }
+  };
+
+  const handleSendOrderInvoice = async () => {
+    if (!orderInvoice) return;
+    setSendingInvoice(true);
+    try {
+      const invoice = await api.post(`/api/v1/invoices/${orderInvoice.id}/send`);
+      setOrderInvoice(invoice);
+      toast.success(`Invoice ${invoice.invoice_number} sent`);
+    } catch (err) {
+      toast.error(err.response?.data?.detail || err.message || "Failed to send invoice");
+    } finally {
+      setSendingInvoice(false);
+    }
+  };
+
+  const handleDownloadOrderInvoice = () => {
+    if (!orderInvoice) return;
+    window.open(
+      `${API_URL}/api/v1/invoices/${orderInvoice.id}/pdf`,
+      "_blank"
+    );
   };
 
   const canGenerateInvoice = () => {
@@ -555,7 +611,7 @@ export default function OrderDetail() {
       "delivered",
       "completed",
     ];
-    return order && invoiceableStatuses.includes(order.status);
+    return order && !orderInvoice && invoiceableStatuses.includes(order.status);
   };
 
   if (loading) {
@@ -715,6 +771,56 @@ export default function OrderDetail() {
           </svg>
           Quick Actions
         </h2>
+        {invoiceLoading && !orderInvoice && (
+          <div className="mb-4 rounded-lg border border-gray-700 bg-gray-900/70 px-4 py-3 text-sm text-gray-400">
+            Checking invoice status...
+          </div>
+        )}
+        {orderInvoice && (
+          <div className="mb-4 rounded-lg border border-emerald-500/30 bg-emerald-950/20 px-4 py-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-emerald-300">
+                  Invoice on this order
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-3">
+                  <span className="font-mono text-sm font-semibold text-white">
+                    {orderInvoice.invoice_number}
+                  </span>
+                  <span className="rounded-full bg-gray-900 px-2 py-1 text-xs text-gray-300">
+                    {orderInvoice.status?.replace(/_/g, " ") || "draft"}
+                  </span>
+                  <span className="text-sm text-gray-300">
+                    Balance {formatMoney(getInvoiceBalanceDue(orderInvoice))}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => navigate(`/admin/invoices?invoice=${orderInvoice.id}`)}
+                  className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600"
+                >
+                  Open Invoice
+                </button>
+                {orderInvoice.status === "draft" && (
+                  <button
+                    onClick={handleSendOrderInvoice}
+                    disabled={sendingInvoice}
+                    className="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {sendingInvoice ? "Sending..." : "Send Invoice"}
+                  </button>
+                )}
+                <button
+                  onClick={handleDownloadOrderInvoice}
+                  className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600"
+                >
+                  Download PDF
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <button
             onClick={handleCreateProductionOrder}
@@ -761,7 +867,7 @@ export default function OrderDetail() {
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
               </svg>
-              {generatingInvoice ? "Generating..." : "Generate Invoice"}
+              {generatingInvoice ? "Creating..." : "Create Invoice"}
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Add `sales_order_id` filtering to invoice listing so Order Detail can find its invoice directly.
- Keep invoice creation in the order context instead of navigating away to the invoice list.
- Show the linked invoice on Order Detail with open, send, and download actions.
- Let `/admin/invoices?invoice=<id>` open the invoice modal and read balances from `amount_due` when `balance_due` is absent.

## Validation
- `python -m py_compile backend/app/api/v1/endpoints/invoices.py backend/app/services/invoice_service.py backend/tests/test_invoice_service.py`
- `npm ci`
- `npx eslint src/pages/admin/AdminInvoices.jsx src/pages/admin/OrderDetail.jsx`
- `npm run build`
- `git diff --check`

## Local Test Note
- Added `TestInvoiceAPI::test_list_invoices_filters_by_sales_order_id`.
- Could not execute pytest locally because the configured test DB connection used `DATABASE_URL=$null`, `DB_NAME=filaops_test`, `DEBUG=false` and failed auth for `postgres:postgres@localhost:5432/filaops_test`.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-order-workflow-command-ui-20260608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter invoices by sales order in the invoices list.
  * PDF download for invoices from order details.
  * Create/send invoices from order details without navigating away.
  * Quick Actions: invoice status panel showing number, status, and balance due.

* **UI Improvements**
  * Consistent "Balance Due" computation across table, modal, and payment input.
  * Invoice details auto-load from query param and avoid unnecessary refetches.

* **Tests**
  * Added test coverage for sales-order invoice filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->