### PR TITLE
fix: rename Manufacturing nav to Work Centers & Routings with distinct icon

### DIFF
--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -173,24 +173,26 @@ const PurchasingIcon = () => (
   </svg>
 );
 
-const ManufacturingIcon = () => (
+// Work Centers & Routings — factory/map-route glyph (distinct from the cog used by Settings)
+const WorkCentersIcon = () => (
   <svg
     className="w-5 h-5"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
   >
+    {/* Factory building silhouette */}
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={2}
-      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+      d="M19 21H5a2 2 0 01-2-2V9l4-4 4 4V5l4 4v10a2 2 0 01-2 2z"
     />
     <path
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={2}
-      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      d="M9 21v-6h6v6"
     />
   </svg>
 );
@@ -494,8 +496,8 @@ const navGroups = [
       { path: "/admin/production", label: "Production", icon: ProductionIcon },
       {
         path: "/admin/manufacturing",
-        label: "Manufacturing",
-        icon: ManufacturingIcon,
+        label: "Work Centers & Routings",
+        icon: WorkCentersIcon,
       },
       { path: "/admin/printers", label: "Printers", icon: PrintersIcon },
       {

--- a/frontend/src/components/breadcrumbs.utils.js
+++ b/frontend/src/components/breadcrumbs.utils.js
@@ -34,7 +34,7 @@ export const ROUTE_LABELS = {
   "/admin/spools": "Material Spools",
   // Operations
   "/admin/production": "Production",
-  "/admin/manufacturing": "Manufacturing",
+  "/admin/manufacturing": "Work Centers & Routings",
   "/admin/printers": "Printers",
   "/admin/bambuddy": "Bambuddy",
   "/admin/purchasing": "Purchasing",

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -136,9 +136,9 @@ export default function AdminManufacturing() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-white">Manufacturing</h1>
+          <h1 className="text-2xl font-bold text-white">Work Centers &amp; Routings</h1>
           <p className="text-gray-400 mt-1">
-            Work centers, resources, and production routings
+            Define where and how things get made. Day-to-day orders live in Production.
           </p>
         </div>
       </div>

--- a/frontend/tests/e2e/flows/order-to-ship.spec.ts
+++ b/frontend/tests/e2e/flows/order-to-ship.spec.ts
@@ -367,8 +367,8 @@ test.describe('Order-to-Ship Workflow', () => {
     await expect(page).toHaveURL('/admin/manufacturing');
     await page.waitForLoadState('networkidle');
 
-    // Verify Manufacturing page loaded
-    await expect(page.locator('h1:has-text("Manufacturing")')).toBeVisible();
+    // Verify Work Centers & Routings page loaded
+    await expect(page.locator('h1:has-text("Work Centers")')).toBeVisible();
 
     // Check for Work Centers tab button
     const workCentersTab = page.getByRole('button', { name: /Work Centers/i });
@@ -386,7 +386,7 @@ test.describe('Order-to-Ship Workflow', () => {
     await routingsTab.click();
     await page.waitForTimeout(500);
 
-    console.log('✅ Manufacturing page accessible with Work Centers and Routings');
+    console.log('✅ Work Centers & Routings page accessible with Work Centers and Routings tabs');
   });
 
   test('verify production kanban board shows all status columns', async ({ authenticatedPage: page }) => {

--- a/frontend/tests/e2e/pages/capture-screenshots.spec.ts
+++ b/frontend/tests/e2e/pages/capture-screenshots.spec.ts
@@ -57,7 +57,7 @@ const PAGES = [
   { url: '/admin/production', name: 'production-page', title: 'Production' },
   { url: '/admin/bom', name: 'bom-page', title: 'Bill of Materials' },
   { url: '/admin/purchasing', name: 'purchasing-page', title: 'Purchasing' },
-  { url: '/admin/manufacturing', name: 'manufacturing-page', title: 'Manufacturing' },
+  { url: '/admin/manufacturing', name: 'manufacturing-page', title: 'Work Centers & Routings' },
   { url: '/admin/shipping', name: 'shipping-page', title: 'Shipping' },
   { url: '/admin/payments', name: 'payments-page', title: 'Payments' },
   { url: '/admin/settings', name: 'settings-page', title: 'Settings' },

--- a/frontend/tests/e2e/pages/sop-comprehensive.spec.ts
+++ b/frontend/tests/e2e/pages/sop-comprehensive.spec.ts
@@ -865,7 +865,7 @@ test.describe('Sidebar Navigation', () => {
       'Production',
       'Bill of Materials',
       'Purchasing',
-      'Manufacturing',
+      'Work Centers & Routings',
       'Shipping',
       'Payments',
       'Settings',


### PR DESCRIPTION
## Summary

- Renames the \"Manufacturing\" nav entry to **\"Work Centers & Routings\"** so operators no longer confuse it with \"Production\" (execution).
- Replaces `ManufacturingIcon` (which duplicated the `SettingsIcon` cog/gear path) with a new `WorkCentersIcon` — a factory-building glyph that is visually distinct.
- Updates `AdminManufacturing.jsx` page title and adds a clarifying subtitle: _\"Define where and how things get made. Day-to-day orders live in Production.\"_
- Updates `breadcrumbs.utils.js` `ROUTE_LABELS` to match the new label.
- Updates E2E label assertions (`order-to-ship.spec.ts`, `capture-screenshots.spec.ts`, `sop-comprehensive.spec.ts`) — **route paths are unchanged** (`/admin/manufacturing`), no broken links or bookmarks.

Implements plan PR-6 from `docs/plans/2026-06-09-ux-gtm-readiness.md`.

## Test plan

- [x] `npm run test:unit` — 289 tests pass
- [x] `npm run build` — production build clean (no warnings)
- [x] Route `/admin/manufacturing` unchanged — existing bookmarks/links unaffected
- [x] `ManufacturingIcon` removed; `SettingsIcon` cog no longer duplicated in nav
- [x] E2E label assertions updated to `"Work Centers & Routings"` / `h1:has-text("Work Centers")`
- [x] Breadcrumb label updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)