### PR TITLE
fix: post sales accounting entries

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -20,6 +20,7 @@ from app.models.order_event import OrderEvent
 from app.services.payment_service import (
     outstanding_balance_summary,
     generate_payment_number,
+    reverse_payment_receipt,
     sales_order_total,
     update_order_payment_status,
 )
@@ -413,6 +414,13 @@ async def update_payment(
 
     if update_data.status is not None:
         old_status = payment.status
+        if old_status == "completed" and update_data.status != "completed":
+            reverse_payment_receipt(
+                db,
+                payment,
+                user_id=current_user.id,
+                reason=f"status changed to {update_data.status}",
+            )
         payment.status = update_data.status
 
         # If status changed, update order payment status
@@ -448,6 +456,13 @@ async def void_payment(
             detail="Payment is already voided"
         )
 
+    if payment.status == "completed":
+        reverse_payment_receipt(
+            db,
+            payment,
+            user_id=current_user.id,
+            reason="payment voided",
+        )
     payment.status = "voided"
 
     # Update order payment status

--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -17,6 +17,7 @@ from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.user import User
 from app.services.payment_service import (
     generate_payment_number,
+    post_invoice_receivable,
     update_order_payment_status,
 )
 
@@ -263,6 +264,7 @@ def record_payment(
     invoice.amount_paid = new_paid
     invoice.payment_method = method
     invoice.payment_reference = reference
+    post_invoice_receivable(db, invoice)
 
     if invoice.sales_order_id:
         order = (
@@ -389,6 +391,7 @@ def mark_sent(db: Session, invoice_id: int) -> Invoice:
         raise HTTPException(status_code=400, detail="Only draft invoices can be sent")
     invoice.status = "sent"
     invoice.sent_at = datetime.now(timezone.utc)
+    post_invoice_receivable(db, invoice)
     db.commit()
     db.refresh(invoice)
     return invoice

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -5,10 +5,177 @@ from decimal import Decimal
 from sqlalchemy import Integer, cast, func, text
 from sqlalchemy.orm import Session
 
+from app.models.accounting import GLAccount, GLJournalEntry
 from app.models.payment import Payment
 from app.models.sales_order import SalesOrder
+from app.services.transaction_service import TransactionService
 
 _PAYMENT_NUMBER_LOCK_NAMESPACE = 74001
+
+_CORE_SALES_ACCOUNTS = {
+    "1000": ("Cash", "asset", None, True, "Cash on hand and in bank accounts"),
+    "1100": ("Accounts Receivable", "asset", None, True, "Amounts owed by customers"),
+    "2100": ("Sales Tax Payable", "liability", None, False, "Collected sales tax owed to government"),
+    "4000": ("Sales Revenue", "revenue", "1", True, "Gross receipts from sales"),
+    "4200": ("Shipping Revenue", "revenue", "1", False, "Shipping charges collected"),
+}
+
+
+def _money(value) -> Decimal:
+    """Normalize nullable numeric model values to GL currency precision."""
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"))
+
+
+def _ensure_core_sales_accounts(db: Session) -> None:
+    """Create missing canonical sales accounts for older local databases."""
+    existing = {
+        row[0]
+        for row in db.query(GLAccount.account_code).filter(
+            GLAccount.account_code.in_(_CORE_SALES_ACCOUNTS.keys())
+        )
+    }
+    for code, (name, account_type, schedule_c_line, is_system, description) in _CORE_SALES_ACCOUNTS.items():
+        if code in existing:
+            continue
+        db.add(GLAccount(
+            account_code=code,
+            name=name,
+            account_type=account_type,
+            schedule_c_line=schedule_c_line,
+            is_system=is_system,
+            active=True,
+            description=description,
+        ))
+    db.flush()
+
+
+def _posted_entry_exists(db: Session, *, source_type: str, source_id: int) -> bool:
+    return db.query(GLJournalEntry.id).filter(
+        GLJournalEntry.source_type == source_type,
+        GLJournalEntry.source_id == source_id,
+        GLJournalEntry.status != "voided",
+    ).first() is not None
+
+
+def post_invoice_receivable(db: Session, invoice, user_id: int | None = None) -> GLJournalEntry | None:
+    """Post an invoice to AR, revenue, shipping revenue, and tax payable once."""
+    if not invoice or not invoice.id:
+        return None
+    if _posted_entry_exists(db, source_type="invoice", source_id=invoice.id):
+        return None
+
+    revenue = max(_money(invoice.subtotal) - _money(invoice.discount_amount), Decimal("0"))
+    tax = _money(invoice.tax_amount)
+    shipping = _money(invoice.shipping_amount)
+
+    credit_lines: list[tuple[str, Decimal, str]] = []
+    if revenue > 0:
+        credit_lines.append(("4000", revenue, "CR"))
+    if tax > 0:
+        credit_lines.append(("2100", tax, "CR"))
+    if shipping > 0:
+        credit_lines.append(("4200", shipping, "CR"))
+
+    receivable = sum((amount for _, amount, _ in credit_lines), Decimal("0"))
+    if receivable <= 0:
+        return None
+
+    _ensure_core_sales_accounts(db)
+    return TransactionService(db)._create_journal_entry(
+        description=f"Invoice {invoice.invoice_number}",
+        lines=[("1100", receivable, "DR"), *credit_lines],
+        source_type="invoice",
+        source_id=invoice.id,
+        user_id=user_id,
+    )
+
+
+def post_payment_receipt(db: Session, payment: Payment) -> GLJournalEntry | None:
+    """Post a completed payment or refund to cash and AR once."""
+    if not payment or not payment.id or payment.status != "completed":
+        return None
+    if _posted_entry_exists(db, source_type="payment", source_id=payment.id):
+        return None
+
+    amount = _money(payment.amount)
+    if amount == 0:
+        return None
+
+    absolute_amount = abs(amount)
+    if amount > 0:
+        lines = [
+            ("1000", absolute_amount, "DR"),
+            ("1100", absolute_amount, "CR"),
+        ]
+        description = f"Payment {payment.payment_number}"
+    else:
+        lines = [
+            ("1100", absolute_amount, "DR"),
+            ("1000", absolute_amount, "CR"),
+        ]
+        description = f"Refund {payment.payment_number}"
+
+    _ensure_core_sales_accounts(db)
+    return TransactionService(db)._create_journal_entry(
+        description=description,
+        lines=lines,
+        source_type="payment",
+        source_id=payment.id,
+        user_id=payment.recorded_by_id,
+    )
+
+
+def reverse_payment_receipt(
+    db: Session,
+    payment: Payment,
+    user_id: int | None = None,
+    reason: str | None = None,
+) -> GLJournalEntry | None:
+    """Post a one-time reversal for a previously posted payment."""
+    if not payment or not payment.id:
+        return None
+    if not _posted_entry_exists(db, source_type="payment", source_id=payment.id):
+        return None
+    if _posted_entry_exists(db, source_type="payment_reversal", source_id=payment.id):
+        return None
+
+    amount = _money(payment.amount)
+    if amount == 0:
+        return None
+
+    absolute_amount = abs(amount)
+    if amount > 0:
+        lines = [
+            ("1100", absolute_amount, "DR"),
+            ("1000", absolute_amount, "CR"),
+        ]
+    else:
+        lines = [
+            ("1000", absolute_amount, "DR"),
+            ("1100", absolute_amount, "CR"),
+        ]
+
+    _ensure_core_sales_accounts(db)
+    description = f"Reverse payment {payment.payment_number}"
+    if reason:
+        description = f"{description}: {reason}"[:255]
+    return TransactionService(db)._create_journal_entry(
+        description=description,
+        lines=lines,
+        source_type="payment_reversal",
+        source_id=payment.id,
+        user_id=user_id,
+    )
+
+
+def post_completed_payments_for_order(db: Session, order_id: int) -> None:
+    """Post all unposted completed payments for an order."""
+    payments = db.query(Payment).filter(
+        Payment.sales_order_id == order_id,
+        Payment.status == "completed",
+    ).all()
+    for payment in payments:
+        post_payment_receipt(db, payment)
 
 
 def sales_order_total(order: SalesOrder) -> Decimal:
@@ -102,6 +269,8 @@ def generate_payment_number(db: Session) -> str:
 
 def update_order_payment_status(db: Session, order: SalesOrder) -> None:
     """Update order payment_status based on completed ledger payments."""
+    post_completed_payments_for_order(db, order.id)
+
     total_paid = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
         Payment.sales_order_id == order.id,
         Payment.status == "completed",

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -15,9 +15,13 @@ _PAYMENT_NUMBER_LOCK_NAMESPACE = 74001
 _CORE_SALES_ACCOUNTS = {
     "1000": ("Cash", "asset", None, True, "Cash on hand and in bank accounts"),
     "1100": ("Accounts Receivable", "asset", None, True, "Amounts owed by customers"),
+    "1220": ("Finished Goods Inventory", "asset", None, True, "Finished goods held for sale"),
+    "1230": ("Packaging Inventory", "asset", None, True, "Packaging materials inventory"),
     "2100": ("Sales Tax Payable", "liability", None, False, "Collected sales tax owed to government"),
     "4000": ("Sales Revenue", "revenue", "1", True, "Gross receipts from sales"),
     "4200": ("Shipping Revenue", "revenue", "1", False, "Shipping charges collected"),
+    "5000": ("Cost of Goods Sold", "expense", "36", True, "Cost of goods sold for shipped products"),
+    "5010": ("Shipping Supplies Expense", "expense", "22", False, "Packaging consumed when shipping"),
 }
 
 
@@ -47,6 +51,11 @@ def _ensure_core_sales_accounts(db: Session) -> None:
             description=description,
         ))
     db.flush()
+
+
+def ensure_core_sales_accounts(db: Session) -> None:
+    """Public wrapper for services that need canonical sales accounts."""
+    _ensure_core_sales_accounts(db)
 
 
 def _posted_entry_exists(db: Session, *, source_type: str, source_id: int) -> bool:
@@ -81,7 +90,7 @@ def post_invoice_receivable(db: Session, invoice, user_id: int | None = None) ->
         return None
 
     _ensure_core_sales_accounts(db)
-    return TransactionService(db)._create_journal_entry(
+    return TransactionService(db).create_journal_entry(
         description=f"Invoice {invoice.invoice_number}",
         lines=[("1100", receivable, "DR"), *credit_lines],
         source_type="invoice",
@@ -116,7 +125,7 @@ def post_payment_receipt(db: Session, payment: Payment) -> GLJournalEntry | None
         description = f"Refund {payment.payment_number}"
 
     _ensure_core_sales_accounts(db)
-    return TransactionService(db)._create_journal_entry(
+    return TransactionService(db).create_journal_entry(
         description=description,
         lines=lines,
         source_type="payment",
@@ -159,7 +168,7 @@ def reverse_payment_receipt(
     description = f"Reverse payment {payment.payment_number}"
     if reason:
         description = f"{description}: {reason}"[:255]
-    return TransactionService(db)._create_journal_entry(
+    return TransactionService(db).create_journal_entry(
         description=description,
         lines=lines,
         source_type="payment_reversal",

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -45,6 +45,17 @@ _SHIPMENT_TRANSACTION_COST_TYPES = {
     "consumption": "consumption",
 }
 _NEGATIVE_SHIPMENT_ADJUSTMENT_TYPE = "negative_adjustment"
+_MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE = (
+    "Shipment GL posting for material-backed sales orders needs raw-material account mapping"
+)
+
+
+def _has_material_backed_lines(order: "SalesOrder") -> bool:
+    return any(
+        (getattr(line, "line_type", None) or "").lower() == "material"
+        or getattr(line, "material_inventory_id", None) is not None
+        for line in (order.lines or [])
+    )
 
 
 # =============================================================================
@@ -2533,6 +2544,9 @@ def _create_shipment_gl_entry(
     from app.services.payment_service import ensure_core_sales_accounts
     from app.services.transaction_service import TransactionService
 
+    if _has_material_backed_lines(order):
+        raise ValueError(_MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE)
+
     existing = db.query(GLJournalEntry.id).filter(
         GLJournalEntry.source_type == "sales_order",
         GLJournalEntry.source_id == order.id,
@@ -2659,6 +2673,11 @@ def ship_order(
         raise HTTPException(
             status_code=400,
             detail="Order has no shipping address. Please add one first."
+        )
+    if _has_material_backed_lines(order):
+        raise HTTPException(
+            status_code=400,
+            detail=_MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE,
         )
 
     # Generate tracking number if not provided

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -27,7 +27,7 @@ from app.models.manufacturing import Routing, RoutingOperation, RoutingOperation
 from app.models.product import Product
 from app.models.material import MaterialInventory
 from app.models.bom import BOM, BOMLine
-from app.models.inventory import Inventory
+from app.models.inventory import Inventory, InventoryTransaction
 from app.models.company_settings import CompanySettings
 from app.models.order_event import OrderEvent
 from app.core.status_config import StatusTransitionError, validate_sales_order_transition
@@ -2501,43 +2501,93 @@ def get_material_requirements(
 # Shipping
 # =============================================================================
 
-def _create_shipment_gl_entry(db: Session, order: "SalesOrder", user_id: int) -> None:
+def _create_shipment_gl_entry(
+    db: Session,
+    order: "SalesOrder",
+    user_id: int,
+    shipment_transactions: Optional[list[InventoryTransaction]] = None,
+) -> None:
     """
     Create GL journal entry for a sales order shipment.
 
-    DR COGS (5000), CR FG Inventory (1220) for each shipped product line.
-    Uses standard_cost → average_cost → last_cost as the cost basis.
+    DR COGS (5000), CR FG Inventory (1220) for shipped goods.
+    DR Shipping Supplies (5010), CR Packaging Inventory (1230) for packaging.
+    Uses the inventory transactions created by process_shipment() when provided.
     Skips lines with no cost set — no entry is created if total is zero.
 
     Called from ship_order() AFTER process_shipment() handles inventory
-    transactions, so this only creates the accounting entry (no double-count).
+    transactions, so this only creates the accounting entry and links those
+    inventory transactions to it.
     """
+    from app.models.accounting import GLJournalEntry
     from app.services.transaction_service import TransactionService
 
-    total_cost = Decimal("0")
-    for line in (order.lines or []):
-        if not line.product_id or not line.product:
-            continue
-        product = line.product
-        cost = product.standard_cost or product.average_cost or product.last_cost
-        if not cost or cost <= 0:
-            continue
-        total_cost += Decimal(str(line.quantity)) * Decimal(str(cost))
+    existing = db.query(GLJournalEntry.id).filter(
+        GLJournalEntry.source_type == "sales_order",
+        GLJournalEntry.source_id == order.id,
+        GLJournalEntry.status != "voided",
+    ).first()
+    if existing:
+        return
 
-    if total_cost <= 0:
+    if shipment_transactions is None:
+        shipment_transactions = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "sales_order",
+            InventoryTransaction.reference_id == order.id,
+            InventoryTransaction.transaction_type.in_(["shipment", "consumption"]),
+        ).all()
+
+    def txn_cost(txn: InventoryTransaction) -> Decimal:
+        if txn.total_cost is not None:
+            return Decimal(str(txn.total_cost or 0)).quantize(Decimal("0.01"))
+        quantity = abs(Decimal(str(txn.quantity or 0)))
+        unit_cost = Decimal(str(txn.cost_per_unit or 0))
+        return (quantity * unit_cost).quantize(Decimal("0.01"))
+
+    product_cost = Decimal("0")
+    packaging_cost = Decimal("0")
+    for txn in shipment_transactions:
+        if txn.transaction_type == "shipment":
+            product_cost += txn_cost(txn)
+        elif txn.transaction_type == "consumption":
+            packaging_cost += txn_cost(txn)
+
+    if product_cost <= 0 and not shipment_transactions:
+        for line in (order.lines or []):
+            if not line.product_id or not line.product:
+                continue
+            product = line.product
+            cost = product.standard_cost or product.average_cost or product.last_cost
+            if not cost or cost <= 0:
+                continue
+            product_cost += Decimal(str(line.quantity)) * Decimal(str(cost))
+
+    lines = []
+    if product_cost > 0:
+        lines.extend([
+            ("5000", product_cost, "DR"),   # Cost of Goods Sold
+            ("1220", product_cost, "CR"),   # Finished Goods Inventory
+        ])
+    if packaging_cost > 0:
+        lines.extend([
+            ("5010", packaging_cost, "DR"),  # Shipping Supplies Expense
+            ("1230", packaging_cost, "CR"),  # Packaging Inventory
+        ])
+
+    if not lines:
         return  # No costed items — skip GL entry
 
     ts = TransactionService(db)
-    ts._create_journal_entry(
+    journal_entry = ts._create_journal_entry(
         description=f"Shipment for SO#{order.order_number}",
-        lines=[
-            ("5000", total_cost, "DR"),   # Cost of Goods Sold
-            ("1220", total_cost, "CR"),   # Finished Goods Inventory
-        ],
+        lines=lines,
         source_type="sales_order",
         source_id=order.id,
         user_id=user_id,
     )
+
+    for txn in shipment_transactions:
+        txn.journal_entry_id = journal_entry.id
 
 
 def ship_order(
@@ -2592,14 +2642,14 @@ def ship_order(
     order.updated_at = datetime.now(timezone.utc)
 
     # Process inventory transactions
-    process_shipment(
+    packaging_txns, issue_txns = process_shipment(
         db=db,
         sales_order=order,
         created_by=user_email,
     )
 
     # Create GL journal entry for COGS and FG inventory relief
-    _create_shipment_gl_entry(db, order, user_id)
+    _create_shipment_gl_entry(db, order, user_id, [*packaging_txns, *issue_txns])
 
     # Record order event
     record_order_event(

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -36,6 +36,16 @@ from app.services.tax_calculation_service import calculate_sales_tax
 
 logger = get_logger(__name__)
 
+_SHIPMENT_COST_ACCOUNTS = {
+    "shipment": ("5000", "1220"),
+    "consumption": ("5010", "1230"),
+}
+_SHIPMENT_TRANSACTION_COST_TYPES = {
+    "shipment": "shipment",
+    "consumption": "consumption",
+}
+_NEGATIVE_SHIPMENT_ADJUSTMENT_TYPE = "negative_adjustment"
+
 
 # =============================================================================
 # Code Generation Helpers
@@ -2520,6 +2530,7 @@ def _create_shipment_gl_entry(
     inventory transactions to it.
     """
     from app.models.accounting import GLJournalEntry
+    from app.services.payment_service import ensure_core_sales_accounts
     from app.services.transaction_service import TransactionService
 
     existing = db.query(GLJournalEntry.id).filter(
@@ -2534,8 +2545,31 @@ def _create_shipment_gl_entry(
         shipment_transactions = db.query(InventoryTransaction).filter(
             InventoryTransaction.reference_type == "sales_order",
             InventoryTransaction.reference_id == order.id,
-            InventoryTransaction.transaction_type.in_(["shipment", "consumption"]),
+            InventoryTransaction.transaction_type.in_([
+                *_SHIPMENT_TRANSACTION_COST_TYPES,
+                _NEGATIVE_SHIPMENT_ADJUSTMENT_TYPE,
+            ]),
         ).all()
+
+    def shipment_cost_type(txn: InventoryTransaction) -> str | None:
+        if txn.transaction_type in _SHIPMENT_TRANSACTION_COST_TYPES:
+            return _SHIPMENT_TRANSACTION_COST_TYPES[txn.transaction_type]
+        if txn.transaction_type == _NEGATIVE_SHIPMENT_ADJUSTMENT_TYPE:
+            if txn.product and txn.product.item_type == "packaging":
+                return "consumption"
+            return "shipment"
+        return None
+
+    unexpected_types = sorted({
+        txn.transaction_type
+        for txn in shipment_transactions
+        if shipment_cost_type(txn) is None
+    })
+    if unexpected_types:
+        raise ValueError(
+            "Unexpected shipment transaction types for "
+            f"SO#{order.order_number}: {', '.join(unexpected_types)}"
+        )
 
     def txn_cost(txn: InventoryTransaction) -> Decimal:
         if txn.total_cost is not None:
@@ -2544,15 +2578,16 @@ def _create_shipment_gl_entry(
         unit_cost = Decimal(str(txn.cost_per_unit or 0))
         return (quantity * unit_cost).quantize(Decimal("0.01"))
 
-    product_cost = Decimal("0")
-    packaging_cost = Decimal("0")
+    cost_by_transaction_type = {
+        transaction_type: Decimal("0")
+        for transaction_type in _SHIPMENT_COST_ACCOUNTS
+    }
     for txn in shipment_transactions:
-        if txn.transaction_type == "shipment":
-            product_cost += txn_cost(txn)
-        elif txn.transaction_type == "consumption":
-            packaging_cost += txn_cost(txn)
+        cost_type = shipment_cost_type(txn)
+        if cost_type is not None:
+            cost_by_transaction_type[cost_type] += txn_cost(txn)
 
-    if product_cost <= 0 and not shipment_transactions:
+    if cost_by_transaction_type["shipment"] <= 0 and not shipment_transactions:
         for line in (order.lines or []):
             if not line.product_id or not line.product:
                 continue
@@ -2560,25 +2595,24 @@ def _create_shipment_gl_entry(
             cost = product.standard_cost or product.average_cost or product.last_cost
             if not cost or cost <= 0:
                 continue
-            product_cost += Decimal(str(line.quantity)) * Decimal(str(cost))
+            cost_by_transaction_type["shipment"] += Decimal(str(line.quantity)) * Decimal(str(cost))
 
     lines = []
-    if product_cost > 0:
+    for transaction_type, amount in cost_by_transaction_type.items():
+        if amount <= 0:
+            continue
+        debit_account, credit_account = _SHIPMENT_COST_ACCOUNTS[transaction_type]
         lines.extend([
-            ("5000", product_cost, "DR"),   # Cost of Goods Sold
-            ("1220", product_cost, "CR"),   # Finished Goods Inventory
-        ])
-    if packaging_cost > 0:
-        lines.extend([
-            ("5010", packaging_cost, "DR"),  # Shipping Supplies Expense
-            ("1230", packaging_cost, "CR"),  # Packaging Inventory
+            (debit_account, amount, "DR"),
+            (credit_account, amount, "CR"),
         ])
 
     if not lines:
         return  # No costed items — skip GL entry
 
+    ensure_core_sales_accounts(db)
     ts = TransactionService(db)
-    journal_entry = ts._create_journal_entry(
+    journal_entry = ts.create_journal_entry(
         description=f"Shipment for SO#{order.order_number}",
         lines=lines,
         source_type="sales_order",

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -18,12 +18,14 @@ from decimal import Decimal
 from typing import List, Tuple, Optional, NamedTuple
 
 from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, text
 
 from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.inventory import Inventory, InventoryTransaction
 from app.models.production_order import ScrapRecord
 from app.models.product import Product
+
+_JOURNAL_ENTRY_NUMBER_LOCK_NAMESPACE = 74002
 
 
 class MaterialConsumption(NamedTuple):
@@ -83,13 +85,26 @@ class TransactionService:
         return self._account_cache[account_code]
 
     def _next_entry_number(self) -> str:
-        """Generate next journal entry number: JE-{year}-{seq:06d}"""
+        """Generate next journal entry number under a transaction-scoped DB lock."""
         year = datetime.now(timezone.utc).year
+
+        self.db.execute(
+            text(
+                """
+                SELECT pg_advisory_xact_lock(
+                    CAST(:namespace AS integer),
+                    CAST(:year AS integer)
+                )
+                """
+            ),
+            {"namespace": _JOURNAL_ENTRY_NUMBER_LOCK_NAMESPACE, "year": year},
+        )
 
         # Find max entry number for this year
         pattern = f"JE-{year}-%"
         result = self.db.query(func.max(GLJournalEntry.entry_number)).filter(
-            GLJournalEntry.entry_number.like(pattern)
+            GLJournalEntry.entry_number.like(pattern),
+            GLJournalEntry.entry_number.op("~")(rf"^JE-{year}-\d{{6}}$"),
         ).scalar()
 
         if result:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -119,9 +119,9 @@ class TransactionService:
         self,
         description: str,
         lines: List[Tuple[str, Decimal, str]],
-        source_type: str = None,
-        source_id: int = None,
-        user_id: int = None,
+        source_type: Optional[str] = None,
+        source_id: Optional[int] = None,
+        user_id: Optional[int] = None,
     ) -> GLJournalEntry:
         """Create a balanced posted journal entry for service-level callers."""
         return self._create_journal_entry(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -100,6 +100,23 @@ class TransactionService:
 
         return f"JE-{year}-{seq:06d}"
 
+    def create_journal_entry(
+        self,
+        description: str,
+        lines: List[Tuple[str, Decimal, str]],
+        source_type: str = None,
+        source_id: int = None,
+        user_id: int = None,
+    ) -> GLJournalEntry:
+        """Create a balanced posted journal entry for service-level callers."""
+        return self._create_journal_entry(
+            description=description,
+            lines=lines,
+            source_type=source_type,
+            source_id=source_id,
+            user_id=user_id,
+        )
+
     def _create_journal_entry(
         self,
         description: str,

--- a/backend/tests/services/test_sales_accounting_posting.py
+++ b/backend/tests/services/test_sales_accounting_posting.py
@@ -7,6 +7,7 @@ import pytest
 from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.bom import BOM, BOMLine
 from app.models.inventory import Inventory, InventoryTransaction
+from app.models.material import Color, MaterialInventory, MaterialType
 from app.models.payment import Payment
 from app.models.sales_order import SalesOrderLine
 
@@ -294,3 +295,52 @@ def test_shipment_gl_entry_rejects_unexpected_transaction_type(
 
     with pytest.raises(ValueError, match="Unexpected shipment transaction types"):
         _create_shipment_gl_entry(db, order, user_id=1, shipment_transactions=[txn])
+
+
+def test_shipment_gl_entry_rejects_material_backed_order_lines(
+    db, make_sales_order
+):
+    from app.services.sales_order_service import _create_shipment_gl_entry
+
+    order = make_sales_order(
+        quantity=1,
+        unit_price=Decimal("20.00"),
+        status="ready_to_ship",
+    )
+    material_type = MaterialType(
+        code=f"CR-MT-{order.id}",
+        name=f"CodeRabbit Material {order.id}",
+        base_material="PLA",
+        density=Decimal("1.2400"),
+        base_price_per_kg=Decimal("20.00"),
+    )
+    color = Color(
+        code=f"CR-C-{order.id}",
+        name=f"CodeRabbit Color {order.id}",
+        hex_code="#000000",
+    )
+    db.add_all([material_type, color])
+    db.flush()
+    material = MaterialInventory(
+        material_type_id=material_type.id,
+        color_id=color.id,
+        sku=f"CR-MAT-{order.id}",
+        quantity_kg=Decimal("1.000"),
+        cost_per_kg=Decimal("20.00"),
+    )
+    db.add(material)
+    db.flush()
+    db.add(
+        SalesOrderLine(
+            sales_order_id=order.id,
+            line_type="material",
+            material_inventory_id=material.id,
+            quantity=Decimal("1.00"),
+            unit_price=Decimal("20.00"),
+            total=Decimal("20.00"),
+        )
+    )
+    db.flush()
+
+    with pytest.raises(ValueError, match="raw-material account mapping"):
+        _create_shipment_gl_entry(db, order, user_id=1, shipment_transactions=[])

--- a/backend/tests/services/test_sales_accounting_posting.py
+++ b/backend/tests/services/test_sales_accounting_posting.py
@@ -2,6 +2,8 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
+
 from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.bom import BOM, BOMLine
 from app.models.inventory import Inventory, InventoryTransaction
@@ -227,6 +229,12 @@ def test_ship_order_posts_product_and_packaging_costs(
     )
     db.flush()
 
+    for account in db.query(GLAccount).filter(
+        GLAccount.account_code.in_(["1220", "1230", "5000", "5010"])
+    ).all():
+        account.account_code = f"OLD-{account.account_code}-{order.id}"[:20]
+    db.flush()
+
     ship_order(
         db,
         order.id,
@@ -251,3 +259,38 @@ def test_ship_order_posts_product_and_packaging_costs(
     assert lines["5010"]["debit"] == Decimal("3.00")
     assert lines["1230"]["credit"] == Decimal("3.00")
     assert linked_txn_count == 2
+
+
+def test_shipment_gl_entry_rejects_unexpected_transaction_type(
+    db, make_product, make_sales_order
+):
+    from app.services.inventory_service import get_or_create_default_location
+    from app.services.sales_order_service import _create_shipment_gl_entry
+
+    product = make_product(
+        item_type="finished_good",
+        cost_method="standard",
+        standard_cost=Decimal("8.00"),
+    )
+    order = make_sales_order(
+        product_id=product.id,
+        quantity=1,
+        unit_price=Decimal("20.00"),
+        status="ready_to_ship",
+    )
+    location = get_or_create_default_location(db)
+    txn = InventoryTransaction(
+        product_id=product.id,
+        location_id=location.id,
+        transaction_type="adjustment",
+        reference_type="sales_order",
+        reference_id=order.id,
+        quantity=Decimal("-1.00"),
+        cost_per_unit=Decimal("8.00"),
+        total_cost=Decimal("8.00"),
+    )
+    db.add(txn)
+    db.flush()
+
+    with pytest.raises(ValueError, match="Unexpected shipment transaction types"):
+        _create_shipment_gl_entry(db, order, user_id=1, shipment_transactions=[txn])

--- a/backend/tests/services/test_sales_accounting_posting.py
+++ b/backend/tests/services/test_sales_accounting_posting.py
@@ -1,0 +1,253 @@
+"""Sales accounting posting tests for quote-to-cash flow."""
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+from app.models.bom import BOM, BOMLine
+from app.models.inventory import Inventory, InventoryTransaction
+from app.models.payment import Payment
+from app.models.sales_order import SalesOrderLine
+
+
+def _entry_lines(db, *, source_type: str, source_id: int) -> dict[str, dict[str, Decimal]]:
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            GLJournalEntryLine.debit_amount,
+            GLJournalEntryLine.credit_amount,
+        )
+        .join(GLJournalEntryLine, GLJournalEntryLine.account_id == GLAccount.id)
+        .join(GLJournalEntry, GLJournalEntry.id == GLJournalEntryLine.journal_entry_id)
+        .filter(
+            GLJournalEntry.source_type == source_type,
+            GLJournalEntry.source_id == source_id,
+            GLJournalEntry.status == "posted",
+        )
+        .all()
+    )
+    return {
+        row.account_code: {
+            "debit": row.debit_amount or Decimal("0"),
+            "credit": row.credit_amount or Decimal("0"),
+        }
+        for row in rows
+    }
+
+
+def test_mark_sent_posts_invoice_receivable_revenue_tax_and_shipping(
+    db, make_product, make_sales_order
+):
+    from app.services.invoice_service import create_invoice, mark_sent
+
+    product = make_product(selling_price=Decimal("20.00"))
+    order = make_sales_order(
+        product_id=product.id,
+        quantity=1,
+        unit_price=Decimal("20.00"),
+        status="confirmed",
+    )
+    order.tax_rate = Decimal("0.0875")
+    order.tax_amount = Decimal("1.75")
+    order.shipping_cost = Decimal("5.00")
+    order.grand_total = Decimal("26.75")
+    invoice = create_invoice(db, order.id)
+
+    mark_sent(db, invoice.id)
+
+    lines = _entry_lines(db, source_type="invoice", source_id=invoice.id)
+    assert lines["1100"]["debit"] == Decimal("26.75")
+    assert lines["4000"]["credit"] == Decimal("20.00")
+    assert lines["2100"]["credit"] == Decimal("1.75")
+    assert lines["4200"]["credit"] == Decimal("5.00")
+
+
+def test_record_payment_posts_invoice_if_needed_and_payment_receipt(
+    db, make_product, make_sales_order
+):
+    from app.models.payment import Payment
+    from app.services.invoice_service import create_invoice, record_payment
+
+    product = make_product(selling_price=Decimal("45.00"))
+    order = make_sales_order(
+        product_id=product.id,
+        quantity=1,
+        unit_price=Decimal("45.00"),
+        status="confirmed",
+    )
+    order.tax_amount = Decimal("3.15")
+    order.shipping_cost = Decimal("5.00")
+    order.grand_total = Decimal("53.15")
+    invoice = create_invoice(db, order.id)
+
+    record_payment(db, invoice.id, Decimal("53.15"), "credit_card", reference="txn-53")
+
+    payment = db.query(Payment).filter(Payment.sales_order_id == order.id).one()
+    invoice_lines = _entry_lines(db, source_type="invoice", source_id=invoice.id)
+    payment_lines = _entry_lines(db, source_type="payment", source_id=payment.id)
+
+    assert invoice_lines["1100"]["debit"] == Decimal("53.15")
+    assert payment_lines["1000"]["debit"] == Decimal("53.15")
+    assert payment_lines["1100"]["credit"] == Decimal("53.15")
+
+
+def test_update_order_payment_status_posts_manual_payment_once(db, make_sales_order):
+    from app.services.payment_service import update_order_payment_status
+
+    order = make_sales_order(
+        quantity=1,
+        unit_price=Decimal("75.00"),
+        status="confirmed",
+        payment_status="pending",
+    )
+    payment = Payment(
+        payment_number=f"PAY-POST-{order.id}",
+        sales_order_id=order.id,
+        amount=Decimal("25.00"),
+        payment_method="cash",
+        payment_type="payment",
+        status="completed",
+        payment_date=datetime.now(timezone.utc),
+    )
+    db.add(payment)
+    db.flush()
+
+    update_order_payment_status(db, order)
+    update_order_payment_status(db, order)
+
+    entries = (
+        db.query(GLJournalEntry)
+        .filter(
+            GLJournalEntry.source_type == "payment",
+            GLJournalEntry.source_id == payment.id,
+        )
+        .all()
+    )
+    lines = _entry_lines(db, source_type="payment", source_id=payment.id)
+
+    assert len(entries) == 1
+    assert lines["1000"]["debit"] == Decimal("25.00")
+    assert lines["1100"]["credit"] == Decimal("25.00")
+
+
+def test_void_payment_posts_cash_ar_reversal(client, db, make_sales_order):
+    order = make_sales_order(
+        quantity=1,
+        unit_price=Decimal("30.00"),
+        status="confirmed",
+        payment_status="pending",
+    )
+    response = client.post(
+        "/api/v1/payments",
+        json={
+            "sales_order_id": order.id,
+            "amount": "30.00",
+            "payment_method": "cash",
+        },
+    )
+    assert response.status_code == 201
+    payment_id = response.json()["id"]
+
+    void_response = client.delete(f"/api/v1/payments/{payment_id}")
+    assert void_response.status_code == 204
+
+    lines = _entry_lines(db, source_type="payment_reversal", source_id=payment_id)
+    assert lines["1100"]["debit"] == Decimal("30.00")
+    assert lines["1000"]["credit"] == Decimal("30.00")
+
+
+def test_ship_order_posts_product_and_packaging_costs(
+    db, make_product, make_sales_order
+):
+    from app.services.inventory_service import get_or_create_default_location
+    from app.services.sales_order_service import ship_order
+
+    fg = make_product(
+        item_type="finished_good",
+        cost_method="standard",
+        standard_cost=Decimal("8.00"),
+    )
+    box = make_product(
+        item_type="packaging",
+        unit="EA",
+        cost_method="average",
+        average_cost=Decimal("1.50"),
+    )
+
+    bom = BOM(product_id=fg.id, name=f"BOM-SHIP-{fg.id}", active=True)
+    db.add(bom)
+    db.flush()
+    db.add(
+        BOMLine(
+            bom_id=bom.id,
+            component_id=box.id,
+            quantity=Decimal("1.00"),
+            unit="EA",
+            consume_stage="shipping",
+            sequence=10,
+        )
+    )
+
+    location = get_or_create_default_location(db)
+    db.add_all(
+        [
+            Inventory(
+                product_id=fg.id,
+                location_id=location.id,
+                on_hand_quantity=Decimal("10.00"),
+                allocated_quantity=Decimal("0"),
+            ),
+            Inventory(
+                product_id=box.id,
+                location_id=location.id,
+                on_hand_quantity=Decimal("10.00"),
+                allocated_quantity=Decimal("0"),
+            ),
+        ]
+    )
+
+    order = make_sales_order(
+        product_id=fg.id,
+        quantity=2,
+        unit_price=Decimal("20.00"),
+        status="ready_to_ship",
+        shipping_address_line1="123 Test St",
+        shipping_city="Bluffton",
+        shipping_state="IN",
+        shipping_zip="46714",
+    )
+    db.add(
+        SalesOrderLine(
+            sales_order_id=order.id,
+            product_id=fg.id,
+            quantity=Decimal("2.00"),
+            unit_price=Decimal("20.00"),
+            total=Decimal("40.00"),
+            line_type="product",
+        )
+    )
+    db.flush()
+
+    ship_order(
+        db,
+        order.id,
+        user_id=1,
+        user_email="admin@example.com",
+        tracking_number="TESTTRACK",
+    )
+
+    lines = _entry_lines(db, source_type="sales_order", source_id=order.id)
+    linked_txn_count = (
+        db.query(InventoryTransaction)
+        .filter(
+            InventoryTransaction.reference_type == "sales_order",
+            InventoryTransaction.reference_id == order.id,
+            InventoryTransaction.journal_entry_id.isnot(None),
+        )
+        .count()
+    )
+
+    assert lines["5000"]["debit"] == Decimal("16.00")
+    assert lines["1220"]["credit"] == Decimal("16.00")
+    assert lines["5010"]["debit"] == Decimal("3.00")
+    assert lines["1230"]["credit"] == Decimal("3.00")
+    assert linked_txn_count == 2


### PR DESCRIPTION
## Summary
- post invoice receivables to GL when invoices are marked sent or paid directly
- post completed payments/refunds to cash and AR, with one-time reversal entries when completed payments are voided
- include shipping/packaging material cost in the shipment GL entry and link sales-order inventory transactions to that journal entry
- create missing canonical sales accounts (`1100`, `2100`, `4200`) on demand for older local databases

## Core / PRO boundary
This stays in Core as basic GL accounting. Square/QBO invoice delivery and external accounting sync remain PRO integration work.

## Validation
- `pytest tests/services/test_sales_accounting_posting.py -q` -> 5 passed
- `pytest tests/services/test_sales_accounting_posting.py tests/api/v1/test_payments.py -q` -> 38 passed
- `pytest tests/services/test_sales_accounting_posting.py tests/test_invoice_service.py tests/api/v1/test_payments.py tests/services/test_sales_order_service.py -q` -> 229 passed

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-sales-accounting-posting-20260608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic ledger posting for invoices and completed payments (including reversing receipts when payments are voided or status-changed); order payment status now reflects posted ledger activity and posting is idempotent.
  * Shipment accounting becomes transaction-aware: validates transaction types, splits shipment vs. consumption costs, links postings to inventory transactions, and blocks material-backed orders from GL shipment posting.
  * Journal numbers are generated with a transaction-scoped lock to ensure sequentiality.

* **Tests**
  * Added end-to-end tests covering invoice posting, payment posting/reversal, idempotent posting, shipment accounting, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->