### PR TITLE
fix: post-merge review findings from #694/#696/#698 sweep

### DIFF
--- a/backend/app/api/v1/endpoints/admin/reconciliation.py
+++ b/backend/app/api/v1/endpoints/admin/reconciliation.py
@@ -25,6 +25,7 @@ POST /api/v1/admin/inventory/reconciliation/count/all-to-stored
 Staff-gated: uses the same router-level dependency as mrp.py (post-#683).
 """
 import logging
+from decimal import Decimal
 from typing import List, Optional
 from datetime import datetime
 
@@ -85,7 +86,7 @@ class CountEntryRequest(BaseModel):
     """Payload for a single physical count entry."""
     product_id: int = Field(..., description="Product being counted")
     location_id: int = Field(..., description="Inventory location being counted")
-    counted_qty: float = Field(..., ge=0, description="Physically counted quantity (>= 0)")
+    counted_qty: Decimal = Field(..., ge=0, description="Physically counted quantity (>= 0)")
     notes: Optional[str] = Field(None, max_length=500, description="Optional count note")
 
 
@@ -210,20 +211,15 @@ def post_count_entry(
     The row will appear as **clean** (not drifted, counted) in the
     reconciliation report after this call.
     """
-    from decimal import Decimal as D
-    from decimal import InvalidOperation
-
-    try:
-        counted = D(str(body.counted_qty))
-    except InvalidOperation:
-        raise HTTPException(status_code=422, detail="Invalid counted_qty value")
-
+    # body.counted_qty is already a Decimal (Pydantic v2 native coercion).
+    # The D(str(...)) conversion is no longer needed here; the service-side
+    # TypeError guard is kept as defence-in-depth for other callers.
     try:
         txn = post_reconciliation_baseline(
             db,
             product_id=body.product_id,
             location_id=body.location_id,
-            counted_qty=counted,
+            counted_qty=body.counted_qty,
             user=current_user.email,
             notes=body.notes,
         )
@@ -244,7 +240,7 @@ def post_count_entry(
         raise HTTPException(status_code=500, detail="Inventory row missing after baseline post")
 
     # Re-derive delta from the transaction row (posted by service)
-    actual_delta = D(str(txn.quantity)) if txn else D("0")
+    actual_delta = Decimal(str(txn.quantity)) if txn else Decimal("0")
 
     db.commit()
 

--- a/backend/app/api/v1/endpoints/admin/reservations.py
+++ b/backend/app/api/v1/endpoints/admin/reservations.py
@@ -144,12 +144,13 @@ def get_reservation_reconciliation(
     Use the ``POST /repair/{production_order_id}`` endpoint to release a specific
     stranded allocation after explicit staff confirmation.
     """
-    report = get_allocation_reconciliation_report(db, drifted_only=drifted_only)
-
-    all_report = (
-        get_allocation_reconciliation_report(db)
+    # Run once (unfiltered) so summary stats and filtered items share one DB
+    # round-trip — mirrors the pattern in endpoints/admin/reconciliation.py.
+    all_report = get_allocation_reconciliation_report(db, drifted_only=False)
+    drift_items = (
+        [d for d in all_report.drift_items if d.has_drift]
         if drifted_only
-        else report
+        else all_report.drift_items
     )
 
     drift_schemas = [
@@ -168,7 +169,7 @@ def get_reservation_reconciliation(
             stored_available=float(d.stored_available),
             ledger_available=float(d.ledger_available),
         )
-        for d in report.drift_items
+        for d in drift_items
     ]
 
     stranded_schemas = [
@@ -185,7 +186,7 @@ def get_reservation_reconciliation(
             completed_at=s.completed_at,
             cancelled_at=s.cancelled_at,
         )
-        for s in report.stranded_items
+        for s in all_report.stranded_items
     ]
 
     return AllocationReconciliationReportSchema(
@@ -195,7 +196,7 @@ def get_reservation_reconciliation(
         drifted_rows=all_report.drifted_rows,
         stranded_po_count=all_report.stranded_po_count,
         total_stranded_quantity=float(all_report.total_stranded_quantity),
-        generated_at=report.generated_at,
+        generated_at=all_report.generated_at,
     )
 
 

--- a/backend/app/services/reconciliation_service.py
+++ b/backend/app/services/reconciliation_service.py
@@ -381,7 +381,15 @@ def post_reconciliation_baseline(
         # --- Step 3: post GL entry (cycle-count variance semantics) ---
         product = db.get(ProductModel, product_id)
         if product is not None:
-            unit_cost = product.standard_cost or product.average_cost or Decimal("0")
+            unit_cost = (
+                product.standard_cost
+                if product.standard_cost is not None
+                else (
+                    product.average_cost
+                    if product.average_cost is not None
+                    else Decimal("0")
+                )
+            )
             total_cost = abs(delta) * unit_cost
 
             # Map product type to inventory account (mirrors cycle_count_adjustment)

--- a/backend/app/services/reservation_reconciliation_service.py
+++ b/backend/app/services/reservation_reconciliation_service.py
@@ -451,13 +451,16 @@ def release_stranded_allocations(
             # Already fully released — skip
             continue
 
-        # Fetch inventory row
+        # Fetch inventory row with a row-level lock to prevent concurrent
+        # repair calls on the same (product, location) from racing and
+        # double-releasing the allocated_quantity.
         inventory = (
             db.query(Inventory)
             .filter(
                 Inventory.product_id == product_id,
                 Inventory.location_id == location_id,
             )
+            .with_for_update()
             .first()
         )
 

--- a/backend/tests/endpoints/test_admin_accounting_auth.py
+++ b/backend/tests/endpoints/test_admin_accounting_auth.py
@@ -122,3 +122,22 @@ class TestTraceabilityAuthenticated:
         """GET /admin/traceability/profiles returns 200 with valid auth."""
         resp = client.get("/api/v1/admin/traceability/profiles")
         assert resp.status_code == 200
+
+
+class TestUploadsAuth:
+    """All /admin/uploads endpoints must reject unauthenticated requests with 401."""
+
+    def test_upload_product_image_requires_auth(self, unauthed_client):
+        """POST /admin/uploads/product-image returns 401 without auth."""
+        resp = unauthed_client.post(
+            "/api/v1/admin/uploads/product-image",
+            files={"file": ("test.jpg", b"fake-image-data", "image/jpeg")},
+        )
+        assert resp.status_code == 401
+
+    def test_delete_product_image_requires_auth(self, unauthed_client):
+        """DELETE /admin/uploads/product-image/{filename} returns 401 without auth."""
+        resp = unauthed_client.delete(
+            "/api/v1/admin/uploads/product-image/test.jpg"
+        )
+        assert resp.status_code == 401

--- a/backend/tests/services/test_reconciliation_service.py
+++ b/backend/tests/services/test_reconciliation_service.py
@@ -18,13 +18,12 @@ Scenarios:
  13. Report shows item as counted+clean after a matching count.
  14. Uncounted item is unaffected by another item's baseline.
 """
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
 
 from app.models.inventory import Inventory, InventoryTransaction
-from app.services.inventory_ledger import get_or_create_inventory_row
 from app.services.reconciliation_service import (
     BASELINE_TO_STORED_CONFIRM_TOKEN,
     baseline_to_stored,
@@ -360,8 +359,8 @@ class TestPostReconciliationBaseline:
             .filter(GLJournalEntryLine.journal_entry_id == je.id)
             .all()
         )
-        total_dr = sum(l.debit_amount or D("0") for l in lines)
-        total_cr = sum(l.credit_amount or D("0") for l in lines)
+        total_dr = sum(line.debit_amount or D("0") for line in lines)
+        total_cr = sum(line.credit_amount or D("0") for line in lines)
         assert abs(total_dr - total_cr) <= D("0.01"), (
             f"Journal entry not balanced: DR={total_dr} CR={total_cr}"
         )
@@ -589,3 +588,59 @@ class TestBaselineToStored:
                 user="admin@example.com",
                 confirm="wrong-token",
             )
+
+
+class TestZeroCostGLEntry:
+    """Regression: product with standard_cost=0 must NOT fall through to average_cost."""
+
+    def test_zero_standard_cost_uses_zero_not_average(self, db, make_product, location):
+        """
+        A product with standard_cost=Decimal("0") and average_cost=Decimal("5")
+        must post a GL entry priced at 0, not 5.
+
+        The old ``or`` chain treated Decimal("0") as falsy and wrongly fell
+        through to average_cost, posting an incorrect GL amount.
+        """
+        from app.models.accounting import GLJournalEntry, GLJournalEntryLine
+        from app.services.inventory_ledger import post as ledger_post
+
+        product = make_product(
+            standard_cost=Decimal("0"),
+            average_cost=Decimal("5.00"),
+        )
+        # Seed 100 units so a count of 110 gives delta +10
+        ledger_post(
+            db, product_id=product.id, location_id=location.id,
+            transaction_type="receipt", quantity_delta=Decimal("100"),
+        )
+
+        txn = post_reconciliation_baseline(
+            db,
+            product_id=product.id,
+            location_id=location.id,
+            counted_qty=Decimal("110"),  # delta +10
+            user="counter@example.com",
+        )
+
+        # With standard_cost=0 the GL total_cost = 10 * 0 = 0, so no entry is written
+        # (the service skips the GL block when total_cost == 0).
+        # Crucially it must NOT use average_cost=5 (which would give total_cost=50).
+        assert txn is not None
+
+        if txn.journal_entry_id is not None:
+            je = db.get(GLJournalEntry, txn.journal_entry_id)
+            assert je is not None
+            lines = (
+                db.query(GLJournalEntryLine)
+                .filter(GLJournalEntryLine.journal_entry_id == je.id)
+                .all()
+            )
+            total_dr = sum(line.debit_amount or Decimal("0") for line in lines)
+            # If a GL entry was posted it must be for 0-cost math (total_cost=0),
+            # meaning no lines with non-zero amounts.
+            assert total_dr == Decimal("0"), (
+                f"Expected zero-cost GL (standard_cost=0) but got DR={total_dr}; "
+                "average_cost fallthrough regression detected."
+            )
+        # If journal_entry_id is None the service correctly skipped the GL block
+        # because total_cost was 0 — that is the expected happy path.


### PR DESCRIPTION
## Summary

Five verified findings from the deep review of merged PRs #694/#696/#698, all confirmed against `origin/main` before fixing:

1. **CRITICAL — `reconciliation_service.py` zero-cost GL fallthrough** (`backend/app/services/reconciliation_service.py`): The `unit_cost = product.standard_cost or product.average_cost or Decimal("0")` chain treated `Decimal("0")` as falsy, causing a product with `standard_cost=0` to fall through to `average_cost` and post an incorrect GL amount. Replaced with explicit `is not None` checks.

2. **`counted_qty: float` → `Decimal`** (`backend/app/api/v1/endpoints/admin/reconciliation.py`): `CountEntryRequest.counted_qty` was `float`, which caused Pydantic to silently coerce the input and lose precision before it reached the service. Changed to `Decimal` (native in Pydantic v2). Removed the now-unnecessary `D(str(...))` conversion in the endpoint; kept the service-side `TypeError` guard for defence-in-depth.

3. **Missing row lock in stranded-allocation repair** (`backend/app/services/reservation_reconciliation_service.py`): The `Inventory` row read in the repair path lacked `.with_for_update()`, allowing concurrent repairs on the same `(product, location)` to race and double-release `allocated_quantity`. Lock added.

4. **Double full-table scan with `drifted_only=True`** (`backend/app/api/v1/endpoints/admin/reservations.py`): When `drifted_only=True`, the endpoint was calling `get_allocation_reconciliation_report` twice (full scans). Now calls once unfiltered, Python-filters `drift_items`, and derives all summary stats from the single result — mirroring the pattern already in `endpoints/admin/reconciliation.py ~161`.

5. **Missing uploads auth tests** (`backend/tests/endpoints/test_admin_accounting_auth.py`): The docstring claimed `/admin/uploads/*` coverage but no tests existed. Added `TestUploadsAuth`: POST `/api/v1/admin/uploads/product-image` → 401 unauthenticated; DELETE `/api/v1/admin/uploads/product-image/test.jpg` → 401 unauthenticated.

Also cleaned pre-existing `ruff` `F401`/`E741` violations in `test_reconciliation_service.py` (unused imports, ambiguous variable name `l`).

## Test plan

- [x] `pytest tests/services/test_reconciliation_service.py tests/test_reservation_reconciliation.py tests/endpoints/test_admin_accounting_auth.py` — **68 passed** locally
- [x] `ruff check` on all 6 modified files — clean
- [ ] CI green on push
- [ ] Bot review triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)