### PR TITLE
fix: surface PRO tier-limit and PRO-feature errors (re: #367)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { LocaleProvider } from "./contexts/LocaleContext";
 import { useFeatureFlags } from "./hooks/useFeatureFlags";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ApiErrorToaster from "./components/ApiErrorToaster";
+import UpgradeModal from "./components/UpgradeModal";
 import AdminLayout from "./components/AdminLayout";
 import Setup from "./pages/Setup";
 import Onboarding from "./pages/Onboarding";
@@ -126,6 +127,9 @@ export default function App() {
             <ToastProvider>
               {/* Global API error toasts */}
               <ApiErrorToaster />
+              {/* Tier-limit upgrade modal — must be mounted at app root so
+                  it can receive tier:limit-reached events from any page */}
+              <UpgradeModal />
               <BrowserRouter>
                 <Routes>
                   {/* Redirect root to admin */}

--- a/frontend/src/components/ApiErrorToaster.jsx
+++ b/frontend/src/components/ApiErrorToaster.jsx
@@ -77,13 +77,17 @@ export default function ApiErrorToaster() {
       // PRO-feature 403: backend's require_tier decorator sends a plain string
       // like "This feature requires Professional tier or higher".  Show an
       // actionable message linking straight to the License page.
-      if (
-        status === 403 &&
-        typeof detail === "string" &&
-        detail.toLowerCase().includes("requires")
-      ) {
-        toast.info("This is a PRO feature — view upgrade options at Settings → License.");
-        return;
+      // Guard: require both "requires" AND a whole-word tier/plan keyword so
+      // strings like "Admin approval requires manager role" are not misclassified
+      // ("approval" contains "pro" as a substring — use \b word boundaries).
+      if (status === 403 && typeof detail === "string") {
+        const isTierRequirement =
+          /\brequires\b/i.test(detail) &&
+          /\b(tier|professional|enterprise|pro)\b/i.test(detail);
+        if (isTierRequirement) {
+          toast.info("This is a PRO feature — view upgrade options at Settings → License.");
+          return;
+        }
       }
 
       // Structured 403 with a message field (other PRO-endpoint errors)

--- a/frontend/src/components/ApiErrorToaster.jsx
+++ b/frontend/src/components/ApiErrorToaster.jsx
@@ -1,6 +1,14 @@
 /**
  * Listens for 'api:error' and shows a toast. Central place -> fewer silent failures.
  * Also detects tier limit errors and emits 'tier:limit-reached' event.
+ *
+ * 403 handling matrix:
+ *  - detail.code === "TIER_LIMIT_EXCEEDED" → emit tier:limit-reached (opens UpgradeModal)
+ *    + show toast.info fallback so something always appears if the modal listener fails.
+ *  - detail (string) contains "requires" (require_tier decorator) → PRO-feature toast
+ *    with link to /admin/license.
+ *  - detail.message present → show detail.message directly.
+ *  - anything else → generic "no permission" text.
  */
 import { useEffect, useRef } from "react";
 import { on, emit } from "../lib/events";
@@ -52,9 +60,9 @@ export default function ApiErrorToaster() {
         url.includes("/api/v1/pro/integrations/bambuddy") ||
         url.includes("/api/v1/pro/printer-providers/bambuddy");
 
-      // Check if this is a tier limit error
+      // Tier-limit 403: open upgrade modal AND show a fallback toast so
+      // something is always visible even if UpgradeModal is not mounted.
       if (status === 403 && detail && typeof detail === "object" && detail.code === "TIER_LIMIT_EXCEEDED") {
-        // Emit special event for upgrade modal
         emit("tier:limit-reached", {
           resource: detail.resource,
           limit: detail.limit,
@@ -62,10 +70,23 @@ export default function ApiErrorToaster() {
           tier: detail.tier,
           message: detail.message,
         });
-        return; // Don't show regular toast for tier limits
+        toast.info(detail.message || "You've reached a tier limit. Upgrade to PRO for more.");
+        return;
       }
 
-      // PRO feature endpoint returned 403 — show contextual message
+      // PRO-feature 403: backend's require_tier decorator sends a plain string
+      // like "This feature requires Professional tier or higher".  Show an
+      // actionable message linking straight to the License page.
+      if (
+        status === 403 &&
+        typeof detail === "string" &&
+        detail.toLowerCase().includes("requires")
+      ) {
+        toast.info("This is a PRO feature — view upgrade options at Settings → License.");
+        return;
+      }
+
+      // Structured 403 with a message field (other PRO-endpoint errors)
       if (status === 403 && detail && typeof detail === "object" && detail.message) {
         toast.error(detail.message);
         return;

--- a/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
+++ b/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
@@ -154,13 +154,26 @@ describe("ApiErrorToaster", () => {
       );
     });
 
-    it("matches case-insensitively on the word 'requires'", () => {
+    it("matches case-insensitively on the word 'requires' + tier keyword", () => {
       render(<ApiErrorToaster />);
       fireApiError({
         status: 403,
         detail: "REQUIRES enterprise tier",
       });
       expect(mocks.toastInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT misclassify non-tier 'requires' messages as PRO upsells", () => {
+      render(<ApiErrorToaster />);
+      // "requires" present but no tier/plan keyword — should fall through to generic 403
+      fireApiError({
+        status: 403,
+        detail: "Admin approval requires manager role",
+      });
+      expect(mocks.toastInfo).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
     });
 
     it("does NOT emit tier:limit-reached for string 403", () => {

--- a/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
+++ b/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for ApiErrorToaster.
+ *
+ * Covers:
+ *  - TIER_LIMIT_EXCEEDED 403 → emits tier:limit-reached + shows toast.info fallback
+ *  - require_tier string 403 → shows PRO-feature toast.info
+ *  - structured 403 with message → shows toast.error with that message
+ *  - generic 403 → shows permission-denied toast
+ *  - 401 → session-expired toast
+ *  - 5xx → server-error toast
+ */
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── hoisted mocks (must be first) ───────────────────────────────────────────
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    toastError: vi.fn(),
+    toastInfo: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastWarning: vi.fn(),
+    emitted: [],
+  },
+}));
+
+vi.mock("../Toast", () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+    info: mocks.toastInfo,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  }),
+}));
+
+// Real event bus — we capture emits ourselves
+vi.mock("../../lib/events", async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,
+    emit: vi.fn((...args) => {
+      mocks.emitted.push(args);
+      real.emit(...args);
+    }),
+  };
+});
+
+import { emit as mockEmit, emit } from "../../lib/events";
+import ApiErrorToaster from "../ApiErrorToaster";
+
+// Helper: fire an api:error event and flush effects
+function fireApiError(payload) {
+  act(() => {
+    emit("api:error", payload);
+  });
+}
+
+beforeEach(() => {
+  mocks.toastError.mockReset();
+  mocks.toastInfo.mockReset();
+  mocks.toastSuccess.mockReset();
+  mocks.toastWarning.mockReset();
+  mocks.emitted.length = 0;
+  mockEmit.mockClear();
+});
+
+describe("ApiErrorToaster", () => {
+  it("renders nothing (returns null)", () => {
+    const { container } = render(<ApiErrorToaster />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("TIER_LIMIT_EXCEEDED 403", () => {
+    it("emits tier:limit-reached with resource info", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: {
+          code: "TIER_LIMIT_EXCEEDED",
+          resource: "users",
+          limit: 3,
+          current: 3,
+          tier: "community",
+          message: "You've reached the user limit.",
+        },
+      });
+      expect(mockEmit).toHaveBeenCalledWith("tier:limit-reached", {
+        resource: "users",
+        limit: 3,
+        current: 3,
+        tier: "community",
+        message: "You've reached the user limit.",
+      });
+    });
+
+    it("shows a toast.info fallback so something always appears", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: {
+          code: "TIER_LIMIT_EXCEEDED",
+          resource: "printers",
+          limit: 5,
+          current: 5,
+          tier: "community",
+          message: "Printer limit reached.",
+        },
+      });
+      expect(mocks.toastInfo).toHaveBeenCalledWith("Printer limit reached.");
+    });
+
+    it("uses generic fallback message when detail.message is absent", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: {
+          code: "TIER_LIMIT_EXCEEDED",
+          resource: "users",
+          limit: 3,
+          current: 3,
+          tier: "community",
+        },
+      });
+      expect(mocks.toastInfo).toHaveBeenCalledWith(
+        "You've reached a tier limit. Upgrade to PRO for more."
+      );
+    });
+
+    it("does NOT call toast.error for tier-limit 403", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: {
+          code: "TIER_LIMIT_EXCEEDED",
+          resource: "users",
+          limit: 3,
+          current: 3,
+          tier: "community",
+          message: "Limit hit.",
+        },
+      });
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("require_tier string 403 (PRO-feature gate)", () => {
+    it("shows PRO-feature toast.info for 'requires Professional tier' message", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: "This feature requires Professional tier or higher",
+      });
+      expect(mocks.toastInfo).toHaveBeenCalledWith(
+        "This is a PRO feature — view upgrade options at Settings → License."
+      );
+    });
+
+    it("matches case-insensitively on the word 'requires'", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: "REQUIRES enterprise tier",
+      });
+      expect(mocks.toastInfo).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT emit tier:limit-reached for string 403", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: "This feature requires Professional tier or higher",
+      });
+      // mockEmit is only called once (for api:error itself) — NOT for tier:limit-reached
+      const tierEmits = mocks.emitted.filter(([ev]) => ev === "tier:limit-reached");
+      expect(tierEmits).toHaveLength(0);
+    });
+
+    it("does NOT treat a generic string 403 as PRO-feature", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({ status: 403, detail: "Admin access required" });
+      expect(mocks.toastInfo).not.toHaveBeenCalled();
+      // Falls through to generic permission toast
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+    });
+  });
+
+  describe("structured 403 with message (other PRO endpoints)", () => {
+    it("shows toast.error with the detail.message", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: { message: "Shopify integration not licensed" },
+      });
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Shopify integration not licensed"
+      );
+    });
+  });
+
+  describe("generic 403 (permission denied)", () => {
+    it("shows the generic permission-denied message", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({ status: 403, message: "Forbidden" });
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+    });
+  });
+
+  describe("401", () => {
+    it("shows session-expired message", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({ status: 401, message: "Unauthorized" });
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Your session has expired. Please log in again."
+      );
+    });
+  });
+
+  describe("5xx", () => {
+    it("shows server-error message for 500", () => {
+      render(<ApiErrorToaster />);
+      fireApiError({ status: 500, message: "Internal Server Error" });
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Something went wrong on the server. Please try again."
+      );
+    });
+  });
+});

--- a/frontend/src/components/__tests__/UpgradeModal.test.jsx
+++ b/frontend/src/components/__tests__/UpgradeModal.test.jsx
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for UpgradeModal.
+ *
+ * Covers:
+ *  - Modal is closed by default (nothing rendered)
+ *  - Opens when tier:limit-reached event is emitted, shows resource/limit info
+ *  - "Maybe Later" closes the modal
+ *  - "View Plans" link points to PRICING_URL
+ *  - Modal is importable from App.jsx (mount smoke test)
+ */
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { emit } from "../../lib/events";
+import UpgradeModal from "../UpgradeModal";
+
+// Suppress requestAnimationFrame in jsdom (Modal uses it for focus)
+beforeEach(() => {
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function fireLimit(payload = {}) {
+  act(() => {
+    emit("tier:limit-reached", {
+      resource: "users",
+      limit: 3,
+      current: 3,
+      tier: "community",
+      message: "You've reached the user limit.",
+      ...payload,
+    });
+  });
+}
+
+describe("UpgradeModal", () => {
+  it("renders nothing when no event has been emitted", () => {
+    const { container } = render(<UpgradeModal />);
+    // Modal returns null when closed
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("opens when tier:limit-reached is emitted", () => {
+    render(<UpgradeModal />);
+    fireLimit();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Modal renders title in both an sr-only span (aria) and a visible h2
+    expect(screen.getAllByText("Upgrade to PRO").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows resource name and limit/current counts", () => {
+    render(<UpgradeModal />);
+    fireLimit({ resource: "printers", limit: 5, current: 5 });
+    expect(screen.getByText(/printers/)).toBeInTheDocument();
+    expect(screen.getByText(/5\/5/)).toBeInTheDocument();
+  });
+
+  it("replaces underscores in resource name with spaces", () => {
+    render(<UpgradeModal />);
+    fireLimit({ resource: "active_users" });
+    expect(screen.getByText(/active users/)).toBeInTheDocument();
+  });
+
+  it("closes when Maybe Later is clicked", () => {
+    render(<UpgradeModal />);
+    fireLimit();
+    fireEvent.click(screen.getByText("Maybe Later"));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("View Plans link points to PRICING_URL", () => {
+    render(<UpgradeModal />);
+    fireLimit();
+    const link = screen.getByRole("link", { name: /View Plans/i });
+    expect(link).toHaveAttribute("href", "https://blb3dprinting.com/pro/pricing/");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("can be imported and rendered without crashing (mount smoke test)", () => {
+    // This verifies UpgradeModal is a valid, importable React component
+    expect(() => render(<UpgradeModal />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Root cause

`UpgradeModal.jsx` has existed in the codebase since at least April 2026. It listens for the `tier:limit-reached` event and renders an upgrade dialog — but was **never imported or mounted anywhere**. As a result, every `TIER_LIMIT_EXCEEDED` 403 from the backend was silently swallowed by `ApiErrorToaster`'s early-return (`return;` on line 65), and nothing was shown to the user. Issue #367 was closed 2026-03-13 but the core problem (nothing visible on PRO-gated 403s) remained.

## Changes

### `frontend/src/App.jsx`
- Import and mount `<UpgradeModal />` once, next to `<ApiErrorToaster />`, inside `<ToastProvider>`. Being inside `ToastProvider` is required since the modal's toast fallback needs the toast context.

### `frontend/src/components/ApiErrorToaster.jsx`
- **TIER_LIMIT_EXCEEDED branch**: After emitting `tier:limit-reached` (which opens the modal), also call `toast.info(detail.message || fallback)` so something is always visible even if the modal ever fails to mount in the future.
- **`require_tier` string-detail 403**: The backend's `require_tier` decorator sends a plain string like `"This feature requires Professional tier or higher"`. Previously this fell through to the generic `"You don't have permission..."` message. Now detected by checking `typeof detail === "string" && detail.toLowerCase().includes("requires")` and surfaces `"This is a PRO feature — view upgrade options at Settings → License."` instead.
- Structured 403 with `detail.message` (other PRO endpoint errors) — unchanged, still shows `detail.message`.

### `frontend/src/components/__tests__/ApiErrorToaster.test.jsx` (new)
Full branch coverage: TIER_LIMIT_EXCEEDED (event emit + toast.info fallback + no toast.error), require_tier string 403 (toast.info + no tier event), structured detail.message 403, generic 403, 401, 5xx.

### `frontend/src/components/__tests__/UpgradeModal.test.jsx` (new)
Covers: closed by default, opens on `tier:limit-reached`, resource/limit display, underscore-to-space, "Maybe Later" closes, "View Plans" link target, mount smoke test.

## Verification

```
npm run test:unit  →  288 passed (288), 36 files
npm run build      →  ✓ built in 1.17s, no errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a modal that appears when users reach tier limits, displaying affected resource and usage details.
  * Improved error messaging to guide users toward license upgrades via Settings.

* **Tests**
  * Added test coverage for tier-limit handling and error messaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->