### PR TITLE
feat: inventory reconciliation report (HARD-4b)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from . import (
     bom, dashboard, fulfillment_queue, fulfillment_shipping, audit, accounting, traceability,
     customers, inventory_transactions, analytics, export, data_import, orders,
-    users, uom, locations, system, uploads, pro_install
+    users, uom, locations, system, uploads, pro_install, reconciliation
 )
 
 router = APIRouter()
@@ -40,6 +40,9 @@ router.include_router(traceability.router)
 
 # Inventory Transactions
 router.include_router(inventory_transactions.router)
+
+# Inventory Reconciliation Report (HARD-4b)
+router.include_router(reconciliation.router)
 
 # Export/Import
 router.include_router(export.router)

--- a/backend/app/api/v1/endpoints/admin/reconciliation.py
+++ b/backend/app/api/v1/endpoints/admin/reconciliation.py
@@ -1,0 +1,124 @@
+"""
+Admin: Inventory Reconciliation Report endpoint (HARD-4b).
+
+GET /api/v1/admin/inventory/reconciliation
+  Returns one row per Inventory record comparing stored on_hand against
+  the transaction-ledger sum for the item's epoch.
+
+  Query params:
+    drifted_only (bool, default False): return only items where
+      stored_on_hand != ledger_sum.
+
+Staff-gated: uses the same router-level dependency as mrp.py (post-#683).
+"""
+from typing import List, Optional
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.api.v1.deps import get_current_staff_user
+from app.services.reconciliation_service import (
+    ReconciliationItem,
+    get_reconciliation_report,
+)
+
+router = APIRouter(
+    prefix="/inventory/reconciliation",
+    tags=["Admin - Inventory Reconciliation"],
+    dependencies=[Depends(get_current_staff_user)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response schema
+# ---------------------------------------------------------------------------
+
+class ReconciliationItemSchema(BaseModel):
+    inventory_id: int
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    location_name: Optional[str]
+
+    stored_on_hand: float
+    ledger_sum: float
+    drift: float
+
+    baseline_timestamp: Optional[datetime]
+    is_counted: bool
+    has_drift: bool
+
+    model_config = {"from_attributes": True}
+
+
+class ReconciliationReportSchema(BaseModel):
+    items: List[ReconciliationItemSchema]
+    total_items: int
+    drifted_items: int
+    uncounted_items: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=ReconciliationReportSchema)
+def get_inventory_reconciliation(
+    drifted_only: bool = Query(
+        False,
+        description="Return only items where stored on_hand diverges from ledger sum",
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    Inventory reconciliation report — the operator's counting work queue.
+
+    Each row compares the stored ``on_hand_quantity`` against the sum of
+    transaction-ledger quantities for the item's epoch:
+
+    - Items with a ``baseline_timestamp`` sum only transactions at-or-after
+      that timestamp (post-count history).
+    - Items with ``baseline_timestamp = null`` sum ALL transactions and are
+      shown as **uncounted** — they belong at the top of the physical-count
+      queue.
+
+    ``drift = stored_on_hand - ledger_sum``.  Non-zero drift means the stored
+    balance diverged from what the ledger recorded — likely a SET-style write
+    outside the canonical poster, a pre-4a legacy write, or unrecorded
+    physical movement (scrap/remake).  Drift direction matters:
+
+    - positive drift → stored is higher than ledger (phantom stock)
+    - negative drift → stored is lower (consumed but not recorded)
+    """
+    service_rows = get_reconciliation_report(db, drifted_only=drifted_only)
+
+    items = [
+        ReconciliationItemSchema(
+            inventory_id=r.inventory_id,
+            product_id=r.product_id,
+            sku=r.sku,
+            name=r.name,
+            location_id=r.location_id,
+            location_name=r.location_name,
+            stored_on_hand=float(r.stored_on_hand),
+            ledger_sum=float(r.ledger_sum),
+            drift=float(r.drift),
+            baseline_timestamp=r.baseline_timestamp,
+            is_counted=r.is_counted,
+            has_drift=r.has_drift,
+        )
+        for r in service_rows
+    ]
+
+    all_rows = get_reconciliation_report(db) if drifted_only else service_rows
+
+    return ReconciliationReportSchema(
+        items=items,
+        total_items=len(all_rows) if drifted_only else len(items),
+        drifted_items=sum(1 for r in (all_rows if drifted_only else service_rows) if r.has_drift),
+        uncounted_items=sum(1 for r in all_rows if not r.is_counted),
+    )

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -2,6 +2,7 @@
 Inventory models
 """
 from sqlalchemy import Column, Integer, String, Numeric, DateTime, Date, ForeignKey, Text, Boolean, Computed
+from sqlalchemy.dialects.postgresql import TIMESTAMP as PG_TIMESTAMP
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
@@ -47,6 +48,19 @@ class Inventory(Base):
 
     # Metadata
     last_counted = Column(DateTime, nullable=True)
+    # HARD-4b: epoch anchor for reconciliation report.
+    # NULL = never baselined (item never physically counted).
+    # When a reconciliation_baseline transaction is posted (HARD-4c), this is
+    # stamped with the transaction timestamp. The reconciliation report then
+    # sums only transactions >= baseline_timestamp; NULL rows sum ALL history.
+    baseline_timestamp = Column(
+        PG_TIMESTAMP(timezone=True),
+        nullable=True,
+        comment=(
+            "UTC timestamp of the last reconciliation_baseline (physical count). "
+            "NULL means the item has never been counted."
+        ),
+    )
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False)
 

--- a/backend/app/services/reconciliation_service.py
+++ b/backend/app/services/reconciliation_service.py
@@ -1,0 +1,236 @@
+"""
+Inventory reconciliation report (HARD-4b).
+
+Computes, per Inventory row, the divergence between:
+  - stored ``Inventory.on_hand_quantity``  (the running balance maintained by
+    inventory_ledger.post)
+  - Σ(InventoryTransaction.quantity) filtered to the item's epoch
+
+EPOCH SEMANTICS
+---------------
+``Inventory.baseline_timestamp`` (added by migration 086) anchors the epoch.
+
+  NULL baseline  → item has never been physically counted.  The report sums
+                   ALL non-excluded transactions from the dawn of time and
+                   classifies the item as ``uncounted``.
+
+  Non-NULL       → item has been counted at least once.  Only transactions
+                   with ``created_at >= baseline_timestamp`` are summed.
+
+SIGN CONVENTION (HARD-4a)
+--------------------------
+inventory_ledger.post() writes SIGNED quantities: positive = stock in,
+negative = stock out.  So ``Σ(quantity)`` IS the expected on-hand for the
+epoch.  Pre-4a rows used mixed conventions (positive magnitudes); the plan
+documents abs() as the migration-safe reader fix.  However, for
+RECONCILIATION the meaningful comparison is:
+
+    drift = stored_on_hand − ledger_sum_for_epoch
+
+A non-zero drift for a fully-4a-posted item means a SET-style write happened
+outside the poster.  The absolute value of drift signals how far off counts
+are without requiring ABS() on the sum — callers see both stored_on_hand and
+ledger_sum so they can interpret the sign themselves.
+
+EXCLUSIONS
+----------
+Rows with ``location_id IS NULL`` are excluded from sums.  These are
+untracked spool-weight adjustment rows documented in PR #690 (HARD-4a).
+``requires_approval=True`` rows that have NOT been approved are pending
+transactions that have not yet affected on_hand; excluding them keeps the
+math honest (the poster also skips on_hand mutation for those rows).
+
+OUTPUT
+------
+One ``ReconciliationItem`` per Inventory row that has a matching Product.
+Rows with no transaction history for their epoch return ledger_sum = 0 and
+drift = stored_on_hand.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional
+
+from sqlalchemy import func, case
+from sqlalchemy.orm import Session
+
+from app.models.inventory import Inventory, InventoryTransaction
+from app.models.product import Product
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ReconciliationItem:
+    """One row in the reconciliation report."""
+
+    # Identity
+    inventory_id: int
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    location_name: Optional[str]
+
+    # Quantities (Decimal; sign-correct from the poster)
+    stored_on_hand: Decimal
+    ledger_sum: Decimal          # Σ(quantity) for the epoch (may be 0 if no txns)
+    drift: Decimal               # stored_on_hand − ledger_sum
+
+    # Epoch anchor
+    baseline_timestamp: Optional[datetime]  # None → uncounted
+
+    # Derived
+    is_counted: bool  # False when baseline_timestamp IS NULL
+
+    @property
+    def has_drift(self) -> bool:
+        return self.drift != Decimal("0")
+
+
+def get_reconciliation_report(
+    db: Session,
+    *,
+    drifted_only: bool = False,
+) -> List[ReconciliationItem]:
+    """
+    Compute the inventory reconciliation report.
+
+    Args:
+        db: SQLAlchemy session (read-only — no writes).
+        drifted_only: when True, return only rows where drift != 0.
+
+    Returns:
+        List of ReconciliationItem, one per Inventory row with a product.
+        Sorted by abs(drift) descending so the worst offenders are first.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: pull all inventory rows with product data
+    # ------------------------------------------------------------------
+    from app.models.inventory import InventoryLocation
+
+    inv_rows = (
+        db.query(
+            Inventory,
+            Product,
+            InventoryLocation.name.label("location_name"),
+        )
+        .join(Product, Inventory.product_id == Product.id)
+        .outerjoin(InventoryLocation, Inventory.location_id == InventoryLocation.id)
+        .all()
+    )
+
+    if not inv_rows:
+        return []
+
+    # ------------------------------------------------------------------
+    # Step 2: build a single aggregation query for all (product, location)
+    # pairs that appear in our inventory set.
+    # We run one query instead of N to keep this O(1) DB round-trips.
+    # ------------------------------------------------------------------
+    # We need per-(product_id, location_id, epoch) sums.  Because the
+    # epoch varies per row we cannot push the epoch filter into a single
+    # SQL GROUP BY.  Strategy: pull all non-excluded transaction rows for
+    # the products we care about, then aggregate in Python.  Transaction
+    # tables in typical deployments are small enough for this to be fine;
+    # if they grow large the natural optimisation is a partial index on
+    # (product_id, location_id, created_at).
+
+    product_ids = [r.Inventory.product_id for r in inv_rows]
+
+    # Fetch: only rows with a non-NULL location AND not pending-approval.
+    txn_rows = (
+        db.query(
+            InventoryTransaction.product_id,
+            InventoryTransaction.location_id,
+            InventoryTransaction.quantity,
+            InventoryTransaction.created_at,
+        )
+        .filter(
+            InventoryTransaction.product_id.in_(product_ids),
+            InventoryTransaction.location_id.isnot(None),   # exclude untracked spool-weight rows
+            InventoryTransaction.requires_approval.is_(False),  # exclude unapproved pending rows
+        )
+        .all()
+    )
+
+    # Index by (product_id, location_id) → list of (quantity, created_at)
+    from collections import defaultdict
+    txn_index: dict[tuple, list] = defaultdict(list)
+    for row in txn_rows:
+        txn_index[(row.product_id, row.location_id)].append(
+            (Decimal(str(row.quantity)), row.created_at)
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3: assemble report rows
+    # ------------------------------------------------------------------
+    report: List[ReconciliationItem] = []
+
+    for r in inv_rows:
+        inv = r.Inventory
+        prod = r.Product
+
+        stored = Decimal(str(inv.on_hand_quantity or 0))
+        baseline_ts = inv.baseline_timestamp
+        is_counted = baseline_ts is not None
+
+        key = (inv.product_id, inv.location_id)
+        txns_for_item = txn_index.get(key, [])
+
+        if is_counted:
+            # Ensure baseline_ts is timezone-aware for comparison
+            if baseline_ts.tzinfo is None:
+                baseline_ts = baseline_ts.replace(tzinfo=timezone.utc)
+
+            # Sum only transactions at-or-after the baseline
+            ledger_sum = Decimal("0")
+            for qty, created_at in txns_for_item:
+                if created_at is None:
+                    continue
+                # Normalise created_at tz
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=timezone.utc)
+                if created_at >= baseline_ts:
+                    ledger_sum += qty
+        else:
+            # NULL baseline: sum ALL transactions
+            ledger_sum = sum(
+                (qty for qty, _ in txns_for_item),
+                Decimal("0"),
+            )
+
+        drift = stored - ledger_sum
+
+        item = ReconciliationItem(
+            inventory_id=inv.id,
+            product_id=prod.id,
+            sku=prod.sku,
+            name=prod.name,
+            location_id=inv.location_id,
+            location_name=r.location_name,
+            stored_on_hand=stored,
+            ledger_sum=ledger_sum,
+            drift=drift,
+            baseline_timestamp=inv.baseline_timestamp,
+            is_counted=is_counted,
+        )
+        report.append(item)
+
+    if drifted_only:
+        report = [r for r in report if r.has_drift]
+
+    # Sort: worst absolute drift first, then uncounted last within each tier
+    report.sort(key=lambda r: (-abs(r.drift), r.is_counted, r.sku))
+
+    logger.debug(
+        "Reconciliation report: %d rows total, %d drifted, %d uncounted",
+        len(report),
+        sum(1 for r in report if r.has_drift),
+        sum(1 for r in report if not r.is_counted),
+    )
+
+    return report

--- a/backend/migrations/versions/086_add_inventory_baseline_timestamp.py
+++ b/backend/migrations/versions/086_add_inventory_baseline_timestamp.py
@@ -1,0 +1,52 @@
+"""Add baseline_timestamp to inventory table.
+
+Revision ID: 086
+Revises: 085
+Create Date: 2026-06-10
+
+Part of HARD-4b: inventory reconciliation report.
+
+NULL baseline_timestamp means the item has never been baselined (counted).
+The reconciliation service (4b) sums ALL transactions for those items and
+displays them as "uncounted".  When a physical count posts a
+reconciliation_baseline transaction (4c) the poster stamps this column with
+the transaction timestamp so all SUBSEQUENT sums start from that epoch.
+
+NO data is written by this migration — column addition only.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "086"
+down_revision = "085"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if not _column_exists("inventory", "baseline_timestamp"):
+        op.add_column(
+            "inventory",
+            sa.Column(
+                "baseline_timestamp",
+                sa.DateTime(timezone=True),
+                nullable=True,
+                comment=(
+                    "UTC timestamp of the last physical count / reconciliation_baseline "
+                    "transaction. NULL = never baselined. The reconciliation report sums "
+                    "only transactions at-or-after this timestamp; NULL rows sum ALL "
+                    "transactions and are shown as uncounted."
+                ),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("inventory", "baseline_timestamp"):
+        op.drop_column("inventory", "baseline_timestamp")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -253,6 +253,11 @@ def setup_database():
             "SET filament_diameter = 1.75 "
             "WHERE filament_diameter IS NULL"
         ))
+        # Migration 086: HARD-4b reconciliation baseline epoch column
+        conn.execute(text(
+            "ALTER TABLE inventory "
+            "ADD COLUMN IF NOT EXISTS baseline_timestamp TIMESTAMPTZ"
+        ))
         conn.commit()
 
     # Seed required data
@@ -699,3 +704,14 @@ def finished_good(make_product):
         procurement_type="make",
         name="Test Widget (FG)",
     )
+
+
+@pytest.fixture
+def location(db):
+    """Default inventory location (id=1, seeded by setup_database).
+
+    Used by reconciliation tests and any other test that needs a real
+    InventoryLocation row without building one from scratch.
+    """
+    from app.services.inventory_service import get_or_create_default_location
+    return get_or_create_default_location(db)

--- a/backend/tests/services/test_reconciliation_service.py
+++ b/backend/tests/services/test_reconciliation_service.py
@@ -1,0 +1,237 @@
+"""
+Tests for the inventory reconciliation report (HARD-4b).
+
+Scenarios:
+  1. Item with NULL baseline → sums ALL transactions, shows as uncounted.
+  2. Item with a baseline_timestamp → sums ONLY post-baseline transactions.
+  3. Item with deliberate drift (stored_on_hand != ledger_sum).
+  4. location_id IS NULL transactions are excluded from sums.
+  5. requires_approval=True (pending) rows are excluded from sums.
+  6. drifted_only filter.
+"""
+from datetime import datetime, timezone, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.models.inventory import Inventory, InventoryTransaction
+from app.services.inventory_ledger import get_or_create_inventory_row
+from app.services.reconciliation_service import get_reconciliation_report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_inventory(db, product, location, on_hand: Decimal, baseline_ts=None):
+    """Create an Inventory row directly (bypassing the poster to simulate drift)."""
+    inv = Inventory(
+        product_id=product.id,
+        location_id=location.id,
+        on_hand_quantity=on_hand,
+        allocated_quantity=Decimal("0"),
+        baseline_timestamp=baseline_ts,
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+def _make_txn(db, product, location_id, quantity: Decimal, created_at=None, requires_approval=False):
+    """Write a raw InventoryTransaction without touching on_hand (simulates pre-4a rows)."""
+    txn = InventoryTransaction(
+        product_id=product.id,
+        location_id=location_id,
+        transaction_type="adjustment",
+        quantity=quantity,
+        created_at=created_at or datetime.now(timezone.utc),
+        requires_approval=requires_approval,
+    )
+    db.add(txn)
+    db.flush()
+    return txn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNullBaseline:
+    """NULL baseline: sums ALL transactions, classified as uncounted."""
+
+    def test_sums_all_transactions(self, db, make_product, location):
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("0"))
+
+        # Three transactions at different times
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t1 = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        _make_txn(db, product, location.id, Decimal("100"), created_at=t0)
+        _make_txn(db, product, location.id, Decimal("-30"), created_at=t1)
+        _make_txn(db, product, location.id, Decimal("50"), created_at=t2)
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.is_counted is False
+        assert row.baseline_timestamp is None
+        assert row.ledger_sum == Decimal("120")  # 100 - 30 + 50
+
+    def test_zero_transactions_gives_ledger_zero(self, db, make_product, location):
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("50"))
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.ledger_sum == Decimal("0")
+        assert row.drift == Decimal("50")  # stored 50, ledger 0
+
+
+class TestBaselinedItem:
+    """Non-NULL baseline: only post-baseline transactions count."""
+
+    def test_pre_baseline_transactions_excluded(self, db, make_product, location):
+        product = make_product()
+        baseline_ts = datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+        _make_inventory(db, product, location, Decimal("80"), baseline_ts=baseline_ts)
+
+        # Pre-baseline (should be ignored)
+        _make_txn(db, product, location.id, Decimal("500"), created_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        # Post-baseline (should be counted)
+        _make_txn(db, product, location.id, Decimal("80"), created_at=datetime(2026, 5, 1, tzinfo=timezone.utc))
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.is_counted is True
+        assert row.ledger_sum == Decimal("80")  # only post-baseline
+
+    def test_exactly_at_baseline_included(self, db, make_product, location):
+        product = make_product()
+        baseline_ts = datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+        _make_inventory(db, product, location, Decimal("20"), baseline_ts=baseline_ts)
+        # Created exactly AT baseline_ts — should be included (>=)
+        _make_txn(db, product, location.id, Decimal("20"), created_at=baseline_ts)
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.ledger_sum == Decimal("20")
+        assert row.drift == Decimal("0")
+
+
+class TestDrift:
+    """Deliberate drift: stored_on_hand != ledger_sum."""
+
+    def test_positive_drift_phantom_stock(self, db, make_product, location):
+        """Stored is higher than ledger → phantom stock."""
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("140"))  # stored
+
+        _make_txn(db, product, location.id, Decimal("100"))  # ledger says +100
+        _make_txn(db, product, location.id, Decimal("-8"))    # ledger says -8 → net 92
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.stored_on_hand == Decimal("140")
+        assert row.ledger_sum == Decimal("92")
+        assert row.drift == Decimal("48")
+        assert row.has_drift is True
+
+    def test_negative_drift_missing_transactions(self, db, make_product, location):
+        """Stored is lower than ledger → unrecorded consumption."""
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("50"))  # stored
+
+        _make_txn(db, product, location.id, Decimal("100"))
+        # ledger says net 100, stored only 50
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.drift == Decimal("-50")
+
+    def test_no_drift_when_balanced(self, db, make_product, location):
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("70"))
+
+        _make_txn(db, product, location.id, Decimal("100"))
+        _make_txn(db, product, location.id, Decimal("-30"))
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.drift == Decimal("0")
+        assert row.has_drift is False
+
+
+class TestLocationNullExclusion:
+    """Transactions with location_id IS NULL (untracked spool-weight rows) must be excluded."""
+
+    def test_null_location_txn_excluded(self, db, make_product, location):
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("100"))
+
+        # This transaction has location_id=None → must NOT be summed
+        _make_txn(db, product, None, Decimal("999"))
+        # This one has a real location → included
+        _make_txn(db, product, location.id, Decimal("100"))
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.ledger_sum == Decimal("100")  # 999 excluded, only 100 counted
+        assert row.drift == Decimal("0")
+
+
+class TestApprovalExclusion:
+    """requires_approval=True rows not yet approved must be excluded."""
+
+    def test_pending_approval_row_excluded(self, db, make_product, location):
+        product = make_product()
+        _make_inventory(db, product, location, Decimal("50"))
+
+        # Approved row → included
+        _make_txn(db, product, location.id, Decimal("50"), requires_approval=False)
+        # Pending row → excluded (on_hand not yet affected)
+        _make_txn(db, product, location.id, Decimal("-200"), requires_approval=True)
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.ledger_sum == Decimal("50")
+        assert row.drift == Decimal("0")
+
+
+class TestDriftedOnlyFilter:
+    """drifted_only=True excludes balanced items."""
+
+    def test_balanced_items_excluded(self, db, make_product, location):
+        drifted = make_product()
+        balanced = make_product()
+
+        _make_inventory(db, drifted, location, Decimal("100"))
+        _make_txn(db, drifted, location.id, Decimal("50"))  # drift=50
+
+        _make_inventory(db, balanced, location, Decimal("75"))
+        _make_txn(db, balanced, location.id, Decimal("75"))  # drift=0
+
+        report = get_reconciliation_report(db, drifted_only=True)
+        ids = {r.product_id for r in report}
+
+        assert drifted.id in ids
+        assert balanced.id not in ids

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -3,6 +3,205 @@ import { Link } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { useFormatCurrency } from "../../hooks/useFormatCurrency";
 
+// ---------------------------------------------------------------------------
+// Reconciliation report — counting work queue (HARD-4b)
+// ---------------------------------------------------------------------------
+
+function ReconciliationReport() {
+  const api = useApi();
+  const [report, setReport] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [driftedOnly, setDriftedOnly] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const fetchReport = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = driftedOnly ? "?drifted_only=true" : "";
+      const data = await api.get(`/api/v1/admin/inventory/reconciliation${params}`);
+      setReport(data);
+    } catch (err) {
+      setError(err.message || "Failed to load reconciliation report");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Fetch whenever the filter or expanded state changes
+  useEffect(() => {
+    if (expanded) {
+      fetchReport();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded, driftedOnly]);
+
+  const formatQty = (val) =>
+    val == null ? "—" : Number(val).toLocaleString(undefined, { maximumFractionDigits: 4 });
+
+  const driftColor = (drift) => {
+    if (drift === 0) return "text-gray-400";
+    return drift > 0 ? "text-yellow-400" : "text-red-400";
+  };
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      {/* Collapsible header */}
+      <button
+        className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-gray-800/40 transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div>
+          <h2 className="text-lg font-semibold text-white">
+            Reconciliation — items needing a count
+          </h2>
+          <p className="text-gray-400 text-sm mt-0.5">
+            Compares stored on-hand against the transaction ledger to identify
+            drift. Items without a baseline have never been physically counted.
+          </p>
+        </div>
+        <svg
+          className={`w-5 h-5 text-gray-400 flex-shrink-0 ml-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-800">
+          {/* Controls */}
+          <div className="flex items-center gap-4 px-6 py-3 bg-gray-900/60">
+            <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={driftedOnly}
+                onChange={(e) => setDriftedOnly(e.target.checked)}
+                className="rounded border-gray-600 bg-gray-800 text-blue-500"
+              />
+              Show drifted items only
+            </label>
+            <button
+              onClick={fetchReport}
+              disabled={loading}
+              className="ml-auto px-3 py-1.5 text-xs bg-gray-700 text-gray-200 rounded hover:bg-gray-600 disabled:opacity-50"
+            >
+              {loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
+
+          {/* Summary badges */}
+          {report && !loading && (
+            <div className="flex gap-4 px-6 py-3 border-b border-gray-800">
+              <div className="text-sm text-gray-400">
+                <span className="font-medium text-white">{report.total_items}</span> total items
+              </div>
+              <div className="text-sm text-gray-400">
+                <span className={`font-medium ${report.drifted_items > 0 ? "text-yellow-400" : "text-green-400"}`}>
+                  {report.drifted_items}
+                </span> drifted
+              </div>
+              <div className="text-sm text-gray-400">
+                <span className={`font-medium ${report.uncounted_items > 0 ? "text-orange-400" : "text-gray-300"}`}>
+                  {report.uncounted_items}
+                </span> uncounted
+              </div>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="mx-6 my-3 bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* Loading spinner */}
+          {loading && (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+            </div>
+          )}
+
+          {/* Table */}
+          {!loading && report && (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-800/50">
+                  <tr>
+                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
+                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Name</th>
+                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Location</th>
+                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Stored</th>
+                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Ledger Sum</th>
+                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Drift</th>
+                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Baseline</th>
+                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.items.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="py-8 text-center text-gray-500 text-sm">
+                        {driftedOnly ? "No drifted items — all balanced." : "No inventory rows found."}
+                      </td>
+                    </tr>
+                  ) : (
+                    report.items.map((item) => (
+                      <tr
+                        key={`${item.product_id}-${item.location_id}`}
+                        className={`border-b border-gray-800 hover:bg-gray-800/30 ${
+                          item.has_drift ? "bg-yellow-500/5" : ""
+                        }`}
+                      >
+                        <td className="py-2.5 px-4 font-mono text-sm text-white">{item.sku}</td>
+                        <td className="py-2.5 px-4 text-gray-300 text-sm max-w-xs truncate">{item.name}</td>
+                        <td className="py-2.5 px-4 text-gray-400 text-sm">{item.location_name || "—"}</td>
+                        <td className="py-2.5 px-4 text-right text-white tabular-nums">{formatQty(item.stored_on_hand)}</td>
+                        <td className="py-2.5 px-4 text-right text-gray-300 tabular-nums">{formatQty(item.ledger_sum)}</td>
+                        <td className={`py-2.5 px-4 text-right font-semibold tabular-nums ${driftColor(item.drift)}`}>
+                          {item.drift > 0 ? "+" : ""}{formatQty(item.drift)}
+                        </td>
+                        <td className="py-2.5 px-4 text-gray-500 text-xs">
+                          {item.baseline_timestamp
+                            ? new Date(item.baseline_timestamp).toLocaleDateString()
+                            : "—"}
+                        </td>
+                        <td className="py-2.5 px-4">
+                          {item.is_counted ? (
+                            item.has_drift ? (
+                              <span className="px-2 py-0.5 rounded-full text-xs bg-yellow-500/20 text-yellow-400">
+                                drifted
+                              </span>
+                            ) : (
+                              <span className="px-2 py-0.5 rounded-full text-xs bg-green-500/20 text-green-400">
+                                clean
+                              </span>
+                            )
+                          ) : (
+                            <span className="px-2 py-0.5 rounded-full text-xs bg-orange-500/20 text-orange-400">
+                              uncounted
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
 export default function AdminInventoryTransactions() {
   const api = useApi();
   const formatCurrency = useFormatCurrency();
@@ -170,6 +369,9 @@ export default function AdminInventoryTransactions() {
           {showForm ? "Cancel" : "+ New Transaction"}
         </button>
       </div>
+
+      {/* Reconciliation Report — counting work queue */}
+      <ReconciliationReport />
 
       {/* Error Message */}
       {error && (


### PR DESCRIPTION
## Summary

- **Service** (`reconciliation_service.py`): computes per-item `drift = stored_on_hand − Σ(ledger)` using epoch semantics — NULL `baseline_timestamp` sums ALL transactions (item is *uncounted*); non-NULL sums only transactions `>= baseline_timestamp`. Excludes `location_id IS NULL` rows (untracked spool-weight adjustments per PR #690) and `requires_approval=True` pending rows. Pure read, Decimal throughout.
- **Migration 086** (`086_add_inventory_baseline_timestamp.py`): adds `inventory.baseline_timestamp TIMESTAMPTZ NULL` with column-exists guard. Zero data writes. Revises 085.
- **Model** (`inventory.py`): adds `baseline_timestamp` as `PG_TIMESTAMP(timezone=True)` column.
- **Endpoint** (`admin/reconciliation.py`): `GET /api/v1/admin/inventory/reconciliation?drifted_only=bool` — staff-gated, returns `ReconciliationReportSchema` with summary counts.
- **Router registration** (`admin/__init__.py`): includes reconciliation router.
- **Frontend** (`AdminInventoryTransactions.jsx`): collapsible `ReconciliationReport` section at page top — drift table with stored/ledger/drift/baseline/status columns; yellow *drifted* badge, orange *uncounted* badge, green *clean* badge; *Show drifted only* checkbox; lazy-load on expand; Refresh button.
- **Tests** (`test_reconciliation_service.py`): 10 tests covering NULL baseline epoch, non-NULL baseline epoch (pre-baseline excluded, exactly-at included), positive/negative/zero drift, location_id=NULL exclusion, requires_approval exclusion, drifted_only filter. All pass.
- **conftest.py**: adds shared `location` fixture for reconciliation and future tests.
- **Bug fix**: dead agent had `from app.models.products import Product` (wrong module name) — corrected to `app.models.product`.

## Test plan

- [x] `pytest tests/services/test_reconciliation_service.py` — 10/10 pass
- [x] `pytest -k reconciliation` — 10/10 pass
- [x] `ruff check app/ --select E712` — all checks passed
- [x] `npm run test:unit` — 301/301 pass
- [x] `npm run build` — built in 871ms, no errors
- [x] Migration applied to dev DB (085 → 086), report runs successfully
- [x] Live dev DB: 86 total items, 31 drifted, 86 uncounted (baseline_timestamp all NULL, pre-4c)

## Dev DB counting work queue (drifted items, sorted by abs drift)

| SKU | Stored | Ledger | Drift |
|-----|--------|--------|-------|
| MAT-PLA-BLK | 5,460 | 32,870 | −27,410 |
| MAT-PLA-BLU | 6,910 | 12,810 | −5,900 |
| MAT-PLAM-CHAR | 200 | 5,600 | −5,400 |
| MAT-PETG-BLK | 2,440 | 7,720 | −5,280 |
| MAT-PLAM-WHT | 1,040 | 5,360 | −4,320 |
| MAT-PLA-GRY | 2,045 | 5,555 | −3,510 |
| MAT-PLA-WHT | 5,210 | 7,910 | −2,700 |
| MAT-PLA-RED | 6,900 | 7,900 | −1,000 |
| MAT-PETG_BASIC-BLU | 790 | 1,510 | −720 |
| CMP-INSERT-M3 | 285 | 863 | −578 |
| (21 more rows) | | | |

All 86 items are UNCOUNTED (baseline_timestamp NULL) as expected before HARD-4c runs.

## Notes

- HARD-4c (physical count posting + data repair) requires explicit human approval before executing against any real DB per the plan spec.
- The `location` fixture added to conftest.py is non-breaking — uses `get_or_create_default_location` which already runs in the seeded default location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)