### PR TITLE
fix: reconcile reservations and release stranded allocations (HARD-5)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from . import (
     bom, dashboard, fulfillment_queue, fulfillment_shipping, audit, accounting, traceability,
     customers, inventory_transactions, analytics, export, data_import, orders,
-    users, uom, locations, system, uploads, pro_install, reconciliation
+    users, uom, locations, system, uploads, pro_install, reconciliation, reservations
 )
 
 router = APIRouter()
@@ -43,6 +43,9 @@ router.include_router(inventory_transactions.router)
 
 # Inventory Reconciliation Report (HARD-4b)
 router.include_router(reconciliation.router)
+
+# Reservation Reconciliation + Stranded Allocation Repair (HARD-5)
+router.include_router(reservations.router)
 
 # Export/Import
 router.include_router(export.router)

--- a/backend/app/api/v1/endpoints/admin/reservations.py
+++ b/backend/app/api/v1/endpoints/admin/reservations.py
@@ -1,0 +1,264 @@
+"""
+Admin: Reservation Reconciliation endpoint (HARD-5).
+
+GET  /api/v1/admin/inventory/reservations/reconciliation
+     Returns the allocation drift report (stored vs ledger-derived allocated_quantity)
+     and the stranded-allocation list for every inventory row.
+
+POST /api/v1/admin/inventory/reservations/repair/{production_order_id}
+     Release stranded allocations for a specific terminal/deleted production order.
+     Staff-gated, requires explicit confirmation via request body.
+
+Both endpoints are staff-gated via the router-level dependency.
+"""
+from typing import List, Optional
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Path, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.api.v1.deps import get_current_staff_user
+from app.services.reservation_reconciliation_service import (
+    get_allocation_reconciliation_report,
+    release_stranded_allocations,
+)
+
+router = APIRouter(
+    prefix="/inventory/reservations",
+    tags=["Admin - Reservation Reconciliation"],
+    dependencies=[Depends(get_current_staff_user)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+class AllocationDriftItemSchema(BaseModel):
+    inventory_id: int
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    location_name: Optional[str]
+
+    on_hand: float
+    stored_allocated: float
+    ledger_allocated: float
+    drift: float
+
+    has_drift: bool
+    stored_available: float
+    ledger_available: float
+
+    model_config = {"from_attributes": True}
+
+
+class StrandedAllocationItemSchema(BaseModel):
+    production_order_id: int
+    production_order_code: str
+    status: str
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    net_reserved: float
+    stranded_reason: str
+    completed_at: Optional[datetime]
+    cancelled_at: Optional[datetime]
+
+    model_config = {"from_attributes": True}
+
+
+class AllocationReconciliationReportSchema(BaseModel):
+    drift_items: List[AllocationDriftItemSchema]
+    stranded_items: List[StrandedAllocationItemSchema]
+
+    total_inventory_rows: int
+    drifted_rows: int
+    stranded_po_count: int
+    total_stranded_quantity: float
+    generated_at: datetime
+
+
+class RepairRequestSchema(BaseModel):
+    confirm: bool = Field(
+        ...,
+        description="Must be true to confirm the repair action.",
+    )
+    reason: str = Field(
+        default="Staff-initiated stranded allocation release",
+        description="Human-readable reason recorded in the audit transaction.",
+        max_length=500,
+    )
+
+
+class ReleaseResultItemSchema(BaseModel):
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    quantity_released: float
+    old_allocated: float
+    new_allocated: float
+
+
+class RepairResultSchema(BaseModel):
+    production_order_id: int
+    production_order_code: Optional[str]
+    releases: List[ReleaseResultItemSchema]
+    total_released_items: int
+    errors: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/reconciliation", response_model=AllocationReconciliationReportSchema)
+def get_reservation_reconciliation(
+    drifted_only: bool = Query(
+        False,
+        description=(
+            "Return only inventory rows where stored allocated_quantity diverges "
+            "from the ledger-derived sum."
+        ),
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    Reservation / allocation reconciliation report.
+
+    Returns two sections:
+
+    **drift_items** — per-inventory-row comparison of stored ``allocated_quantity``
+    vs the sum derived from reservation/reservation_release ledger rows.
+    A non-zero drift means the lump-sum column diverged from the audit trail.
+
+    **stranded_items** — production orders in a terminal state (complete, cancelled,
+    closed) or deleted, that still have a positive net reservation in the ledger.
+    These permanently reduce available quantity and poison MRP until repaired.
+
+    Use the ``POST /repair/{production_order_id}`` endpoint to release a specific
+    stranded allocation after explicit staff confirmation.
+    """
+    report = get_allocation_reconciliation_report(db, drifted_only=drifted_only)
+
+    all_report = (
+        get_allocation_reconciliation_report(db)
+        if drifted_only
+        else report
+    )
+
+    drift_schemas = [
+        AllocationDriftItemSchema(
+            inventory_id=d.inventory_id,
+            product_id=d.product_id,
+            sku=d.sku,
+            name=d.name,
+            location_id=d.location_id,
+            location_name=d.location_name,
+            on_hand=float(d.on_hand),
+            stored_allocated=float(d.stored_allocated),
+            ledger_allocated=float(d.ledger_allocated),
+            drift=float(d.drift),
+            has_drift=d.has_drift,
+            stored_available=float(d.stored_available),
+            ledger_available=float(d.ledger_available),
+        )
+        for d in report.drift_items
+    ]
+
+    stranded_schemas = [
+        StrandedAllocationItemSchema(
+            production_order_id=s.production_order_id,
+            production_order_code=s.production_order_code,
+            status=s.status,
+            product_id=s.product_id,
+            sku=s.sku,
+            name=s.name,
+            location_id=s.location_id,
+            net_reserved=float(s.net_reserved),
+            stranded_reason=s.stranded_reason,
+            completed_at=s.completed_at,
+            cancelled_at=s.cancelled_at,
+        )
+        for s in report.stranded_items
+    ]
+
+    return AllocationReconciliationReportSchema(
+        drift_items=drift_schemas,
+        stranded_items=stranded_schemas,
+        total_inventory_rows=all_report.total_inventory_rows,
+        drifted_rows=all_report.drifted_rows,
+        stranded_po_count=all_report.stranded_po_count,
+        total_stranded_quantity=float(all_report.total_stranded_quantity),
+        generated_at=report.generated_at,
+    )
+
+
+@router.post(
+    "/repair/{production_order_id}",
+    response_model=RepairResultSchema,
+)
+def repair_stranded_allocations(
+    production_order_id: int = Path(
+        ...,
+        description="Production order ID whose stranded allocations to release.",
+    ),
+    body: RepairRequestSchema = ...,
+    current_user=Depends(get_current_staff_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Release stranded allocations for a specific production order.
+
+    **This is a destructive, irreversible action.**  Calling this endpoint
+    decreases ``Inventory.allocated_quantity`` by the net reservation quantity
+    for the specified production order and writes a ``reservation_release``
+    audit transaction.
+
+    Guards:
+    - ``confirm`` must be ``true`` in the request body.
+    - The production order must be in a terminal state
+      (``complete``, ``completed``, ``cancelled``, ``closed``) or deleted.
+    - Live (non-terminal) orders are rejected — cancel or complete the order
+      first.
+
+    Idempotent: if the PO already has no net reservation, returns an empty
+    releases list (no error).
+    """
+    if not body.confirm:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "You must set confirm=true to release stranded allocations. "
+                "This action is irreversible."
+            ),
+        )
+
+    released_by = getattr(current_user, "email", str(current_user))
+
+    result = release_stranded_allocations(
+        db=db,
+        production_order_id=production_order_id,
+        released_by=released_by,
+        reason=body.reason,
+    )
+
+    # Commit only if no errors (partial-failure stays rolled back)
+    if not result["errors"]:
+        db.commit()
+    else:
+        db.rollback()
+
+    return RepairResultSchema(
+        production_order_id=result["production_order_id"],
+        production_order_code=result.get("production_order_code"),
+        releases=[ReleaseResultItemSchema(**r) for r in result["releases"]],
+        total_released_items=result["total_released_items"],
+        errors=result["errors"],
+    )

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -24,6 +24,7 @@ from app.services.uom_service import (
     UOMConversionError,
     convert_cost_for_unit,
 )
+from app.services.reservation_reconciliation_service import check_allocation_guard
 
 logger = get_logger(__name__)
 
@@ -577,16 +578,37 @@ def reserve_production_materials(
         
         # Get or create inventory record
         inventory = get_or_create_inventory(db, line.component_id, location.id)
-        
+
         # Increase allocated quantity
         current_allocated = Decimal(str(inventory.allocated_quantity))
         current_on_hand = Decimal(str(inventory.on_hand_quantity))
         new_allocated = current_allocated + total_qty
-        available_after = current_on_hand - new_allocated
-        
+
+        # HARD-5 write-time guard: flag (not block) when reservation would
+        # exceed on_hand.  Production is allowed to reserve ahead of receipt,
+        # so we log + flag but proceed.  The shortage is visible in the
+        # reservation return value so callers/UIs can surface it.
+        would_exceed, available_after = check_allocation_guard(
+            current_on_hand, current_allocated, total_qty
+        )
+        if would_exceed:
+            logger.warning(
+                "HARD-5 allocation guard: reserving %s %s of %s for PO#%s "
+                "would exceed on_hand (%s). allocated %s → %s, available_after=%s. "
+                "Proceeding (legitimate ahead-of-receipt reservation).",
+                total_qty,
+                component_unit,
+                component.sku,
+                production_order.code,
+                current_on_hand,
+                current_allocated,
+                new_allocated,
+                available_after,
+            )
+
         inventory.allocated_quantity = new_allocated
         inventory.updated_at = datetime.now(timezone.utc)
-        
+
         # Create reservation transaction for audit trail
         unit_cost = get_effective_cost_per_inventory_unit(component)
         total_cost = abs(total_qty) * unit_cost if unit_cost else None
@@ -605,7 +627,7 @@ def reserve_production_materials(
             created_at=datetime.now(timezone.utc),
         )
         db.add(txn)
-        
+
         reservation_info = {
             "product_id": line.component_id,
             "product_sku": component.sku,
@@ -615,16 +637,11 @@ def reserve_production_materials(
             "on_hand": float(current_on_hand),
             "allocated_after": float(new_allocated),
             "available_after": float(available_after),
-            "is_shortage": available_after < 0,
+            "is_shortage": would_exceed,
         }
         reservations.append(reservation_info)
-        
-        if available_after < 0:
-            logger.warning(
-                f"Material shortage after reservation: {component.sku} - "
-                f"Available: {available_after} {component_unit} (shortage of {-available_after})"
-            )
-        else:
+
+        if not would_exceed:
             logger.info(
                 f"Reserved {total_qty} {component_unit} of {component.sku} "
                 f"for PO#{production_order.code}"

--- a/backend/app/services/reservation_reconciliation_service.py
+++ b/backend/app/services/reservation_reconciliation_service.py
@@ -1,0 +1,555 @@
+"""
+Reservation reconciliation service (HARD-5).
+
+Responsibilities:
+1. Derive allocation truth — compute per-item allocated_quantity from the
+   reservation / reservation_release ledger and compare against the stored
+   ``Inventory.allocated_quantity`` lump-sum column.
+
+2. Identify stranded allocations — ledger rows whose production_order is in a
+   terminal state (complete, cancelled, closed) or no longer exists, but whose
+   net reservation quantity is still > 0.
+
+3. Repair path — release stranded allocations for a specific production order
+   (staff-gated, explicit confirm required, no silent auto-repair).
+
+4. Write-time guard hint — utility to check whether a proposed allocated_quantity
+   increase would exceed on_hand, for use by reserve_production_materials.
+
+DESIGN DECISIONS (document for PR body):
+- Allocation ahead of receipt is legitimate (production reserves before PO
+  arrives), so the write-time guard is a LOG + FLAG, not a hard block.
+  ``reserve_production_materials`` already logs a shortage warning; this module
+  adds an explicit flag to the reservation return dict so callers/UIs can surface
+  it without coupling to the log.
+- The "derive truth" function re-uses the logic from
+  ``get_allocations_by_production_order`` but aggregates across all products
+  to produce a per-inventory-row comparison (one round-trip vs N).
+- Stranded = net reservation > 0 AND production order is terminal or missing.
+  Terminal statuses: complete, completed, cancelled, closed.  "Short" is NOT
+  terminal — the production order may still have reservations legitimately
+  while the operator is deciding how to proceed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.inventory import Inventory, InventoryTransaction, InventoryLocation
+from app.models.production_order import ProductionOrder
+from app.models.product import Product
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Terminal production-order statuses: reservations held by these orders are
+# candidates for stranded-allocation repair.
+TERMINAL_PO_STATUSES = frozenset({"complete", "completed", "cancelled", "closed"})
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AllocationDriftItem:
+    """Per-inventory-row comparison between stored and ledger-derived allocation."""
+
+    # Identity
+    inventory_id: int
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    location_name: Optional[str]
+
+    # Quantities (Decimal)
+    on_hand: Decimal
+    stored_allocated: Decimal      # Inventory.allocated_quantity
+    ledger_allocated: Decimal      # Σ(reservation) - Σ(reservation_release)
+    drift: Decimal                 # stored_allocated - ledger_allocated
+
+    @property
+    def has_drift(self) -> bool:
+        return self.drift != Decimal("0")
+
+    @property
+    def stored_available(self) -> Decimal:
+        return self.on_hand - self.stored_allocated
+
+    @property
+    def ledger_available(self) -> Decimal:
+        return self.on_hand - self.ledger_allocated
+
+
+@dataclass
+class StrandedAllocationItem:
+    """A production order whose net reservation is still positive but the order is terminal."""
+
+    production_order_id: int
+    production_order_code: str
+    status: str                        # terminal status that triggered flag
+    product_id: int
+    sku: str
+    name: str
+    location_id: int
+    net_reserved: Decimal              # Σ(reservation) - Σ(reservation_release) for this PO
+    stranded_reason: str               # "terminal_status" | "order_missing"
+
+    # Populated only for terminal_status items
+    completed_at: Optional[datetime] = None
+    cancelled_at: Optional[datetime] = None
+
+
+@dataclass
+class AllocationReconciliationReport:
+    """Full reservation reconciliation report returned to the endpoint."""
+
+    drift_items: List[AllocationDriftItem]
+    stranded_items: List[StrandedAllocationItem]
+
+    # Aggregate counts
+    total_inventory_rows: int
+    drifted_rows: int
+    stranded_po_count: int
+    total_stranded_quantity: Decimal
+
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# 1. Derive allocation truth — per-inventory-row comparison
+# ---------------------------------------------------------------------------
+
+def get_allocation_reconciliation_report(
+    db: Session,
+    *,
+    drifted_only: bool = False,
+) -> AllocationReconciliationReport:
+    """
+    Compare stored Inventory.allocated_quantity with the ledger-derived sum
+    for every inventory row, and identify stranded allocations.
+
+    Returns:
+        AllocationReconciliationReport with drift_items and stranded_items.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: all inventory rows with product/location info
+    # ------------------------------------------------------------------
+    inv_rows = (
+        db.query(
+            Inventory,
+            Product,
+            InventoryLocation.name.label("location_name"),
+        )
+        .join(Product, Inventory.product_id == Product.id)
+        .outerjoin(InventoryLocation, Inventory.location_id == InventoryLocation.id)
+        .all()
+    )
+
+    if not inv_rows:
+        return AllocationReconciliationReport(
+            drift_items=[],
+            stranded_items=[],
+            total_inventory_rows=0,
+            drifted_rows=0,
+            stranded_po_count=0,
+            total_stranded_quantity=Decimal("0"),
+        )
+
+    product_ids = [r.Inventory.product_id for r in inv_rows]
+
+    # ------------------------------------------------------------------
+    # Step 2: aggregate reservation / reservation_release per
+    # (product_id, location_id, reference_id) in one query
+    # ------------------------------------------------------------------
+    from sqlalchemy import case as sa_case
+
+    agg_rows = (
+        db.query(
+            InventoryTransaction.product_id,
+            InventoryTransaction.location_id,
+            InventoryTransaction.reference_id.label("production_order_id"),
+            func.sum(
+                sa_case(
+                    (
+                        InventoryTransaction.transaction_type == "reservation",
+                        InventoryTransaction.quantity,
+                    ),
+                    (
+                        InventoryTransaction.transaction_type == "reservation_release",
+                        -InventoryTransaction.quantity,
+                    ),
+                    else_=Decimal("0"),
+                )
+            ).label("net_qty"),
+        )
+        .filter(
+            InventoryTransaction.product_id.in_(product_ids),
+            InventoryTransaction.transaction_type.in_(
+                ["reservation", "reservation_release"]
+            ),
+        )
+        .group_by(
+            InventoryTransaction.product_id,
+            InventoryTransaction.location_id,
+            InventoryTransaction.reference_id,
+        )
+        .all()
+    )
+
+    # Index: (product_id, location_id) -> total net reserved (across all POs)
+    # Also: (product_id, location_id, po_id) -> net reserved per PO
+    ledger_by_inv: Dict[Tuple[int, int], Decimal] = {}
+    per_po: Dict[Tuple[int, int, Optional[int]], Decimal] = {}
+
+    for row in agg_rows:
+        net = Decimal(str(row.net_qty)) if row.net_qty is not None else Decimal("0")
+        loc = row.location_id
+        pid = row.product_id
+        po_id = row.production_order_id
+
+        key = (pid, loc)
+        ledger_by_inv[key] = ledger_by_inv.get(key, Decimal("0")) + net
+
+        po_key = (pid, loc, po_id)
+        per_po[po_key] = per_po.get(po_key, Decimal("0")) + net
+
+    # ------------------------------------------------------------------
+    # Step 3: build drift items
+    # ------------------------------------------------------------------
+    drift_items: List[AllocationDriftItem] = []
+
+    for r in inv_rows:
+        inv = r.Inventory
+        prod = r.Product
+        stored = Decimal(str(inv.allocated_quantity or 0))
+        on_hand = Decimal(str(inv.on_hand_quantity or 0))
+        key = (inv.product_id, inv.location_id)
+        ledger_alloc = ledger_by_inv.get(key, Decimal("0"))
+        drift = stored - ledger_alloc
+
+        item = AllocationDriftItem(
+            inventory_id=inv.id,
+            product_id=prod.id,
+            sku=prod.sku,
+            name=prod.name,
+            location_id=inv.location_id,
+            location_name=r.location_name,
+            on_hand=on_hand,
+            stored_allocated=stored,
+            ledger_allocated=ledger_alloc,
+            drift=drift,
+        )
+        drift_items.append(item)
+
+    if drifted_only:
+        drift_items = [d for d in drift_items if d.has_drift]
+
+    drift_items.sort(key=lambda d: (-abs(d.drift), d.sku))
+
+    # ------------------------------------------------------------------
+    # Step 4: identify stranded allocations
+    # Only positive net reservations are actionable (negatives mean over-release,
+    # which is a separate kind of drift already captured in drift_items).
+    # ------------------------------------------------------------------
+    stranded_items: List[StrandedAllocationItem] = []
+
+    # Collect all unique PO IDs with positive net reservations
+    positive_po_keys = [
+        (pid, loc, po_id)
+        for (pid, loc, po_id), net in per_po.items()
+        if net > Decimal("0") and po_id is not None
+    ]
+
+    if positive_po_keys:
+        po_ids = list({pk[2] for pk in positive_po_keys})
+
+        # Fetch PO records in bulk
+        po_records = (
+            db.query(ProductionOrder)
+            .filter(ProductionOrder.id.in_(po_ids))
+            .all()
+        )
+        po_by_id: Dict[int, ProductionOrder] = {po.id: po for po in po_records}
+
+        # Build product lookup for display names
+        prod_ids_needed = {pk[0] for pk in positive_po_keys}
+        prod_records = (
+            db.query(Product).filter(Product.id.in_(prod_ids_needed)).all()
+        )
+        prod_by_id: Dict[int, Product] = {p.id: p for p in prod_records}
+
+        for pid, loc, po_id in positive_po_keys:
+            net = per_po[(pid, loc, po_id)]
+            po = po_by_id.get(po_id)
+            prod = prod_by_id.get(pid)
+
+            if po is None:
+                # Production order no longer exists — definitely stranded
+                stranded_items.append(
+                    StrandedAllocationItem(
+                        production_order_id=po_id,
+                        production_order_code=f"(deleted PO #{po_id})",
+                        status="deleted",
+                        product_id=pid,
+                        sku=prod.sku if prod else f"(product #{pid})",
+                        name=prod.name if prod else f"(product #{pid})",
+                        location_id=loc or 0,
+                        net_reserved=net,
+                        stranded_reason="order_missing",
+                    )
+                )
+            elif po.status in TERMINAL_PO_STATUSES:
+                stranded_items.append(
+                    StrandedAllocationItem(
+                        production_order_id=po.id,
+                        production_order_code=po.code,
+                        status=po.status,
+                        product_id=pid,
+                        sku=prod.sku if prod else f"(product #{pid})",
+                        name=prod.name if prod else f"(product #{pid})",
+                        location_id=loc or 0,
+                        net_reserved=net,
+                        stranded_reason="terminal_status",
+                        completed_at=getattr(po, "completed_at", None),
+                        cancelled_at=None,
+                    )
+                )
+
+    stranded_items.sort(key=lambda s: (-s.net_reserved, s.production_order_code))
+
+    total_stranded_qty = sum(
+        (s.net_reserved for s in stranded_items), Decimal("0")
+    )
+
+    logger.debug(
+        "Allocation reconciliation: %d rows, %d drifted, %d stranded POs, "
+        "total stranded qty=%s",
+        len(inv_rows),
+        sum(1 for d in drift_items if d.has_drift),
+        len(stranded_items),
+        total_stranded_qty,
+    )
+
+    return AllocationReconciliationReport(
+        drift_items=drift_items,
+        stranded_items=stranded_items,
+        total_inventory_rows=len(inv_rows),
+        drifted_rows=sum(1 for d in drift_items if d.has_drift),
+        stranded_po_count=len(stranded_items),
+        total_stranded_quantity=total_stranded_qty,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Repair path — release stranded allocations for a specific PO
+# ---------------------------------------------------------------------------
+
+def release_stranded_allocations(
+    db: Session,
+    production_order_id: int,
+    released_by: str,
+    reason: str = "Staff-initiated stranded allocation release (HARD-5)",
+) -> Dict:
+    """
+    Release all remaining reservations for a specific production order that
+    is in a terminal state or no longer exists.
+
+    This is the repair action for stranded allocations.  It must be called
+    explicitly (staff-gated endpoint with confirmation); it does NOT run
+    automatically.
+
+    The function:
+    1. Verifies the PO is terminal or missing (guards against releasing live orders).
+    2. Computes the net reservation from the ledger for each (product, location).
+    3. For each net-positive pair, decreases Inventory.allocated_quantity by the
+       net amount (floored at 0) and writes a reservation_release transaction.
+
+    Returns:
+        Dict with keys: production_order_id, production_order_code, releases (list),
+        total_released_items, errors (list).
+    """
+    result = {
+        "production_order_id": production_order_id,
+        "production_order_code": None,
+        "releases": [],
+        "total_released_items": 0,
+        "errors": [],
+    }
+
+    # -- Guard: PO must be terminal or absent --
+    po = db.query(ProductionOrder).filter(
+        ProductionOrder.id == production_order_id
+    ).first()
+
+    if po is not None:
+        result["production_order_code"] = po.code
+        if po.status not in TERMINAL_PO_STATUSES:
+            result["errors"].append(
+                f"Production order {po.code} is in status '{po.status}', "
+                f"which is not a terminal status. Only orders in "
+                f"{sorted(TERMINAL_PO_STATUSES)} can have stranded allocations "
+                f"force-released. Cancel or complete the order first."
+            )
+            return result
+    else:
+        result["production_order_code"] = f"(deleted PO #{production_order_id})"
+        logger.warning(
+            "Releasing stranded allocations for deleted PO #%d by %s",
+            production_order_id,
+            released_by,
+        )
+
+    # -- Find all reservation transactions for this PO --
+    reservation_txns = (
+        db.query(InventoryTransaction)
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order_id,
+            InventoryTransaction.transaction_type == "reservation",
+        )
+        .all()
+    )
+
+    if not reservation_txns:
+        logger.info(
+            "No reservation transactions found for PO #%d — nothing to release.",
+            production_order_id,
+        )
+        return result
+
+    # Compute net per (product_id, location_id) — subtract existing releases
+    release_txns = (
+        db.query(InventoryTransaction)
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order_id,
+            InventoryTransaction.transaction_type == "reservation_release",
+        )
+        .all()
+    )
+
+    # Build net-reservation map
+    net_map: Dict[Tuple[int, int], Decimal] = {}
+    for txn in reservation_txns:
+        k = (txn.product_id, txn.location_id)
+        net_map[k] = net_map.get(k, Decimal("0")) + Decimal(str(txn.quantity))
+    for txn in release_txns:
+        k = (txn.product_id, txn.location_id)
+        net_map[k] = net_map.get(k, Decimal("0")) - Decimal(str(txn.quantity))
+
+    now = datetime.now(timezone.utc)
+
+    for (product_id, location_id), net_qty in net_map.items():
+        if net_qty <= Decimal("0"):
+            # Already fully released — skip
+            continue
+
+        # Fetch inventory row
+        inventory = (
+            db.query(Inventory)
+            .filter(
+                Inventory.product_id == product_id,
+                Inventory.location_id == location_id,
+            )
+            .first()
+        )
+
+        if not inventory:
+            result["errors"].append(
+                f"No inventory row for product_id={product_id}, "
+                f"location_id={location_id}. Reservation transaction exists "
+                f"but inventory row is missing — skipping."
+            )
+            continue
+
+        current_allocated = Decimal(str(inventory.allocated_quantity or 0))
+        new_allocated = max(Decimal("0"), current_allocated - net_qty)
+
+        inventory.allocated_quantity = new_allocated
+        inventory.updated_at = now
+
+        # Write audit transaction
+        release_txn = InventoryTransaction(
+            product_id=product_id,
+            location_id=location_id,
+            transaction_type="reservation_release",
+            quantity=net_qty,
+            reference_type="production_order",
+            reference_id=production_order_id,
+            notes=(
+                f"Stranded-allocation repair by {released_by}: {reason}. "
+                f"PO code: {result['production_order_code']}"
+            ),
+            created_by=released_by,
+            created_at=now,
+        )
+        db.add(release_txn)
+
+        # Build product info for response
+        prod = db.query(Product).filter(Product.id == product_id).first()
+
+        result["releases"].append(
+            {
+                "product_id": product_id,
+                "sku": prod.sku if prod else f"(product #{product_id})",
+                "name": prod.name if prod else f"(product #{product_id})",
+                "location_id": location_id,
+                "quantity_released": float(net_qty),
+                "old_allocated": float(current_allocated),
+                "new_allocated": float(new_allocated),
+            }
+        )
+        result["total_released_items"] += 1
+
+        logger.info(
+            "Released stranded allocation for PO #%d (%s), product %s: "
+            "qty=%s, allocated %s → %s, by %s",
+            production_order_id,
+            result["production_order_code"],
+            prod.sku if prod else f"#{product_id}",
+            net_qty,
+            current_allocated,
+            new_allocated,
+            released_by,
+        )
+
+    db.flush()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 3. Write-time guard — called from reserve_production_materials
+# ---------------------------------------------------------------------------
+
+def check_allocation_guard(
+    on_hand: Decimal,
+    current_allocated: Decimal,
+    additional: Decimal,
+) -> Tuple[bool, Decimal]:
+    """
+    Check whether increasing allocated_quantity by `additional` would exceed on_hand.
+
+    DESIGN CHOICE (HARD-5): This is a FLAG, not a hard block.
+    Rationale: production legitimately reserves ahead of receipt.  A shortage at
+    reserve-time means the PO will need incoming stock; blocking the reservation
+    prevents the MRP signal entirely, which is worse.  The caller should log a
+    shortage warning and include ``is_shortage=True`` in the reservation result.
+
+    Args:
+        on_hand: Current on_hand_quantity.
+        current_allocated: Current allocated_quantity.
+        additional: Quantity being reserved.
+
+    Returns:
+        Tuple (would_exceed: bool, available_after: Decimal).
+    """
+    new_allocated = current_allocated + additional
+    available_after = on_hand - new_allocated
+    return available_after < Decimal("0"), available_after

--- a/backend/tests/test_reservation_reconciliation.py
+++ b/backend/tests/test_reservation_reconciliation.py
@@ -1,0 +1,544 @@
+"""
+Tests for HARD-5: Reservation reconciliation and stranded allocation repair.
+
+Covers:
+1. get_allocation_reconciliation_report — drift detection and stranded identification
+2. release_stranded_allocations — repair path (terminal PO, deleted PO, live PO guard)
+3. check_allocation_guard — write-time flag (not block)
+4. Terminal-state release for complete, cancel, accept-short paths
+5. API endpoints (GET reconciliation, POST repair)
+"""
+import pytest
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.models.inventory import Inventory, InventoryTransaction, InventoryLocation
+from app.models.production_order import ProductionOrder
+from app.models.product import Product
+from app.services.reservation_reconciliation_service import (
+    get_allocation_reconciliation_report,
+    release_stranded_allocations,
+    check_allocation_guard,
+    TERMINAL_PO_STATUSES,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_inventory(db, product_id: int, on_hand: Decimal, allocated: Decimal) -> Inventory:
+    """Create or return inventory row with specified quantities."""
+    loc = db.query(InventoryLocation).filter(InventoryLocation.id == 1).first()
+    inv = db.query(Inventory).filter(
+        Inventory.product_id == product_id,
+        Inventory.location_id == loc.id,
+    ).first()
+    if inv is None:
+        inv = Inventory(
+            product_id=product_id,
+            location_id=loc.id,
+            on_hand_quantity=on_hand,
+            allocated_quantity=allocated,
+        )
+        db.add(inv)
+    else:
+        inv.on_hand_quantity = on_hand
+        inv.allocated_quantity = allocated
+    db.flush()
+    return inv
+
+
+def _make_reservation_txn(
+    db,
+    product_id: int,
+    location_id: int,
+    production_order_id: int,
+    quantity: Decimal,
+    txn_type: str = "reservation",
+) -> InventoryTransaction:
+    txn = InventoryTransaction(
+        product_id=product_id,
+        location_id=location_id,
+        transaction_type=txn_type,
+        quantity=quantity,
+        reference_type="production_order",
+        reference_id=production_order_id,
+        notes=f"Test {txn_type}",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(txn)
+    db.flush()
+    return txn
+
+
+# =============================================================================
+# 1. check_allocation_guard
+# =============================================================================
+
+class TestCheckAllocationGuard:
+    """Write-time guard: LOG + FLAG, never hard block."""
+
+    def test_no_shortage(self):
+        would_exceed, available_after = check_allocation_guard(
+            Decimal("100"), Decimal("30"), Decimal("20")
+        )
+        assert not would_exceed
+        assert available_after == Decimal("50")
+
+    def test_exact_match_not_exceed(self):
+        """Reserving exactly up to on_hand is allowed (available_after == 0)."""
+        would_exceed, available_after = check_allocation_guard(
+            Decimal("50"), Decimal("0"), Decimal("50")
+        )
+        assert not would_exceed
+        assert available_after == Decimal("0")
+
+    def test_shortage_flagged(self):
+        """Reserving more than available flags would_exceed = True."""
+        would_exceed, available_after = check_allocation_guard(
+            Decimal("50"), Decimal("40"), Decimal("20")
+        )
+        assert would_exceed
+        assert available_after == Decimal("-10")
+
+    def test_zero_on_hand(self):
+        """Zero on_hand with any reservation is a shortage."""
+        would_exceed, available_after = check_allocation_guard(
+            Decimal("0"), Decimal("0"), Decimal("5")
+        )
+        assert would_exceed
+        assert available_after == Decimal("-5")
+
+
+# =============================================================================
+# 2. get_allocation_reconciliation_report — drift detection
+# =============================================================================
+
+class TestAllocationDriftReport:
+    """Derive truth from ledger and compare to stored allocated_quantity."""
+
+    def test_no_drift_when_in_sync(self, db, make_product, make_production_order):
+        """When stored == ledger-derived, no drift reported."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="draft")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("40"))
+
+        # Ledger: 40 reserved, none released
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("40"))
+
+        report = get_allocation_reconciliation_report(db)
+        matching = [d for d in report.drift_items if d.inventory_id == inv.id]
+        assert len(matching) == 1
+        assert not matching[0].has_drift
+        assert matching[0].drift == Decimal("0")
+
+    def test_drift_detected_stored_higher(self, db, make_product, make_production_order):
+        """Stored allocated > ledger sum → positive drift (phantom allocation)."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("500"))
+
+        # Ledger: 500 reserved, 500 released  → net = 0
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("500"))
+        _make_reservation_txn(
+            db, product.id, inv.location_id, po.id, Decimal("500"), "reservation_release"
+        )
+
+        report = get_allocation_reconciliation_report(db)
+        matching = [d for d in report.drift_items if d.inventory_id == inv.id]
+        assert len(matching) == 1
+        assert matching[0].has_drift
+        # stored=500, ledger_net=0 → drift=500
+        assert matching[0].drift == Decimal("500")
+        assert matching[0].stored_allocated == Decimal("500")
+        assert matching[0].ledger_allocated == Decimal("0")
+
+    def test_drift_detected_stored_lower(self, db, make_product, make_production_order):
+        """Stored allocated < ledger sum → negative drift."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="released")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("10"))
+
+        # Ledger: 40 reserved → net = 40
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("40"))
+
+        report = get_allocation_reconciliation_report(db)
+        matching = [d for d in report.drift_items if d.inventory_id == inv.id]
+        assert len(matching) == 1
+        assert matching[0].has_drift
+        # stored=10, ledger_net=40 → drift = -30
+        assert matching[0].drift == Decimal("-30")
+
+    def test_drifted_only_filter(self, db, make_product, make_production_order):
+        """drifted_only=True returns only rows with non-zero drift."""
+        product1 = make_product()
+        product2 = make_product()
+        po1 = make_production_order(product_id=product1.id, status="draft")
+        po2 = make_production_order(product_id=product2.id, status="cancelled")
+
+        inv1 = _make_inventory(db, product1.id, Decimal("100"), Decimal("40"))
+        inv2 = _make_inventory(db, product2.id, Decimal("100"), Decimal("500"))
+
+        # inv1 in sync: 40 reserved
+        _make_reservation_txn(db, product1.id, inv1.location_id, po1.id, Decimal("40"))
+        # inv2 drifted: 0 ledger, 500 stored
+        # (no reservation transactions for product2)
+
+        report = get_allocation_reconciliation_report(db, drifted_only=True)
+        inv1_rows = [d for d in report.drift_items if d.inventory_id == inv1.id]
+        inv2_rows = [d for d in report.drift_items if d.inventory_id == inv2.id]
+        assert not inv1_rows  # in-sync row filtered out
+        assert len(inv2_rows) == 1
+        assert inv2_rows[0].has_drift
+
+
+# =============================================================================
+# 3. get_allocation_reconciliation_report — stranded detection
+# =============================================================================
+
+class TestStrandedAllocationDetection:
+    """Stranded = positive net reservation + terminal or deleted PO."""
+
+    def test_stranded_terminal_status(self, db, make_product, make_production_order):
+        """Cancelled PO with remaining reservations appears in stranded_items."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("50"))
+
+        # Partial release: 50 reserved, 10 released → 40 stranded
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("50"))
+        _make_reservation_txn(
+            db, product.id, inv.location_id, po.id, Decimal("10"), "reservation_release"
+        )
+
+        report = get_allocation_reconciliation_report(db)
+        stranded = [s for s in report.stranded_items if s.production_order_id == po.id]
+        assert len(stranded) == 1
+        assert stranded[0].stranded_reason == "terminal_status"
+        assert stranded[0].net_reserved == Decimal("40")
+        assert stranded[0].status == "cancelled"
+
+    def test_complete_po_stranded(self, db, make_product, make_production_order):
+        """Complete PO with remaining reservations is also stranded."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="complete")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("30"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("30"))
+
+        report = get_allocation_reconciliation_report(db)
+        stranded = [s for s in report.stranded_items if s.production_order_id == po.id]
+        assert len(stranded) == 1
+        assert stranded[0].status == "complete"
+
+    def test_live_po_not_stranded(self, db, make_product, make_production_order):
+        """Live (in_progress) PO with reservations is NOT stranded."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="in_progress")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("60"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("60"))
+
+        report = get_allocation_reconciliation_report(db)
+        stranded = [s for s in report.stranded_items if s.production_order_id == po.id]
+        assert not stranded
+
+    def test_fully_released_not_stranded(self, db, make_product, make_production_order):
+        """Cancelled PO that was fully released is not stranded."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("0"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("50"))
+        _make_reservation_txn(
+            db, product.id, inv.location_id, po.id, Decimal("50"), "reservation_release"
+        )
+
+        report = get_allocation_reconciliation_report(db)
+        stranded = [s for s in report.stranded_items if s.production_order_id == po.id]
+        assert not stranded
+
+    def test_deleted_po_stranded(self, db, make_product):
+        """Reservation for a non-existent PO id appears as stranded (order_missing)."""
+        product = make_product()
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("25"))
+        ghost_po_id = 999999
+
+        _make_reservation_txn(db, product.id, inv.location_id, ghost_po_id, Decimal("25"))
+
+        report = get_allocation_reconciliation_report(db)
+        stranded = [s for s in report.stranded_items if s.production_order_id == ghost_po_id]
+        assert len(stranded) == 1
+        assert stranded[0].stranded_reason == "order_missing"
+
+
+# =============================================================================
+# 4. release_stranded_allocations — repair path
+# =============================================================================
+
+class TestReleaseStrandedAllocations:
+    """Repair action: releases net reservations for terminal/deleted POs."""
+
+    def test_release_cancelled_po(self, db, make_product, make_production_order):
+        """Release stranded allocations for a cancelled PO."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("50"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("50"))
+
+        result = release_stranded_allocations(db, po.id, "test@filaops.dev")
+
+        assert result["total_released_items"] == 1
+        assert not result["errors"]
+        assert len(result["releases"]) == 1
+        assert result["releases"][0]["quantity_released"] == 50.0
+
+        # Verify inventory updated
+        db.refresh(inv)
+        assert inv.allocated_quantity == Decimal("0")
+
+    def test_release_complete_po(self, db, make_product, make_production_order):
+        """Release stranded allocations for a complete PO."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="complete")
+        inv = _make_inventory(db, product.id, Decimal("200"), Decimal("75"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("75"))
+
+        result = release_stranded_allocations(db, po.id, "staff@test.dev")
+
+        assert result["total_released_items"] == 1
+        assert result["releases"][0]["new_allocated"] == 0.0
+
+    def test_partial_release_only_net_positive(self, db, make_product, make_production_order):
+        """Only the net-positive amount is released (partially released PO)."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("30"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("50"))
+        _make_reservation_txn(
+            db, product.id, inv.location_id, po.id, Decimal("20"), "reservation_release"
+        )
+        # Net = 30 remaining
+
+        result = release_stranded_allocations(db, po.id, "staff@test.dev")
+
+        assert result["releases"][0]["quantity_released"] == 30.0
+        db.refresh(inv)
+        assert inv.allocated_quantity == Decimal("0")
+
+    def test_live_po_rejected(self, db, make_product, make_production_order):
+        """Attempting to repair a live (in_progress) PO returns an error."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="in_progress")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("60"))
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("60"))
+
+        result = release_stranded_allocations(db, po.id, "staff@test.dev")
+
+        assert len(result["errors"]) == 1
+        assert "not a terminal status" in result["errors"][0]
+        assert result["total_released_items"] == 0
+
+        # Inventory unchanged
+        db.refresh(inv)
+        assert inv.allocated_quantity == Decimal("60")
+
+    def test_release_deleted_po(self, db, make_product):
+        """Release for a non-existent PO id works (order_missing path)."""
+        product = make_product()
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("25"))
+        ghost_po_id = 888888
+
+        _make_reservation_txn(db, product.id, inv.location_id, ghost_po_id, Decimal("25"))
+
+        result = release_stranded_allocations(db, ghost_po_id, "staff@test.dev")
+
+        assert result["total_released_items"] == 1
+        assert not result["errors"]
+        db.refresh(inv)
+        assert inv.allocated_quantity == Decimal("0")
+
+    def test_idempotent_already_released(self, db, make_product, make_production_order):
+        """Calling repair on a fully-released PO is a no-op (no errors, 0 releases)."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("0"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("40"))
+        _make_reservation_txn(
+            db, product.id, inv.location_id, po.id, Decimal("40"), "reservation_release"
+        )
+
+        result = release_stranded_allocations(db, po.id, "staff@test.dev")
+
+        assert result["total_released_items"] == 0
+        assert not result["errors"]
+
+    def test_audit_transaction_created(self, db, make_product, make_production_order):
+        """A reservation_release audit transaction is written after repair."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("35"))
+
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("35"))
+
+        before_count = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "reservation_release",
+        ).count()
+
+        release_stranded_allocations(db, po.id, "auditor@test.dev")
+
+        after_count = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "reservation_release",
+        ).count()
+        assert after_count == before_count + 1
+
+
+# =============================================================================
+# 5. Terminal-state release verification (via service layer calls)
+# =============================================================================
+
+class TestTerminalStateReleases:
+    """Verify every terminal path calls release_production_reservations."""
+
+    def test_cancel_releases_reservations(self, db, make_product, make_production_order):
+        """cancel_production_order releases reservations before setting cancelled."""
+        from app.services.production_order_service import cancel_production_order
+        from app.services.inventory_service import reserve_production_materials
+        from app.models.bom import BOM, BOMLine
+
+        product_fg = make_product(item_type="finished_good", unit="EA", procurement_type="make")
+        product_rm = make_product(item_type="supply", unit="EA")
+
+        # Setup BOM
+        bom = BOM(product_id=product_fg.id, active=True, name="Test BOM")
+        db.add(bom)
+        db.flush()
+        bom_line = BOMLine(
+            bom_id=bom.id,
+            component_id=product_rm.id,
+            quantity=Decimal("5"),
+            unit="EA",
+            consume_stage="production",
+            is_cost_only=False,
+        )
+        db.add(bom_line)
+        db.flush()
+
+        inv = _make_inventory(db, product_rm.id, Decimal("100"), Decimal("0"))
+
+        po = make_production_order(product_id=product_fg.id, status="released", quantity=2)
+
+        # Reserve materials
+        reserve_production_materials(db, po, "test@filaops.dev")
+        db.flush()
+
+        db.refresh(inv)
+        assert inv.allocated_quantity > Decimal("0"), "Should have reserved materials"
+
+        # Cancel should release
+        cancel_production_order(db, po.id, "test@filaops.dev", notes="Test cancel")
+        db.flush()
+
+        db.refresh(inv)
+        assert inv.allocated_quantity == Decimal("0"), (
+            "cancel_production_order must release reservations"
+        )
+
+    def test_delete_draft_releases_reservations(self, db, make_product, make_production_order):
+        """delete_production_order (draft only) releases reservations."""
+        from app.services.production_order_service import delete_production_order
+
+        product_fg = make_product(item_type="finished_good", unit="EA", procurement_type="make")
+        product_rm = make_product(item_type="supply", unit="EA")
+        inv = _make_inventory(db, product_rm.id, Decimal("100"), Decimal("40"))
+
+        po = make_production_order(product_id=product_fg.id, status="draft")
+
+        # Manually inject a reservation (simulating a previously-reserved draft)
+        _make_reservation_txn(db, product_rm.id, inv.location_id, po.id, Decimal("40"))
+
+        delete_production_order(db, po.id)
+        db.flush()
+
+        db.refresh(inv)
+        # allocated_quantity should have been decremented
+        assert inv.allocated_quantity == Decimal("0"), (
+            "delete_production_order must release reservations"
+        )
+
+
+# =============================================================================
+# 6. API endpoint tests
+# =============================================================================
+
+class TestReservationReconciliationAPI:
+    """Integration tests for the admin reservation reconciliation endpoints."""
+
+    def test_get_reconciliation_returns_200(self, client):
+        response = client.get("/api/v1/admin/inventory/reservations/reconciliation")
+        assert response.status_code == 200
+        data = response.json()
+        assert "drift_items" in data
+        assert "stranded_items" in data
+        assert "total_inventory_rows" in data
+        assert "stranded_po_count" in data
+
+    def test_get_reconciliation_drifted_only(self, client):
+        response = client.get(
+            "/api/v1/admin/inventory/reservations/reconciliation?drifted_only=true"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # All returned drift_items should have has_drift == True
+        for item in data["drift_items"]:
+            assert item["has_drift"] is True
+
+    def test_repair_requires_confirm_true(self, client):
+        """POST repair with confirm=false must return 400."""
+        response = client.post(
+            "/api/v1/admin/inventory/reservations/repair/1",
+            json={"confirm": False, "reason": "test"},
+        )
+        assert response.status_code == 400
+
+    def test_repair_live_po_returns_errors(self, client, db, make_product, make_production_order):
+        """Repair a live PO via API returns errors list (not 4xx)."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="released")
+        inv = _make_inventory(db, product.id, Decimal("50"), Decimal("30"))
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("30"))
+        db.commit()
+
+        response = client.post(
+            f"/api/v1/admin/inventory/reservations/repair/{po.id}",
+            json={"confirm": True, "reason": "test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["errors"]) > 0
+        assert data["total_released_items"] == 0
+
+    def test_repair_cancelled_po_succeeds(self, client, db, make_product, make_production_order):
+        """Repair a cancelled PO with stranded reservations succeeds via API."""
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="cancelled")
+        inv = _make_inventory(db, product.id, Decimal("100"), Decimal("45"))
+        _make_reservation_txn(db, product.id, inv.location_id, po.id, Decimal("45"))
+        db.commit()
+
+        response = client.post(
+            f"/api/v1/admin/inventory/reservations/repair/{po.id}",
+            json={"confirm": True, "reason": "Clearing stranded allocation from test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert not data["errors"]
+        assert data["total_released_items"] == 1
+        assert data["releases"][0]["new_allocated"] == 0.0

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useApi } from "../../hooks/useApi";
 import { useFormatCurrency } from "../../hooks/useFormatCurrency";
+import ReservationReconciliationReport from "./ReservationReconciliationReport";
 
 // ---------------------------------------------------------------------------
 // Reconciliation report — counting work queue (HARD-4b)
@@ -370,8 +371,11 @@ export default function AdminInventoryTransactions() {
         </button>
       </div>
 
-      {/* Reconciliation Report — counting work queue */}
+      {/* Reconciliation Report — counting work queue (HARD-4b) */}
       <ReconciliationReport />
+
+      {/* Reservation Reconciliation — stranded allocation report (HARD-5) */}
+      <ReservationReconciliationReport />
 
       {/* Error Message */}
       {error && (

--- a/frontend/src/pages/admin/ReservationReconciliationReport.jsx
+++ b/frontend/src/pages/admin/ReservationReconciliationReport.jsx
@@ -1,0 +1,446 @@
+/**
+ * ReservationReconciliationReport — HARD-5
+ *
+ * Collapsible admin section showing:
+ *   1. Allocation drift table — stored allocated_quantity vs ledger-derived sum.
+ *   2. Stranded allocations — production orders in a terminal state or deleted
+ *      that still hold positive net reservations.
+ *   3. Per-PO repair button with confirmation dialog.
+ *
+ * Mounted alongside ReconciliationReport in AdminInventoryTransactions.jsx.
+ * Staff-gated at the API level; this component assumes auth is already checked.
+ */
+import { useState, useEffect } from "react";
+import { useApi } from "../../hooks/useApi";
+
+const API_BASE = "/api/v1/admin/inventory/reservations";
+
+// ---------------------------------------------------------------------------
+// Small utilities
+// ---------------------------------------------------------------------------
+
+function formatQty(val) {
+  if (val == null) return "—";
+  return Number(val).toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+function driftColor(drift) {
+  if (drift === 0) return "text-gray-400";
+  return drift > 0 ? "text-yellow-400" : "text-red-400";
+}
+
+function StatusBadge({ status }) {
+  const map = {
+    complete: "bg-green-500/20 text-green-400",
+    completed: "bg-green-500/20 text-green-400",
+    cancelled: "bg-gray-500/20 text-gray-400",
+    closed: "bg-blue-500/20 text-blue-400",
+    deleted: "bg-red-500/20 text-red-400",
+  };
+  const cls = map[status] || "bg-gray-700 text-gray-300";
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs ${cls}`}>{status}</span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Repair confirmation dialog
+// ---------------------------------------------------------------------------
+
+function RepairConfirmDialog({ item, onConfirm, onCancel, loading }) {
+  const [reason, setReason] = useState(
+    `Staff-initiated stranded allocation release — PO ${item.production_order_code}`
+  );
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-gray-900 border border-red-500/40 rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl">
+        <h3 className="text-lg font-semibold text-white mb-2">
+          Release stranded allocation?
+        </h3>
+        <p className="text-sm text-gray-300 mb-4">
+          This will release{" "}
+          <span className="font-semibold text-white">
+            {formatQty(item.net_reserved)}
+          </span>{" "}
+          units of{" "}
+          <span className="font-mono text-white">{item.sku}</span>{" "}
+          reserved by production order{" "}
+          <span className="font-mono text-white">{item.production_order_code}</span>{" "}
+          (<StatusBadge status={item.status} />
+          ). This action is irreversible.
+        </p>
+        <div className="mb-4">
+          <label className="block text-xs text-gray-400 mb-1">Reason (recorded in audit trail)</label>
+          <textarea
+            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white resize-none"
+            rows={2}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="px-4 py-2 text-sm text-gray-300 bg-gray-700 rounded hover:bg-gray-600 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm(reason)}
+            disabled={loading || !reason.trim()}
+            className="px-4 py-2 text-sm text-white bg-red-600 rounded hover:bg-red-700 disabled:opacity-50 font-semibold"
+          >
+            {loading ? "Releasing…" : "Release Allocation"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Drift table sub-section
+// ---------------------------------------------------------------------------
+
+function DriftTable({ items, driftedOnly, onToggleDriftedOnly, onRefresh, loading }) {
+  return (
+    <div>
+      {/* Controls */}
+      <div className="flex items-center gap-4 px-6 py-3 bg-gray-900/60 border-b border-gray-800">
+        <span className="text-sm font-medium text-gray-300">Allocation drift</span>
+        <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer select-none ml-2">
+          <input
+            type="checkbox"
+            checked={driftedOnly}
+            onChange={(e) => onToggleDriftedOnly(e.target.checked)}
+            className="rounded border-gray-600 bg-gray-800 text-blue-500"
+          />
+          Drifted only
+        </label>
+        <button
+          onClick={onRefresh}
+          disabled={loading}
+          className="ml-auto px-3 py-1.5 text-xs bg-gray-700 text-gray-200 rounded hover:bg-gray-600 disabled:opacity-50"
+        >
+          {loading ? "Loading…" : "Refresh"}
+        </button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-800/50">
+            <tr>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Name</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Location</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">On Hand</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Stored Alloc</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Ledger Alloc</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Drift</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Avail (stored)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!items || items.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="py-8 text-center text-gray-500 text-sm">
+                  {driftedOnly
+                    ? "No allocation drift detected — all inventory rows balanced."
+                    : "No inventory rows found."}
+                </td>
+              </tr>
+            ) : (
+              items.map((item) => (
+                <tr
+                  key={`${item.product_id}-${item.location_id}`}
+                  className={`border-b border-gray-800 hover:bg-gray-800/30 ${
+                    item.has_drift ? "bg-yellow-500/5" : ""
+                  }`}
+                >
+                  <td className="py-2.5 px-4 font-mono text-sm text-white">{item.sku}</td>
+                  <td className="py-2.5 px-4 text-gray-300 text-sm max-w-xs truncate">{item.name}</td>
+                  <td className="py-2.5 px-4 text-gray-400 text-sm">{item.location_name || "—"}</td>
+                  <td className="py-2.5 px-4 text-right text-white tabular-nums">{formatQty(item.on_hand)}</td>
+                  <td className="py-2.5 px-4 text-right text-gray-300 tabular-nums">{formatQty(item.stored_allocated)}</td>
+                  <td className="py-2.5 px-4 text-right text-blue-300 tabular-nums">{formatQty(item.ledger_allocated)}</td>
+                  <td className={`py-2.5 px-4 text-right font-semibold tabular-nums ${driftColor(item.drift)}`}>
+                    {item.drift > 0 ? "+" : ""}{formatQty(item.drift)}
+                  </td>
+                  <td className={`py-2.5 px-4 text-right tabular-nums ${item.stored_available < 0 ? "text-red-400 font-semibold" : "text-gray-300"}`}>
+                    {formatQty(item.stored_available)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stranded allocations sub-section
+// ---------------------------------------------------------------------------
+
+function StrandedTable({ items, onRepair }) {
+  if (!items) return null;
+
+  return (
+    <div>
+      <div className="px-6 py-3 bg-gray-900/60 border-b border-gray-800">
+        <span className="text-sm font-medium text-gray-300">Stranded allocations</span>
+        <span className="ml-2 text-xs text-gray-500">
+          — production orders in a terminal state still holding reservations
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-800/50">
+            <tr>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">PO</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Status</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Name</th>
+              <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Net Reserved</th>
+              <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">Reason</th>
+              <th className="py-2 px-4 text-xs font-medium text-gray-400 uppercase">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="py-8 text-center text-gray-500 text-sm">
+                  No stranded allocations found — all reservations belong to live orders.
+                </td>
+              </tr>
+            ) : (
+              items.map((item) => (
+                <tr
+                  key={`${item.production_order_id}-${item.product_id}-${item.location_id}`}
+                  className="border-b border-gray-800 hover:bg-gray-800/30 bg-red-500/5"
+                >
+                  <td className="py-2.5 px-4 font-mono text-sm text-white">
+                    {item.production_order_code}
+                  </td>
+                  <td className="py-2.5 px-4">
+                    <StatusBadge status={item.status} />
+                  </td>
+                  <td className="py-2.5 px-4 font-mono text-sm text-white">{item.sku}</td>
+                  <td className="py-2.5 px-4 text-gray-300 text-sm max-w-xs truncate">{item.name}</td>
+                  <td className="py-2.5 px-4 text-right text-red-400 font-semibold tabular-nums">
+                    {formatQty(item.net_reserved)}
+                  </td>
+                  <td className="py-2.5 px-4 text-xs text-gray-500">
+                    {item.stranded_reason === "order_missing" ? "Order deleted" : "Terminal status"}
+                  </td>
+                  <td className="py-2.5 px-4 text-center">
+                    <button
+                      onClick={() => onRepair(item)}
+                      className="px-3 py-1 text-xs text-red-300 border border-red-500/40 rounded hover:bg-red-500/20 transition-colors"
+                    >
+                      Release
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function ReservationReconciliationReport() {
+  const api = useApi();
+  const [report, setReport] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [expanded, setExpanded] = useState(false);
+  const [driftedOnly, setDriftedOnly] = useState(false);
+  const [repairTarget, setRepairTarget] = useState(null);
+  const [repairing, setRepairing] = useState(false);
+  const [repairError, setRepairError] = useState(null);
+  const [repairSuccess, setRepairSuccess] = useState(null);
+
+  const fetchReport = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = driftedOnly ? "?drifted_only=true" : "";
+      const data = await api.get(`${API_BASE}/reconciliation${params}`);
+      setReport(data);
+    } catch (err) {
+      setError(err.message || "Failed to load reservation reconciliation report");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (expanded) {
+      fetchReport();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded, driftedOnly]);
+
+  const handleRepairConfirm = async (reason) => {
+    if (!repairTarget) return;
+    try {
+      setRepairing(true);
+      setRepairError(null);
+      const result = await api.post(
+        `${API_BASE}/repair/${repairTarget.production_order_id}`,
+        { confirm: true, reason }
+      );
+      if (result.errors && result.errors.length > 0) {
+        setRepairError(result.errors.join("; "));
+      } else {
+        setRepairSuccess(
+          `Released ${result.total_released_items} allocation(s) for ${repairTarget.production_order_code}.`
+        );
+        // Refresh the report to reflect the repair
+        await fetchReport();
+      }
+    } catch (err) {
+      setRepairError(err.message || "Repair failed");
+    } finally {
+      setRepairing(false);
+      setRepairTarget(null);
+    }
+  };
+
+  const strandedCount = report?.stranded_po_count ?? 0;
+  const driftedCount = report?.drifted_rows ?? 0;
+
+  return (
+    <>
+      {repairTarget && (
+        <RepairConfirmDialog
+          item={repairTarget}
+          onConfirm={handleRepairConfirm}
+          onCancel={() => setRepairTarget(null)}
+          loading={repairing}
+        />
+      )}
+
+      <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+        {/* Collapsible header */}
+        <button
+          className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-gray-800/40 transition-colors"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <div>
+            <div className="flex items-center gap-3">
+              <h2 className="text-lg font-semibold text-white">
+                Reservation Reconciliation — stranded allocations
+              </h2>
+              {strandedCount > 0 && (
+                <span className="px-2 py-0.5 rounded-full text-xs bg-red-500/20 text-red-400 font-semibold">
+                  {strandedCount} stranded
+                </span>
+              )}
+            </div>
+            <p className="text-gray-400 text-sm mt-0.5">
+              Compares stored allocated_quantity against the reservation ledger.
+              Identifies allocations held by terminal or deleted production orders that
+              permanently understate availability.
+            </p>
+          </div>
+          <svg
+            className={`w-5 h-5 text-gray-400 flex-shrink-0 ml-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {expanded && (
+          <div className="border-t border-gray-800">
+            {/* Summary badges */}
+            {report && !loading && (
+              <div className="flex flex-wrap gap-4 px-6 py-3 border-b border-gray-800 bg-gray-900/60">
+                <div className="text-sm text-gray-400">
+                  <span className="font-medium text-white">{report.total_inventory_rows}</span> inventory rows
+                </div>
+                <div className="text-sm text-gray-400">
+                  <span className={`font-medium ${driftedCount > 0 ? "text-yellow-400" : "text-green-400"}`}>
+                    {driftedCount}
+                  </span> allocation drift
+                </div>
+                <div className="text-sm text-gray-400">
+                  <span className={`font-medium ${strandedCount > 0 ? "text-red-400" : "text-green-400"}`}>
+                    {strandedCount}
+                  </span> stranded POs
+                </div>
+                {report.total_stranded_quantity > 0 && (
+                  <div className="text-sm text-gray-400">
+                    <span className="font-medium text-red-300">
+                      {formatQty(report.total_stranded_quantity)}
+                    </span> total stranded qty
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Repair success/error toasts */}
+            {repairSuccess && (
+              <div className="mx-6 my-3 bg-green-500/10 border border-green-500/30 rounded-lg p-3 text-green-400 text-sm flex justify-between">
+                <span>{repairSuccess}</span>
+                <button onClick={() => setRepairSuccess(null)} className="text-green-500 hover:text-green-300 ml-3">✕</button>
+              </div>
+            )}
+            {repairError && (
+              <div className="mx-6 my-3 bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm flex justify-between">
+                <span>{repairError}</span>
+                <button onClick={() => setRepairError(null)} className="text-red-500 hover:text-red-300 ml-3">✕</button>
+              </div>
+            )}
+
+            {/* Error */}
+            {error && (
+              <div className="mx-6 my-3 bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Loading spinner */}
+            {loading && (
+              <div className="flex items-center justify-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+              </div>
+            )}
+
+            {/* Drift table */}
+            {!loading && report && (
+              <DriftTable
+                items={report.drift_items}
+                driftedOnly={driftedOnly}
+                onToggleDriftedOnly={setDriftedOnly}
+                onRefresh={fetchReport}
+                loading={loading}
+              />
+            )}
+
+            {/* Divider */}
+            {!loading && report && <div className="border-t border-gray-800 my-0" />}
+
+            {/* Stranded table */}
+            {!loading && report && (
+              <StrandedTable
+                items={report.stranded_items}
+                onRepair={setRepairTarget}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- **Derive allocation truth**: New `reservation_reconciliation_service.py` computes per-item `allocated_quantity` from the `reservation`/`reservation_release` ledger (extending the logic in `get_allocations_by_production_order`) and compares against the stored lump-sum column. Surfaces drift and stranded allocations.
- **Repair path**: Staff-gated `POST /api/v1/admin/inventory/reservations/repair/{po_id}` releases stranded allocations (PO must be terminal or deleted; requires `confirm: true` in body; writes `reservation_release` audit transactions; atomic).
- **Report endpoint**: `GET /api/v1/admin/inventory/reservations/reconciliation` returns drift table + stranded list. Mounted alongside the HARD-4b `ReconciliationReport` in `AdminInventoryTransactions.jsx` via a separate `ReservationReconciliationReport.jsx` component (avoids conflicts with concurrent HARD-4c edits to that page).
- **Write-time guard**: `inventory_service.reserve_production_materials` now calls `check_allocation_guard` and logs a structured WARNING + sets `is_shortage=True` in the return dict when reserving would exceed on_hand. **No hard block** — see decision below.
- **27 tests**: guard utility, drift detection, stranded identification, repair path (terminal/deleted/live/idempotent), audit transaction creation, terminal-path release verification via cancel and delete service calls, API endpoints.

## Terminal-path audit

All four production-order terminal paths already called `release_production_reservations` before this PR:

| Path | Status |
|------|--------|
| `cancel_production_order` | Calls `release_production_reservations` ✅ |
| `delete_production_order` (draft only) | Calls `release_production_reservations` ✅ |
| `complete_production_order` | Calls `process_production_completion` → `consume_production_materials(release_reservations=True)` ✅ |
| `accept_short_production_order` | Calls `consume_production_materials(release_reservations=True)` ✅ |

The stranded-allocation problem is from pre-existing rows (POs deleted via DB, or before the release wiring existed) — HARD-5's repair path is the safety net for those rows.

## Write-time guard decision: LOG + FLAG, not hard block

Production legitimately reserves materials before the incoming PO arrives (e.g. a print farm scheduling a job while filament is on-order). A hard block at `reserve_production_materials` time would:
1. Break the ahead-of-receipt workflow.
2. Suppress the MRP shortage signal entirely.

Decision: log a structured `WARNING` at reservation time and set `is_shortage: True` in the return dict. The shortage is already visible to callers (the existing code already computed `available_after < 0`); this PR makes the structured flag explicit so UIs can render it without log-scraping.

## Coordination notes

- Does **not** modify `inventory_ledger.py` (posts through its public API only), avoiding conflict with concurrent HARD-4c work.
- Frontend `ReservationReconciliationReport.jsx` is a separate file from `AdminInventoryTransactions.jsx` changes (only the import + one mount line touches that file), minimizing conflict surface with HARD-4c's edits there.
- No migration needed — no new schema columns; the reservation/reservation_release ledger already exists.

## Test plan

- [x] `pytest tests/test_reservation_reconciliation.py` — 27 passed
- [x] `pytest tests/services/test_inventory_service.py tests/services/test_inventory_ledger.py` — 59 passed (no regression)
- [x] `ruff check` on all modified/new files — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)