### PR TITLE
fix: separate order confirmation from production release

### DIFF
--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -30,6 +30,7 @@ from app.models.bom import BOM, BOMLine
 from app.models.inventory import Inventory
 from app.models.company_settings import CompanySettings
 from app.models.order_event import OrderEvent
+from app.core.status_config import StatusTransitionError, validate_sales_order_transition
 from app.services.customer_service import get_customer_discount_percent as _get_customer_discount_percent
 from app.services.tax_calculation_service import calculate_sales_tax
 
@@ -1109,35 +1110,17 @@ def update_sales_order_status(
     """
     order = get_sales_order(db, order_id)
     old_status = order.status
+
+    try:
+        validate_sales_order_transition(old_status, new_status)
+    except StatusTransitionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     order.status = new_status
 
     # Set timestamps based on status
-    if new_status == "confirmed" and old_status == "pending":
+    if new_status == "confirmed" and old_status in ("pending", "pending_confirmation"):
         order.confirmed_at = datetime.now(timezone.utc)
-
-        # Auto-create production orders
-        existing_pos = db.query(ProductionOrder).filter(
-            ProductionOrder.sales_order_id == order_id
-        ).all()
-
-        if not existing_pos:
-            created_orders = create_production_orders_for_sales_order(db, order, user_email)
-            if created_orders:
-                order.status = "in_production"
-
-                # Trigger MRP check if enabled
-                try:
-                    from app.services.mrp_trigger_service import trigger_mrp_check
-                    from app.core.settings import get_settings
-                    settings = get_settings()
-
-                    if settings.AUTO_MRP_ON_CONFIRMATION:
-                        trigger_mrp_check(db, order.id)
-                except Exception as e:
-                    logger.warning(
-                        f"MRP trigger failed after order confirmation {order.id}: {str(e)}",
-                        exc_info=True
-                    )
 
     if new_status == "shipped":
         order.shipped_at = datetime.now(timezone.utc)
@@ -2714,6 +2697,12 @@ def generate_production_orders(
             "created_orders": []
         }
 
+    if order.status != "confirmed":
+        raise HTTPException(
+            status_code=400,
+            detail="Confirm the sales order before generating production orders"
+        )
+
     created_orders = []
     year = datetime.now(timezone.utc).year
 
@@ -2869,16 +2858,12 @@ def generate_production_orders(
         )
 
         # Update order status — only move to in_production when work orders exist
-        if order.status == "pending":
-            order.status = "in_production"
-            order.confirmed_at = datetime.now(timezone.utc)
-        elif order.status == "confirmed":
+        if order.status == "confirmed":
             order.status = "in_production"
     elif order.order_type == "line_item":
         # All lines are material-only — no production needed (pick and ship)
-        if order.status == "pending":
-            order.status = "confirmed"
-            order.confirmed_at = datetime.now(timezone.utc)
+        if order.status == "confirmed":
+            logger.info("No production orders created for material-only sales order %s", order.id)
 
     return {
         "message": f"Created {len(created_orders)} production order(s)",

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -2679,18 +2679,30 @@ def generate_production_orders(
         )
 
     # Check for existing production orders
+    producible_line_ids: list[int] = []
+    existing_po_line_ids: set[int] = set()
     if order.order_type == "line_item":
-        line_product_ids = [line.product_id for line in order.lines if line.product_id]
-        existing_pos = db.query(ProductionOrder).filter(
-            ProductionOrder.sales_order_id == order_id,
-            ProductionOrder.product_id.in_(line_product_ids)
-        ).all()
+        producible_line_ids = [line.id for line in order.lines if line.product_id]
+        existing_pos = []
+        if producible_line_ids:
+            existing_pos = db.query(ProductionOrder).filter(
+                ProductionOrder.sales_order_id == order_id,
+                ProductionOrder.sales_order_line_id.in_(producible_line_ids)
+            ).all()
+            existing_po_line_ids = {
+                po.sales_order_line_id
+                for po in existing_pos
+                if po.sales_order_line_id is not None
+            }
     else:
         existing_pos = db.query(ProductionOrder).filter(
             ProductionOrder.sales_order_id == order_id
         ).all()
 
-    if existing_pos:
+    if existing_pos and (
+        order.order_type != "line_item"
+        or len(existing_po_line_ids) == len(producible_line_ids)
+    ):
         return {
             "message": "Production orders already exist",
             "existing_orders": [po.code for po in existing_pos],
@@ -2733,6 +2745,9 @@ def generate_production_orders(
             )
 
         for idx, line in enumerate(lines, start=1):
+            if line.id in existing_po_line_ids:
+                continue
+
             # Skip material-only lines — raw materials don't need production orders
             if not line.product_id:
                 continue
@@ -2868,7 +2883,7 @@ def generate_production_orders(
     return {
         "message": f"Created {len(created_orders)} production order(s)",
         "created_orders": created_orders,
-        "existing_orders": []
+        "existing_orders": [po.code for po in existing_pos]
     }
 
 

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1673,7 +1673,7 @@ class TestGenerateProductionOrders:
 
     def test_rejects_line_item_order_with_no_lines(self, db, make_sales_order):
         """line_item order with no lines raises 400."""
-        so = make_sales_order(status="pending", order_type="line_item")
+        so = make_sales_order(status="confirmed", order_type="line_item")
 
         with pytest.raises(HTTPException) as exc_info:
             sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -764,9 +764,41 @@ class TestUpdateSalesOrderStatus:
         )
         assert result.confirmed_at is not None
 
+    def test_pending_to_confirmed_does_not_create_production_order(
+        self, db, make_sales_order, make_product
+    ):
+        """Commercial confirmation does not release the order to production."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="pending", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        result = sales_order_service.update_sales_order_status(
+            db, so.id, "confirmed", user_id=1, user_email="test@filaops.dev"
+        )
+
+        linked_pos = db.query(ProductionOrder).filter(
+            ProductionOrder.sales_order_id == so.id
+        ).all()
+        assert result.status == "confirmed"
+        assert result.confirmed_at is not None
+        assert linked_pos == []
+
+    def test_invalid_status_transition_is_rejected(self, db, make_sales_order):
+        """Status updates must follow the configured sales order state machine."""
+        so = make_sales_order(status="pending")
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.update_sales_order_status(
+                db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid sales order status transition" in exc_info.value.detail
+        assert so.status == "pending"
+
     def test_shipped_sets_shipped_at(self, db, make_sales_order):
         """Setting status to shipped sets shipped_at."""
-        so = make_sales_order(status="in_production")
+        so = make_sales_order(status="ready_to_ship")
         result = sales_order_service.update_sales_order_status(
             db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
         )
@@ -810,7 +842,7 @@ class TestUpdateSalesOrderStatus:
         """Status change records an event in the timeline."""
         so = make_sales_order(status="pending")
         sales_order_service.update_sales_order_status(
-            db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
+            db, so.id, "confirmed", user_id=1, user_email="test@filaops.dev"
         )
         db.flush()
 
@@ -821,7 +853,7 @@ class TestUpdateSalesOrderStatus:
         assert len(events) >= 1
         latest = events[-1]
         assert latest.old_value == "pending"
-        assert latest.new_value == "shipped"
+        assert latest.new_value == "confirmed"
 
     def test_raises_404_for_missing_order(self, db):
         """Raises 404 when order does not exist."""
@@ -1574,6 +1606,20 @@ class TestGenerateProductionOrders:
         assert exc_info.value.status_code == 400
         assert "cancelled" in exc_info.value.detail.lower()
 
+    def test_rejects_unconfirmed_order_without_existing_pos(
+        self, db, make_sales_order, make_product
+    ):
+        """New work orders cannot be released before commercial confirmation."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="pending", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+
+        assert exc_info.value.status_code == 400
+        assert "confirm" in exc_info.value.detail.lower()
+
     def test_returns_existing_pos_for_line_item_order(self, db, make_sales_order, make_product):
         """If POs already exist for a line_item order, returns them."""
         product = make_product(selling_price=Decimal("10.00"))
@@ -1637,7 +1683,7 @@ class TestGenerateProductionOrders:
     def test_creates_po_for_line_item_order(self, db, make_sales_order, make_product):
         """Creates a production order for each line item."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="pending", order_type="line_item")
+        so = make_sales_order(status="confirmed", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=3)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1650,13 +1696,12 @@ class TestGenerateProductionOrders:
         db.flush()
         db.refresh(so)
         assert so.status == "in_production"
-        assert so.confirmed_at is not None
 
     def test_creates_po_for_multiple_line_items(self, db, make_sales_order, make_product):
         """Creates one PO per line item."""
         p1 = make_product(selling_price=Decimal("10.00"))
         p2 = make_product(selling_price=Decimal("20.00"))
-        so = make_sales_order(status="pending", order_type="line_item")
+        so = make_sales_order(status="confirmed", order_type="line_item")
         _make_order_line(db, so.id, p1.id, quantity=2)
         _make_order_line(db, so.id, p2.id, quantity=5)
 
@@ -1677,7 +1722,7 @@ class TestGenerateProductionOrders:
     def test_records_production_started_event(self, db, make_sales_order, make_product):
         """Records a production_started event after PO creation."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="pending", order_type="line_item")
+        so = make_sales_order(status="confirmed", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=1)
 
         sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1691,7 +1736,7 @@ class TestGenerateProductionOrders:
 
     def test_rejects_quote_based_order_without_quote(self, db, make_sales_order):
         """quote_based order without a quote_id raises 400."""
-        so = make_sales_order(status="pending", order_type="quote_based")
+        so = make_sales_order(status="confirmed", order_type="quote_based")
         # quote_id is None by default
 
         with pytest.raises(HTTPException) as exc_info:
@@ -1725,7 +1770,7 @@ class TestGenerateProductionOrders:
         db.flush()
 
         so = make_sales_order(
-            status="pending",
+            status="confirmed",
             order_type="quote_based",
             product_id=product.id,
             quote_id=quote.id,
@@ -2395,7 +2440,7 @@ class TestGenerateProductionOrdersQuoteBased:
         db.flush()
 
         so = make_sales_order(
-            status="pending",
+            status="confirmed",
             order_type="quote_based",
             quote_id=quote.id,
         )
@@ -2642,7 +2687,7 @@ class TestCopyRoutingToOperations:
              "setup_time_minutes": 0, "run_time_minutes": 10},
         ])
 
-        so = make_sales_order(status="pending", order_type="line_item")
+        so = make_sales_order(status="confirmed", order_type="line_item")
         _make_order_line(db, so.id, fg.id, quantity=2)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1624,13 +1624,14 @@ class TestGenerateProductionOrders:
         """If POs already exist for a line_item order, returns them."""
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(status="pending", order_type="line_item")
-        _make_order_line(db, so.id, product.id, quantity=2)
+        line = _make_order_line(db, so.id, product.id, quantity=2)
 
         # Create existing production order linked to this SO
         po = ProductionOrder(
             code="PO-EXIST-LI-001",
             product_id=product.id,
             sales_order_id=so.id,
+            sales_order_line_id=line.id,
             quantity_ordered=2,
             quantity_completed=0,
             quantity_scrapped=0,
@@ -1644,6 +1645,39 @@ class TestGenerateProductionOrders:
         assert result["message"] == "Production orders already exist"
         assert "PO-EXIST-LI-001" in result["existing_orders"]
         assert result["created_orders"] == []
+
+    def test_creates_pos_for_uncovered_line_items(
+        self, db, make_sales_order, make_product
+    ):
+        """Existing line-level POs do not block release of uncovered lines."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        line1 = _make_order_line(db, so.id, product.id, quantity=1)
+        line2 = _make_order_line(db, so.id, product.id, quantity=2)
+
+        existing_po = ProductionOrder(
+            code="PO-EXIST-PARTIAL-001",
+            product_id=product.id,
+            sales_order_id=so.id,
+            sales_order_line_id=line1.id,
+            quantity_ordered=1,
+            quantity_completed=0,
+            quantity_scrapped=0,
+            status="draft",
+            created_by="test",
+        )
+        db.add(existing_po)
+        db.flush()
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+
+        linked_pos = db.query(ProductionOrder).filter(
+            ProductionOrder.sales_order_id == so.id
+        ).all()
+        linked_line_ids = {po.sales_order_line_id for po in linked_pos}
+        assert len(result["created_orders"]) == 1
+        assert result["existing_orders"] == ["PO-EXIST-PARTIAL-001"]
+        assert linked_line_ids == {line1.id, line2.id}
 
     def test_returns_existing_pos_for_quote_based_order(self, db, make_sales_order, make_product):
         """If POs already exist for a quote_based order, returns them."""

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -42,6 +42,13 @@ export default function OrderDetail() {
   const [productionOrders, setProductionOrders] = useState([]);
   const [loading, setLoading] = useState(true);
 
+  const hasOrderProduct = () => {
+    return Boolean(
+      order?.product_id ||
+        order?.lines?.some((line) => Boolean(line.product_id))
+    );
+  };
+
   const hasMainProductWO = () => {
     if (!order?.lines || order.lines.length === 0) {
       return productionOrders.some((po) => po.product_id === order?.product_id);
@@ -49,6 +56,9 @@ export default function OrderDetail() {
     const lineProductIds = order.lines
       .filter((line) => line.product_id)
       .map((line) => line.product_id);
+    if (lineProductIds.length === 0) {
+      return false;
+    }
     const woProductIds = productionOrders
       .filter((po) => po.sales_order_line_id)
       .map((po) => po.product_id);
@@ -76,6 +86,31 @@ export default function OrderDetail() {
   const [orderInvoice, setOrderInvoice] = useState(null);
   const [invoiceLoading, setInvoiceLoading] = useState(false);
   const [sendingInvoice, setSendingInvoice] = useState(false);
+
+  const isBillingReleaseSatisfied = () => {
+    const invoiceStatus = orderInvoice?.status || "";
+    const totalPaid = Number(paymentSummary?.total_paid || 0);
+    return (
+      order?.payment_status === "paid" ||
+      totalPaid > 0 ||
+      ["sent", "partially_paid", "paid"].includes(invoiceStatus)
+    );
+  };
+
+  const getProductionReleaseBlockReason = () => {
+    if (!order) return "Order is still loading";
+    if (!hasOrderProduct()) return "Order must have a product line";
+    if (hasMainProductWO()) return "Production order already exists";
+    if (order.status === "pending" || order.status === "pending_confirmation") {
+      return "Confirm the order before production release";
+    }
+    if (!isBillingReleaseSatisfied()) {
+      return "Create/send an invoice or record payment before production release";
+    }
+    return "";
+  };
+
+  const canGenerateProductionOrder = () => !getProductionReleaseBlockReason();
 
   // Line editing state
   const [editingLineId, setEditingLineId] = useState(null);
@@ -382,11 +417,9 @@ export default function OrderDetail() {
   };
 
   const handleCreateProductionOrder = async () => {
-    const hasProduct =
-      order?.product_id ||
-      (order?.lines && order.lines.length > 0 && order.lines[0].product_id);
-    if (!order || !hasProduct) {
-      toast.error("Order must have a product to create production order");
+    const blockReason = getProductionReleaseBlockReason();
+    if (blockReason) {
+      toast.error(blockReason);
       return;
     }
 
@@ -529,9 +562,21 @@ export default function OrderDetail() {
   const handleConfirmOrder = async () => {
     setConfirmingOrder(true);
     try {
-      await api.post(`/api/v1/sales-orders/${orderId}/confirm`);
+      if (order.status === "pending_confirmation") {
+        await api.post(`/api/v1/sales-orders/${orderId}/confirm`);
+      } else {
+        await api.patch(`/api/v1/sales-orders/${orderId}/status`, {
+          status: "confirmed",
+        });
+      }
       toast.success(`Order ${order.order_number} confirmed`);
-      fetchOrder();
+      await Promise.all([
+        fetchOrder(),
+        fetchOrderInvoice(),
+        fetchPaymentData(),
+        fetchProductionOrders(),
+        refetchFulfillment(),
+      ]);
     } catch (err) {
       toast.error(err.message || "Failed to confirm order");
     } finally {
@@ -650,7 +695,7 @@ export default function OrderDetail() {
   }
 
   const handleCheckAvailability = async () => {
-    if (!order.product_id && !(order.lines?.length > 0 && order.lines[0].product_id)) {
+    if (!hasOrderProduct()) {
       toast.error("Order must have a product to check availability");
       return;
     }
@@ -746,7 +791,7 @@ export default function OrderDetail() {
               Ship Order
             </button>
           )}
-          {order.status === "pending_confirmation" && (
+          {(order.status === "pending" || order.status === "pending_confirmation") && (
             <>
               <button
                 onClick={handleConfirmOrder}
@@ -755,12 +800,14 @@ export default function OrderDetail() {
               >
                 {confirmingOrder ? "Confirming..." : "Confirm Order"}
               </button>
-              <button
-                onClick={() => setShowRejectModal(true)}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg"
-              >
-                Reject Order
-              </button>
+              {order.status === "pending_confirmation" && (
+                <button
+                  onClick={() => setShowRejectModal(true)}
+                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg"
+                >
+                  Reject Order
+                </button>
+              )}
             </>
           )}
           {canCancelOrder() && (
@@ -843,12 +890,9 @@ export default function OrderDetail() {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <button
             onClick={handleCreateProductionOrder}
-            disabled={
-              (!order.product_id &&
-                !(order.lines?.length > 0 && order.lines[0].product_id)) ||
-              hasMainProductWO()
-            }
+            disabled={!canGenerateProductionOrder()}
             className="px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
+            title={getProductionReleaseBlockReason() || "Generate production order"}
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -50,8 +50,14 @@ export default function OrderDetail() {
   };
 
   const hasMainProductWO = () => {
+    if (
+      order?.product_id &&
+      productionOrders.some((po) => po.product_id === order.product_id)
+    ) {
+      return true;
+    }
     if (!order?.lines || order.lines.length === 0) {
-      return productionOrders.some((po) => po.product_id === order?.product_id);
+      return false;
     }
     const lineProductIds = order.lines
       .filter((line) => line.product_id)
@@ -101,8 +107,8 @@ export default function OrderDetail() {
     if (!order) return "Order is still loading";
     if (!hasOrderProduct()) return "Order must have a product line";
     if (hasMainProductWO()) return "Production order already exists";
-    if (order.status === "pending" || order.status === "pending_confirmation") {
-      return "Confirm the order before production release";
+    if (order.status !== "confirmed") {
+      return "Order must be confirmed before production release";
     }
     if (!isBillingReleaseSatisfied()) {
       return "Create/send an invoice or record payment before production release";
@@ -570,13 +576,16 @@ export default function OrderDetail() {
         });
       }
       toast.success(`Order ${order.order_number} confirmed`);
-      await Promise.all([
+      const refreshResults = await Promise.allSettled([
         fetchOrder(),
         fetchOrderInvoice(),
         fetchPaymentData(),
         fetchProductionOrders(),
         refetchFulfillment(),
       ]);
+      if (refreshResults.some((result) => result.status === "rejected")) {
+        toast.error("Order confirmed, but some related data failed to refresh");
+      }
     } catch (err) {
       toast.error(err.message || "Failed to confirm order");
     } finally {


### PR DESCRIPTION
## Summary
- enforce configured sales order status transitions in `update_sales_order_status`
- stop commercial confirmation from auto-creating production orders
- require confirmed orders before creating new work orders, while keeping existing-work-order calls idempotent
- add pending-order Confirm Order UI and gate production release behind confirmation plus invoice/payment signal

## Validation
- `python -m py_compile backend/app/services/sales_order_service.py`
- `python -m py_compile backend/tests/services/test_sales_order_service.py`
- `git diff --check`
- `cd frontend && npx eslint src/pages/admin/OrderDetail.jsx`
- `cd frontend && npm run build`
- Attempted `python -m pytest backend/tests/services/test_sales_order_service.py::TestUpdateSalesOrderStatus backend/tests/services/test_sales_order_service.py::TestGenerateProductionOrders backend/tests/services/test_sales_order_service.py::TestGenerateProductionOrdersQuoteBased backend/tests/services/test_sales_order_service.py::TestCopyRoutingToOperations -q`; blocked by local Postgres auth for `postgres:postgres@localhost:5432/filaops_test`.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-009-20260608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status transitions are strictly validated; invalid transitions return errors and do not change orders. Confirming no longer auto-creates production orders or triggers production unless allowed; confirmed timestamp is set only for appropriate prior statuses.

* **New Features**
  * Confirm flow refreshes order/invoice/payment/production/fulfillment data and surfaces refresh failures. UI blocks production-order generation with clear reasons and updates confirm/reject button visibility by status.

* **Tests**
  * Added coverage for transition validation, production-order generation rules, and partial existing-order scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->