### PR TITLE
Sync prepaid order payments into invoices

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -87,6 +87,29 @@ def _calculate_due_date(payment_terms: str, from_date: Optional[date] = None) ->
     return base + timedelta(days=days)
 
 
+def _completed_payment_total(db: Session, sales_order_id: int) -> Decimal:
+    """Return net completed payments already recorded against the order."""
+    total = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
+        Payment.sales_order_id == sales_order_id,
+        Payment.status == "completed",
+    ).scalar()
+    return Decimal(str(total or "0"))
+
+
+def _latest_completed_payment(db: Session, sales_order_id: int) -> Payment | None:
+    """Return the latest positive completed payment for invoice display fields."""
+    return (
+        db.query(Payment)
+        .filter(
+            Payment.sales_order_id == sales_order_id,
+            Payment.status == "completed",
+            Payment.amount > 0,
+        )
+        .order_by(desc(Payment.payment_date), desc(Payment.id))
+        .first()
+    )
+
+
 # ============================================================================
 # Create Invoice
 # ============================================================================
@@ -195,6 +218,20 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
     tax_amount = order.tax_amount or Decimal("0")
     shipping = order.shipping_cost or Decimal("0")
     total = subtotal + tax_amount + shipping
+    existing_paid = _completed_payment_total(db, order.id)
+    latest_payment = None
+
+    if existing_paid != 0:
+        update_order_payment_status(db, order)
+        existing_paid = _completed_payment_total(db, order.id)
+        latest_payment = _latest_completed_payment(db, order.id)
+
+    amount_paid = max(existing_paid, Decimal("0"))
+    invoice_status = "paid" if total > 0 and amount_paid >= total else "draft"
+    paid_at = latest_payment.payment_date if invoice_status == "paid" and latest_payment else None
+    payment_reference = None
+    if latest_payment:
+        payment_reference = latest_payment.transaction_id or latest_payment.check_number
 
     # Build customer name from order or User record
     customer_name = order.customer_name or (
@@ -220,6 +257,11 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
         tax_amount=tax_amount,
         shipping_amount=shipping,
         total=total,
+        status=invoice_status,
+        amount_paid=amount_paid,
+        paid_at=paid_at,
+        payment_method=latest_payment.payment_method if latest_payment else None,
+        payment_reference=payment_reference,
     )
 
     db.add(invoice)
@@ -228,6 +270,9 @@ def create_invoice(db: Session, sales_order_id: int) -> Invoice:
     for il in invoice_lines:
         il.invoice_id = invoice.id
         db.add(il)
+
+    if invoice_status == "paid":
+        post_invoice_receivable(db, invoice)
 
     db.commit()
     db.refresh(invoice)

--- a/backend/tests/services/test_sales_accounting_posting.py
+++ b/backend/tests/services/test_sales_accounting_posting.py
@@ -93,6 +93,50 @@ def test_record_payment_posts_invoice_if_needed_and_payment_receipt(
     assert payment_lines["1100"]["credit"] == Decimal("53.15")
 
 
+def test_create_invoice_for_prepaid_order_posts_invoice_receivable(
+    db, make_product, make_sales_order
+):
+    from app.services.invoice_service import create_invoice
+
+    product = make_product(selling_price=Decimal("45.00"))
+    order = make_sales_order(
+        product_id=product.id,
+        quantity=1,
+        unit_price=Decimal("45.00"),
+        status="confirmed",
+        payment_status="pending",
+    )
+    order.tax_amount = Decimal("3.15")
+    order.shipping_cost = Decimal("5.00")
+    order.grand_total = Decimal("53.15")
+    payment = Payment(
+        payment_number=f"PAY-PREPAID-{order.id}",
+        sales_order_id=order.id,
+        amount=Decimal("53.15"),
+        payment_method="credit_card",
+        payment_type="payment",
+        status="completed",
+        transaction_id="txn-prepaid",
+        payment_date=datetime.now(timezone.utc),
+    )
+    db.add(payment)
+    db.flush()
+
+    invoice = create_invoice(db, order.id)
+
+    invoice_lines = _entry_lines(db, source_type="invoice", source_id=invoice.id)
+    payment_lines = _entry_lines(db, source_type="payment", source_id=payment.id)
+
+    assert invoice.status == "paid"
+    assert invoice.amount_paid == Decimal("53.15")
+    assert invoice_lines["1100"]["debit"] == Decimal("53.15")
+    assert invoice_lines["4000"]["credit"] == Decimal("45.00")
+    assert invoice_lines["2100"]["credit"] == Decimal("3.15")
+    assert invoice_lines["4200"]["credit"] == Decimal("5.00")
+    assert payment_lines["1000"]["debit"] == Decimal("53.15")
+    assert payment_lines["1100"]["credit"] == Decimal("53.15")
+
+
 def test_update_order_payment_status_posts_manual_payment_once(db, make_sales_order):
     from app.services.payment_service import update_order_payment_status
 

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -1,6 +1,6 @@
 """Tests for invoice service and API endpoints."""
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -242,6 +242,79 @@ class TestCreateInvoice:
             create_invoice(db, so.id)
         assert exc_info.value.status_code == 400
         assert "already exists" in exc_info.value.detail
+
+    def test_create_invoice_reflects_existing_order_payment(
+        self, db, make_product, make_sales_order
+    ):
+        from app.models.payment import Payment
+        from app.services.invoice_service import create_invoice
+
+        product = make_product(selling_price=Decimal("50.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("50.00"),
+            status="confirmed",
+            payment_status="pending",
+        )
+        paid_at = datetime.now(timezone.utc)
+        db.add(Payment(
+            payment_number=f"PAY-EXISTING-{so.id}",
+            sales_order_id=so.id,
+            amount=Decimal("50.00"),
+            payment_method="cash",
+            payment_type="payment",
+            status="completed",
+            transaction_id="cash-50",
+            payment_date=paid_at,
+        ))
+        db.flush()
+
+        invoice = create_invoice(db, so.id)
+        db.refresh(so)
+
+        assert invoice.amount_paid == Decimal("50.00")
+        assert invoice.status == "paid"
+        assert invoice.paid_at is not None
+        assert invoice.payment_method == "cash"
+        assert invoice.payment_reference == "cash-50"
+        assert so.payment_status == "paid"
+
+    def test_create_invoice_reflects_existing_partial_order_payment(
+        self, db, make_product, make_sales_order
+    ):
+        from app.models.payment import Payment
+        from app.services.invoice_service import create_invoice
+
+        product = make_product(selling_price=Decimal("80.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("80.00"),
+            status="confirmed",
+            payment_status="pending",
+        )
+        db.add(Payment(
+            payment_number=f"PAY-PARTIAL-{so.id}",
+            sales_order_id=so.id,
+            amount=Decimal("25.00"),
+            payment_method="card",
+            payment_type="payment",
+            status="completed",
+            transaction_id="txn-25",
+            payment_date=datetime.now(timezone.utc),
+        ))
+        db.flush()
+
+        invoice = create_invoice(db, so.id)
+        db.refresh(so)
+
+        assert invoice.amount_paid == Decimal("25.00")
+        assert invoice.status == "draft"
+        assert invoice.paid_at is None
+        assert invoice.payment_method == "card"
+        assert invoice.payment_reference == "txn-25"
+        assert so.payment_status == "partial"
 
 
 class TestRecordPayment:


### PR DESCRIPTION
## Summary
- initialize new invoices from completed payments already recorded on the sales order
- mark fully prepaid invoices as paid and carry over payment method/reference display fields
- post invoice receivable immediately for fully prepaid invoices so revenue, tax, shipping revenue, cash, and AR stay balanced
- add service and accounting regression coverage for full and partial pre-invoice payments

## Validation
- C:\repos\filaops\backend\venv\Scripts\python.exe -m py_compile app/services/invoice_service.py tests/test_invoice_service.py tests/services/test_sales_accounting_posting.py
- git diff --check

## Not Run
- C:\repos\filaops\backend\venv\Scripts\python.exe -m pytest tests/test_invoice_service.py tests/services/test_sales_accounting_posting.py -q
  - Blocked locally: Postgres rejected filaops_test auth for both postgres:postgres and postgres:changeme. The attempted target DB was filaops_test, not production.

Co-authored-by: Codex <Codex@anthropic.com>
Agent-Session: codex-quote-cash-closeout-20260609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Invoices now automatically populate payment information from existing payment records. When creating an invoice for an order with prepaid or partial payments, the invoice status and payment details (amount, date, method, reference) are automatically populated. Sales order payment status is updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->