### PR TITLE
fix: address code-review findings from PRs #673-#675

### DIFF
--- a/frontend/src/components/ApiErrorToaster.jsx
+++ b/frontend/src/components/ApiErrorToaster.jsx
@@ -5,8 +5,8 @@
  * 403 handling matrix:
  *  - detail.code === "TIER_LIMIT_EXCEEDED" → emit tier:limit-reached (opens UpgradeModal)
  *    + show toast.info fallback so something always appears if the modal listener fails.
- *  - detail (string) contains "requires" (require_tier decorator) → PRO-feature toast
- *    with link to /admin/license.
+ *  - detail (string) contains "require"/"requires" (require_tier decorator) → PRO-feature
+ *    toast with link to /admin/license.
  *  - detail.message present → show detail.message directly.
  *  - anything else → generic "no permission" text.
  */
@@ -77,12 +77,14 @@ export default function ApiErrorToaster() {
       // PRO-feature 403: backend's require_tier decorator sends a plain string
       // like "This feature requires Professional tier or higher".  Show an
       // actionable message linking straight to the License page.
-      // Guard: require both "requires" AND a whole-word tier/plan keyword so
+      // Guard: require both "require"/"requires" AND a whole-word tier/plan keyword so
       // strings like "Admin approval requires manager role" are not misclassified
       // ("approval" contains "pro" as a substring — use \b word boundaries).
+      // \brequires?\b matches "require" and "requires" but NOT "required" (word boundary
+      // fails before the trailing 'd').
       if (status === 403 && typeof detail === "string") {
         const isTierRequirement =
-          /\brequires\b/i.test(detail) &&
+          /\brequires?\b/i.test(detail) &&
           /\b(tier|professional|enterprise|pro)\b/i.test(detail);
         if (isTierRequirement) {
           toast.info("This is a PRO feature — view upgrade options at Settings → License.");

--- a/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
+++ b/frontend/src/components/__tests__/ApiErrorToaster.test.jsx
@@ -154,6 +154,38 @@ describe("ApiErrorToaster", () => {
       );
     });
 
+    it("matches the exact printers.py brand-gate string (uses 'require', no trailing s)", () => {
+      // backend/app/api/v1/endpoints/printers.py lines 99-103 says:
+      // "Klipper, OctoPrint, Prusa, and Creality require a PRO license with the filafarm feature enabled."
+      // The word is "require" (no 's'), so \brequires\b would miss it; \brequires?\b must match.
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail:
+          "Brand 'klipper' is not available on this install. " +
+          "Klipper, OctoPrint, Prusa, and Creality require a PRO license " +
+          "with the filafarm feature enabled.",
+      });
+      expect(mocks.toastInfo).toHaveBeenCalledWith(
+        "This is a PRO feature — view upgrade options at Settings → License."
+      );
+    });
+
+    it("does NOT match 'required' (trailing d) — word boundary prevents it", () => {
+      // "required" ends in 'd'; \brequires?\b cannot match because after "require"
+      // the next char is 'd' (not a word boundary), and after "requires" there is
+      // no 'd' — so the regex correctly rejects "Admin approval required".
+      render(<ApiErrorToaster />);
+      fireApiError({
+        status: 403,
+        detail: "Admin approval required",
+      });
+      expect(mocks.toastInfo).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+    });
+
     it("matches case-insensitively on the word 'requires' + tier keyword", () => {
       render(<ApiErrorToaster />);
       fireApiError({

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -3,7 +3,6 @@ import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import SalesOrderWizard from "../../components/SalesOrderWizard";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
-import { validateLength } from "../../utils/validation";
 import { SalesOrderCard } from "../../components/orders";
 import OrderFilters from "../../components/orders/OrderFilters";
 
@@ -26,13 +25,6 @@ export default function AdminOrders() {
   // Create order modal state
   const [showCreateModal, setShowCreateModal] = useState(false);
 
-  // Cancel/Delete modal state
-  const [showCancelModal, setShowCancelModal] = useState(false);
-  const [cancellingOrder, setCancellingOrder] = useState(null);
-  const [cancellationReason, setCancellationReason] = useState("");
-  const [cancellationError, setCancellationError] = useState("");
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [deletingOrder, setDeletingOrder] = useState(null);
 
   // Check if returning from customer/item creation
   useEffect(() => {
@@ -124,56 +116,6 @@ export default function AdminOrders() {
 
   const handleShip = (orderId) => {
     navigate(`/admin/shipping?orderId=${orderId}`);
-  };
-
-  // Handle cancel order
-  const handleCancelOrder = async () => {
-    if (!cancellingOrder) return;
-
-    // Validate cancellation reason if provided
-    setCancellationError("");
-    if (cancellationReason && cancellationReason.trim()) {
-      const lengthError = validateLength(
-        cancellationReason.trim(),
-        "Cancellation reason",
-        { max: 500 }
-      );
-      if (lengthError) {
-        setCancellationError(lengthError);
-        return;
-      }
-    }
-
-    try {
-      await api.post(
-        `/api/v1/sales-orders/${cancellingOrder.id}/cancel`,
-        { cancellation_reason: cancellationReason }
-      );
-
-      toast.success(`Order ${cancellingOrder.order_number} cancelled`);
-      setShowCancelModal(false);
-      setCancellingOrder(null);
-      setCancellationReason("");
-      setCancellationError("");
-      fetchOrders();
-    } catch (err) {
-      toast.error(err.message || "Failed to cancel order");
-    }
-  };
-
-  // Handle delete order
-  const handleDeleteOrder = async () => {
-    if (!deletingOrder) return;
-
-    try {
-      await api.del(`/api/v1/sales-orders/${deletingOrder.id}`);
-      toast.success(`Order ${deletingOrder.order_number} deleted`);
-      setShowDeleteConfirm(false);
-      setDeletingOrder(null);
-      fetchOrders();
-    } catch (err) {
-      toast.error(err.message || "Failed to delete order");
-    }
   };
 
   return (
@@ -295,120 +237,6 @@ export default function AdminOrders() {
         }}
       />
 
-      {/* Cancel Order Modal */}
-      {showCancelModal && cancellingOrder && (
-        <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20">
-            <div
-              className="fixed inset-0 bg-black/70"
-              onClick={() => {
-                setShowCancelModal(false);
-                setCancellingOrder(null);
-                setCancellationReason("");
-              }}
-            />
-            <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-xl max-w-md w-full mx-auto p-6">
-              <h3 className="text-lg font-semibold text-white mb-4">
-                Cancel Order {cancellingOrder.order_number}?
-              </h3>
-              <p className="text-gray-400 mb-4">
-                This will cancel the order. The order can still be deleted after
-                cancellation.
-              </p>
-              <div className="mb-4">
-                <label className="block text-sm text-gray-400 mb-2">
-                  Cancellation Reason (optional)
-                </label>
-                <textarea
-                  value={cancellationReason}
-                  onChange={(e) => {
-                    setCancellationReason(e.target.value);
-                    setCancellationError("");
-                  }}
-                  className={`w-full bg-gray-800 border rounded-lg px-4 py-2 text-white ${
-                    cancellationError
-                      ? "border-red-500 focus:border-red-500"
-                      : "border-gray-700"
-                  }`}
-                  rows={3}
-                  placeholder="Enter reason for cancellation..."
-                  maxLength={500}
-                />
-                {cancellationError && (
-                  <div className="text-red-400 text-sm mt-1">
-                    {cancellationError}
-                  </div>
-                )}
-                {cancellationReason && (
-                  <div className="text-gray-500 text-xs mt-1">
-                    {cancellationReason.length}/500 characters
-                  </div>
-                )}
-              </div>
-              <div className="flex justify-end gap-3">
-                <button
-                  onClick={() => {
-                    setShowCancelModal(false);
-                    setCancellingOrder(null);
-                    setCancellationReason("");
-                    setCancellationError("");
-                  }}
-                  className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
-                >
-                  Keep Order
-                </button>
-                <button
-                  onClick={handleCancelOrder}
-                  className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-500"
-                >
-                  Cancel Order
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Delete Order Confirmation Modal */}
-      {showDeleteConfirm && deletingOrder && (
-        <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20">
-            <div
-              className="fixed inset-0 bg-black/70"
-              onClick={() => {
-                setShowDeleteConfirm(false);
-                setDeletingOrder(null);
-              }}
-            />
-            <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-xl max-w-md w-full mx-auto p-6">
-              <h3 className="text-lg font-semibold text-white mb-4">
-                Delete Order {deletingOrder.order_number}?
-              </h3>
-              <p className="text-gray-400 mb-4">
-                This action cannot be undone. All order data, including line
-                items and payment records, will be permanently deleted.
-              </p>
-              <div className="flex justify-end gap-3">
-                <button
-                  onClick={() => {
-                    setShowDeleteConfirm(false);
-                    setDeletingOrder(null);
-                  }}
-                  className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
-                >
-                  Keep Order
-                </button>
-                <button
-                  onClick={handleDeleteOrder}
-                  className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500"
-                >
-                  Delete Permanently
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -256,6 +256,7 @@ export default function AdminProduction() {
     notes: "",
   });
   const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState(null);
 
   // Scheduling modal state
   const [showSchedulingModal, setShowSchedulingModal] = useState(false);
@@ -350,11 +351,12 @@ export default function AdminProduction() {
   const handleCreateOrder = async (e) => {
     e.preventDefault();
     if (!createForm.product_id) {
-      setError("Please select a product");
+      setCreateError("Please select a product");
       return;
     }
 
     setCreating(true);
+    setCreateError(null);
     try {
       const newOrder = await api.post(`/api/v1/production-orders/`, {
         product_id: parseInt(createForm.product_id),
@@ -375,7 +377,7 @@ export default function AdminProduction() {
       // Navigate to the new production order detail page
       navigate(`/admin/production/${newOrder.id}`);
     } catch (err) {
-      setError(err.message);
+      setCreateError(err.message);
     } finally {
       setCreating(false);
     }
@@ -413,7 +415,7 @@ export default function AdminProduction() {
           </p>
         </div>
         <button
-          onClick={() => setShowCreateModal(true)}
+          onClick={() => { setShowCreateModal(true); setCreateError(null); }}
           className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500"
         >
           + Create Production Order
@@ -596,7 +598,7 @@ export default function AdminProduction() {
       {/* Create Production Order Modal */}
       <Modal
         isOpen={showCreateModal}
-        onClose={() => setShowCreateModal(false)}
+        onClose={() => { setShowCreateModal(false); setCreateError(null); }}
         title="Create Production Order"
         className="w-full max-w-md"
         disableClose={creating}
@@ -604,6 +606,12 @@ export default function AdminProduction() {
         <div className="p-6">
             <h2 className="text-xl font-bold text-white mb-4">Create Production Order</h2>
             <form onSubmit={handleCreateOrder} className="space-y-4">
+              {/* In-modal error feedback (POST failure stays here so the modal remains open) */}
+              {createError && (
+                <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+                  {createError}
+                </div>
+              )}
               {/* Product Selection */}
               <div>
                 <label className="block text-sm text-gray-400 mb-1">


### PR DESCRIPTION
## Summary

Three verified code-review findings from today's merged batch, fixed in a single commit.

### Finding 1 — ApiErrorToaster: regex misses `require` (no trailing s)

`/\brequires\b/i` did not match the printers.py brand-gate detail string (`"...Klipper, OctoPrint, Prusa, and Creality require a PRO license..."` — `require`, no `s`), so the PRO-upsell toast was silently skipped and the user saw a generic 403 error instead.

**Fix:** changed to `/\brequires?\b/i`. The `s?` makes the `s` optional, matching both `require` and `requires`. It does **not** match `required` because after `require` the `d` is not a word boundary, so the alternation fails at both positions.

**Tests added** in `ApiErrorToaster.test.jsx`:
- Positive: fires the exact printers.py string, asserts PRO-upsell toast fires.
- Negative: `"Admin approval required"` — asserts toast.info NOT called and generic 403 toast IS called.

### Finding 2 — AdminProduction: create-order POST failure left modal open with no feedback

On `handleCreateOrder` catch, `setError(err.message)` set the **page-level** error banner (rendered outside the modal), giving the user no visible feedback while the modal stayed open.

**Fix:** introduced modal-local `createError` state. Reset on modal open and close. Set in the catch block. Rendered at the top of the modal form using the same `bg-red-500/10 border border-red-500/30` style used by `CreateProductionOrderModal.jsx`.

### Finding 3 — AdminOrders: cancel/delete modals are unreachable dead code

Since PR #674, `SalesOrderCard` only receives `onViewDetails` and `onShip` — there is no path that calls `setCancellingOrder` or `setDeletingOrder`. Both modal JSX blocks, their state declarations, the two handler functions, and the now-unused `validateLength` import were dead code.

**Removed:**
- State: `showCancelModal`, `cancellingOrder`, `cancellationReason`, `cancellationError`, `showDeleteConfirm`, `deletingOrder`
- Handlers: `handleCancelOrder`, `handleDeleteOrder`
- JSX: both modal blocks (~113 lines)
- Import: `validateLength` (was only used in the deleted handler)

`OrderDetail.jsx` remains the canonical cancel/delete surface and is unaffected.

## Test plan

- [x] `npm run test:unit` — 294 tests pass (37 test files)
- [x] `npm run build` — clean build, no warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)