### PR TITLE
fix: align order workflow invoice actions

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -284,6 +284,7 @@ def build_list_response(order: ProductionOrder, db: Session) -> ProductionOrderL
         scheduled_end=order.scheduled_end,
         sales_order_id=order.sales_order_id,
         sales_order_code=sales_order.order_number if sales_order else None,
+        sales_order_line_id=order.sales_order_line_id,
         assigned_to=order.assigned_to,
         operation_count=op_count,
         current_operation=current_op.operation_name if current_op else None,

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -254,6 +254,7 @@ class ProductionOrderListResponse(BaseModel):
 
     sales_order_id: Optional[int] = None
     sales_order_code: Optional[str] = None
+    sales_order_line_id: Optional[int] = None
 
     assigned_to: Optional[str] = None
     operation_count: int = 0

--- a/backend/tests/endpoints/test_production_orders_endpoint.py
+++ b/backend/tests/endpoints/test_production_orders_endpoint.py
@@ -93,6 +93,44 @@ class TestListProductionOrders:
         assert resp.status_code == 200
         assert len(resp.json()) <= 2
 
+    def test_list_includes_sales_order_line_id(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        """Line-item order views need the linked SO line id to recognize existing WOs."""
+        from app.models.sales_order import SalesOrderLine
+
+        product = make_product(item_type="finished_good", procurement_type="make")
+        sales_order = make_sales_order(
+            product_id=None,
+            status="in_production",
+            order_type="line_item",
+        )
+        line = SalesOrderLine(
+            sales_order_id=sales_order.id,
+            product_id=product.id,
+            line_type="product",
+            quantity=Decimal("1"),
+            unit_price=Decimal("15.00"),
+            total=Decimal("15.00"),
+        )
+        db.add(line)
+        db.flush()
+
+        po = make_production_order(
+            product_id=product.id,
+            sales_order_id=sales_order.id,
+            sales_order_line_id=line.id,
+            status="draft",
+        )
+
+        resp = client.get(
+            f"/api/v1/production-orders/?sales_order_id={sales_order.id}"
+        )
+
+        assert resp.status_code == 200
+        row = next(item for item in resp.json() if item["id"] == po.id)
+        assert row["sales_order_line_id"] == line.id
+
 
 # =============================================================================
 # GET /api/v1/production-orders/{id} — Get Detail

--- a/frontend/src/pages/admin/AdminInvoices.jsx
+++ b/frontend/src/pages/admin/AdminInvoices.jsx
@@ -137,12 +137,12 @@ export default function AdminInvoices() {
     setSendingInvoice(true);
     try {
       const updated = await api.post(`/api/v1/invoices/${selectedInvoice.id}/send`);
-      toast.success("Invoice sent");
+      toast.success("Invoice marked as sent");
       setSelectedInvoice(updated);
       fetchInvoices();
       fetchSummary();
     } catch (err) {
-      toast.error(err.response?.data?.detail || err.message || "Failed to send invoice");
+      toast.error(err.response?.data?.detail || err.message || "Failed to mark invoice sent");
     } finally {
       setSendingInvoice(false);
     }
@@ -622,12 +622,13 @@ export default function AdminInvoices() {
                       <button
                         onClick={handleSendInvoice}
                         disabled={sendingInvoice}
+                        title="Marks this invoice as sent in FilaOps. This does not email the customer."
                         className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
                       >
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                         </svg>
-                        {sendingInvoice ? "Sending..." : "Send Invoice"}
+                        {sendingInvoice ? "Marking..." : "Mark Sent"}
                       </button>
                     )}
                     <button

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -41,6 +41,7 @@ const formatMoney = (value) => `$${parseFloat(value || 0).toFixed(2)}`;
 
 const COMPLETE_PRODUCTION_STATUSES = new Set(["complete", "completed", "closed"]);
 const SHIPPED_ORDER_STATUSES = new Set(["shipped", "delivered", "completed"]);
+const UNCONFIRMED_ORDER_STATUSES = new Set(["draft", "pending", "pending_confirmation"]);
 
 export default function OrderDetail() {
   const { orderId } = useParams();
@@ -113,7 +114,7 @@ export default function OrderDetail() {
     if (!order) return "Order is still loading";
     if (!hasOrderProduct()) return "Order must have a product line";
     if (hasMainProductWO()) return "Production order already exists";
-    if (order.status !== "confirmed") {
+    if (UNCONFIRMED_ORDER_STATUSES.has(order.status)) {
       return "Order must be confirmed before production release";
     }
     if (!isBillingReleaseSatisfied()) {
@@ -665,20 +666,34 @@ export default function OrderDetail() {
     try {
       const invoice = await api.post(`/api/v1/invoices/${orderInvoice.id}/send`);
       setOrderInvoice(invoice);
-      toast.success(`Invoice ${invoice.invoice_number} sent`);
+      toast.success(`Invoice ${invoice.invoice_number} marked as sent`);
     } catch (err) {
-      toast.error(err.response?.data?.detail || err.message || "Failed to send invoice");
+      toast.error(err.response?.data?.detail || err.message || "Failed to mark invoice sent");
     } finally {
       setSendingInvoice(false);
     }
   };
 
-  const handleDownloadOrderInvoice = () => {
+  const handleDownloadOrderInvoice = async () => {
     if (!orderInvoice) return;
-    window.open(
-      `${API_URL}/api/v1/invoices/${orderInvoice.id}/pdf`,
-      "_blank"
-    );
+    try {
+      const response = await fetch(
+        `${API_URL}/api/v1/invoices/${orderInvoice.id}/pdf`,
+        { credentials: "include" }
+      );
+      if (!response.ok) throw new Error("Failed to download invoice PDF");
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${orderInvoice.invoice_number || "invoice"}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err.message || "Failed to download invoice PDF");
+    }
   };
 
   const canGenerateInvoice = () => {
@@ -764,7 +779,7 @@ export default function OrderDetail() {
 
   const getOrderWorkflowSteps = () => {
     const status = order?.status || "";
-    const orderConfirmed = !["draft", "pending", "pending_confirmation"].includes(status);
+    const orderConfirmed = !UNCONFIRMED_ORDER_STATUSES.has(status);
     const canConfirmOrder = ["pending", "pending_confirmation"].includes(status);
     const hasInvoice = Boolean(orderInvoice);
     const invoiceStatus = orderInvoice?.status || "";
@@ -787,7 +802,7 @@ export default function OrderDetail() {
       }
       if (orderInvoice?.status === "draft") {
         return {
-          label: sendingInvoice ? "Sending..." : "Send Invoice",
+          label: sendingInvoice ? "Marking..." : "Mark Sent",
           onClick: handleSendOrderInvoice,
           disabled: sendingInvoice,
         };
@@ -853,7 +868,7 @@ export default function OrderDetail() {
       },
       {
         id: "production",
-        title: "Production Release",
+        title: "Production Orders",
         Icon: Factory,
         state: getStepState({
           done: productionReleased || noProductionNeeded,
@@ -868,16 +883,16 @@ export default function OrderDetail() {
         detail: noProductionNeeded
           ? "No production release is required for service-only lines."
           : productionReleased
-          ? "Work orders are linked to this sales order."
+          ? "Work orders are created and linked. Open production to release, start, and complete them."
           : releaseBlockReason || "Ready to create work orders.",
         action: productionReleased && productionOrders.length > 0
           ? {
-              label: "View Production",
-              onClick: () => navigate(`/admin/production?order=${productionOrders[0].id}`),
+              label: "Open Work Order",
+              onClick: () => navigate(`/admin/production/${productionOrders[0].id}`),
             }
           : !releaseBlockReason
           ? {
-              label: "Release Production",
+              label: "Create Work Orders",
               onClick: handleCreateProductionOrder,
             }
           : null,
@@ -1155,9 +1170,10 @@ export default function OrderDetail() {
                   <button
                     onClick={handleSendOrderInvoice}
                     disabled={sendingInvoice}
+                    title="Marks this invoice as sent in FilaOps. This does not email the customer."
                     className="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
                   >
-                    {sendingInvoice ? "Sending..." : "Send Invoice"}
+                    {sendingInvoice ? "Marking..." : "Mark Sent"}
                   </button>
                 )}
                 <button
@@ -1194,7 +1210,7 @@ export default function OrderDetail() {
           </button>
           {productionOrders.length > 0 && (
             <button
-              onClick={() => navigate(`/admin/production?order=${productionOrders[0].id}`)}
+              onClick={() => navigate(`/admin/production/${productionOrders[0].id}`)}
               className="px-4 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 flex items-center justify-center gap-2 transition-colors"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1542,7 +1558,7 @@ export default function OrderDetail() {
         orderQuantity={order.quantity}
       />
 
-      {/* Production Orders - Read-Only Status Display */}
+      {/* Production Orders - Status Display */}
       {productionOrders.length > 0 && (
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
           <button
@@ -1567,7 +1583,7 @@ export default function OrderDetail() {
                   key={po.id}
                   order={po}
                   onViewInProduction={() =>
-                    navigate(`/admin/production?search=${encodeURIComponent(po.code || `WO-${po.id}`)}`)
+                    navigate(`/admin/production/${po.id}`)
                   }
                   onAcceptShort={handleAcceptShortPO}
                 />


### PR DESCRIPTION
## Summary
- expose `sales_order_line_id` on production order list responses so order detail recognizes linked work orders
- update order workflow actions/navigation for existing work orders and authenticated invoice PDF downloads
- rename invoice draft action from "Send Invoice" to "Mark Sent" because Core only updates invoice status and does not email customers

## Accounting note
Inventory transactions remain physical inventory movements. Shipping charge income, tax liability, AR/cash, and payment posting are not added to GL in this PR; Square invoice delivery/accounting sync belongs in PRO integration work.

## Validation
- `npm run build`
- `$envFile = 'C:\repos\filaops\backend\.env'; Get-Content $envFile | ForEach-Object { if ($_ -match '^\s*([^#=]+)\s*=\s*(.*)\s*$') { $name = $matches[1].Trim(); $value = $matches[2].Trim().Trim('"').Trim("'"); [Environment]::SetEnvironmentVariable($name, $value, 'Process') } }; & 'C:\repos\filaops\backend\venv\Scripts\python.exe' -m pytest tests/endpoints/test_production_orders_endpoint.py::TestListProductionOrders -q`

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-accounting-send-invoice-20260608