### PR TITLE
fix: make MRP triggers honest (HARD-3)

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -405,7 +405,15 @@ class Settings(BaseSettings):
     # MRP Settings (safe defaults)
     # ===================
     INCLUDE_SALES_ORDERS_IN_MRP: bool = True
+    # AUTO_MRP_ON_ORDER_CREATE — NOT YET FUNCTIONAL.
+    # Enabling this flag arms trigger_mrp_check on every sales-order creation.
+    # The trigger currently returns {"status": "not_implemented"} because the
+    # MRP engine requires background-task wiring before it can run inline.
+    # Do not enable in production until the wiring is complete (HARD-3 follow-up).
     AUTO_MRP_ON_ORDER_CREATE: bool = False
+    # AUTO_MRP_ON_SHIPMENT — NOT YET FUNCTIONAL.
+    # Enabling this flag arms trigger_mrp_recalculation on every shipment.
+    # Same constraint as AUTO_MRP_ON_ORDER_CREATE above.
     AUTO_MRP_ON_SHIPMENT: bool = False
     AUTO_MRP_ON_CONFIRMATION: bool = False
     MRP_ENABLE_SUB_ASSEMBLY_CASCADING: bool = False

--- a/backend/app/services/mrp_trigger_service.py
+++ b/backend/app/services/mrp_trigger_service.py
@@ -1,18 +1,40 @@
 """
 MRP Trigger Service
 
-Centralized service for triggering MRP calculations with different contexts.
-All triggers are behind feature flags and include error handling to prevent
-breaking existing functionality.
+Centralised entry points for automatic MRP checks that are wired to business
+events (sales-order creation, shipment).  These are *feature-flagged stubs*.
+The underlying MRP engine (MRPService.run_mrp) is a full, regenerative run
+that commits its own transactions and is too heavyweight to invoke inside an
+order-creation or shipment request without dedicated background-task wiring.
+
+Until that wiring is built (follow-up task), every function in this module
+returns ``{"status": "not_implemented"}`` when the flag is enabled so that
+callers can see the flag is on without being misled into thinking work was done.
+When the flag is off the functions return ``None`` as before.
+
+Flags:
+- AUTO_MRP_ON_ORDER_CREATE  governs trigger_mrp_check
+- AUTO_MRP_ON_SHIPMENT      governs trigger_mrp_recalculation (reason="shipment")
+- INCLUDE_SALES_ORDERS_IN_MRP governs trigger_incremental_mrp
+
+No function may claim completion for work it did not perform.
 """
 from typing import Optional, List
 from sqlalchemy.orm import Session
 from app.core.settings import get_settings
-from app.services.mrp import MRPService
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
 settings = get_settings()
+
+_NOT_IMPLEMENTED = {
+    "status": "not_implemented",
+    "message": (
+        "Automatic MRP runs are not yet implemented. "
+        "Enable AUTO_MRP_ON_ORDER_CREATE / AUTO_MRP_ON_SHIPMENT only after "
+        "background-task wiring is complete."
+    ),
+}
 
 
 def trigger_mrp_check(
@@ -21,55 +43,30 @@ def trigger_mrp_check(
     background: bool = False
 ) -> Optional[dict]:
     """
-    Quick MRP check for a specific sales order.
-    
-    This performs a lightweight check to see if MRP requirements
-    are met for a specific order without running a full MRP calculation.
-    
+    Stub: intended to trigger a scoped MRP check for a specific sales order.
+
+    STUB — automatic MRP runs are not yet implemented.  When
+    AUTO_MRP_ON_ORDER_CREATE is enabled this function acknowledges the request
+    but performs no calculation and returns ``{"status": "not_implemented"}``.
+    Returns ``None`` when the flag is off.
+
     Args:
-        db: Database session
-        sales_order_id: ID of the sales order to check
-        background: If True, run in background (not implemented yet)
-    
-    Returns:
-        Dictionary with check results, or None if feature is disabled
+        db: Database session (unused by stub; retained for future wiring)
+        sales_order_id: ID of the sales order that triggered the check
+        background: Reserved for future background-task routing
     """
-    if not settings.INCLUDE_SALES_ORDERS_IN_MRP:
-        logger.debug(f"MRP check skipped for SO {sales_order_id} - feature disabled")
+    if not settings.AUTO_MRP_ON_ORDER_CREATE:
+        logger.debug(
+            "MRP check skipped for SO %s — AUTO_MRP_ON_ORDER_CREATE is disabled",
+            sales_order_id,
+        )
         return None
-    
-    try:
-        from app.models.sales_order import SalesOrder
-        
-        sales_order = db.query(SalesOrder).filter(
-            SalesOrder.id == sales_order_id
-        ).first()
-        
-        if not sales_order:
-            logger.warning(f"Sales order {sales_order_id} not found for MRP check")
-            return {"error": "Sales order not found"}
-        
-        # For now, just log that check was requested
-        # Full implementation would check if materials are available
-        logger.info(
-            f"MRP check requested for sales order {sales_order.order_number}",
-            extra={"sales_order_id": sales_order_id}
-        )
-        
-        return {
-            "sales_order_id": sales_order_id,
-            "status": "checked",
-            "message": "MRP check completed"
-        }
-    
-    except Exception as e:
-        logger.error(
-            f"Error in MRP check for sales order {sales_order_id}: {str(e)}",
-            exc_info=True,
-            extra={"sales_order_id": sales_order_id, "error": str(e)}
-        )
-        # Don't raise - graceful degradation
-        return {"error": str(e)}
+
+    logger.debug(
+        "MRP check requested for SO %s — stub, no calculation performed",
+        sales_order_id,
+    )
+    return {"sales_order_id": sales_order_id, **_NOT_IMPLEMENTED}
 
 
 def trigger_mrp_recalculation(
@@ -79,61 +76,33 @@ def trigger_mrp_recalculation(
     product_ids: Optional[List[int]] = None
 ) -> Optional[dict]:
     """
-    Trigger full MRP recalculation after inventory changes.
-    
-    This is called after shipping or other inventory-consuming operations
-    to ensure MRP is aware of new shortages.
-    
-    Args:
-        db: Database session
-        context_id: ID of the context (sales_order_id, etc.)
-        reason: Reason for recalculation (e.g., "shipment", "production_completion")
-        product_ids: Optional list of specific products to recalculate
-    
-    Returns:
-        Dictionary with recalculation results, or None if feature is disabled
-    """
-    if not settings.AUTO_MRP_ON_SHIPMENT and reason == "shipment":
-        logger.debug(f"MRP recalculation skipped for {reason} - feature disabled")
-        return None
-    
-    try:
-        _service = MRPService(db)  # noqa: F841 - placeholder for incremental MRP
+    Stub: intended to trigger MRP recalculation after inventory-consuming events.
 
-        # For incremental MRP, we could recalculate only affected products
-        # For now, we'll just log the request
-        # Full implementation would trigger actual MRP run
-        
-        logger.info(
-            f"MRP recalculation requested: {reason}",
-            extra={
-                "context_id": context_id,
-                "reason": reason,
-                "product_ids": product_ids
-            }
+    STUB — automatic MRP runs are not yet implemented.  When
+    AUTO_MRP_ON_SHIPMENT is enabled and reason is ``"shipment"`` this function
+    acknowledges the request but performs no calculation and returns
+    ``{"status": "not_implemented"}``.  Returns ``None`` when the flag is off.
+
+    Args:
+        db: Database session (unused by stub; retained for future wiring)
+        context_id: ID of the context object (e.g., sales_order_id)
+        reason: Trigger reason — currently only "shipment" is flag-gated
+        product_ids: Reserved for future incremental-scope wiring
+    """
+    if reason == "shipment" and not settings.AUTO_MRP_ON_SHIPMENT:
+        logger.debug(
+            "MRP recalculation skipped for %s (%s) — AUTO_MRP_ON_SHIPMENT is disabled",
+            context_id,
+            reason,
         )
-        
-        # Incremental MRP is not yet implemented — logs the request for now
-        
-        return {
-            "context_id": context_id,
-            "reason": reason,
-            "status": "requested",
-            "message": "MRP recalculation requested (feature in development)"
-        }
-    
-    except Exception as e:
-        logger.error(
-            f"Error in MRP recalculation: {str(e)}",
-            exc_info=True,
-            extra={
-                "context_id": context_id,
-                "reason": reason,
-                "error": str(e)
-            }
-        )
-        # Don't raise - graceful degradation
-        return {"error": str(e)}
+        return None
+
+    logger.debug(
+        "MRP recalculation requested for %s (%s) — stub, no calculation performed",
+        context_id,
+        reason,
+    )
+    return {"context_id": context_id, "reason": reason, **_NOT_IMPLEMENTED}
 
 
 def trigger_incremental_mrp(
@@ -141,42 +110,23 @@ def trigger_incremental_mrp(
     product_ids: List[int]
 ) -> Optional[dict]:
     """
-    Recalculate MRP only for specific products.
-    
-    This is more efficient than a full MRP run when only certain
-    products have changed.
-    
+    Stub: intended to trigger a product-scoped incremental MRP recalculation.
+
+    STUB — incremental (scoped) MRP runs are not yet implemented.  When
+    INCLUDE_SALES_ORDERS_IN_MRP is enabled this function acknowledges the
+    request but performs no calculation and returns
+    ``{"status": "not_implemented"}``.  Returns ``None`` when the flag is off.
+
     Args:
-        db: Database session
-        product_ids: List of product IDs to recalculate
-    
-    Returns:
-        Dictionary with results, or None if feature is disabled
+        db: Database session (unused by stub; retained for future wiring)
+        product_ids: Products whose requirements should be recalculated
     """
     if not settings.INCLUDE_SALES_ORDERS_IN_MRP:
-        logger.debug("Incremental MRP skipped - feature disabled")
+        logger.debug("Incremental MRP skipped — INCLUDE_SALES_ORDERS_IN_MRP is disabled")
         return None
-    
-    try:
-        logger.info(
-            f"Incremental MRP requested for {len(product_ids)} products",
-            extra={"product_ids": product_ids}
-        )
-        
-        # Incremental MRP calculation is not yet implemented
-        
-        return {
-            "product_ids": product_ids,
-            "status": "requested",
-            "message": "Incremental MRP requested (feature in development)"
-        }
-    
-    except Exception as e:
-        logger.error(
-            f"Error in incremental MRP: {str(e)}",
-            exc_info=True,
-            extra={"product_ids": product_ids, "error": str(e)}
-        )
-        # Don't raise - graceful degradation
-        return {"error": str(e)}
 
+    logger.debug(
+        "Incremental MRP requested for %d product(s) — stub, no calculation performed",
+        len(product_ids),
+    )
+    return {"product_ids": product_ids, **_NOT_IMPLEMENTED}

--- a/backend/tests/services/test_mrp_trigger_service.py
+++ b/backend/tests/services/test_mrp_trigger_service.py
@@ -1,6 +1,14 @@
-"""Tests for mrp_trigger_service.py — MRP trigger feature flags and routing."""
-import pytest
-from decimal import Decimal
+"""
+Tests for mrp_trigger_service.py — HARD-3 honest-stub contract.
+
+Contract (see mrp_trigger_service module docstring):
+- When the governing flag is OFF  → function returns None (no work attempted).
+- When the governing flag is ON   → function returns {"status": "not_implemented", ...}
+  and NEVER claims completion for work it did not do.
+
+Any test asserting "status": "checked" or "status": "requested" would be
+testing a lie — those statuses are gone.
+"""
 from unittest.mock import patch
 
 from app.services.mrp_trigger_service import (
@@ -11,65 +19,101 @@ from app.services.mrp_trigger_service import (
 
 
 class TestTriggerMRPCheck:
-    def test_returns_none_when_disabled(self, db):
+    """trigger_mrp_check is gated by AUTO_MRP_ON_ORDER_CREATE."""
+
+    def test_returns_none_when_flag_disabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
-            mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = False
+            mock_settings.AUTO_MRP_ON_ORDER_CREATE = False
             result = trigger_mrp_check(db, sales_order_id=1)
-            assert result is None
+        assert result is None
 
-    def test_returns_error_for_missing_so(self, db):
+    def test_returns_not_implemented_when_flag_enabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
-            mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = True
-            result = trigger_mrp_check(db, sales_order_id=999999)
-            assert result["error"] == "Sales order not found"
-
-    def test_returns_checked_for_valid_so(self, db, make_product, make_sales_order):
-        product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(
-            product_id=product.id, quantity=1, unit_price=Decimal("10.00")
+            mock_settings.AUTO_MRP_ON_ORDER_CREATE = True
+            result = trigger_mrp_check(db, sales_order_id=42)
+        assert result is not None
+        assert result["status"] == "not_implemented", (
+            "trigger_mrp_check must not claim completion — stub returns not_implemented"
         )
+        assert result["sales_order_id"] == 42
+
+    def test_never_claims_checked_or_completed(self, db):
+        """Guard: no success-shaped status may escape this function."""
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
-            mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = True
-            result = trigger_mrp_check(db, sales_order_id=so.id)
-            assert result["status"] == "checked"
-            assert result["sales_order_id"] == so.id
+            mock_settings.AUTO_MRP_ON_ORDER_CREATE = True
+            result = trigger_mrp_check(db, sales_order_id=1)
+        assert result["status"] not in ("checked", "completed", "requested"), (
+            "Stub must not return a success-shaped status while doing nothing"
+        )
 
 
 class TestTriggerMRPRecalculation:
-    def test_shipment_returns_none_when_disabled(self, db):
+    """trigger_mrp_recalculation is gated by AUTO_MRP_ON_SHIPMENT for reason='shipment'."""
+
+    def test_shipment_returns_none_when_flag_disabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
             mock_settings.AUTO_MRP_ON_SHIPMENT = False
             result = trigger_mrp_recalculation(db, context_id=1, reason="shipment")
-            assert result is None
+        assert result is None
 
-    def test_returns_requested_for_shipment(self, db):
+    def test_shipment_returns_not_implemented_when_flag_enabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
             mock_settings.AUTO_MRP_ON_SHIPMENT = True
             result = trigger_mrp_recalculation(
-                db, context_id=1, reason="shipment", product_ids=[1, 2]
+                db, context_id=99, reason="shipment", product_ids=[1, 2]
             )
-            assert result["status"] == "requested"
-            assert result["reason"] == "shipment"
+        assert result is not None
+        assert result["status"] == "not_implemented", (
+            "trigger_mrp_recalculation must not claim completion — stub returns not_implemented"
+        )
+        assert result["context_id"] == 99
+        assert result["reason"] == "shipment"
 
-    def test_non_shipment_reason_not_gated(self, db):
+    def test_non_shipment_reason_not_gated_by_shipment_flag(self, db):
+        """Non-shipment reasons bypass the AUTO_MRP_ON_SHIPMENT gate."""
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
             mock_settings.AUTO_MRP_ON_SHIPMENT = False
             result = trigger_mrp_recalculation(
                 db, context_id=1, reason="production_completion"
             )
-            assert result["status"] == "requested"
+        assert result is not None
+        assert result["status"] == "not_implemented"
+        assert result["reason"] == "production_completion"
+
+    def test_never_claims_requested_or_completed(self, db):
+        """Guard: no success-shaped status may escape this function."""
+        with patch("app.services.mrp_trigger_service.settings") as mock_settings:
+            mock_settings.AUTO_MRP_ON_SHIPMENT = True
+            result = trigger_mrp_recalculation(db, context_id=1, reason="shipment")
+        assert result["status"] not in ("checked", "completed", "requested"), (
+            "Stub must not return a success-shaped status while doing nothing"
+        )
 
 
 class TestTriggerIncrementalMRP:
-    def test_returns_none_when_disabled(self, db):
+    """trigger_incremental_mrp is gated by INCLUDE_SALES_ORDERS_IN_MRP."""
+
+    def test_returns_none_when_flag_disabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
             mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = False
             result = trigger_incremental_mrp(db, product_ids=[1, 2])
-            assert result is None
+        assert result is None
 
-    def test_returns_requested_when_enabled(self, db):
+    def test_returns_not_implemented_when_flag_enabled(self, db):
         with patch("app.services.mrp_trigger_service.settings") as mock_settings:
             mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = True
             result = trigger_incremental_mrp(db, product_ids=[1, 2, 3])
-            assert result["status"] == "requested"
-            assert result["product_ids"] == [1, 2, 3]
+        assert result is not None
+        assert result["status"] == "not_implemented", (
+            "trigger_incremental_mrp must not claim completion — stub returns not_implemented"
+        )
+        assert result["product_ids"] == [1, 2, 3]
+
+    def test_never_claims_requested_or_completed(self, db):
+        """Guard: no success-shaped status may escape this function."""
+        with patch("app.services.mrp_trigger_service.settings") as mock_settings:
+            mock_settings.INCLUDE_SALES_ORDERS_IN_MRP = True
+            result = trigger_incremental_mrp(db, product_ids=[5])
+        assert result["status"] not in ("checked", "completed", "requested"), (
+            "Stub must not return a success-shaped status while doing nothing"
+        )


### PR DESCRIPTION
## Summary

- **Path taken: FALLBACK (honest stubs)** — see rationale below.
- Replaces all three stub functions in `mrp_trigger_service.py` with honest `{"status": "not_implemented"}` returns when the governing flag is enabled.
- Marks `AUTO_MRP_ON_ORDER_CREATE` and `AUTO_MRP_ON_SHIPMENT` as NOT YET FUNCTIONAL in `settings.py` comments.
- Updates tests to assert the honest contract and adds guard assertions that success-shaped statuses (`"checked"`, `"requested"`, `"completed"`) can never escape these functions.

## Why FALLBACK (not PREFERRED wire)

The PREFERRED path was to wire `trigger_mrp_check` to `MRPService.run_mrp()` scoped to the order's product IDs.  This was evaluated and deferred for two reasons:

1. **Transaction conflict**: `run_mrp()` issues its own `self.db.commit()` (and a second one in the error path) and deletes/regenerates ALL unfirmed planned orders.  Calling it inline inside `sales_orders.py` `create_sales_order` — which has already committed at line 285 — would trigger a full MRP regeneration on every order save, which is wrong behaviour and a performance hazard.
2. **No scope parameter**: `run_mrp()` is a full regenerative run with no product-scope parameter.  Adding one requires surgery to the explosion loop, netting, and planned-order creation steps, which is a separate concern.

The correct wiring requires FastAPI `BackgroundTasks` (or a job queue) so the MRP run happens post-commit without blocking the order-creation response.  That is filed as a follow-up.

## Files changed

| File | Change |
|---|---|
| `backend/app/services/mrp_trigger_service.py` | Rewrite: all stubs return `not_implemented`; log demoted to `debug`; module docstring added |
| `backend/app/core/settings.py` | Inline comments mark `AUTO_MRP_ON_ORDER_CREATE` / `AUTO_MRP_ON_SHIPMENT` as not yet functional |
| `backend/tests/services/test_mrp_trigger_service.py` | Full rewrite: asserts honest contract, adds guard assertions |

## Test results

```
10 passed in 1.07s
```

Ruff clean (E712 + full check).

## Callers unaffected

- `sales_orders.py` ~294: already wraps the trigger in `try/except` and ignores the return value — `not_implemented` is handled safely.
- `sales_order_service.py` ~2738: same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)