### PR TITLE
fix: require staff auth on all /mrp endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/mrp.py
+++ b/backend/app/api/v1/endpoints/mrp.py
@@ -25,7 +25,11 @@ from app.schemas.mrp import (
 from app.services.mrp import MRPService
 
 
-router = APIRouter(prefix="/mrp", tags=["MRP"])
+router = APIRouter(
+    prefix="/mrp",
+    tags=["MRP"],
+    dependencies=[Depends(get_current_staff_user)],
+)
 
 
 # ============================================================================

--- a/backend/tests/endpoints/test_mrp_auth.py
+++ b/backend/tests/endpoints/test_mrp_auth.py
@@ -1,0 +1,69 @@
+"""
+Auth tests for MRP endpoints (/api/v1/mrp/).
+
+All MRP read endpoints must require staff authentication and return 401
+when accessed without a valid Bearer token.
+"""
+import pytest
+
+
+class TestMRPUnauthenticated:
+    """All /mrp read endpoints must reject unauthenticated requests with 401."""
+
+    def test_list_runs_requires_auth(self, unauthed_client):
+        """GET /mrp/runs returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/runs")
+        assert resp.status_code == 401
+
+    def test_get_run_requires_auth(self, unauthed_client):
+        """GET /mrp/runs/{run_id} returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/runs/1")
+        assert resp.status_code == 401
+
+    def test_list_planned_orders_requires_auth(self, unauthed_client):
+        """GET /mrp/planned-orders returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/planned-orders")
+        assert resp.status_code == 401
+
+    def test_get_planned_order_requires_auth(self, unauthed_client):
+        """GET /mrp/planned-orders/{order_id} returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/planned-orders/1")
+        assert resp.status_code == 401
+
+    def test_requirements_requires_auth(self, unauthed_client):
+        """GET /mrp/requirements returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/requirements?product_id=1")
+        assert resp.status_code == 401
+
+    def test_supply_demand_requires_auth(self, unauthed_client):
+        """GET /mrp/supply-demand/{product_id} returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/supply-demand/1")
+        assert resp.status_code == 401
+
+    def test_explode_bom_requires_auth(self, unauthed_client):
+        """GET /mrp/explode-bom/{product_id} returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/mrp/explode-bom/1")
+        assert resp.status_code == 401
+
+    def test_post_run_requires_auth(self, unauthed_client):
+        """POST /mrp/run returns 401 without auth."""
+        resp = unauthed_client.post("/api/v1/mrp/run", json={
+            "planning_horizon_days": 30,
+            "include_draft_orders": False,
+            "regenerate_planned": True,
+        })
+        assert resp.status_code == 401
+
+
+class TestMRPAuthenticated:
+    """Authenticated staff users can reach MRP endpoints (no 401/403)."""
+
+    def test_list_runs_accessible_with_auth(self, client):
+        """GET /mrp/runs returns 200 with valid auth."""
+        resp = client.get("/api/v1/mrp/runs")
+        assert resp.status_code == 200
+
+    def test_list_planned_orders_accessible_with_auth(self, client):
+        """GET /mrp/planned-orders returns 200 with valid auth."""
+        resp = client.get("/api/v1/mrp/planned-orders")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- **Exposure**: Seven MRP read endpoints (`GET /mrp/runs`, `GET /mrp/runs/{id}`, `GET /mrp/planned-orders`, `GET /mrp/planned-orders/{id}`, `GET /mrp/requirements`, `GET /mrp/supply-demand/{product_id}`, `GET /mrp/explode-bom/{product_id}`) had **no authentication dependency**. BOM structures, unit costs, inventory on-hand levels, demand timelines, and supplier lead times were readable by any unauthenticated caller. The `POST /mrp/run` and mutating planned-order actions were similarly unguarded.
- **Fix**: Added `dependencies=[Depends(get_current_staff_user)]` at the `APIRouter` level in `backend/app/api/v1/endpoints/mrp.py`. This gates every route in the file at once. `POST /run` retains its explicit `Depends(get_current_staff_user)` parameter to capture the `User` object for `user_id` audit logging — the router-level dep is additive and FastAPI deduplicates the dependency call.
- **Tests**: Added `backend/tests/endpoints/test_mrp_auth.py` with 10 tests covering all 8 endpoints (unauthenticated → 401, authenticated → not 401/403).

## Sibling Routers for Follow-up

The following routers have endpoints with no auth dependency (listed for a separate PR — not fixed here to keep scope narrow):

| Router | Issue |
|--------|-------|
| `materials.py` | `GET /materials/options`, `GET /materials/types`, `GET /materials/types/{code}/colors`, `GET /materials/for-bom` — no `Depends(get_current_user)`, public read of material catalog and pricing data |
| `system.py` | `GET /system/version`, `GET /system/info`, `GET /system/updates/check`, `GET /system/updates/instructions`, `GET /system/health` — intentionally public for health probes; `/updates/check` and `/updates/instructions` may be acceptable but worth reviewing |
| `test.py` | Test/seed endpoints are presumably dev-only; should be disabled or auth-gated in production |

## Test Plan

- [x] `python -m pytest tests/endpoints/test_mrp_auth.py -v` — 10/10 pass
- [x] `python -m pytest tests/ -q -k mrp` — 147 passed, 0 failed
- [x] `python -m ruff check app/api/v1/endpoints/mrp.py --select E712` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)