### PR TITLE
Clarify production order workflow

### DIFF
--- a/frontend/src/pages/admin/ProductionOrderDetail.jsx
+++ b/frontend/src/pages/admin/ProductionOrderDetail.jsx
@@ -7,8 +7,19 @@
  * - Blocking issues analysis
  * - Action buttons (Release, Start, Complete, etc.)
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Circle,
+  Clock3,
+  Factory,
+  FileText,
+  PackageCheck,
+  PlayCircle,
+  RefreshCw,
+} from "lucide-react";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import BlockingIssuesPanel from "../../components/orders/BlockingIssuesPanel";
@@ -21,6 +32,164 @@ import {
   PRODUCTION_ORDER_COLORS,
   getStatusColor,
 } from "../../lib/statusColors.js";
+
+const DONE_STATUSES = new Set(["complete", "completed", "closed"]);
+const ACTIVE_STATUSES = new Set(["in_progress", "scheduled"]);
+
+const formatStatusLabel = (status) =>
+  (status || "unknown").replace(/_/g, " ");
+
+function buildProductionWorkflowSteps(order) {
+  const status = order?.status || "draft";
+  const isReleased = status === "released";
+  const isActive = ACTIVE_STATUSES.has(status);
+  const isDone = DONE_STATUSES.has(status);
+
+  return [
+    {
+      key: "draft",
+      step: "Step 1",
+      title: "Work Order",
+      status: status === "draft" ? "current" : "done",
+      headline: status === "draft" ? "Draft" : "Created",
+      detail: order?.sales_order_id
+        ? "Created from the sales order and waiting for shop release."
+        : "Created for stock or internal production.",
+      icon: FileText,
+    },
+    {
+      key: "release",
+      step: "Step 2",
+      title: "Release",
+      status: status === "draft" ? "waiting" : isReleased ? "current" : "done",
+      headline:
+        status === "draft"
+          ? "Not Released"
+          : isReleased
+            ? "Released"
+            : "Released",
+      detail:
+        status === "draft"
+          ? "Release when material and commercial checks are satisfied."
+          : "This order is released to production.",
+      action: status === "draft" ? "release" : null,
+      actionLabel: "Release to Floor",
+      icon: CheckCircle2,
+    },
+    {
+      key: "build",
+      step: "Step 3",
+      title: "Build",
+      status: isDone
+        ? "done"
+        : isActive
+          ? "current"
+          : isReleased
+            ? "waiting"
+            : "blocked",
+      headline: isActive
+        ? "In Production"
+        : isDone
+          ? "Production Done"
+          : isReleased
+            ? "Ready to Start"
+            : "Waiting",
+      detail: isReleased
+        ? "Start production when the operator is ready to run."
+        : isActive
+          ? "Operations are being worked on the floor."
+          : isDone
+            ? "Finished goods are ready for fulfillment."
+            : "Release the work order before starting production.",
+      action: isReleased ? "start" : null,
+      actionLabel: "Start Production",
+      icon: PlayCircle,
+    },
+    {
+      key: "complete",
+      step: "Step 4",
+      title: "Complete",
+      status: isDone ? "done" : isActive ? "waiting" : "blocked",
+      headline: isDone ? "Complete" : isActive ? "Ready to Complete" : "Waiting",
+      detail: isActive
+        ? "Complete after the accepted quantity is produced."
+        : isDone
+          ? "Production is complete for this work order."
+          : "Start production before completion.",
+      action: isActive ? "complete" : null,
+      actionLabel: "Complete Production",
+      icon: PackageCheck,
+    },
+  ];
+}
+
+function WorkflowStepCard({ step, onAction, updating }) {
+  const Icon = step.icon || Circle;
+  const statusStyles = {
+    done: {
+      container: "border-emerald-500/50 bg-emerald-950/20",
+      icon: "bg-emerald-500/20 text-emerald-300",
+      label: "text-emerald-300",
+      badge: "bg-emerald-500/20 text-emerald-200",
+      badgeText: "Done",
+    },
+    current: {
+      container: "border-blue-500/60 bg-blue-950/20",
+      icon: "bg-blue-500/20 text-blue-300",
+      label: "text-blue-300",
+      badge: "bg-blue-500/20 text-blue-200",
+      badgeText: "Current",
+    },
+    waiting: {
+      container: "border-yellow-500/60 bg-yellow-950/20",
+      icon: "bg-yellow-500/20 text-yellow-300",
+      label: "text-yellow-300",
+      badge: "bg-yellow-500/20 text-yellow-200",
+      badgeText: "Waiting",
+    },
+    blocked: {
+      container: "border-gray-700 bg-gray-950/30",
+      icon: "bg-gray-800 text-gray-400",
+      label: "text-gray-400",
+      badge: "bg-gray-800 text-gray-400",
+      badgeText: "Blocked",
+    },
+  };
+  const styles = statusStyles[step.status] || statusStyles.blocked;
+
+  return (
+    <div className={`rounded-lg border p-4 ${styles.container}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className={`rounded-lg p-2 ${styles.icon}`}>
+            <Icon className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="text-xs uppercase text-gray-500">{step.step}</div>
+            <div className="text-sm font-semibold text-white">{step.title}</div>
+          </div>
+        </div>
+        <span className={`rounded-full px-2 py-1 text-xs ${styles.badge}`}>
+          {styles.badgeText}
+        </span>
+      </div>
+      <div className={`mt-4 text-sm font-semibold ${styles.label}`}>
+        {step.headline}
+      </div>
+      <p className="mt-2 min-h-10 text-sm text-gray-300">{step.detail}</p>
+      {step.action && (
+        <button
+          type="button"
+          onClick={() => onAction(step.action)}
+          disabled={updating}
+          className="mt-4 w-full rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {step.actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
 
 /**
  * Wrapper to fetch operations for timeline
@@ -63,14 +232,7 @@ export default function ProductionOrderDetail() {
   const [schedulerOpen, setSchedulerOpen] = useState(false);
   const [selectedOperation, setSelectedOperation] = useState(null);
 
-  useEffect(() => {
-    if (orderId) {
-      fetchOrder();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderId]);
-
-  const fetchOrder = async ({ silent = false } = {}) => {
+  const fetchOrder = useCallback(async ({ silent = false } = {}) => {
     if (!silent) {
       setLoading(true);
       setError(null);
@@ -90,7 +252,15 @@ export default function ProductionOrderDetail() {
     } finally {
       if (!silent) setLoading(false);
     }
-  };
+  }, [api, orderId]);
+
+  useEffect(() => {
+    if (orderId) {
+      // Route-driven data fetch updates loading/error state.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      fetchOrder();
+    }
+  }, [fetchOrder, orderId]);
 
   const handleStatusUpdate = async (action) => {
     setUpdating(true);
@@ -149,6 +319,9 @@ export default function ProductionOrderDetail() {
     );
   }
 
+  const workflowSteps = buildProductionWorkflowSteps(order);
+  const hasLinkedSalesOrder = Boolean(order.sales_order_id);
+
   const progress =
     order.quantity_ordered > 0
       ? Math.round((order.quantity_completed / order.quantity_ordered) * 100)
@@ -157,60 +330,109 @@ export default function ProductionOrderDetail() {
   return (
     <div className="space-y-6 p-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <button
             onClick={() => navigate("/admin/production")}
-            className="text-gray-400 hover:text-white mb-2"
+            className="mb-2 inline-flex items-center gap-2 text-gray-400 hover:text-white"
           >
-            ← Back to Production
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Back to Production
           </button>
           <h1 className="text-2xl font-bold text-white">
             Production Order: {order.code}
           </h1>
-          <p className="text-gray-400 mt-1">Production Command Center</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-400">
+            <span>Production Command Center</span>
+            {hasLinkedSalesOrder && (
+              <>
+                <span className="text-gray-600">-</span>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/admin/orders/${order.sales_order_id}`)}
+                  className="inline-flex items-center gap-1 text-blue-300 hover:text-blue-200"
+                >
+                  <FileText className="h-4 w-4" aria-hidden="true" />
+                  {order.sales_order_code || `SO-${order.sales_order_id}`}
+                </button>
+              </>
+            )}
+          </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <button
             onClick={fetchOrder}
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="inline-flex items-center gap-2 rounded-lg bg-gray-700 px-4 py-2 text-white hover:bg-gray-600"
           >
-            ↻ Refresh
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            Refresh
           </button>
           {order.status === "draft" && (
             <button
               onClick={() => handleStatusUpdate("release")}
               disabled={updating}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
             >
-              Release
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              Release to Floor
             </button>
           )}
           {order.status === "released" && (
             <button
               onClick={() => handleStatusUpdate("start")}
               disabled={updating}
-              className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700 disabled:opacity-50"
             >
+              <PlayCircle className="h-4 w-4" aria-hidden="true" />
               Start Production
             </button>
           )}
-          {order.status === "in_progress" && (
+          {ACTIVE_STATUSES.has(order.status) && (
             <button
               onClick={() => handleStatusUpdate("complete")}
               disabled={updating}
-              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700 disabled:opacity-50"
             >
-              Complete
+              <PackageCheck className="h-4 w-4" aria-hidden="true" />
+              Complete Production
             </button>
           )}
+        </div>
+      </div>
+
+      {/* Production Workflow */}
+      <div className="rounded-xl border border-blue-700/40 bg-blue-950/20 p-6">
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-white">
+              <Factory className="h-5 w-5 text-blue-300" aria-hidden="true" />
+              Production Workflow
+            </h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Draft, release, run, then complete the work order.
+            </p>
+          </div>
+          <span className="inline-flex w-fit items-center gap-2 rounded-full bg-gray-800 px-3 py-1 text-sm text-gray-300">
+            <Clock3 className="h-4 w-4" aria-hidden="true" />
+            {formatStatusLabel(order.status)}
+          </span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {workflowSteps.map((step) => (
+            <WorkflowStepCard
+              key={step.key}
+              step={step}
+              onAction={handleStatusUpdate}
+              updating={updating}
+            />
+          ))}
         </div>
       </div>
 
       {/* Order Summary */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
         <h2 className="text-lg font-semibold text-white mb-4">Order Summary</h2>
-        <div className="grid grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
           <div>
             <div className="text-sm text-gray-400">Product</div>
             <div className="text-white font-medium">
@@ -228,7 +450,7 @@ export default function ProductionOrderDetail() {
             <span
               className={`inline-block px-2 py-1 rounded-full text-sm ${getProductionStatusColor(order.status)}`}
             >
-              {order.status}
+              {formatStatusLabel(order.status)}
             </span>
           </div>
           <div>
@@ -352,22 +574,27 @@ export default function ProductionOrderDetail() {
       {/* Linked Sales Order */}
       {order.sales_order_id && (
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-          <h2 className="text-lg font-semibold text-white mb-4">
-            Linked Sales Order
-          </h2>
-          <div className="flex items-center justify-between">
+          <div className="mb-4 flex items-center gap-2">
+            <FileText className="h-5 w-5 text-blue-300" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-white">
+              Linked Sales Order
+            </h2>
+          </div>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-white font-medium">
                 {order.sales_order_code || `SO-${order.sales_order_id}`}
               </p>
               <p className="text-gray-400 text-sm">
-                {order.customer_name || "Customer"}
+                {order.customer_name || "Customer"} - Open the sales order for
+                invoice, payment, and shipment controls.
               </p>
             </div>
             <button
               onClick={() => navigate(`/admin/orders/${order.sales_order_id}`)}
-              className="px-4 py-2 bg-blue-600/20 text-blue-400 rounded-lg hover:bg-blue-600/30"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600/20 px-4 py-2 text-blue-300 hover:bg-blue-600/30"
             >
+              <ArrowLeft className="h-4 w-4 rotate-180" aria-hidden="true" />
               View Sales Order
             </button>
           </div>

--- a/frontend/src/pages/admin/__tests__/ProductionOrderDetail.test.jsx
+++ b/frontend/src/pages/admin/__tests__/ProductionOrderDetail.test.jsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => {
+  const mocks = {
+    get: vi.fn(),
+    post: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+  }
+  mocks.api = {
+    get: mocks.get,
+    post: mocks.post,
+  }
+  mocks.toast = {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  }
+  return { mocks }
+})
+
+vi.mock('../../../hooks/useApi', () => ({
+  useApi: () => mocks.api,
+}))
+
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => mocks.toast,
+}))
+
+vi.mock('../../../components/orders/BlockingIssuesPanel', () => ({
+  default: () => <div>Blocking issues</div>,
+}))
+
+vi.mock('../../../components/production', () => ({
+  OperationsPanel: () => <div>Operations panel</div>,
+  OperationSchedulerModal: () => null,
+  OperationsTimeline: () => <div>Operations timeline</div>,
+}))
+
+import ProductionOrderDetail from '../ProductionOrderDetail'
+
+const draftOrder = {
+  id: 2782,
+  code: 'PO-2026-0024',
+  status: 'draft',
+  product_name: 'Raspberry Pi 5 Enclosure',
+  product_sku: 'FG-ENCLOSURE-01',
+  quantity_ordered: 1,
+  quantity_completed: 0,
+  priority: 3,
+  due_date: null,
+  sales_order_id: 2789,
+  sales_order_code: 'SO-2026-054',
+  customer_name: 'Walk-in Customer',
+}
+
+let currentOrder = draftOrder
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/production/2782']}>
+      <Routes>
+        <Route path="/admin/production/:orderId" element={<ProductionOrderDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  currentOrder = draftOrder
+  mocks.get.mockReset()
+  mocks.post.mockReset()
+  mocks.toastError.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.get.mockImplementation((path) => {
+    if (path === '/api/v1/production-orders/2782') {
+      return Promise.resolve(currentOrder)
+    }
+    return Promise.reject(new Error(`unexpected path ${path}`))
+  })
+  mocks.post.mockResolvedValue({})
+})
+
+describe('ProductionOrderDetail', () => {
+  it('renders production workflow and linked sales order context', async () => {
+    renderPage()
+
+    expect(await screen.findByText('Production Workflow')).toBeInTheDocument()
+    expect(screen.getByText('Not Released')).toBeInTheDocument()
+    expect(screen.getAllByText('SO-2026-054')).toHaveLength(2)
+    expect(screen.getByText(/invoice, payment, and shipment controls/i)).toBeInTheDocument()
+  })
+
+  it('shows draft orders as not released with a release action', async () => {
+    renderPage()
+
+    expect(await screen.findByText('Not Released')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /release to floor/i })).toHaveLength(2)
+  })
+
+  it('shows released orders as ready to start', async () => {
+    currentOrder = { ...draftOrder, status: 'released' }
+
+    renderPage()
+
+    expect(await screen.findByText('Ready to Start')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /start production/i })).toHaveLength(2)
+  })
+
+  it('shows active orders as ready to complete', async () => {
+    currentOrder = { ...draftOrder, status: 'in_progress' }
+
+    renderPage()
+
+    expect(await screen.findByText('Ready to Complete')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /complete production/i })).toHaveLength(2)
+  })
+
+  it('calls the release endpoint from the workflow action', async () => {
+    renderPage()
+
+    const releaseButtons = await screen.findAllByRole('button', {
+      name: /release to floor/i,
+    })
+    fireEvent.click(releaseButtons[0])
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith('/api/v1/production-orders/2782/release')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a visible draft -> release -> build -> complete workflow strip to production order detail
- surface the linked sales order near the header and in the linked order section for quick return to invoice/payment/shipment controls
- add focused unit coverage for draft, released, and in-progress production workflow states

## Validation
- npm run test:unit -- ProductionOrderDetail.test.jsx
- npx eslint src/pages/admin/ProductionOrderDetail.jsx src/pages/admin/__tests__/ProductionOrderDetail.test.jsx
- npm run build

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-next-20260609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added production order workflow visualization with step-by-step status tracking and visual indicators
  * Enhanced action controls (Release, Start, Complete) with improved accessibility and clarity

* **Style**
  * Redesigned production order header layout and workflow command center section
  * Updated Linked Sales Order panel with improved iconography and button presentation

* **Tests**
  * Added comprehensive test coverage for production order detail page functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->