### PR TITLE
fix: route PO receiving exclusively through the receive workflow (HARD-2)

### DIFF
--- a/backend/app/services/purchase_order_service.py
+++ b/backend/app/services/purchase_order_service.py
@@ -406,6 +406,18 @@ def update_po_status(
             detail=f"Cannot transition from '{old_status}' to '{new_status}'",
         )
 
+    # HARD-2: received status must only be set by the /receive endpoint, which
+    # creates inventory transactions, material lots, and updates costs.  A raw
+    # status PATCH would mark the PO received while stock never arrives.
+    if new_status == "received":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Purchase orders are marked received through the Receive workflow "
+                "so inventory and costs are recorded. Use the Receive button."
+            ),
+        )
+
     if new_status == "ordered":
         if not po.lines:
             raise HTTPException(status_code=400, detail="Cannot order a PO with no lines")
@@ -416,8 +428,6 @@ def update_po_status(
             po.tracking_number = tracking_number
         if carrier:
             po.carrier = carrier
-    elif new_status == "received":
-        po.received_date = date.today()
 
     po.status = new_status
     po.updated_at = datetime.now(timezone.utc)

--- a/backend/tests/api/v1/test_purchase_orders.py
+++ b/backend/tests/api/v1/test_purchase_orders.py
@@ -623,7 +623,10 @@ class TestPurchaseOrderStatusTransitions:
         assert data["tracking_number"] == "1Z999AA10123456784"
         assert data["carrier"] == "UPS"
 
-    def test_ordered_to_received(self, client, db, make_vendor, make_purchase_order):
+    def test_ordered_to_received_via_status_patch_is_blocked(
+        self, client, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: Direct status PATCH to 'received' is forbidden; use /receive."""
         vendor = make_vendor()
         po = make_purchase_order(vendor_id=vendor.id, status="ordered")
         db.flush()
@@ -631,8 +634,9 @@ class TestPurchaseOrderStatusTransitions:
         response = client.post(f"{BASE_URL}/{po.id}/status", json={
             "status": "received",
         })
-        assert response.status_code == 200
-        assert response.json()["status"] == "received"
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "Receive" in detail or "receive" in detail
 
     def test_ordered_to_cancelled(self, client, db, make_vendor, make_purchase_order):
         vendor = make_vendor()
@@ -645,7 +649,10 @@ class TestPurchaseOrderStatusTransitions:
         assert response.status_code == 200
         assert response.json()["status"] == "cancelled"
 
-    def test_shipped_to_received(self, client, db, make_vendor, make_purchase_order):
+    def test_shipped_to_received_via_status_patch_is_blocked(
+        self, client, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: Direct status PATCH to 'received' is forbidden even from shipped."""
         vendor = make_vendor()
         po = make_purchase_order(vendor_id=vendor.id, status="shipped")
         db.flush()
@@ -653,8 +660,9 @@ class TestPurchaseOrderStatusTransitions:
         response = client.post(f"{BASE_URL}/{po.id}/status", json={
             "status": "received",
         })
-        assert response.status_code == 200
-        assert response.json()["status"] == "received"
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "Receive" in detail or "receive" in detail
 
     def test_received_to_closed(self, client, db, make_vendor, make_purchase_order):
         vendor = make_vendor()

--- a/backend/tests/endpoints/test_purchase_orders_endpoint.py
+++ b/backend/tests/endpoints/test_purchase_orders_endpoint.py
@@ -245,6 +245,76 @@ class TestUpdatePOStatus:
         )
         assert resp.status_code == 400
 
+    # HARD-2 tests -----------------------------------------------------------
+
+    def test_status_patch_to_received_from_ordered_returns_400(
+        self, client, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: raw status PATCH to received is blocked; message names the remedy."""
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+
+        resp = client.post(
+            f"/api/v1/purchase-orders/{po.id}/status",
+            json={"status": "received"},
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        # Error message must name the rule and the remedy
+        assert "inventory" in detail.lower() or "Receive" in detail
+
+    def test_status_patch_to_received_from_shipped_returns_400(
+        self, client, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: raw status PATCH to received is blocked even from shipped."""
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="shipped")
+
+        resp = client.post(
+            f"/api/v1/purchase-orders/{po.id}/status",
+            json={"status": "received"},
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "inventory" in detail.lower() or "Receive" in detail
+
+    def test_receive_endpoint_sets_received_status(
+        self, client, db, make_vendor, make_product
+    ):
+        """HARD-2: the /receive endpoint is the only valid path to received status."""
+        vendor = make_vendor()
+        product = make_product(item_type="supply", unit="EA")
+
+        # Create PO with a line
+        create_resp = client.post("/api/v1/purchase-orders/", json={
+            "vendor_id": vendor.id,
+            "lines": [
+                {"product_id": product.id, "quantity_ordered": "5", "unit_cost": "10.00"},
+            ],
+        })
+        assert create_resp.status_code == 201
+        po_id = create_resp.json()["id"]
+        line_id = create_resp.json()["lines"][0]["id"]
+
+        # Advance to ordered
+        order_resp = client.post(
+            f"/api/v1/purchase-orders/{po_id}/status",
+            json={"status": "ordered"},
+        )
+        assert order_resp.status_code == 200
+
+        # Receive all items via the receive endpoint
+        receive_resp = client.post(
+            f"/api/v1/purchase-orders/{po_id}/receive",
+            json={"lines": [{"line_id": line_id, "quantity_received": "5"}]},
+        )
+        assert receive_resp.status_code == 200
+
+        # PO status must be received after the receive flow
+        get_resp = client.get(f"/api/v1/purchase-orders/{po_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["status"] == "received"
+
     def test_status_update_nonexistent_po(self, client):
         """POST /status on non-existent PO returns 404."""
         resp = client.post(

--- a/backend/tests/services/test_purchase_order_service.py
+++ b/backend/tests/services/test_purchase_order_service.py
@@ -1322,25 +1322,31 @@ class TestUpdatePoStatus:
         assert updated.status == "shipped"
         assert updated.shipped_date is not None
 
-    def test_shipped_to_received(self, db, make_vendor, make_purchase_order):
-        """Valid transition: shipped -> received. Sets received_date."""
+    def test_shipped_to_received_via_status_patch_is_blocked(
+        self, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: update_po_status rejects 'received' even from shipped — use /receive."""
         vendor = make_vendor()
         po = make_purchase_order(vendor_id=vendor.id, status="shipped")
         db.commit()
 
-        updated = update_po_status(db, po.id, new_status="received", user_id=1)
-        assert updated.status == "received"
-        assert updated.received_date is not None
+        with pytest.raises(HTTPException) as exc_info:
+            update_po_status(db, po.id, new_status="received", user_id=1)
+        assert exc_info.value.status_code == 400
+        assert "receive" in str(exc_info.value.detail).lower()
 
-    def test_ordered_to_received_direct(self, db, make_vendor, make_purchase_order):
-        """Valid transition: ordered -> received (skip shipped)."""
+    def test_ordered_to_received_direct_via_status_patch_is_blocked(
+        self, db, make_vendor, make_purchase_order
+    ):
+        """HARD-2: update_po_status rejects 'received' from ordered — use /receive."""
         vendor = make_vendor()
         po = make_purchase_order(vendor_id=vendor.id, status="ordered")
         db.commit()
 
-        updated = update_po_status(db, po.id, new_status="received", user_id=1)
-        assert updated.status == "received"
-        assert updated.received_date is not None
+        with pytest.raises(HTTPException) as exc_info:
+            update_po_status(db, po.id, new_status="received", user_id=1)
+        assert exc_info.value.status_code == 400
+        assert "receive" in str(exc_info.value.detail).lower()
 
     def test_received_to_closed(self, db, make_vendor, make_purchase_order):
         """Valid transition: received -> closed."""


### PR DESCRIPTION
## Summary

- **Problem**: `update_po_status` allowed a raw `PATCH /status` call to set a purchase order to `received`, bypassing `receive_purchase_order` entirely — no inventory transactions, no material lots, no weighted-average cost updates. The PO said received; stock never arrived.
- **Fix**: A guard in `update_po_status` now rejects any direct transition to `received` with a `400` that names the rule and the remedy: _"Purchase orders are marked received through the Receive workflow so inventory and costs are recorded. Use the Receive button."_  The `/receive` endpoint sets `po.status = "received"` directly (never calls `update_po_status`), so that path is unaffected.
- **VALID_TRANSITIONS** is left intact (it still lists `received` as reachable from `ordered`/`shipped`) because the receive flow relies on the transition map being logically valid; the guard distinguishes the raw-PATCH attack surface from the receive flow by sitting inside `update_po_status` — a function the receive flow never calls.

## How the guard distinguishes raw PATCH from the receive flow

`receive_purchase_order` directly assigns `po.status = "received"` after posting inventory (line ~968 of `purchase_order_service.py`). It **does not** call `update_po_status`. The guard is inside `update_po_status` only, so it blocks the attack surface (the `/status` endpoint) without touching the receive path at all.

## Test plan

- [x] `test_ordered_to_received_via_status_patch_is_blocked` — raw PATCH from `ordered` → 400 with receive-workflow message
- [x] `test_shipped_to_received_via_status_patch_is_blocked` — raw PATCH from `shipped` → 400 with receive-workflow message
- [x] `test_status_patch_to_received_from_ordered_returns_400` (endpoint test) — same guard
- [x] `test_status_patch_to_received_from_shipped_returns_400` (endpoint test) — same guard
- [x] `test_receive_endpoint_sets_received_status` — `/receive` endpoint still completes and the PO becomes `received`
- [x] `test_invalid_transition_draft_to_received` — still asserts 400 with "cannot transition" (transition-table block fires first for draft)
- [x] All 73 purchase-order backend tests pass; all 3 procure-to-pay integration tests pass
- [x] 301/301 frontend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)