### PR TITLE
fix: tolerate NULL is_taxable in sales journal response

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -776,7 +776,7 @@ async def get_sales_journal(
             "subtotal": float(subtotal),
             "tax_rate": float(order.tax_rate or 0) if order.tax_rate else None,
             "tax_amount": float(tax),
-            "is_taxable": order.is_taxable if hasattr(order, 'is_taxable') else (tax > 0),
+            "is_taxable": bool(order.is_taxable or False),
             "shipping": float(shipping),
             "grand_total": float(grand_total),
             "paid_at": order.paid_at.isoformat() if order.paid_at else None,

--- a/backend/app/schemas/accounting.py
+++ b/backend/app/schemas/accounting.py
@@ -502,7 +502,7 @@ class SalesJournalEntry(BaseModel):
     subtotal: float
     tax_rate: Optional[float] = None
     tax_amount: float
-    is_taxable: bool
+    is_taxable: bool = False  # nullable DB column; treat NULL as False
     shipping: float
     grand_total: float
     paid_at: Optional[str] = None

--- a/backend/app/schemas/accounting.py
+++ b/backend/app/schemas/accounting.py
@@ -508,6 +508,12 @@ class SalesJournalEntry(BaseModel):
     paid_at: Optional[str] = None
     shipped_at: Optional[str] = None
 
+    @field_validator("is_taxable", mode="before")
+    @classmethod
+    def coalesce_null_is_taxable(cls, v):
+        """Coerce NULL/None from the DB column to False before bool validation."""
+        return False if v is None else bool(v)
+
 
 class SalesJournalPeriod(BaseModel):
     """Period range for the sales journal."""

--- a/backend/tests/api/v1/test_admin_accounting.py
+++ b/backend/tests/api/v1/test_admin_accounting.py
@@ -465,6 +465,49 @@ class TestSalesJournal:
             entry_count = len(data["entries"])
             assert data["totals"]["order_count"] == entry_count
 
+    def test_null_is_taxable_does_not_500(self, client, db, make_sales_order):
+        """A shipped order with is_taxable=NULL must appear as is_taxable=False, not 500.
+
+        Regression for: ResponseValidationError bool_type on is_taxable=None.
+        The sales_orders.is_taxable column is nullable; legacy/dev orders may have
+        no value.  The endpoint must coalesce NULL->False instead of letting
+        Pydantic raise a 500.
+
+        Creates the order via the ORM factory then patches is_taxable to NULL via
+        raw SQL, bypassing the ORM column default=True.
+        """
+        from datetime import datetime, timezone
+        from sqlalchemy import text
+
+        order = make_sales_order(
+            status="shipped",
+            shipped_at=datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        order_number = order.order_number
+
+        # Patch to NULL — the ORM model has default=True so we must go raw.
+        db.execute(
+            text("UPDATE sales_orders SET is_taxable = NULL WHERE id = :id"),
+            {"id": order.id},
+        )
+        db.flush()
+        # Expire the identity map so the endpoint query re-reads from DB (not cache).
+        db.expire_all()
+
+        params = {
+            "start_date": "2026-01-01T00:00:00",
+            "end_date": "2026-01-31T23:59:59",
+        }
+        resp = client.get(f"{BASE}/sales-journal", params=params)
+
+        assert resp.status_code == 200, f"Expected 200, got 500: {resp.text[:500]}"
+        entries = resp.json()["entries"]
+        null_entries = [e for e in entries if e["order_number"] == order_number]
+        assert len(null_entries) == 1, "NULL-taxable order should appear in journal"
+        assert null_entries[0]["is_taxable"] is False, (
+            "NULL is_taxable should be coalesced to False, not cause a 500"
+        )
+
 
 # =============================================================================
 # TEST: Sales Journal Export (CSV)


### PR DESCRIPTION
## Summary

- **Bug**: `GET /api/v1/admin/accounting/sales-journal` raised `ResponseValidationError` (Pydantic `bool_type`) when any shipped order had `sales_orders.is_taxable = NULL`. Because CORS headers are absent on unhandled FastAPI 500s, the browser logged "Network error: Failed to fetch" with no actionable detail.
- **Root cause**: `SalesJournalEntry.is_taxable: bool` was a required non-Optional field in the Pydantic schema, and the endpoint dict builder passed the raw ORM value (`None`) directly without coalescing.
- **Reproducer**: `SO-TEST-BOM` (dev order with NULL `is_taxable`) appeared in the 30-day window and caused the entire journal to 500.

## Fix

**Two-layer defence** (belt-and-suspenders):

1. **Endpoint** (`backend/app/api/v1/endpoints/admin/accounting.py` ~779): coalesce the raw ORM value — `bool(order.is_taxable or False)` — before building the response dict.
2. **Schema** (`backend/app/schemas/accounting.py`, `SalesJournalEntry`): changed `is_taxable: bool` → `is_taxable: bool = False` so the Pydantic model tolerates a missing/None input gracefully.

## Sweep — other raw-ORM fields in the same entry dict

The other non-Optional numeric fields (`subtotal`, `tax_amount`, `shipping`, `grand_total`) were **already safe** — coalesced via `or Decimal("0")` at lines 757–760. All remaining string fields (`order_number`, `status`, `payment_status`, `source`, `product_name`, `quantity`) are typed `Optional[...] = None` in the schema, so they accept NULL without error. No additional raw-field coalesces were needed.

## Test

Added `TestSalesJournal::test_null_is_taxable_does_not_500`:
- Creates a shipped order via `make_sales_order` factory
- Patches `is_taxable = NULL` via raw SQL (bypasses ORM `default=True`)
- Expires SQLAlchemy identity map so the endpoint query re-reads from DB
- Asserts `200 OK` and `is_taxable == False` in the response entry

All 93 tests in `test_admin_accounting.py` pass.

## Checklist

- [x] Ruff clean on changed files
- [x] 93/93 accounting tests pass
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sales journal endpoint to robustly handle missing or null taxable status values, now consistently defaulting to `False` for improved reliability in accounting reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->