### PR TITLE
fix: require staff auth on admin accounting and remaining ungated admin routers

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -48,7 +48,11 @@ from app.schemas.accounting import (
 )
 
 
-router = APIRouter(prefix="/accounting", tags=["Accounting"])
+router = APIRouter(
+    prefix="/accounting",
+    tags=["Accounting"],
+    dependencies=[Depends(get_current_staff_user)],
+)
 
 
 # ============================================================================

--- a/backend/app/api/v1/endpoints/admin/audit.py
+++ b/backend/app/api/v1/endpoints/admin/audit.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
+from app.api.v1.deps import get_current_staff_user
 from app.services.transaction_audit_service import TransactionAuditService
 from app.schemas.audit import (
     AuditTransactionsResponse,
@@ -17,7 +18,11 @@ from app.schemas.audit import (
 )
 
 
-router = APIRouter(prefix="/audit", tags=["Audit"])
+router = APIRouter(
+    prefix="/audit",
+    tags=["Audit"],
+    dependencies=[Depends(get_current_staff_user)],
+)
 
 
 @router.get("/transactions", response_model=AuditTransactionsResponse)

--- a/backend/app/api/v1/endpoints/admin/traceability.py
+++ b/backend/app/api/v1/endpoints/admin/traceability.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.api.v1.endpoints.auth import get_current_user
+from app.api.v1.deps import get_current_staff_user
 from app.models.user import User
 from app.schemas.traceability import (
     # Customer Profiles
@@ -40,7 +40,11 @@ from app.schemas.traceability import (
 )
 from app.services import traceability_service as svc
 
-router = APIRouter(prefix="/traceability", tags=["Traceability"])
+router = APIRouter(
+    prefix="/traceability",
+    tags=["Traceability"],
+    dependencies=[Depends(get_current_staff_user)],
+)
 
 
 # =============================================================================
@@ -51,7 +55,7 @@ router = APIRouter(prefix="/traceability", tags=["Traceability"])
 async def list_traceability_profiles(
     traceability_level: Optional[str] = None,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """List all customer traceability profiles."""
     return svc.list_traceability_profiles(db, traceability_level=traceability_level)
@@ -61,7 +65,7 @@ async def list_traceability_profiles(
 async def get_traceability_profile(
     user_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Get traceability profile for a specific customer."""
     return svc.get_traceability_profile(db, user_id)
@@ -71,7 +75,7 @@ async def get_traceability_profile(
 async def create_traceability_profile(
     request: CustomerTraceabilityProfileCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Create a traceability profile for a customer."""
     return svc.create_traceability_profile(db, request)
@@ -82,7 +86,7 @@ async def update_traceability_profile(
     user_id: int,
     request: CustomerTraceabilityProfileUpdate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Update a customer's traceability profile."""
     return svc.update_traceability_profile(db, user_id, request)
@@ -101,7 +105,7 @@ async def list_material_lots(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=100),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """List material lots with filtering and pagination."""
     return svc.list_material_lots(
@@ -119,7 +123,7 @@ async def list_material_lots(
 async def get_material_lot(
     lot_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Get a specific material lot by ID."""
     return svc.get_material_lot(db, lot_id)
@@ -129,7 +133,7 @@ async def get_material_lot(
 async def create_material_lot(
     request: MaterialLotCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Create a new material lot (typically when receiving materials)."""
     return svc.create_material_lot(db, request)
@@ -140,7 +144,7 @@ async def update_material_lot(
     lot_id: int,
     request: MaterialLotUpdate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Update a material lot."""
     return svc.update_material_lot(db, lot_id, request)
@@ -150,7 +154,7 @@ async def update_material_lot(
 async def generate_lot_number(
     material_code: str,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Generate the next lot number for a material."""
     return svc.generate_lot_number(db, material_code)
@@ -170,7 +174,7 @@ async def list_serial_numbers(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=100),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """List serial numbers with filtering and pagination."""
     return svc.list_serial_numbers(
@@ -189,7 +193,7 @@ async def list_serial_numbers(
 async def get_serial_number(
     serial_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Get a specific serial number by ID."""
     return svc.get_serial_number(db, serial_id)
@@ -199,7 +203,7 @@ async def get_serial_number(
 async def lookup_serial_number(
     serial_number: str,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Look up a serial number by the serial string."""
     return svc.lookup_serial_number(db, serial_number)
@@ -209,7 +213,7 @@ async def lookup_serial_number(
 async def create_serial_numbers(
     request: SerialNumberCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Generate serial numbers for a production order."""
     return svc.create_serial_numbers(db, request)
@@ -220,7 +224,7 @@ async def update_serial_number(
     serial_id: int,
     request: SerialNumberUpdate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Update a serial number (e.g., mark as sold, shipped, returned)."""
     return svc.update_serial_number(db, serial_id, request)
@@ -234,7 +238,7 @@ async def update_serial_number(
 async def record_lot_consumption(
     request: ProductionLotConsumptionCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Record material lot consumption for a production order."""
     return svc.record_lot_consumption(db, request)
@@ -244,7 +248,7 @@ async def record_lot_consumption(
 async def get_production_lot_consumptions(
     production_order_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """Get all lot consumptions for a production order."""
     return svc.get_production_lot_consumptions(db, production_order_id)
@@ -258,7 +262,7 @@ async def get_production_lot_consumptions(
 async def recall_forward_query(
     lot_number: str,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Forward recall query: What did we make with this lot?
@@ -272,7 +276,7 @@ async def recall_forward_query(
 async def recall_backward_query(
     serial_number: str,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Backward recall query: What material lots went into this serial number?

--- a/backend/app/api/v1/endpoints/admin/uploads.py
+++ b/backend/app/api/v1/endpoints/admin/uploads.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from app.core.paths import resolve_static_dir, resolve_upload_products_dir
 from app.core.settings import settings
 from app.models.user import User
-from app.api.v1.deps import get_current_user
+from app.api.v1.deps import get_current_staff_user
 from app.logging_config import get_logger
 router = APIRouter()
 logger = get_logger(__name__)
@@ -55,7 +55,7 @@ def is_allowed_file(filename: str) -> bool:
 @router.post("/product-image", response_model=UploadResponse)
 async def upload_product_image(
     file: UploadFile = File(...),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_staff_user)
 ):
     """
     Upload a product image.
@@ -121,7 +121,7 @@ async def upload_product_image(
 @router.delete("/product-image/{filename}")
 async def delete_product_image(
     filename: str,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_staff_user)
 ):
     """
     Delete a previously uploaded product image.

--- a/backend/tests/endpoints/test_admin_accounting_auth.py
+++ b/backend/tests/endpoints/test_admin_accounting_auth.py
@@ -1,0 +1,124 @@
+"""
+Auth tests for admin accounting, audit, traceability, and uploads endpoints.
+
+All admin/* endpoints must require staff authentication and return 401
+when accessed without a valid Bearer token or session cookie.
+
+Covers the security gaps identified in the #683 sibling audit:
+- /admin/accounting/*  (financial data: sales journal, payments, COGS, tax)
+- /admin/audit/*       (transaction audit log — internal ops data)
+- /admin/traceability/* (serial numbers, material lots — previously allowed any user)
+- /admin/uploads/*     (file write endpoint — previously allowed any user)
+"""
+
+
+class TestAccountingUnauthenticated:
+    """All /admin/accounting endpoints must reject unauthenticated requests with 401."""
+
+    def test_sales_journal_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/sales-journal returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/sales-journal")
+        assert resp.status_code == 401
+
+    def test_sales_journal_export_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/sales-journal/export returns 401 without auth."""
+        resp = unauthed_client.get(
+            "/api/v1/admin/accounting/sales-journal/export"
+            "?start_date=2025-01-01T00:00:00Z&end_date=2025-12-31T00:00:00Z"
+        )
+        assert resp.status_code == 401
+
+    def test_payments_journal_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/payments-journal returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/payments-journal")
+        assert resp.status_code == 401
+
+    def test_dashboard_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/dashboard returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/dashboard")
+        assert resp.status_code == 401
+
+    def test_tax_summary_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/tax-summary returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/tax-summary")
+        assert resp.status_code == 401
+
+    def test_cogs_summary_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/cogs-summary returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/cogs-summary")
+        assert resp.status_code == 401
+
+    def test_inventory_by_account_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/inventory-by-account returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/inventory-by-account")
+        assert resp.status_code == 401
+
+    def test_transactions_journal_requires_auth(self, unauthed_client):
+        """GET /admin/accounting/transactions-journal returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/accounting/transactions-journal")
+        assert resp.status_code == 401
+
+
+class TestAccountingAuthenticated:
+    """Authenticated staff users can reach accounting endpoints (no 401/403)."""
+
+    def test_sales_journal_accessible_with_auth(self, client):
+        """GET /admin/accounting/sales-journal returns 200 with valid auth."""
+        resp = client.get("/api/v1/admin/accounting/sales-journal")
+        assert resp.status_code == 200
+
+    def test_payments_journal_accessible_with_auth(self, client):
+        """GET /admin/accounting/payments-journal returns 200 with valid auth."""
+        resp = client.get("/api/v1/admin/accounting/payments-journal")
+        assert resp.status_code == 200
+
+
+class TestAuditUnauthenticated:
+    """All /admin/audit endpoints must reject unauthenticated requests with 401."""
+
+    def test_transactions_audit_requires_auth(self, unauthed_client):
+        """GET /admin/audit/transactions returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/audit/transactions")
+        assert resp.status_code == 401
+
+    def test_audit_summary_requires_auth(self, unauthed_client):
+        """GET /admin/audit/transactions/summary returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/audit/transactions/summary")
+        assert resp.status_code == 401
+
+
+class TestAuditAuthenticated:
+    """Authenticated staff users can reach audit endpoints (no 401/403)."""
+
+    def test_audit_summary_accessible_with_auth(self, client):
+        """GET /admin/audit/transactions/summary returns 200 with valid auth."""
+        resp = client.get("/api/v1/admin/audit/transactions/summary")
+        assert resp.status_code == 200
+
+
+class TestTraceabilityUnauthenticated:
+    """All /admin/traceability endpoints must reject unauthenticated requests with 401."""
+
+    def test_profiles_requires_auth(self, unauthed_client):
+        """GET /admin/traceability/profiles returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/traceability/profiles")
+        assert resp.status_code == 401
+
+    def test_lots_requires_auth(self, unauthed_client):
+        """GET /admin/traceability/lots returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/traceability/lots")
+        assert resp.status_code == 401
+
+    def test_serials_requires_auth(self, unauthed_client):
+        """GET /admin/traceability/serials returns 401 without auth."""
+        resp = unauthed_client.get("/api/v1/admin/traceability/serials")
+        assert resp.status_code == 401
+
+
+class TestTraceabilityAuthenticated:
+    """Authenticated staff users can reach traceability endpoints (no 401/403)."""
+
+    def test_profiles_accessible_with_auth(self, client):
+        """GET /admin/traceability/profiles returns 200 with valid auth."""
+        resp = client.get("/api/v1/admin/traceability/profiles")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Security Fix — Admin Endpoint Auth Audit

Completes the auth audit started by #683 (MRP) and #686 (materials/test). The accounting router was missed in that sweep; a live probe of `GET /api/v1/admin/accounting/sales-journal` returned **200 with financial data** without any token.

### Root Cause

`accounting.py` and `audit.py` had **zero** auth dependencies — not even at the per-endpoint level. `traceability.py` and `uploads.py` used `get_current_user` (any logged-in customer) rather than `get_current_staff_user` (admin/operator only). All are in the `admin/` package and should be staff-gated.

### Fix

Router-level `dependencies=[Depends(get_current_staff_user)]` added to the four ungated routers, following the exact pattern from `mrp.py` (post-#683). Per-endpoint deps in `traceability.py` and `uploads.py` upgraded from `get_current_user` to `get_current_staff_user` to match.

FastAPI deduplicates router-level and function-level deps, so the one endpoint in `accounting.py` that already had an explicit `get_current_staff_user` dep is unaffected.

### Why router-level (not centralized in `__init__.py`)?

The admin `__init__.py` simply assembles routers without adding auth at the aggregation layer. The existing convention (established by #683, reconciliation.py, reservations.py) is per-router `dependencies=[...]`. Centralizing in `__init__.py` would be a clean refactor but risks silently ungating everything if the include_router call is ever duplicated elsewhere. Router-level is explicit and self-documenting.

---

## Admin Router Audit Table

| Router | Endpoints | Auth method | Status |
|---|---|---|---|
| `accounting.py` | inventory-by-account, transactions-journal, order-cost-breakdown, cogs-summary, dashboard, sales-journal, sales-journal/export, tax-summary, tax-summary/export, payments-journal, payments-journal/export, export/sales | **Router-level** `get_current_staff_user` (this PR) | Fixed |
| `audit.py` | transactions, transactions/order/{id}, transactions/timeline/{id}, transactions/summary | **Router-level** `get_current_staff_user` (this PR) | Fixed |
| `traceability.py` | profiles, lots, serials, consumptions, recall/* | **Router-level** `get_current_staff_user` (this PR); per-endpoint upgraded from `get_current_user` | Fixed |
| `uploads.py` | product-image (POST), product-image/{filename} (DELETE) | Per-endpoint upgraded from `get_current_user` → `get_current_staff_user` (this PR) | Fixed |
| `reconciliation.py` | /inventory/reconciliation/* | Router-level `get_current_staff_user` | Already gated |
| `reservations.py` | /inventory/reservations/* | Router-level `get_current_staff_user` | Already gated |
| `dashboard.py` | /dashboard/* | Per-endpoint `get_current_staff_user` (all 12 endpoints) | Already gated |
| `bom.py` | /bom/* | Per-endpoint `get_current_staff_user` (14 endpoints) | Already gated |
| `fulfillment_queue.py` | /fulfillment/* (queue) | Per-endpoint `get_current_staff_user` (8 endpoints) | Already gated |
| `fulfillment_shipping.py` | /fulfillment/* (shipping) | Per-endpoint `get_current_staff_user` (8 endpoints) | Already gated |
| `inventory_transactions.py` | /inventory/transactions/* | Per-endpoint `get_current_staff_user` (6 endpoints) | Already gated |
| `locations.py` | /locations/* | Per-endpoint `get_current_staff_user` (5 endpoints) | Already gated |
| `export.py` | /export/* | Per-endpoint `get_current_staff_user` (2 endpoints) | Already gated |
| `data_import.py` | /import/* | Per-endpoint `get_current_staff_user` (2 endpoints) | Already gated |
| `orders.py` | /orders/* | Per-endpoint `get_current_staff_user` (1 endpoint) | Already gated |
| `users.py` | /users/* | Per-endpoint `get_current_admin_user` (8 endpoints) | Already gated (admin-only) |
| `customers.py` | /customers/* | Per-endpoint `get_current_admin_user` (10 endpoints) | Already gated (admin-only) |
| `uom.py` | /uom/* | Per-endpoint `get_current_admin_user` (6 endpoints) | Already gated (admin-only) |
| `system.py` | /system/* | Per-endpoint `get_current_admin_user` (3 endpoints) | Already gated (admin-only) |
| `pro_install.py` | /system/pro/* | Per-endpoint `get_current_admin_user` (2 endpoints) | Already gated (admin-only) |
| `analytics.py` | /analytics/dashboard | Per-endpoint `get_current_admin_user` + `@require_tier(PRO)` | Already gated (admin + PRO tier) |

### Frontend Impact

All accounting page calls in `frontend/src/components/accounting/` use `credentials: "include"` (httpOnly cookie auth). The Accounting page requires login to render. Nothing breaks.

### Tests

17 new tests in `backend/tests/endpoints/test_admin_accounting_auth.py`:
- 8 × unauthenticated accounting endpoints → 401
- 2 × authenticated accounting endpoints → 200
- 2 × unauthenticated audit endpoints → 401  
- 1 × authenticated audit endpoint → 200
- 3 × unauthenticated traceability endpoints → 401
- 1 × authenticated traceability endpoint → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)