### PR TITLE
feat: HARD-4c reconciliation count-entry tool + explicit fallback

### DIFF
--- a/backend/app/api/v1/endpoints/admin/reconciliation.py
+++ b/backend/app/api/v1/endpoints/admin/reconciliation.py
@@ -1,7 +1,7 @@
 """
-Admin: Inventory Reconciliation Report endpoint (HARD-4b).
+Admin: Inventory Reconciliation Report + Baseline endpoints (HARD-4b + HARD-4c).
 
-GET /api/v1/admin/inventory/reconciliation
+GET  /api/v1/admin/inventory/reconciliation
   Returns one row per Inventory record comparing stored on_hand against
   the transaction-ledger sum for the item's epoch.
 
@@ -9,20 +9,36 @@ GET /api/v1/admin/inventory/reconciliation
     drifted_only (bool, default False): return only items where
       stored_on_hand != ledger_sum.
 
+POST /api/v1/admin/inventory/reconciliation/count
+  Record a physical count for one (product_id, location_id) pair.
+  Computes delta = counted_qty - stored, posts a reconciliation_baseline
+  transaction through the canonical ledger, stamps baseline_timestamp, and
+  creates the matching GL entry (cycle-count variance semantics).
+
+POST /api/v1/admin/inventory/reconciliation/count/all-to-stored
+  EXPLICIT FALLBACK: stamp baseline_timestamp to NOW with zero delta for
+  every inventory row (or one row if product_id + location_id are supplied).
+  Does NOT write ledger rows -- only stamps the epoch.
+  Requires {"confirm": "BASELINE_TO_STORED"} in the request body.
+  Labeled "Baseline to stored -- dev/test only" in the UI.
+
 Staff-gated: uses the same router-level dependency as mrp.py (post-#683).
 """
 from typing import List, Optional
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.api.v1.deps import get_current_staff_user
+from app.models.user import User
 from app.services.reconciliation_service import (
-    ReconciliationItem,
+    BASELINE_TO_STORED_CONFIRM_TOKEN,
+    baseline_to_stored,
     get_reconciliation_report,
+    post_reconciliation_baseline,
 )
 
 router = APIRouter(
@@ -33,7 +49,7 @@ router = APIRouter(
 
 
 # ---------------------------------------------------------------------------
-# Response schema
+# Response schemas
 # ---------------------------------------------------------------------------
 
 class ReconciliationItemSchema(BaseModel):
@@ -62,8 +78,52 @@ class ReconciliationReportSchema(BaseModel):
     uncounted_items: int
 
 
+class CountEntryRequest(BaseModel):
+    """Payload for a single physical count entry."""
+    product_id: int = Field(..., description="Product being counted")
+    location_id: int = Field(..., description="Inventory location being counted")
+    counted_qty: float = Field(..., ge=0, description="Physically counted quantity (>= 0)")
+    notes: Optional[str] = Field(None, max_length=500, description="Optional count note")
+
+
+class CountEntryResponse(BaseModel):
+    """Response from a count entry."""
+    transaction_id: Optional[int] = Field(
+        None, description="Ledger transaction id, or null if delta was zero"
+    )
+    delta: float = Field(..., description="Signed delta applied (counted - stored)")
+    baseline_timestamp: datetime = Field(..., description="New epoch anchor")
+    message: str
+
+
+class FallbackRequest(BaseModel):
+    """Payload for the explicit stored-as-baseline fallback."""
+    confirm: str = Field(
+        ...,
+        description=(
+            f'Must equal "{BASELINE_TO_STORED_CONFIRM_TOKEN}" to prevent '
+            "accidental invocation"
+        ),
+    )
+    product_id: Optional[int] = Field(
+        None,
+        description="Specific product to baseline (omit to process ALL inventory rows)",
+    )
+    location_id: Optional[int] = Field(
+        None,
+        description=(
+            "Specific location to baseline (required when product_id is supplied)"
+        ),
+    )
+
+
+class FallbackResponse(BaseModel):
+    stamped_rows: int = Field(..., description="Number of inventory rows stamped")
+    message: str
+
+
 # ---------------------------------------------------------------------------
-# Endpoint
+# GET: reconciliation report
 # ---------------------------------------------------------------------------
 
 @router.get("", response_model=ReconciliationReportSchema)
@@ -75,7 +135,7 @@ def get_inventory_reconciliation(
     db: Session = Depends(get_db),
 ):
     """
-    Inventory reconciliation report — the operator's counting work queue.
+    Inventory reconciliation report -- the operator's counting work queue.
 
     Each row compares the stored ``on_hand_quantity`` against the sum of
     transaction-ledger quantities for the item's epoch:
@@ -83,16 +143,16 @@ def get_inventory_reconciliation(
     - Items with a ``baseline_timestamp`` sum only transactions at-or-after
       that timestamp (post-count history).
     - Items with ``baseline_timestamp = null`` sum ALL transactions and are
-      shown as **uncounted** — they belong at the top of the physical-count
+      shown as **uncounted** -- they belong at the top of the physical-count
       queue.
 
     ``drift = stored_on_hand - ledger_sum``.  Non-zero drift means the stored
-    balance diverged from what the ledger recorded — likely a SET-style write
+    balance diverged from what the ledger recorded -- likely a SET-style write
     outside the canonical poster, a pre-4a legacy write, or unrecorded
     physical movement (scrap/remake).  Drift direction matters:
 
-    - positive drift → stored is higher than ledger (phantom stock)
-    - negative drift → stored is lower (consumed but not recorded)
+    - positive drift -> stored is higher than ledger (phantom stock)
+    - negative drift -> stored is lower (consumed but not recorded)
     """
     service_rows = get_reconciliation_report(db, drifted_only=drifted_only)
 
@@ -121,4 +181,161 @@ def get_inventory_reconciliation(
         total_items=len(all_rows) if drifted_only else len(items),
         drifted_items=sum(1 for r in (all_rows if drifted_only else service_rows) if r.has_drift),
         uncounted_items=sum(1 for r in all_rows if not r.is_counted),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST: count entry (HARD-4c primary path)
+# ---------------------------------------------------------------------------
+
+@router.post("/count", response_model=CountEntryResponse)
+def post_count_entry(
+    body: CountEntryRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """
+    Record a physical count for one (product, location) pair.
+
+    Posts a ``reconciliation_baseline`` transaction through the canonical
+    inventory ledger and stamps ``Inventory.baseline_timestamp``.
+
+    - Delta = counted_qty - stored_on_hand (computed under a row lock).
+    - GL entry posted for cycle-count variance semantics (DR/CR 1200 vs 5030).
+    - If delta == 0 the baseline_timestamp is still stamped (count happened).
+
+    The row will appear as **clean** (not drifted, counted) in the
+    reconciliation report after this call.
+    """
+    from decimal import Decimal as D
+    from decimal import InvalidOperation
+
+    try:
+        counted = D(str(body.counted_qty))
+    except InvalidOperation:
+        raise HTTPException(status_code=422, detail="Invalid counted_qty value")
+
+    try:
+        txn = post_reconciliation_baseline(
+            db,
+            product_id=body.product_id,
+            location_id=body.location_id,
+            counted_qty=counted,
+            user=current_user.email,
+            notes=body.notes,
+        )
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    # Re-read inventory for the response
+    from app.models.inventory import Inventory
+    inv = (
+        db.query(Inventory)
+        .filter(
+            Inventory.product_id == body.product_id,
+            Inventory.location_id == body.location_id,
+        )
+        .first()
+    )
+    if inv is None:
+        raise HTTPException(status_code=500, detail="Inventory row missing after baseline post")
+
+    # Re-derive delta from the transaction row (posted by service)
+    actual_delta = D(str(txn.quantity)) if txn else D("0")
+
+    db.commit()
+
+    return CountEntryResponse(
+        transaction_id=txn.id if txn else None,
+        delta=float(actual_delta),
+        baseline_timestamp=inv.baseline_timestamp,
+        message=(
+            f"Count recorded. Delta {float(actual_delta):+.4f} applied; "
+            f"baseline stamped to {inv.baseline_timestamp.isoformat()}."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST: explicit fallback ("baseline to stored")
+# ---------------------------------------------------------------------------
+
+@router.post("/count/all-to-stored", response_model=FallbackResponse)
+def baseline_all_to_stored(
+    body: FallbackRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """
+    EXPLICIT FALLBACK (dev/test/first-install only).
+
+    Stamps ``Inventory.baseline_timestamp`` to NOW for the specified row (or
+    ALL rows if no product_id is given), using the CURRENT stored on-hand as
+    the physical-count value.  No ledger rows are written.
+
+    This action is intentionally labeled "Baseline to stored -- dev/test only"
+    in the UI and requires:
+
+      {"confirm": "BASELINE_TO_STORED"}
+
+    ... in the request body.  Without this token the endpoint returns 422.
+
+    EXECUTION GATE: Do NOT invoke this against a production database without
+    explicit owner sign-off recorded outside this request.  The endpoint
+    exists to repair dev/demo/test databases and to provide a first-install
+    bootstrap -- running it in production silently discards pre-existing
+    transaction history from the drift calculation.
+    """
+    if body.confirm != BASELINE_TO_STORED_CONFIRM_TOKEN:
+        raise HTTPException(
+            status_code=422,
+            detail=f"confirm must equal {BASELINE_TO_STORED_CONFIRM_TOKEN!r}",
+        )
+
+    if body.product_id is not None:
+        # Single-row mode
+        if body.location_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="location_id is required when product_id is supplied",
+            )
+        try:
+            baseline_to_stored(
+                db,
+                product_id=body.product_id,
+                location_id=body.location_id,
+                user=current_user.email,
+                confirm=body.confirm,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        stamped = 1
+    else:
+        # All-rows mode
+        from app.models.inventory import Inventory
+
+        all_inv = db.query(Inventory).all()
+        stamped = 0
+        for inv in all_inv:
+            try:
+                baseline_to_stored(
+                    db,
+                    product_id=inv.product_id,
+                    location_id=inv.location_id,
+                    user=current_user.email,
+                    confirm=body.confirm,
+                )
+                stamped += 1
+            except Exception:
+                # Log and continue -- one bad row shouldn't abort the batch
+                pass
+
+    db.commit()
+
+    return FallbackResponse(
+        stamped_rows=stamped,
+        message=(
+            f"Baseline-to-stored complete: {stamped} row(s) stamped. "
+            "No ledger rows were written."
+        ),
     )

--- a/backend/app/api/v1/endpoints/admin/reconciliation.py
+++ b/backend/app/api/v1/endpoints/admin/reconciliation.py
@@ -24,6 +24,7 @@ POST /api/v1/admin/inventory/reconciliation/count/all-to-stored
 
 Staff-gated: uses the same router-level dependency as mrp.py (post-#683).
 """
+import logging
 from typing import List, Optional
 from datetime import datetime
 
@@ -40,6 +41,8 @@ from app.services.reconciliation_service import (
     get_reconciliation_report,
     post_reconciliation_baseline,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/inventory/reconciliation",
@@ -154,7 +157,9 @@ def get_inventory_reconciliation(
     - positive drift -> stored is higher than ledger (phantom stock)
     - negative drift -> stored is lower (consumed but not recorded)
     """
-    service_rows = get_reconciliation_report(db, drifted_only=drifted_only)
+    # Fetch once (unfiltered) so summary stats and filtered items share one DB round-trip.
+    all_rows = get_reconciliation_report(db, drifted_only=False)
+    service_rows = [r for r in all_rows if r.has_drift] if drifted_only else all_rows
 
     items = [
         ReconciliationItemSchema(
@@ -174,12 +179,10 @@ def get_inventory_reconciliation(
         for r in service_rows
     ]
 
-    all_rows = get_reconciliation_report(db) if drifted_only else service_rows
-
     return ReconciliationReportSchema(
         items=items,
-        total_items=len(all_rows) if drifted_only else len(items),
-        drifted_items=sum(1 for r in (all_rows if drifted_only else service_rows) if r.has_drift),
+        total_items=len(all_rows),
+        drifted_items=sum(1 for r in all_rows if r.has_drift),
         uncounted_items=sum(1 for r in all_rows if not r.is_counted),
     )
 
@@ -327,8 +330,12 @@ def baseline_all_to_stored(
                 )
                 stamped += 1
             except Exception:
-                # Log and continue -- one bad row shouldn't abort the batch
-                pass
+                logger.exception(
+                    "baseline_to_stored failed for product_id=%s location_id=%s; "
+                    "continuing batch",
+                    inv.product_id,
+                    inv.location_id,
+                )
 
     db.commit()
 

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -61,6 +61,20 @@ class Inventory(Base):
             "NULL means the item has never been counted."
         ),
     )
+    # HARD-4c: on-hand at the moment of the last reconciliation_baseline.
+    # The reconciliation report computes:
+    #   drift = stored_on_hand - (baseline_on_hand + sum(post-baseline transactions))
+    # This makes zero-delta baselines correct: the opening balance of the new
+    # epoch is the physical count result, and post-count ledger activity is
+    # tracked on top of it.  NULL when baseline_timestamp IS NULL.
+    baseline_on_hand = Column(
+        Numeric(18, 4),
+        nullable=True,
+        comment=(
+            "on_hand_quantity snapshotted at the last reconciliation_baseline (physical count). "
+            "Used by the reconciliation report as the epoch opening balance."
+        ),
+    )
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False)
 

--- a/backend/app/services/reconciliation_service.py
+++ b/backend/app/services/reconciliation_service.py
@@ -1,35 +1,37 @@
 """
-Inventory reconciliation report (HARD-4b).
+Inventory reconciliation report and baseline posting (HARD-4b + HARD-4c).
 
+RECONCILIATION REPORT
+---------------------
 Computes, per Inventory row, the divergence between:
   - stored ``Inventory.on_hand_quantity``  (the running balance maintained by
     inventory_ledger.post)
-  - Σ(InventoryTransaction.quantity) filtered to the item's epoch
+  - Sigma(InventoryTransaction.quantity) filtered to the item's epoch
 
 EPOCH SEMANTICS
 ---------------
 ``Inventory.baseline_timestamp`` (added by migration 086) anchors the epoch.
 
-  NULL baseline  → item has never been physically counted.  The report sums
+  NULL baseline  -> item has never been physically counted.  The report sums
                    ALL non-excluded transactions from the dawn of time and
                    classifies the item as ``uncounted``.
 
-  Non-NULL       → item has been counted at least once.  Only transactions
+  Non-NULL       -> item has been counted at least once.  Only transactions
                    with ``created_at >= baseline_timestamp`` are summed.
 
 SIGN CONVENTION (HARD-4a)
 --------------------------
 inventory_ledger.post() writes SIGNED quantities: positive = stock in,
-negative = stock out.  So ``Σ(quantity)`` IS the expected on-hand for the
+negative = stock out.  So ``Sigma(quantity)`` IS the expected on-hand for the
 epoch.  Pre-4a rows used mixed conventions (positive magnitudes); the plan
 documents abs() as the migration-safe reader fix.  However, for
 RECONCILIATION the meaningful comparison is:
 
-    drift = stored_on_hand − ledger_sum_for_epoch
+    drift = stored_on_hand - ledger_sum
 
 A non-zero drift for a fully-4a-posted item means a SET-style write happened
 outside the poster.  The absolute value of drift signals how far off counts
-are without requiring ABS() on the sum — callers see both stored_on_hand and
+are without requiring ABS() on the sum -- callers see both stored_on_hand and
 ledger_sum so they can interpret the sign themselves.
 
 EXCLUSIONS
@@ -45,15 +47,42 @@ OUTPUT
 One ``ReconciliationItem`` per Inventory row that has a matching Product.
 Rows with no transaction history for their epoch return ledger_sum = 0 and
 drift = stored_on_hand.
+
+BASELINE POSTING (HARD-4c)
+--------------------------
+``post_reconciliation_baseline`` records a physical count result:
+
+  1. Acquires a FOR UPDATE lock on the Inventory row (via the canonical
+     poster's get_or_create_inventory_row) so the stored quantity read and
+     the ledger write are atomic under a single row lock.
+  2. Computes ``delta = counted_qty - stored_at_lock_time``.
+  3. For non-zero delta: posts through ``inventory_ledger.post`` with
+     ``transaction_type="reconciliation"`` (a SIGNED_TYPE in the poster)
+     and ``reason_code="reconciliation_baseline"``.  GL treatment: identical
+     to cycle-count variance (DR/CR 1200 Inventory vs 5030 Inventory
+     Adjustment) via TransactionService.cycle_count_adjustment's GL logic.
+  4. For zero delta: skips the ledger post (poster rejects zero) but still
+     stamps ``Inventory.baseline_timestamp`` -- the count happened, even if
+     it found no variance.
+  5. Stamps ``Inventory.baseline_timestamp`` to the transaction's
+     ``created_at`` timestamp (or NOW for zero-delta) IN THE SAME FLUSH,
+     so the epoch anchor and the ledger row are atomically consistent.
+
+EXPLICIT FALLBACK (dev/test/first-install only)
+------------------------------------------------
+``baseline_to_stored`` stamps ``baseline_timestamp`` to NOW with delta=0.
+No ledger row is written (nothing changed -- the stored value is accepted
+as the baseline).  The caller MUST supply ``confirm="BASELINE_TO_STORED"``
+to prevent silent invocation.
 """
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional
 
-from sqlalchemy import func, case
 from sqlalchemy.orm import Session
 
 from app.models.inventory import Inventory, InventoryTransaction
@@ -61,6 +90,9 @@ from app.models.product import Product
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# Confirmation token required by baseline_to_stored.
+BASELINE_TO_STORED_CONFIRM_TOKEN = "BASELINE_TO_STORED"
 
 
 @dataclass
@@ -77,11 +109,11 @@ class ReconciliationItem:
 
     # Quantities (Decimal; sign-correct from the poster)
     stored_on_hand: Decimal
-    ledger_sum: Decimal          # Σ(quantity) for the epoch (may be 0 if no txns)
-    drift: Decimal               # stored_on_hand − ledger_sum
+    ledger_sum: Decimal          # Sigma(quantity) for the epoch (may be 0 if no txns)
+    drift: Decimal               # stored_on_hand - ledger_sum
 
     # Epoch anchor
-    baseline_timestamp: Optional[datetime]  # None → uncounted
+    baseline_timestamp: Optional[datetime]  # None -> uncounted
 
     # Derived
     is_counted: bool  # False when baseline_timestamp IS NULL
@@ -100,7 +132,7 @@ def get_reconciliation_report(
     Compute the inventory reconciliation report.
 
     Args:
-        db: SQLAlchemy session (read-only — no writes).
+        db: SQLAlchemy session (read-only -- no writes).
         drifted_only: when True, return only rows where drift != 0.
 
     Returns:
@@ -157,8 +189,7 @@ def get_reconciliation_report(
         .all()
     )
 
-    # Index by (product_id, location_id) → list of (quantity, created_at)
-    from collections import defaultdict
+    # Index by (product_id, location_id) -> list of (quantity, created_at)
     txn_index: dict[tuple, list] = defaultdict(list)
     for row in txn_rows:
         txn_index[(row.product_id, row.location_id)].append(
@@ -186,16 +217,42 @@ def get_reconciliation_report(
             if baseline_ts.tzinfo is None:
                 baseline_ts = baseline_ts.replace(tzinfo=timezone.utc)
 
-            # Sum only transactions at-or-after the baseline
-            ledger_sum = Decimal("0")
-            for qty, created_at in txns_for_item:
-                if created_at is None:
-                    continue
-                # Normalise created_at tz
-                if created_at.tzinfo is None:
-                    created_at = created_at.replace(tzinfo=timezone.utc)
-                if created_at >= baseline_ts:
-                    ledger_sum += qty
+            # Sum only transactions STRICTLY AFTER the baseline.
+            # The epoch opening balance is baseline_on_hand (the physically
+            # counted quantity snapshotted at the moment of the last baseline).
+            # For rows that have baseline_on_hand NULL (pre-4c baselines or
+            # rows created before this column was added), we fall back to
+            # summing transactions at-or-after the baseline (old formula).
+            baseline_on_hand = (
+                Decimal(str(inv.baseline_on_hand))
+                if inv.baseline_on_hand is not None
+                else None
+            )
+
+            if baseline_on_hand is not None:
+                # New formula: opening_balance + post-baseline movement
+                post_baseline_sum = Decimal("0")
+                for qty, created_at in txns_for_item:
+                    if created_at is None:
+                        continue
+                    if created_at.tzinfo is None:
+                        created_at = created_at.replace(tzinfo=timezone.utc)
+                    # Strictly AFTER the baseline timestamp to avoid double-
+                    # counting the baseline transaction itself (which already
+                    # is captured in baseline_on_hand).
+                    if created_at > baseline_ts:
+                        post_baseline_sum += qty
+                ledger_sum = baseline_on_hand + post_baseline_sum
+            else:
+                # Legacy fallback: at-or-after (old behaviour pre-4c)
+                ledger_sum = Decimal("0")
+                for qty, created_at in txns_for_item:
+                    if created_at is None:
+                        continue
+                    if created_at.tzinfo is None:
+                        created_at = created_at.replace(tzinfo=timezone.utc)
+                    if created_at >= baseline_ts:
+                        ledger_sum += qty
         else:
             # NULL baseline: sum ALL transactions
             ledger_sum = sum(
@@ -234,3 +291,203 @@ def get_reconciliation_report(
     )
 
     return report
+
+
+# ---------------------------------------------------------------------------
+# HARD-4c: baseline posting
+# ---------------------------------------------------------------------------
+
+def post_reconciliation_baseline(
+    db: Session,
+    *,
+    product_id: int,
+    location_id: int,
+    counted_qty: Decimal,
+    user: str,
+    notes: Optional[str] = None,
+) -> InventoryTransaction | None:
+    """Post a reconciliation_baseline transaction and stamp the epoch.
+
+    This is the physical-count entry point for HARD-4c.  The function:
+
+      1. Acquires a FOR UPDATE lock on the Inventory row so the read of
+         ``stored`` and the ledger write are serialised under one lock.
+      2. Computes ``delta = counted_qty - stored_at_lock_time``.
+      3. If delta != 0: posts through inventory_ledger.post with
+         transaction_type="reconciliation" and
+         reason_code="reconciliation_baseline", then creates the matching
+         GL journal entry (DR/CR 1200 Inventory vs 5030 Inventory
+         Adjustment, by delta sign -- identical to cycle-count variance).
+      4. Whether or not delta is zero, stamps
+         ``Inventory.baseline_timestamp`` to the transaction timestamp
+         (or NOW for zero-delta) in the SAME flush.
+
+    The session is NOT committed here -- that is the caller's responsibility.
+
+    Args:
+        db: SQLAlchemy session.
+        product_id: Product to count.
+        location_id: Location being counted.
+        counted_qty: Physically counted quantity (Decimal, >= 0).
+        user: Staff username / email for audit trail.
+        notes: Optional operator note (e.g. "shelf count 2026-06-10").
+
+    Returns:
+        The InventoryTransaction row if a ledger post was made (delta != 0),
+        or None if delta was zero (baseline_timestamp still stamped).
+
+    Raises:
+        TypeError: if counted_qty is a float.
+        ValueError: if counted_qty is negative.
+    """
+    if isinstance(counted_qty, float):
+        raise TypeError(
+            "post_reconciliation_baseline requires Decimal counted_qty, got float"
+        )
+    counted_qty = Decimal(str(counted_qty))
+    if counted_qty < 0:
+        raise ValueError(f"counted_qty must be >= 0, got {counted_qty}")
+
+    # --- Step 1: lock the inventory row and read stored qty ---
+    from app.services.inventory_ledger import get_or_create_inventory_row
+
+    inventory = get_or_create_inventory_row(db, product_id, location_id)
+    stored = Decimal(str(inventory.on_hand_quantity or 0))
+
+    delta = counted_qty - stored
+
+    now = datetime.now(timezone.utc)
+    txn: InventoryTransaction | None = None
+
+    if delta != 0:
+        # --- Step 2: post the ledger row ---
+        from app.services.inventory_ledger import post as ledger_post
+        from app.models.product import Product as ProductModel
+        from app.services.transaction_service import TransactionService
+
+        txn = ledger_post(
+            db,
+            product_id=product_id,
+            location_id=location_id,
+            transaction_type="reconciliation",
+            quantity_delta=delta,
+            reason_code="reconciliation_baseline",
+            notes=notes or f"Physical count: {counted_qty}",
+            created_by=user,
+        )
+        # Use the transaction's created_at as the epoch anchor.
+        now = txn.created_at  # type: ignore[assignment]
+
+        # --- Step 3: post GL entry (cycle-count variance semantics) ---
+        product = db.get(ProductModel, product_id)
+        if product is not None:
+            unit_cost = product.standard_cost or product.average_cost or Decimal("0")
+            total_cost = abs(delta) * unit_cost
+
+            # Map product type to inventory account (mirrors cycle_count_adjustment)
+            inv_account = "1200"
+            if product.item_type == "finished_good":
+                inv_account = "1220"
+            elif product.item_type == "packaging":
+                inv_account = "1230"
+
+            if total_cost > 0:
+                # overage (delta > 0): DR Inventory, CR Inv Adjustment
+                # shortage (delta < 0): DR Inv Adjustment, CR Inventory
+                if delta > 0:
+                    je_lines = [
+                        (inv_account, total_cost, "DR"),
+                        ("5030", total_cost, "CR"),
+                    ]
+                else:
+                    je_lines = [
+                        ("5030", total_cost, "DR"),
+                        (inv_account, total_cost, "CR"),
+                    ]
+
+                svc = TransactionService(db)
+                je = svc.create_journal_entry(
+                    description=f"Reconciliation baseline: {notes or 'physical count'}",
+                    lines=je_lines,
+                    source_type="adjustment",
+                )
+                txn.journal_entry_id = je.id
+
+        logger.info(
+            "Reconciliation baseline posted for product %s @ location %s: "
+            "stored=%s counted=%s delta=%s by %s",
+            product_id, location_id, stored, counted_qty, delta, user,
+        )
+    else:
+        logger.info(
+            "Reconciliation baseline: product %s @ location %s stored=%s "
+            "matches count (delta=0) — no ledger row written, baseline stamped by %s",
+            product_id, location_id, stored, user,
+        )
+
+    # --- Step 4: stamp baseline_timestamp + baseline_on_hand atomically ---
+    # baseline_on_hand captures the physically counted quantity as the epoch
+    # opening balance.  The reconciliation report uses:
+    #   drift = stored - (baseline_on_hand + sum(post-baseline transactions))
+    # so zero-delta counts correctly show drift=0 immediately after counting.
+    inventory.baseline_timestamp = now
+    inventory.baseline_on_hand = counted_qty
+    db.flush()
+
+    return txn
+
+
+def baseline_to_stored(
+    db: Session,
+    *,
+    product_id: int,
+    location_id: int,
+    user: str,
+    confirm: str,
+) -> None:
+    """Stamp baseline_timestamp to NOW with zero delta (no ledger write).
+
+    This is the EXPLICIT FALLBACK for dev/test/first-install scenarios where
+    the stored on-hand value is accepted as the physical-count baseline
+    without an actual count event.  Requires ``confirm="BASELINE_TO_STORED"``
+    to prevent silent invocation.
+
+    NO ledger row is written (delta = 0, nothing to record).  Only
+    ``Inventory.baseline_timestamp`` is stamped.
+
+    EXECUTION GATE: this function only stamps -- it does NOT execute any
+    data repair against a real database.  Running the fallback against a
+    production database requires explicit owner sign-off documented outside
+    this call.
+
+    Args:
+        db: SQLAlchemy session.
+        product_id: Product to baseline.
+        location_id: Location to baseline.
+        user: Staff username / email for audit trail.
+        confirm: Must equal "BASELINE_TO_STORED" -- prevents accidental calls.
+
+    Raises:
+        ValueError: if confirm token is wrong.
+    """
+    if confirm != BASELINE_TO_STORED_CONFIRM_TOKEN:
+        raise ValueError(
+            f"Confirmation token required: pass confirm={BASELINE_TO_STORED_CONFIRM_TOKEN!r}"
+        )
+
+    from app.services.inventory_ledger import get_or_create_inventory_row
+
+    inventory = get_or_create_inventory_row(db, product_id, location_id)
+    stored = Decimal(str(inventory.on_hand_quantity or 0))
+    now = datetime.now(timezone.utc)
+    inventory.baseline_timestamp = now
+    # Set baseline_on_hand to stored so the reconciliation report correctly
+    # shows drift=0 immediately after the fallback.
+    inventory.baseline_on_hand = stored
+    db.flush()
+
+    logger.info(
+        "baseline_to_stored: stamped product %s @ location %s to %s (on_hand=%s) "
+        "by %s (no ledger row written)",
+        product_id, location_id, now.isoformat(), stored, user,
+    )

--- a/backend/migrations/versions/087_add_inventory_baseline_on_hand.py
+++ b/backend/migrations/versions/087_add_inventory_baseline_on_hand.py
@@ -1,0 +1,59 @@
+"""Add baseline_on_hand to inventory table.
+
+Revision ID: 087
+Revises: 086
+Create Date: 2026-06-10
+
+Part of HARD-4c: reconciliation count-entry tool.
+
+baseline_on_hand stores the physically-counted quantity at the moment of the
+last reconciliation_baseline transaction.  The reconciliation report (4b)
+uses it as the epoch opening balance:
+
+    drift = stored_on_hand - (baseline_on_hand + sum(post-baseline txns))
+
+This makes zero-delta baselines correct: if the count matched stored exactly,
+baseline_on_hand == stored, no post-baseline transactions exist yet, so
+drift == 0 immediately after counting.
+
+Legacy rows (NULL baseline_on_hand, NULL baseline_timestamp) fall back to the
+old at-or-after sum formula so pre-4c history is never reinterpreted.
+
+NO data is written by this migration -- column addition only.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "087"
+down_revision = "086"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if not _column_exists("inventory", "baseline_on_hand"):
+        op.add_column(
+            "inventory",
+            sa.Column(
+                "baseline_on_hand",
+                sa.Numeric(18, 4),
+                nullable=True,
+                comment=(
+                    "on_hand_quantity snapshotted at the last reconciliation_baseline "
+                    "(physical count). Used by the reconciliation report as the epoch "
+                    "opening balance: drift = stored - (baseline_on_hand + sum(post-baseline txns)). "
+                    "NULL when baseline_timestamp IS NULL (item never counted)."
+                ),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("inventory", "baseline_on_hand"):
+        op.drop_column("inventory", "baseline_on_hand")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -258,6 +258,11 @@ def setup_database():
             "ALTER TABLE inventory "
             "ADD COLUMN IF NOT EXISTS baseline_timestamp TIMESTAMPTZ"
         ))
+        # Migration 087: HARD-4c baseline_on_hand snapshot (epoch opening balance)
+        conn.execute(text(
+            "ALTER TABLE inventory "
+            "ADD COLUMN IF NOT EXISTS baseline_on_hand NUMERIC(18, 4)"
+        ))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/services/test_reconciliation_service.py
+++ b/backend/tests/services/test_reconciliation_service.py
@@ -1,13 +1,22 @@
 """
-Tests for the inventory reconciliation report (HARD-4b).
+Tests for the inventory reconciliation report (HARD-4b) and baseline
+posting (HARD-4c).
 
 Scenarios:
-  1. Item with NULL baseline → sums ALL transactions, shows as uncounted.
-  2. Item with a baseline_timestamp → sums ONLY post-baseline transactions.
+  1. Item with NULL baseline -> sums ALL transactions, shows as uncounted.
+  2. Item with a baseline_timestamp -> sums ONLY post-baseline transactions.
   3. Item with deliberate drift (stored_on_hand != ledger_sum).
   4. location_id IS NULL transactions are excluded from sums.
   5. requires_approval=True (pending) rows are excluded from sums.
   6. drifted_only filter.
+  7. post_reconciliation_baseline posts exactly one ledger row (non-zero delta).
+  8. post_reconciliation_baseline stamps baseline_timestamp atomically.
+  9. post_reconciliation_baseline creates a balanced GL journal entry.
+ 10. Recount (second baseline) updates baseline_timestamp.
+ 11. Zero-delta count stamps baseline_timestamp without writing a ledger row.
+ 12. baseline_to_stored stamps with zero-delta row (no ledger write).
+ 13. Report shows item as counted+clean after a matching count.
+ 14. Uncounted item is unaffected by another item's baseline.
 """
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
@@ -16,7 +25,12 @@ import pytest
 
 from app.models.inventory import Inventory, InventoryTransaction
 from app.services.inventory_ledger import get_or_create_inventory_row
-from app.services.reconciliation_service import get_reconciliation_report
+from app.services.reconciliation_service import (
+    BASELINE_TO_STORED_CONFIRM_TOKEN,
+    baseline_to_stored,
+    get_reconciliation_report,
+    post_reconciliation_baseline,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +67,7 @@ def _make_txn(db, product, location_id, quantity: Decimal, created_at=None, requ
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# HARD-4b: Reconciliation Report Tests
 # ---------------------------------------------------------------------------
 
 class TestNullBaseline:
@@ -117,7 +131,7 @@ class TestBaselinedItem:
         baseline_ts = datetime(2026, 4, 1, tzinfo=timezone.utc)
 
         _make_inventory(db, product, location, Decimal("20"), baseline_ts=baseline_ts)
-        # Created exactly AT baseline_ts — should be included (>=)
+        # Created exactly AT baseline_ts -- should be included (>=)
         _make_txn(db, product, location.id, Decimal("20"), created_at=baseline_ts)
 
         report = get_reconciliation_report(db)
@@ -132,12 +146,12 @@ class TestDrift:
     """Deliberate drift: stored_on_hand != ledger_sum."""
 
     def test_positive_drift_phantom_stock(self, db, make_product, location):
-        """Stored is higher than ledger → phantom stock."""
+        """Stored is higher than ledger -> phantom stock."""
         product = make_product()
         _make_inventory(db, product, location, Decimal("140"))  # stored
 
         _make_txn(db, product, location.id, Decimal("100"))  # ledger says +100
-        _make_txn(db, product, location.id, Decimal("-8"))    # ledger says -8 → net 92
+        _make_txn(db, product, location.id, Decimal("-8"))    # ledger says -8 -> net 92
 
         report = get_reconciliation_report(db)
         row = next((r for r in report if r.product_id == product.id), None)
@@ -149,7 +163,7 @@ class TestDrift:
         assert row.has_drift is True
 
     def test_negative_drift_missing_transactions(self, db, make_product, location):
-        """Stored is lower than ledger → unrecorded consumption."""
+        """Stored is lower than ledger -> unrecorded consumption."""
         product = make_product()
         _make_inventory(db, product, location, Decimal("50"))  # stored
 
@@ -184,9 +198,9 @@ class TestLocationNullExclusion:
         product = make_product()
         _make_inventory(db, product, location, Decimal("100"))
 
-        # This transaction has location_id=None → must NOT be summed
+        # This transaction has location_id=None -> must NOT be summed
         _make_txn(db, product, None, Decimal("999"))
-        # This one has a real location → included
+        # This one has a real location -> included
         _make_txn(db, product, location.id, Decimal("100"))
 
         report = get_reconciliation_report(db)
@@ -204,9 +218,9 @@ class TestApprovalExclusion:
         product = make_product()
         _make_inventory(db, product, location, Decimal("50"))
 
-        # Approved row → included
+        # Approved row -> included
         _make_txn(db, product, location.id, Decimal("50"), requires_approval=False)
-        # Pending row → excluded (on_hand not yet affected)
+        # Pending row -> excluded (on_hand not yet affected)
         _make_txn(db, product, location.id, Decimal("-200"), requires_approval=True)
 
         report = get_reconciliation_report(db)
@@ -235,3 +249,343 @@ class TestDriftedOnlyFilter:
 
         assert drifted.id in ids
         assert balanced.id not in ids
+
+
+# ---------------------------------------------------------------------------
+# HARD-4c: Baseline Posting Tests
+# ---------------------------------------------------------------------------
+
+class TestPostReconciliationBaseline:
+    """post_reconciliation_baseline core behaviour."""
+
+    def test_posts_exactly_one_ledger_row_nonzero_delta(self, db, make_product, location):
+        """Non-zero delta posts exactly one InventoryTransaction row."""
+        product = make_product(standard_cost=Decimal("2.00"))
+        # Seed inventory via ledger to get a known stored value
+        from app.services.inventory_ledger import post as ledger_post
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("100"),
+        )
+        # Stored is now 100; count says 110 -> delta = +10
+        before_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+
+        txn = post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("110"),
+            user="test@example.com",
+        )
+
+        after_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+
+        assert txn is not None
+        assert after_count == before_count + 1, "exactly one ledger row added"
+        assert txn.transaction_type == "reconciliation"
+        assert txn.reason_code == "reconciliation_baseline"
+        assert Decimal(str(txn.quantity)) == Decimal("10")  # delta +10
+
+    def test_stamps_baseline_timestamp_atomically(self, db, make_product, location):
+        """baseline_timestamp is set in the same flush as the ledger row."""
+        product = make_product()
+        from app.services.inventory_ledger import post as ledger_post
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("50"),
+        )
+
+        txn = post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("60"),
+            user="counter@example.com",
+        )
+
+        inv = (
+            db.query(Inventory)
+            .filter(
+                Inventory.product_id == product.id,
+                Inventory.location_id == location.id,
+            )
+            .first()
+        )
+        assert inv is not None
+        assert inv.baseline_timestamp is not None
+        assert txn is not None
+        # Baseline timestamp should equal the transaction's created_at (or very close)
+        # They are set to the same 'now' inside the service
+        assert abs((inv.baseline_timestamp - txn.created_at).total_seconds()) < 1
+
+    def test_gl_entry_is_balanced(self, db, make_product, location):
+        """GL journal entry DR == CR for both overage and shortage."""
+        from app.models.accounting import GLJournalEntry, GLJournalEntryLine
+        from app.services.inventory_ledger import post as ledger_post
+        from decimal import Decimal as D
+
+        product = make_product(
+            item_type="finished_good",
+            standard_cost=D("5.00"),
+        )
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=D("100"),
+        )
+
+        # Overage: count says 120, stored 100, delta +20, cost = 20 * 5 = 100
+        txn = post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=D("120"),
+            user="counter@example.com",
+        )
+
+        assert txn is not None
+        assert txn.journal_entry_id is not None
+
+        je = db.get(GLJournalEntry, txn.journal_entry_id)
+        assert je is not None
+        lines = (
+            db.query(GLJournalEntryLine)
+            .filter(GLJournalEntryLine.journal_entry_id == je.id)
+            .all()
+        )
+        total_dr = sum(l.debit_amount or D("0") for l in lines)
+        total_cr = sum(l.credit_amount or D("0") for l in lines)
+        assert abs(total_dr - total_cr) <= D("0.01"), (
+            f"Journal entry not balanced: DR={total_dr} CR={total_cr}"
+        )
+
+    def test_recount_updates_baseline_timestamp(self, db, make_product, location):
+        """A second count updates baseline_timestamp to the new count time."""
+        from app.services.inventory_ledger import post as ledger_post
+
+        product = make_product()
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("100"),
+        )
+
+        post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("100"),  # zero delta -- baseline stamped
+            user="counter@example.com",
+        )
+        inv = (
+            db.query(Inventory)
+            .filter(
+                Inventory.product_id == product.id,
+                Inventory.location_id == location.id,
+            )
+            .first()
+        )
+        first_ts = inv.baseline_timestamp
+        assert first_ts is not None
+
+        import time
+        time.sleep(0.01)  # ensure timestamp advances
+
+        post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("95"),
+            user="counter@example.com",
+            notes="second count",
+        )
+        db.refresh(inv)
+        second_ts = inv.baseline_timestamp
+        assert second_ts is not None
+        assert second_ts >= first_ts
+
+    def test_zero_delta_stamps_baseline_no_ledger_row(self, db, make_product, location):
+        """Zero delta: baseline_timestamp is stamped but no ledger row is written."""
+        from app.services.inventory_ledger import post as ledger_post
+
+        product = make_product()
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("75"),
+        )
+        before_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+
+        result = post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("75"),  # exact match -> delta 0
+            user="counter@example.com",
+        )
+
+        after_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+        inv = (
+            db.query(Inventory)
+            .filter(
+                Inventory.product_id == product.id,
+                Inventory.location_id == location.id,
+            )
+            .first()
+        )
+
+        assert result is None, "no transaction for zero delta"
+        assert after_count == before_count, "no ledger row added"
+        assert inv.baseline_timestamp is not None, "baseline still stamped"
+
+    def test_float_counted_qty_raises_type_error(self, db, make_product, location):
+        """float counted_qty is rejected with TypeError."""
+        product = make_product()
+        with pytest.raises(TypeError, match="Decimal"):
+            post_reconciliation_baseline(
+                db,
+                product_id=product.id,
+                location_id=location.id,
+                counted_qty=100.0,  # float -- should raise
+                user="counter@example.com",
+            )
+
+    def test_negative_counted_qty_raises_value_error(self, db, make_product, location):
+        """Negative counted_qty is rejected."""
+        product = make_product()
+        with pytest.raises(ValueError, match=">= 0"):
+            post_reconciliation_baseline(
+                db,
+                product_id=product.id,
+                location_id=location.id,
+                counted_qty=Decimal("-1"),
+                user="counter@example.com",
+            )
+
+
+class TestReportAfterBaseline:
+    """Report reflects counted status correctly after baseline posting."""
+
+    def test_report_shows_item_as_counted_after_count(self, db, make_product, location):
+        """After a count entry, item is_counted=True and has_drift=False (exact count)."""
+        from app.services.inventory_ledger import post as ledger_post
+
+        product = make_product()
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("200"),
+        )
+
+        post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("200"),  # exact match
+            user="counter@example.com",
+        )
+
+        report = get_reconciliation_report(db)
+        row = next((r for r in report if r.product_id == product.id), None)
+
+        assert row is not None
+        assert row.is_counted is True
+        assert row.has_drift is False
+
+    def test_uncounted_item_unaffected_by_another_items_baseline(
+        self, db, make_product, location
+    ):
+        """Counting one item does NOT change another item's uncounted status."""
+        from app.services.inventory_ledger import post as ledger_post
+
+        counted_product = make_product()
+        uncounted_product = make_product()
+
+        for p in (counted_product, uncounted_product):
+            ledger_post(
+                db, product_id=p.id, location_id=location.id,
+                transaction_type="receipt", quantity_delta=Decimal("50"),
+            )
+
+        post_reconciliation_baseline(
+            db,
+            product_id=counted_product.id,
+            location_id=location.id,
+            counted_qty=Decimal("50"),
+            user="counter@example.com",
+        )
+
+        report = get_reconciliation_report(db)
+        counted_row = next((r for r in report if r.product_id == counted_product.id), None)
+        uncounted_row = next((r for r in report if r.product_id == uncounted_product.id), None)
+
+        assert counted_row is not None and counted_row.is_counted is True
+        assert uncounted_row is not None and uncounted_row.is_counted is False
+
+
+class TestBaselineToStored:
+    """baseline_to_stored: stamps timestamp, no ledger writes."""
+
+    def test_stamps_baseline_with_zero_delta_no_ledger_row(self, db, make_product, location):
+        """baseline_to_stored stamps baseline_timestamp; no InventoryTransaction written."""
+        from app.services.inventory_ledger import post as ledger_post
+
+        product = make_product()
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("30"),
+        )
+        before_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+
+        baseline_to_stored(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            user="admin@example.com",
+            confirm=BASELINE_TO_STORED_CONFIRM_TOKEN,
+        )
+
+        after_count = (
+            db.query(InventoryTransaction)
+            .filter(InventoryTransaction.product_id == product.id)
+            .count()
+        )
+        inv = (
+            db.query(Inventory)
+            .filter(
+                Inventory.product_id == product.id,
+                Inventory.location_id == location.id,
+            )
+            .first()
+        )
+
+        assert after_count == before_count, "no ledger row written by fallback"
+        assert inv.baseline_timestamp is not None, "baseline_timestamp stamped"
+
+    def test_wrong_confirm_token_raises(self, db, make_product, location):
+        """Wrong confirm token raises ValueError."""
+        product = make_product()
+        with pytest.raises(ValueError, match="BASELINE_TO_STORED"):
+            baseline_to_stored(
+                db,
+                product_id=product.id,
+                location_id=location.id,
+                user="admin@example.com",
+                confirm="wrong-token",
+            )

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -4,7 +4,236 @@ import { useApi } from "../../hooks/useApi";
 import { useFormatCurrency } from "../../hooks/useFormatCurrency";
 
 // ---------------------------------------------------------------------------
-// Reconciliation report — counting work queue (HARD-4b)
+// CountModal — inline count-entry form for a single reconciliation row
+// ---------------------------------------------------------------------------
+
+function CountModal({ item, onClose, onSuccess }) {
+  const api = useApi();
+  const [countedQty, setCountedQty] = useState(
+    item.stored_on_hand != null ? String(item.stored_on_hand) : ""
+  );
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const qty = parseFloat(countedQty);
+    if (isNaN(qty) || qty < 0) {
+      setError("Counted quantity must be a number >= 0");
+      return;
+    }
+    try {
+      setSubmitting(true);
+      setError(null);
+      await api.post("/api/v1/admin/inventory/reconciliation/count", {
+        product_id: item.product_id,
+        location_id: item.location_id,
+        counted_qty: qty,
+        notes: notes || null,
+      });
+      onSuccess();
+    } catch (err) {
+      setError(err.message || "Failed to post count");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-md mx-4">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-800">
+          <div>
+            <h3 className="text-white font-semibold">Record physical count</h3>
+            <p className="text-gray-400 text-xs mt-0.5">
+              {item.sku} — {item.name}
+              {item.location_name ? ` @ ${item.location_name}` : ""}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 text-xl leading-none"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-4">
+          <div className="flex gap-4 text-sm bg-gray-800/60 rounded-lg px-3 py-2">
+            <span className="text-gray-400">Stored:</span>
+            <span className="text-white tabular-nums">
+              {item.stored_on_hand != null
+                ? Number(item.stored_on_hand).toLocaleString(undefined, { maximumFractionDigits: 4 })
+                : "—"}
+            </span>
+            <span className="text-gray-500 ml-auto text-xs">
+              (delta = counted − stored)
+            </span>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Counted quantity <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="number"
+              step="0.0001"
+              min="0"
+              required
+              value={countedQty}
+              onChange={(e) => setCountedQty(e.target.value)}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              Notes (optional)
+            </label>
+            <input
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="e.g. shelf count, bin A3"
+              maxLength={500}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 font-medium"
+            >
+              {submitting ? "Posting…" : "Post count"}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 bg-gray-700 text-gray-200 rounded-lg hover:bg-gray-600 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FallbackModal — "Baseline to stored" confirm dialog
+// ---------------------------------------------------------------------------
+
+function FallbackModal({ onClose, onSuccess }) {
+  const api = useApi();
+  const [confirmText, setConfirmText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const REQUIRED_CONFIRM = "BASELINE_TO_STORED";
+  const isReady = confirmText === REQUIRED_CONFIRM;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!isReady) return;
+    try {
+      setSubmitting(true);
+      setError(null);
+      const result = await api.post(
+        "/api/v1/admin/inventory/reconciliation/count/all-to-stored",
+        { confirm: REQUIRED_CONFIRM }
+      );
+      onSuccess(result);
+    } catch (err) {
+      setError(err.message || "Failed to run fallback");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="bg-gray-900 border border-orange-500/40 rounded-xl shadow-2xl w-full max-w-lg mx-4">
+        <div className="px-5 py-4 border-b border-gray-800 flex items-start gap-3">
+          <div className="mt-0.5 text-orange-400">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+          <div>
+            <h3 className="text-white font-semibold">Baseline to stored — dev/test only</h3>
+            <p className="text-gray-400 text-sm mt-1">
+              Stamps <code className="text-orange-300 text-xs">baseline_timestamp = NOW</code> for
+              ALL inventory rows using the current stored on-hand as the physical baseline.
+              No ledger rows are written.
+            </p>
+            <p className="text-orange-400 text-sm mt-2 font-medium">
+              Do NOT run this on a production database without explicit owner approval.
+              This permanently discards pre-existing transaction history from future
+              drift calculations.
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-4">
+          <div>
+            <label className="block text-sm text-gray-300 mb-1.5">
+              Type <span className="font-mono text-orange-300 select-all">{REQUIRED_CONFIRM}</span> to confirm:
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={REQUIRED_CONFIRM}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white font-mono focus:outline-none focus:border-orange-500"
+              autoFocus
+              autoComplete="off"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={!isReady || submitting}
+              className="flex-1 px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 disabled:opacity-40 font-medium"
+            >
+              {submitting ? "Running…" : "Run fallback"}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 bg-gray-700 text-gray-200 rounded-lg hover:bg-gray-600 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation report — counting work queue (HARD-4b + HARD-4c)
 // ---------------------------------------------------------------------------
 
 function ReconciliationReport() {
@@ -14,6 +243,12 @@ function ReconciliationReport() {
   const [error, setError] = useState(null);
   const [driftedOnly, setDriftedOnly] = useState(false);
   const [expanded, setExpanded] = useState(false);
+
+  // Count modal state
+  const [countingItem, setCountingItem] = useState(null);
+  // Fallback modal state
+  const [showFallback, setShowFallback] = useState(false);
+  const [fallbackResult, setFallbackResult] = useState(null);
 
   const fetchReport = async () => {
     try {
@@ -45,156 +280,220 @@ function ReconciliationReport() {
     return drift > 0 ? "text-yellow-400" : "text-red-400";
   };
 
+  const handleCountSuccess = () => {
+    setCountingItem(null);
+    fetchReport();
+  };
+
+  const handleFallbackSuccess = (result) => {
+    setShowFallback(false);
+    setFallbackResult(result);
+    fetchReport();
+  };
+
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-      {/* Collapsible header */}
-      <button
-        className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-gray-800/40 transition-colors"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <div>
-          <h2 className="text-lg font-semibold text-white">
-            Reconciliation — items needing a count
-          </h2>
-          <p className="text-gray-400 text-sm mt-0.5">
-            Compares stored on-hand against the transaction ledger to identify
-            drift. Items without a baseline have never been physically counted.
-          </p>
-        </div>
-        <svg
-          className={`w-5 h-5 text-gray-400 flex-shrink-0 ml-4 transition-transform ${expanded ? "rotate-180" : ""}`}
-          fill="none" viewBox="0 0 24 24" stroke="currentColor"
+    <>
+      {/* Count entry modal */}
+      {countingItem && (
+        <CountModal
+          item={countingItem}
+          onClose={() => setCountingItem(null)}
+          onSuccess={handleCountSuccess}
+        />
+      )}
+
+      {/* Fallback modal */}
+      {showFallback && (
+        <FallbackModal
+          onClose={() => setShowFallback(false)}
+          onSuccess={handleFallbackSuccess}
+        />
+      )}
+
+      <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+        {/* Collapsible header */}
+        <button
+          className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-gray-800/40 transition-colors"
+          onClick={() => setExpanded((v) => !v)}
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-gray-800">
-          {/* Controls */}
-          <div className="flex items-center gap-4 px-6 py-3 bg-gray-900/60">
-            <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={driftedOnly}
-                onChange={(e) => setDriftedOnly(e.target.checked)}
-                className="rounded border-gray-600 bg-gray-800 text-blue-500"
-              />
-              Show drifted items only
-            </label>
-            <button
-              onClick={fetchReport}
-              disabled={loading}
-              className="ml-auto px-3 py-1.5 text-xs bg-gray-700 text-gray-200 rounded hover:bg-gray-600 disabled:opacity-50"
-            >
-              {loading ? "Loading…" : "Refresh"}
-            </button>
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              Reconciliation — items needing a count
+            </h2>
+            <p className="text-gray-400 text-sm mt-0.5">
+              Compares stored on-hand against the transaction ledger to identify
+              drift. Items without a baseline have never been physically counted.
+            </p>
           </div>
+          <svg
+            className={`w-5 h-5 text-gray-400 flex-shrink-0 ml-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
 
-          {/* Summary badges */}
-          {report && !loading && (
-            <div className="flex gap-4 px-6 py-3 border-b border-gray-800">
-              <div className="text-sm text-gray-400">
-                <span className="font-medium text-white">{report.total_items}</span> total items
-              </div>
-              <div className="text-sm text-gray-400">
-                <span className={`font-medium ${report.drifted_items > 0 ? "text-yellow-400" : "text-green-400"}`}>
-                  {report.drifted_items}
-                </span> drifted
-              </div>
-              <div className="text-sm text-gray-400">
-                <span className={`font-medium ${report.uncounted_items > 0 ? "text-orange-400" : "text-gray-300"}`}>
-                  {report.uncounted_items}
-                </span> uncounted
-              </div>
+        {expanded && (
+          <div className="border-t border-gray-800">
+            {/* Controls */}
+            <div className="flex items-center gap-4 px-6 py-3 bg-gray-900/60">
+              <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={driftedOnly}
+                  onChange={(e) => setDriftedOnly(e.target.checked)}
+                  className="rounded border-gray-600 bg-gray-800 text-blue-500"
+                />
+                Show drifted items only
+              </label>
+              <button
+                onClick={fetchReport}
+                disabled={loading}
+                className="ml-auto px-3 py-1.5 text-xs bg-gray-700 text-gray-200 rounded hover:bg-gray-600 disabled:opacity-50"
+              >
+                {loading ? "Loading…" : "Refresh"}
+              </button>
+              {/* Fallback button — clearly labeled as dev/test only */}
+              <button
+                onClick={() => { setFallbackResult(null); setShowFallback(true); }}
+                className="px-3 py-1.5 text-xs bg-orange-900/60 border border-orange-700/50 text-orange-300 rounded hover:bg-orange-900/80"
+                title="Stamp baseline_timestamp = NOW for all rows using current stored on-hand. Dev/test/first-install only."
+              >
+                Baseline to stored — dev/test only
+              </button>
             </div>
-          )}
 
-          {/* Error */}
-          {error && (
-            <div className="mx-6 my-3 bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
-              {error}
-            </div>
-          )}
+            {/* Fallback success banner */}
+            {fallbackResult && (
+              <div className="mx-6 mt-3 bg-orange-500/10 border border-orange-500/30 rounded-lg px-4 py-2 text-orange-300 text-sm flex items-center justify-between">
+                <span>{fallbackResult.message}</span>
+                <button
+                  onClick={() => setFallbackResult(null)}
+                  className="text-orange-400 hover:text-orange-200 ml-4 text-lg leading-none"
+                >
+                  &times;
+                </button>
+              </div>
+            )}
 
-          {/* Loading spinner */}
-          {loading && (
-            <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
-            </div>
-          )}
+            {/* Summary badges */}
+            {report && !loading && (
+              <div className="flex gap-4 px-6 py-3 border-b border-gray-800">
+                <div className="text-sm text-gray-400">
+                  <span className="font-medium text-white">{report.total_items}</span> total items
+                </div>
+                <div className="text-sm text-gray-400">
+                  <span className={`font-medium ${report.drifted_items > 0 ? "text-yellow-400" : "text-green-400"}`}>
+                    {report.drifted_items}
+                  </span> drifted
+                </div>
+                <div className="text-sm text-gray-400">
+                  <span className={`font-medium ${report.uncounted_items > 0 ? "text-orange-400" : "text-gray-300"}`}>
+                    {report.uncounted_items}
+                  </span> uncounted
+                </div>
+              </div>
+            )}
 
-          {/* Table */}
-          {!loading && report && (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="bg-gray-800/50">
-                  <tr>
-                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
-                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Name</th>
-                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Location</th>
-                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Stored</th>
-                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Ledger Sum</th>
-                    <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Drift</th>
-                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Baseline</th>
-                    <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {report.items.length === 0 ? (
+            {/* Error */}
+            {error && (
+              <div className="mx-6 my-3 bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Loading spinner */}
+            {loading && (
+              <div className="flex items-center justify-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+              </div>
+            )}
+
+            {/* Table */}
+            {!loading && report && (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-gray-800/50">
                     <tr>
-                      <td colSpan={8} className="py-8 text-center text-gray-500 text-sm">
-                        {driftedOnly ? "No drifted items — all balanced." : "No inventory rows found."}
-                      </td>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Name</th>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Location</th>
+                      <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Stored</th>
+                      <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Ledger Sum</th>
+                      <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Drift</th>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Baseline</th>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Status</th>
+                      <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Action</th>
                     </tr>
-                  ) : (
-                    report.items.map((item) => (
-                      <tr
-                        key={`${item.product_id}-${item.location_id}`}
-                        className={`border-b border-gray-800 hover:bg-gray-800/30 ${
-                          item.has_drift ? "bg-yellow-500/5" : ""
-                        }`}
-                      >
-                        <td className="py-2.5 px-4 font-mono text-sm text-white">{item.sku}</td>
-                        <td className="py-2.5 px-4 text-gray-300 text-sm max-w-xs truncate">{item.name}</td>
-                        <td className="py-2.5 px-4 text-gray-400 text-sm">{item.location_name || "—"}</td>
-                        <td className="py-2.5 px-4 text-right text-white tabular-nums">{formatQty(item.stored_on_hand)}</td>
-                        <td className="py-2.5 px-4 text-right text-gray-300 tabular-nums">{formatQty(item.ledger_sum)}</td>
-                        <td className={`py-2.5 px-4 text-right font-semibold tabular-nums ${driftColor(item.drift)}`}>
-                          {item.drift > 0 ? "+" : ""}{formatQty(item.drift)}
-                        </td>
-                        <td className="py-2.5 px-4 text-gray-500 text-xs">
-                          {item.baseline_timestamp
-                            ? new Date(item.baseline_timestamp).toLocaleDateString()
-                            : "—"}
-                        </td>
-                        <td className="py-2.5 px-4">
-                          {item.is_counted ? (
-                            item.has_drift ? (
-                              <span className="px-2 py-0.5 rounded-full text-xs bg-yellow-500/20 text-yellow-400">
-                                drifted
-                              </span>
-                            ) : (
-                              <span className="px-2 py-0.5 rounded-full text-xs bg-green-500/20 text-green-400">
-                                clean
-                              </span>
-                            )
-                          ) : (
-                            <span className="px-2 py-0.5 rounded-full text-xs bg-orange-500/20 text-orange-400">
-                              uncounted
-                            </span>
-                          )}
+                  </thead>
+                  <tbody>
+                    {report.items.length === 0 ? (
+                      <tr>
+                        <td colSpan={9} className="py-8 text-center text-gray-500 text-sm">
+                          {driftedOnly ? "No drifted items — all balanced." : "No inventory rows found."}
                         </td>
                       </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+                    ) : (
+                      report.items.map((item) => (
+                        <tr
+                          key={`${item.product_id}-${item.location_id}`}
+                          className={`border-b border-gray-800 hover:bg-gray-800/30 ${
+                            item.has_drift ? "bg-yellow-500/5" : ""
+                          }`}
+                        >
+                          <td className="py-2.5 px-4 font-mono text-sm text-white">{item.sku}</td>
+                          <td className="py-2.5 px-4 text-gray-300 text-sm max-w-xs truncate">{item.name}</td>
+                          <td className="py-2.5 px-4 text-gray-400 text-sm">{item.location_name || "—"}</td>
+                          <td className="py-2.5 px-4 text-right text-white tabular-nums">{formatQty(item.stored_on_hand)}</td>
+                          <td className="py-2.5 px-4 text-right text-gray-300 tabular-nums">{formatQty(item.ledger_sum)}</td>
+                          <td className={`py-2.5 px-4 text-right font-semibold tabular-nums ${driftColor(item.drift)}`}>
+                            {item.drift > 0 ? "+" : ""}{formatQty(item.drift)}
+                          </td>
+                          <td className="py-2.5 px-4 text-gray-500 text-xs">
+                            {item.baseline_timestamp
+                              ? new Date(item.baseline_timestamp).toLocaleDateString()
+                              : "—"}
+                          </td>
+                          <td className="py-2.5 px-4">
+                            {item.is_counted ? (
+                              item.has_drift ? (
+                                <span className="px-2 py-0.5 rounded-full text-xs bg-yellow-500/20 text-yellow-400">
+                                  drifted
+                                </span>
+                              ) : (
+                                <span className="px-2 py-0.5 rounded-full text-xs bg-green-500/20 text-green-400">
+                                  clean
+                                </span>
+                              )
+                            ) : (
+                              <span className="px-2 py-0.5 rounded-full text-xs bg-orange-500/20 text-orange-400">
+                                uncounted
+                              </span>
+                            )}
+                          </td>
+                          <td className="py-2.5 px-4">
+                            {/* Count action — available for drifted or uncounted items */}
+                            {(item.has_drift || !item.is_counted) && (
+                              <button
+                                onClick={() => setCountingItem(item)}
+                                className="px-2.5 py-1 text-xs bg-blue-600/20 border border-blue-600/40 text-blue-400 rounded hover:bg-blue-600/30 hover:text-blue-300 transition-colors"
+                                title="Enter physical count to post a reconciliation_baseline transaction"
+                              >
+                                Count
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 }
 
@@ -762,7 +1061,7 @@ export default function AdminInventoryTransactions() {
                       </span>
                       {txn.to_location_name && (
                         <div className="text-gray-500 text-xs mt-1">
-                          → {txn.to_location_name}
+                          &rarr; {txn.to_location_name}
                         </div>
                       )}
                     </td>


### PR DESCRIPTION
## Summary

- **Service** `post_reconciliation_baseline(db, product_id, location_id, counted_qty, user, notes)` — the physical-count entry point. Acquires a `FOR UPDATE` lock on the `Inventory` row, computes `delta = counted − stored_at_lock_time`, posts through `inventory_ledger.post` with `transaction_type="reconciliation"` and `reason_code="reconciliation_baseline"` (SIGNED_TYPE, valid alias of adjustment per HARD-4c spec), then stamps `Inventory.baseline_timestamp` AND `Inventory.baseline_on_hand` in the same `flush` as the ledger row. GL treatment: cycle-count variance semantics (DR/CR 1200 Inventory vs 5030 Inventory Adjustment, reusing `TransactionService.create_journal_entry`). Zero-delta counts stamp the epoch without writing a ledger row.
- **Service** `baseline_to_stored(db, ..., confirm="BASELINE_TO_STORED")` — explicit fallback. Stamps `baseline_timestamp = NOW` and `baseline_on_hand = stored`. No ledger write. Requires exact confirm token.
- **Model** `Inventory.baseline_on_hand` (NUMERIC(18,4), nullable) — epoch opening-balance snapshot added alongside `baseline_timestamp`. The reconciliation report formula is updated to `drift = stored − (baseline_on_hand + sum(post-baseline transactions))`. Legacy rows with `NULL baseline_on_hand` fall back to the old at-or-after sum.
- **Endpoints** `POST /api/v1/admin/inventory/reconciliation/count` (count entry) and `POST …/count/all-to-stored` (explicit fallback, requires `{"confirm":"BASELINE_TO_STORED"}`). Both are staff-gated via router-level `Depends(get_current_staff_user)`.
- **Frontend** `ReconciliationReport` component gains a "Count" button on each drifted/uncounted row (opens `CountModal` — counted qty field pre-filled to stored value + optional notes) and a clearly-labeled "Baseline to stored — dev/test only" button (opens `FallbackModal` requiring the operator to type `BASELINE_TO_STORED`).

## Atomicity

`baseline_timestamp` and `baseline_on_hand` are stamped in the same `db.flush()` that assigns the ledger row an id. The `FOR UPDATE` lock on the `Inventory` row (acquired via `inventory_ledger.get_or_create_inventory_row`) serialises concurrent counts against the same (product, location) pair. The session is never committed inside the service — transaction boundary belongs to the endpoint, which calls `db.commit()` after the service returns.

## Zero-delta semantics

The poster rejects `quantity_delta == 0`. For zero-delta counts (counted matches stored), no ledger row is written, but `baseline_timestamp` and `baseline_on_hand = counted_qty` are still stamped. The report formula `drift = stored − (baseline_on_hand + 0) = 0` correctly shows the item as clean.

## ZERO automatic baseline creation

No migration data writes, no startup hooks, no silent baseline anywhere. Baselines are written only by explicit counts or the explicitly-invoked fallback.

## Test coverage (21 tests, all green)

- One ledger row per non-zero count
- `baseline_timestamp` atomic with ledger write (same `flush`)
- GL journal entry balanced (DR == CR) for both overage and shortage
- Recount updates `baseline_timestamp`
- Zero-delta: `baseline_timestamp` stamped, no ledger row
- `float` counted_qty raises `TypeError`
- Negative counted_qty raises `ValueError`
- Report shows item as `counted + clean` after an exact count
- Uncounted item unaffected by another item's baseline
- `baseline_to_stored`: stamps with no ledger row
- Wrong confirm token raises `ValueError`

## Files changed

| File | Change |
|---|---|
| `backend/app/services/reconciliation_service.py` | HARD-4c service functions + updated report formula |
| `backend/app/models/inventory.py` | `baseline_on_hand` column |
| `backend/app/api/v1/endpoints/admin/reconciliation.py` | Count + fallback endpoints |
| `backend/tests/conftest.py` | `baseline_on_hand` column patch for test DB |
| `backend/tests/services/test_reconciliation_service.py` | 11 new HARD-4c tests |
| `frontend/src/pages/admin/AdminInventoryTransactions.jsx` | `CountModal`, `FallbackModal`, Action column |

Closes HARD-4c. Depends on HARD-4a (merged) and HARD-4b (merged as PR #694).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added physical count recording functionality to the admin inventory reconciliation workflow.
  * Introduced bulk baseline synchronization operation for dev/test environments with confirmation gating.
  * Enhanced reconciliation reporting to distinguish between counted, uncounted, and drifted inventory items with improved status indicators.
  * Added admin UI with dedicated modals for recording physical counts and managing baseline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->