### PR TITLE
fix: link invoices to orders, guard shipping deep-link, land on new production order

### DIFF
--- a/frontend/src/pages/admin/AdminBOM.jsx
+++ b/frontend/src/pages/admin/AdminBOM.jsx
@@ -133,8 +133,8 @@ export default function AdminBOM() {
     setShowProductionModal(false);
     setProductionBOM(null);
     setSelectedBOM(null);
-    // Navigate to production orders page to see the new order
-    navigate(`/admin/production?order=${newOrder.id}`);
+    // Navigate directly to the new production order detail page
+    navigate(`/admin/production/${newOrder.id}`);
   };
 
   return (

--- a/frontend/src/pages/admin/AdminInvoices.jsx
+++ b/frontend/src/pages/admin/AdminInvoices.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { useFormatCurrency } from "../../hooks/useFormatCurrency";
@@ -38,6 +38,7 @@ export default function AdminInvoices() {
   const api = useApi();
   const toast = useToast();
   const formatCurrency = useFormatCurrency();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const statusFilter = searchParams.get("status") || "";
@@ -374,8 +375,17 @@ export default function AdminInvoices() {
                     <td className="py-3 px-4 text-white font-mono text-sm">
                       {invoice.invoice_number || "-"}
                     </td>
-                    <td className="py-3 px-4 text-gray-300 font-mono text-sm">
-                      {invoice.order_number || "-"}
+                    <td className="py-3 px-4 font-mono text-sm">
+                      {invoice.sales_order_id ? (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); navigate(`/admin/orders/${invoice.sales_order_id}`); }}
+                          className="text-blue-400 hover:text-blue-300"
+                        >
+                          {invoice.order_number || invoice.sales_order_id}
+                        </button>
+                      ) : (
+                        <span className="text-gray-300">{invoice.order_number || "-"}</span>
+                      )}
                     </td>
                     <td className="py-3 px-4 text-gray-300">
                       {invoice.customer_name || "-"}
@@ -485,7 +495,16 @@ export default function AdminInvoices() {
                     </div>
                     <div>
                       <span className="text-gray-400">Order #</span>
-                      <p className="text-white">{selectedInvoice.order_number || "-"}</p>
+                      {selectedInvoice.sales_order_id ? (
+                        <button
+                          onClick={() => navigate(`/admin/orders/${selectedInvoice.sales_order_id}`)}
+                          className="block text-blue-400 hover:text-blue-300 font-mono"
+                        >
+                          {selectedInvoice.order_number || selectedInvoice.sales_order_id}
+                        </button>
+                      ) : (
+                        <p className="text-white">{selectedInvoice.order_number || "-"}</p>
+                      )}
                     </div>
                   </div>
 
@@ -618,6 +637,17 @@ export default function AdminInvoices() {
 
                   {/* Action Buttons */}
                   <div className="flex flex-wrap gap-3 pt-4 border-t border-gray-800">
+                    {selectedInvoice.sales_order_id && (
+                      <button
+                        onClick={() => navigate(`/admin/orders/${selectedInvoice.sales_order_id}`)}
+                        className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 flex items-center gap-2"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                        </svg>
+                        View Order
+                      </button>
+                    )}
                     {selectedInvoice.status === "draft" && (
                       <button
                         onClick={handleSendInvoice}

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import ProductionOrderModal from "../../components/production/ProductionOrderModal";
 import ProductionQueueList from "../../components/production/ProductionQueueList";
 import SplitOrderModal from "../../components/SplitOrderModal";
@@ -235,6 +235,7 @@ const SoLinkBadge = ({ order }) => {
 
 export default function AdminProduction() {
   const api = useApi();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [productionOrders, setProductionOrders] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -355,7 +356,7 @@ export default function AdminProduction() {
 
     setCreating(true);
     try {
-      await api.post(`/api/v1/production-orders/`, {
+      const newOrder = await api.post(`/api/v1/production-orders/`, {
         product_id: parseInt(createForm.product_id),
         quantity_ordered: parseInt(createForm.quantity_ordered) || 1,
         priority: parseInt(createForm.priority) || 3,
@@ -371,7 +372,8 @@ export default function AdminProduction() {
         due_date: "",
         notes: "",
       });
-      fetchProductionOrders();
+      // Navigate to the new production order detail page
+      navigate(`/admin/production/${newOrder.id}`);
     } catch (err) {
       setError(err.message);
     } finally {

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -599,6 +599,18 @@ export default function AdminShipping() {
         </div>
       )}
 
+      {/* Deep-link banner: orderId param present but order not in ready-to-ship set */}
+      {!loading && orderIdParam && !orders.find((o) => o.id === parseInt(orderIdParam)) && (
+        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg px-4 py-3 flex items-start gap-3">
+          <svg className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          </svg>
+          <p className="text-yellow-300 text-sm">
+            Order isn&apos;t ready to ship yet — production must complete.
+          </p>
+        </div>
+      )}
+
       {/* Tabs */}
       <div className="flex gap-1 border-b border-gray-800">
         {tabs.map((tab) => (

--- a/frontend/src/pages/admin/__tests__/AdminShipping.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminShipping.test.jsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => {
+  const mocks = {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    formatCurrency: vi.fn((v) => `$${Number(v).toFixed(2)}`),
+  }
+  mocks.api = { get: mocks.get, post: mocks.post, patch: mocks.patch }
+  mocks.toast = { error: mocks.toastError, success: mocks.toastSuccess }
+  return { mocks }
+})
+
+vi.mock('../../../hooks/useApi', () => ({ useApi: () => mocks.api }))
+vi.mock('../../../components/Toast', () => ({ useToast: () => mocks.toast }))
+vi.mock('../../../hooks/useFormatCurrency', () => ({
+  useFormatCurrency: () => mocks.formatCurrency,
+}))
+vi.mock('../../../contexts/LocaleContext', () => ({
+  useLocale: () => ({ currency_code: 'USD', locale: 'en-US' }),
+}))
+
+import AdminShipping from '../AdminShipping'
+
+function renderWithParam(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/shipping${search}`]}>
+      <Routes>
+        <Route path="/admin/shipping" element={<AdminShipping />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mocks.get.mockReset()
+  // Default: all API calls resolve with empty arrays
+  mocks.get.mockImplementation((path) => {
+    if (path.includes('shipping-trend')) {
+      return Promise.resolve({ data: [], start_date: null, end_date: null })
+    }
+    if (path.includes('shipped_after')) {
+      return Promise.resolve([])
+    }
+    if (path.includes('production-orders')) {
+      return Promise.resolve([])
+    }
+    // sales-orders ready-to-ship list
+    return Promise.resolve([])
+  })
+})
+
+describe('AdminShipping — deep-link banner', () => {
+  it('shows no banner when orderId param is absent', async () => {
+    renderWithParam()
+    await waitFor(() => expect(mocks.get).toHaveBeenCalled())
+    expect(
+      screen.queryByText(/isn't ready to ship yet/),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows banner when orderId param is present and order is not in the fetched set', async () => {
+    renderWithParam('?orderId=999')
+    await waitFor(() =>
+      expect(
+        screen.getByText(/isn't ready to ship yet — production must complete/),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('does not show banner when the order IS in the fetched ready-to-ship set', async () => {
+    mocks.get.mockImplementation((path) => {
+      if (path.includes('shipping-trend')) {
+        return Promise.resolve({ data: [], start_date: null, end_date: null })
+      }
+      if (path.includes('shipped_after')) return Promise.resolve([])
+      if (path.includes('production-orders')) return Promise.resolve([])
+      // Return the target order in the list
+      return Promise.resolve([
+        {
+          id: 42,
+          order_number: 'SO-2026-042',
+          product_name: 'Test Product',
+          quantity: 1,
+          grand_total: 100,
+          tracking_number: null,
+          status: 'confirmed',
+          shipping_address_line1: null,
+          shipping_city: null,
+        },
+      ])
+    })
+
+    renderWithParam('?orderId=42')
+    await waitFor(() => expect(mocks.get).toHaveBeenCalled())
+    // Wait for loading to complete
+    await waitFor(() =>
+      expect(screen.queryByText('Refresh')).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByText(/isn't ready to ship yet/),
+    ).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Implements PR-4 from `docs/plans/2026-06-09-ux-gtm-readiness.md` — fixes cross-page dead ends in the order-to-cash and production flows.

- **AdminInvoices**: Order # column in table and in the detail modal are now clickable links to `/admin/orders/{sales_order_id}`, matching the existing pattern in AdminPayments. A "View Order" button is also added to the modal action row.
- **AdminShipping**: When the `orderId` query param deep-link is present but the order is not in the fetched ready-to-ship set (i.e., production hasn't completed), an informational yellow banner is shown: "Order isn't ready to ship yet — production must complete." instead of silently showing nothing.
- **AdminBOM + AdminProduction**: After creating a production order (from either entry point), the user is navigated directly to `/admin/production/{newOrderId}` (the order detail page) instead of the filtered list or a silent close.

## Test plan

- [ ] `npm run test:unit` — 30 test files, 252 tests, all pass (3 new tests for the AdminShipping banner)
- [ ] `npm run build` — clean build, no errors
- [ ] Manual: open an invoice → click Order # in table row → lands on order detail
- [ ] Manual: open invoice modal → click Order # or "View Order" button → lands on order detail
- [ ] Manual: navigate to `/admin/shipping?orderId=<non-shippable-id>` → banner appears
- [ ] Manual: navigate to `/admin/shipping?orderId=<shippable-id>` → no banner, order expanded
- [ ] Manual: create production order from BOM page → lands on production order detail
- [ ] Manual: create production order from Production page → lands on production order detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)