### PR TITLE
feat: consolidated buy list (HARD-7, Layer 1 live view)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -21,6 +21,7 @@ from app.api.v1.endpoints import (
     resources,
     routings,
     mrp,
+    buy_list,
     setup,
     quotes,
     settings,
@@ -169,6 +170,9 @@ router.include_router(
 
 # MRP (Material Requirements Planning)
 router.include_router(mrp.router)
+
+# Buy List (HARD-7 — consolidated demand netting, Layer 1 live view)
+router.include_router(buy_list.router)
 
 # Features/Licensing is a PRO feature
 

--- a/backend/app/api/v1/endpoints/buy_list.py
+++ b/backend/app/api/v1/endpoints/buy_list.py
@@ -1,0 +1,58 @@
+"""
+Consolidated Buy List endpoint — HARD-7.
+
+GET /buy-list        — returns the live, computed-on-demand buy list.
+
+Staff-only (same dependency as all MRP endpoints post-HARD-1).
+ZERO writes — pure read.  Never calls run_mrp.
+"""
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.deps import get_current_staff_user
+from app.db.session import get_db
+from app.models.user import User
+from app.schemas.buy_list import BuyListResponse
+from app.services.buy_list_service import get_buy_list
+
+router = APIRouter(
+    prefix="/buy-list",
+    tags=["buy-list"],
+    dependencies=[Depends(get_current_staff_user)],
+)
+
+
+@router.get("", response_model=BuyListResponse)
+async def read_buy_list(
+    vendor_id: Optional[int] = Query(
+        default=None,
+        description="Filter to a single preferred vendor (by vendor ID).",
+    ),
+    _current_user: User = Depends(get_current_staff_user),
+    db: Session = Depends(get_db),
+) -> BuyListResponse:
+    """
+    Return the consolidated buy list.
+
+    Computes gross component demand across **all** open sales orders and open
+    production orders, nets against on-hand + on-order + safety stock, and
+    returns only the components that are still short.
+
+    Per the HARD-7 three-layer design this is always computed fresh — there is
+    no stored MRP run artifact to go stale.
+
+    ### Response
+    - **summary** — counts + total estimated buy value + draft-PO transparency
+    - **items** — one row per short component, sorted by preferred vendor then
+      earliest need; includes incoming PO detail with status labels so operators
+      can see uncommitted (draft) supply for what it is.
+
+    ### Create PO
+    Use the existing PO creation endpoint with the suggested vendor and qty
+    from this response.  The frontend buy-list page provides a per-row
+    "Create PO" button that pre-fills vendor + suggested qty into the
+    POCreateModal.
+    """
+    return get_buy_list(db, vendor_id=vendor_id)

--- a/backend/app/schemas/buy_list.py
+++ b/backend/app/schemas/buy_list.py
@@ -1,0 +1,78 @@
+"""
+Pydantic schemas for the consolidated buy list (HARD-7).
+"""
+from datetime import date
+from decimal import Decimal
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class BuyListIncomingDetail(BaseModel):
+    """One open PO line contributing to projected supply."""
+    purchase_order_id: int
+    po_number: str
+    quantity: Decimal
+    expected_date: Optional[date]
+    status: str  # "draft", "ordered", "shipped" — callers may surface "(draft)" label
+
+    model_config = {"from_attributes": True}
+
+
+class BuyListItem(BaseModel):
+    """
+    One short component that needs to be purchased.
+
+    Net shortage is the quantity we must still buy after netting
+    on-hand, allocated, and all open POs against gross demand.
+    """
+    product_id: int
+    sku: str
+    name: str
+    unit: str
+
+    # Demand
+    gross_demand: Decimal       # Total gross requirement across all open orders
+    on_hand: Decimal
+    allocated: Decimal
+    available: Decimal          # on_hand − allocated (may be negative)
+    incoming_qty: Decimal       # Σ remaining on open POs
+    projected: Decimal          # available + incoming_qty
+    safety_stock: Decimal       # Product.safety_stock threshold applied
+
+    # Shortage
+    net_shortage: Decimal       # max(0, gross_demand − projected + safety_stock)
+    suggested_qty: Decimal      # max(net_shortage, min_order_qty)
+
+    # Purchasing hint
+    preferred_vendor_id: Optional[int]
+    preferred_vendor_name: Optional[str]
+    unit_cost: Decimal          # standard_cost or last_cost
+    estimated_buy_value: Decimal  # suggested_qty × unit_cost
+
+    # Earliest-need hint (earliest due / completion date among demanding orders)
+    earliest_need: Optional[date]
+
+    # Incoming PO detail (for "draft" visibility)
+    incoming_details: List[BuyListIncomingDetail] = []
+
+    model_config = {"from_attributes": True}
+
+
+class BuyListSummary(BaseModel):
+    """Summary header for the buy list page."""
+    components_short: int               # Number of distinct short components
+    total_estimated_buy_value: Decimal  # Σ estimated_buy_value
+    open_sales_orders_included: int
+    open_production_orders_included: int
+    draft_incoming_qty: Decimal         # Σ incoming from draft POs (uncommitted supply)
+
+    model_config = {"from_attributes": True}
+
+
+class BuyListResponse(BaseModel):
+    """Full buy list response."""
+    summary: BuyListSummary
+    items: List[BuyListItem]
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/buy_list_service.py
+++ b/backend/app/services/buy_list_service.py
@@ -1,0 +1,409 @@
+"""
+Consolidated Buy List Service — HARD-7, Layer 1 (live view).
+
+Answers: "Across ALL open demand, what do I buy, how much, and by when?"
+
+Design
+------
+- COMPUTED-ON-DEMAND: no stored MRP run artifact; the view is always current.
+- ZERO WRITES: pure read path; never calls run_mrp (which self-commits and
+  deletes/regenerates planned orders, per PR #688).
+- Single-bucket netting (no time-phasing) — MVP per owner-approved design.
+- Reuses MRPService.explode_bom for BOM/routing-operation explosion (same
+  routing-first / BOM-fallback semantics as the full MRP engine).
+- Reuses supply_netting.get_projected_available for on-hand + open-PO netting
+  (same helper wired into blocking_issues / HARD-6 shortage fixes).
+
+Open-order scope
+----------------
+Sales orders:   status NOT IN ('cancelled', 'completed', 'delivered', 'shipped')
+                (order types: quote_based with product_id, or line_item orders)
+Production orders: status IN ('draft', 'released', 'in_progress')
+                   remaining qty = quantity_ordered − quantity_completed
+
+Safety stock treatment
+----------------------
+  net_shortage = max(0, gross_demand − projected + safety_stock)
+  suggested_qty = max(net_shortage, min_order_qty or 0)
+
+where safety_stock = Product.safety_stock and min_order_qty = Product.min_order_qty.
+The safety-stock floor mirrors mrp.calculate_net_requirements.
+
+Vendor preference
+-----------------
+Uses Product.preferred_vendor_id (FK to vendors table, set NULL on delete).
+This is what exists; HARD-13 will later wire VendorItem catalog pricing.
+"""
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.production_order import ProductionOrder
+from app.models.product import Product
+from app.models.sales_order import SalesOrder, SalesOrderLine
+from app.models.vendor import Vendor
+from app.schemas.buy_list import (
+    BuyListIncomingDetail,
+    BuyListItem,
+    BuyListResponse,
+    BuyListSummary,
+)
+from app.services.mrp import MRPService
+from app.services.supply_netting import get_projected_available
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Sales order statuses that represent open/active demand.
+# Cancelled, completed, delivered, and shipped orders are not outstanding demand.
+_OPEN_SO_STATUSES_EXCLUDE = frozenset(
+    ["cancelled", "completed", "delivered", "shipped"]
+)
+
+# Production order statuses considered open (same as MRPService._get_production_orders
+# with include_draft=True).
+_OPEN_WO_STATUSES = frozenset(["draft", "released", "in_progress"])
+
+
+@dataclass
+class _DemandSource:
+    """Internal: one open order contributing to a component's gross demand."""
+    order_type: str          # "sales_order" or "production_order"
+    order_id: int
+    order_ref: str           # order_number / production code
+    due_date: Optional[date]
+
+
+@dataclass
+class _ComponentDemand:
+    """Internal: aggregated gross demand for one component."""
+    product_id: int
+    gross_quantity: Decimal = Decimal("0")
+    earliest_need: Optional[date] = None
+    sources: List[_DemandSource] = field(default_factory=list)
+
+    def add(self, qty: Decimal, source: _DemandSource) -> None:
+        self.gross_quantity += qty
+        if source.due_date:
+            if self.earliest_need is None or source.due_date < self.earliest_need:
+                self.earliest_need = source.due_date
+        self.sources.append(source)
+
+
+def _collect_open_so_demand(
+    db: Session,
+    mrp_service: MRPService,
+    demand: Dict[int, _ComponentDemand],
+) -> int:
+    """
+    Explode all open sales orders and add component demand to *demand* dict.
+
+    Returns the count of sales orders included.
+    """
+    sos = (
+        db.query(SalesOrder)
+        .filter(SalesOrder.status.notin_(list(_OPEN_SO_STATUSES_EXCLUDE)))
+        .all()
+    )
+    count = 0
+    for so in sos:
+        due = (
+            so.estimated_completion_date.date()
+            if so.estimated_completion_date
+            else None
+        )
+        source = _DemandSource(
+            order_type="sales_order",
+            order_id=so.id,
+            order_ref=so.order_number or str(so.id),
+            due_date=due,
+        )
+        exploded = False
+
+        if so.order_type == "quote_based" and so.product_id:
+            qty = Decimal(str(so.quantity or 1))
+            reqs = mrp_service.explode_bom(
+                product_id=int(so.product_id),
+                quantity=qty,
+                source_demand_type="sales_order",
+                source_demand_id=int(so.id),
+                due_date=due,
+            )
+            for req in reqs:
+                if req.product_id not in demand:
+                    demand[req.product_id] = _ComponentDemand(
+                        product_id=req.product_id
+                    )
+                demand[req.product_id].add(req.gross_quantity, source)
+            exploded = bool(reqs)
+
+        elif so.order_type == "line_item":
+            lines = (
+                db.query(SalesOrderLine)
+                .filter(
+                    SalesOrderLine.sales_order_id == so.id,
+                    SalesOrderLine.product_id.isnot(None),
+                )
+                .all()
+            )
+            for line in lines:
+                qty = Decimal(str(line.quantity or 0))
+                if qty <= Decimal("0"):
+                    continue
+                reqs = mrp_service.explode_bom(
+                    product_id=int(line.product_id),
+                    quantity=qty,
+                    source_demand_type="sales_order",
+                    source_demand_id=int(so.id),
+                    due_date=due,
+                )
+                for req in reqs:
+                    if req.product_id not in demand:
+                        demand[req.product_id] = _ComponentDemand(
+                            product_id=req.product_id
+                        )
+                    demand[req.product_id].add(req.gross_quantity, source)
+                if reqs:
+                    exploded = True
+
+        if exploded:
+            count += 1
+
+    return count
+
+
+def _collect_open_wo_demand(
+    db: Session,
+    mrp_service: MRPService,
+    demand: Dict[int, _ComponentDemand],
+) -> int:
+    """
+    Explode all open production orders (remaining qty only) and add to *demand*.
+
+    Returns the count of production orders included.
+    """
+    wos = (
+        db.query(ProductionOrder)
+        .filter(ProductionOrder.status.in_(list(_OPEN_WO_STATUSES)))
+        .all()
+    )
+    count = 0
+    for wo in wos:
+        ordered = Decimal(str(wo.quantity_ordered or 0))
+        completed = Decimal(str(wo.quantity_completed or 0))
+        remaining = ordered - completed
+        if remaining <= Decimal("0"):
+            continue
+
+        source = _DemandSource(
+            order_type="production_order",
+            order_id=wo.id,
+            order_ref=wo.code or str(wo.id),
+            due_date=wo.due_date,
+        )
+        reqs = mrp_service.explode_bom(
+            product_id=int(wo.product_id),
+            quantity=remaining,
+            source_demand_type="production_order",
+            source_demand_id=int(wo.id),
+            due_date=wo.due_date,
+        )
+        for req in reqs:
+            if req.product_id not in demand:
+                demand[req.product_id] = _ComponentDemand(product_id=req.product_id)
+            demand[req.product_id].add(req.gross_quantity, source)
+
+        if reqs:
+            count += 1
+
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_buy_list(
+    db: Session,
+    vendor_id: Optional[int] = None,
+) -> BuyListResponse:
+    """
+    Compute and return the consolidated buy list.
+
+    Parameters
+    ----------
+    db:
+        SQLAlchemy session.  NEVER committed — pure reads.
+    vendor_id:
+        Optional filter.  When provided, only return items whose
+        preferred_vendor_id matches.
+
+    Returns
+    -------
+    BuyListResponse with summary + list of short components sorted by
+    (preferred_vendor_name ASC, earliest_need ASC NULLS LAST, sku ASC).
+    """
+    mrp_service = MRPService(db)
+
+    # ------------------------------------------------------------------ #
+    # Step 1: Collect gross demand from all open orders                   #
+    # ------------------------------------------------------------------ #
+    demand: Dict[int, _ComponentDemand] = {}
+    so_count = _collect_open_so_demand(db, mrp_service, demand)
+    wo_count = _collect_open_wo_demand(db, mrp_service, demand)
+
+    if not demand:
+        return BuyListResponse(
+            summary=BuyListSummary(
+                components_short=0,
+                total_estimated_buy_value=Decimal("0"),
+                open_sales_orders_included=so_count,
+                open_production_orders_included=wo_count,
+                draft_incoming_qty=Decimal("0"),
+            ),
+            items=[],
+        )
+
+    # ------------------------------------------------------------------ #
+    # Step 2: Load products in bulk                                        #
+    # ------------------------------------------------------------------ #
+    product_ids = list(demand.keys())
+    products: Dict[int, Product] = {
+        p.id: p
+        for p in db.query(Product).filter(Product.id.in_(product_ids)).all()
+    }
+
+    # Vendor name lookup (only preferred_vendor_ids that appear)
+    vendor_ids = {
+        p.preferred_vendor_id
+        for p in products.values()
+        if p.preferred_vendor_id
+    }
+    vendors: Dict[int, Vendor] = {}
+    if vendor_ids:
+        vendors = {
+            v.id: v
+            for v in db.query(Vendor).filter(Vendor.id.in_(vendor_ids)).all()
+        }
+
+    # ------------------------------------------------------------------ #
+    # Step 3: Net each component and build output rows                     #
+    # ------------------------------------------------------------------ #
+    items: List[BuyListItem] = []
+    total_buy_value = Decimal("0")
+    total_draft_incoming = Decimal("0")
+
+    for pid, comp_demand in demand.items():
+        product = products.get(pid)
+        if not product:
+            continue
+
+        avail = get_projected_available(db, pid)
+
+        safety_stock = Decimal(str(product.safety_stock or 0))
+        gross = comp_demand.gross_quantity
+        projected = avail.projected
+
+        # MRP netting formula (same as calculate_net_requirements):
+        # net_shortage = max(0, gross − projected + safety_stock)
+        raw_short = gross - projected + safety_stock
+        net_shortage = max(Decimal("0"), raw_short)
+
+        if net_shortage <= Decimal("0"):
+            # Component is covered — not on the buy list
+            continue
+
+        # Suggested order qty respects min_order_qty
+        min_oq = Decimal(str(product.min_order_qty or 0))
+        suggested_qty = max(net_shortage, min_oq) if min_oq > Decimal("0") else net_shortage
+
+        # Vendor filter
+        pref_vendor_id = product.preferred_vendor_id
+        if vendor_id is not None and pref_vendor_id != vendor_id:
+            continue
+        pref_vendor_name: Optional[str] = None
+        if pref_vendor_id and pref_vendor_id in vendors:
+            pref_vendor_name = vendors[pref_vendor_id].name
+
+        # Unit cost (standard preferred; fall back to last_cost)
+        raw_cost = Decimal(str(product.standard_cost or product.last_cost or 0))
+
+        # Apply UOM cost conversion (filament costs stored per KG, inventory in grams)
+        try:
+            from app.services.uom_service import get_cost_reference_unit, convert_cost_for_unit
+            product_unit = (product.unit or "EA").upper().strip()
+            cost_ref_unit = get_cost_reference_unit(product_unit)
+            converted_cost = convert_cost_for_unit(raw_cost, cost_ref_unit, product_unit)
+            unit_cost = converted_cost if converted_cost is not None else raw_cost
+        except Exception:
+            unit_cost = raw_cost
+
+        est_buy_value = suggested_qty * unit_cost
+        total_buy_value += est_buy_value
+
+        # Draft incoming accumulator for summary transparency
+        draft_incoming = sum(
+            d.quantity for d in avail.details if d.status == "draft"
+        )
+        total_draft_incoming += draft_incoming
+
+        # Build incoming detail list (adds "(draft)" visibility to UI)
+        incoming_details = [
+            BuyListIncomingDetail(
+                purchase_order_id=d.purchase_order_id,
+                po_number=d.po_number,
+                quantity=d.quantity,
+                expected_date=d.expected_date,
+                status=d.status,
+            )
+            for d in avail.details
+        ]
+
+        items.append(
+            BuyListItem(
+                product_id=pid,
+                sku=product.sku,
+                name=product.name,
+                unit=product.unit or "EA",
+                gross_demand=gross,
+                on_hand=avail.on_hand,
+                allocated=avail.allocated,
+                available=avail.available,
+                incoming_qty=avail.incoming_qty,
+                projected=projected,
+                safety_stock=safety_stock,
+                net_shortage=net_shortage,
+                suggested_qty=suggested_qty,
+                preferred_vendor_id=pref_vendor_id,
+                preferred_vendor_name=pref_vendor_name,
+                unit_cost=unit_cost,
+                estimated_buy_value=est_buy_value,
+                earliest_need=comp_demand.earliest_need,
+                incoming_details=incoming_details,
+            )
+        )
+
+    # ------------------------------------------------------------------ #
+    # Step 4: Sort — vendor name, earliest need, then SKU                 #
+    # ------------------------------------------------------------------ #
+    items.sort(
+        key=lambda i: (
+            i.preferred_vendor_name or "\xff",  # no-vendor last
+            i.earliest_need or date.max,
+            i.sku,
+        )
+    )
+
+    summary = BuyListSummary(
+        components_short=len(items),
+        total_estimated_buy_value=total_buy_value,
+        open_sales_orders_included=so_count,
+        open_production_orders_included=wo_count,
+        draft_incoming_qty=total_draft_incoming,
+    )
+
+    return BuyListResponse(summary=summary, items=items)

--- a/backend/tests/test_buy_list_service.py
+++ b/backend/tests/test_buy_list_service.py
@@ -1,0 +1,343 @@
+"""
+Tests for the consolidated buy list service and endpoint (HARD-7).
+
+Coverage:
+- Multi-order demand aggregation for a shared component
+- Netting against on-hand + incoming open POs
+- Safety-stock floor applied correctly
+- Suggested qty respects min_order_qty
+- Zero-shortage component excluded from results
+- Endpoint: 401 when unauthenticated, 200 when authenticated
+"""
+import pytest
+from decimal import Decimal
+from datetime import date, timedelta
+
+from app.models.inventory import Inventory
+from app.models.purchase_order import PurchaseOrderLine
+from app.services.buy_list_service import get_buy_list
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _add_inventory(db, product_id: int, on_hand: Decimal, allocated: Decimal = Decimal("0")):
+    inv = Inventory(
+        product_id=product_id,
+        location_id=1,
+        on_hand_quantity=on_hand,
+        allocated_quantity=allocated,
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+_po_line_counter = [0]
+
+
+def _add_po_line(db, po, product_id: int, qty_ordered: Decimal, qty_received: Decimal = Decimal("0")):
+    _po_line_counter[0] += 1
+    line = PurchaseOrderLine(
+        purchase_order_id=po.id,
+        product_id=product_id,
+        line_number=_po_line_counter[0],
+        quantity_ordered=qty_ordered,
+        quantity_received=qty_received,
+        unit_cost=Decimal("1.00"),
+        line_total=qty_ordered * Decimal("1.00"),
+    )
+    db.add(line)
+    db.flush()
+    return line
+
+
+# ---------------------------------------------------------------------------
+# Service tests
+# ---------------------------------------------------------------------------
+
+class TestBuyListDemandAggregation:
+    """Multi-order demand is summed per component."""
+
+    def test_two_orders_sharing_component_aggregates_demand(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """Two production orders exploding to the same component are summed."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA", standard_cost=Decimal("2.00")
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("3"), "unit": "EA"}],
+        )
+
+        # No inventory — everything is short
+        make_production_order(product_id=fg.id, status="released", quantity=4)
+        make_production_order(product_id=fg.id, status="released", quantity=6)
+
+        result = get_buy_list(db)
+
+        short_ids = {item.product_id for item in result.items}
+        assert comp.id in short_ids, "Component should appear on the buy list"
+
+        item = next(i for i in result.items if i.product_id == comp.id)
+        # Gross = 3 * (4 + 6) = 30
+        assert item.gross_demand == Decimal("30"), (
+            f"Expected gross_demand=30, got {item.gross_demand}"
+        )
+        assert item.net_shortage == Decimal("30")
+
+    def test_sales_order_and_production_order_aggregate(
+        self, db, make_product, make_bom, make_production_order, make_sales_order
+    ):
+        """SO and WO exploding to the same component are aggregated."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA", standard_cost=Decimal("1.00")
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("2"), "unit": "EA"}],
+        )
+
+        # A quote-based sales order with product_id
+        make_sales_order(
+            product_id=fg.id, quantity=5, status="confirmed",
+            order_type="quote_based",
+        )
+        # A production order
+        make_production_order(product_id=fg.id, status="released", quantity=3)
+
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        # Gross = 2*(5+3) = 16
+        assert item.gross_demand == Decimal("16")
+
+
+class TestNettingLogic:
+    """Netting: on-hand, allocated, and incoming open-PO supply."""
+
+    def test_on_hand_covers_demand_component_excluded(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """If on-hand alone covers demand the component is NOT on the buy list."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA")
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("5"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=2)
+        # demand = 10 units; stock = 100
+        _add_inventory(db, comp.id, Decimal("100"))
+
+        result = get_buy_list(db)
+        ids = {i.product_id for i in result.items}
+        assert comp.id not in ids
+
+    def test_incoming_po_covers_shortage(
+        self, db, make_product, make_bom, make_production_order, make_purchase_order,
+        make_vendor
+    ):
+        """An open PO that covers the gap means the component is NOT short."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA")
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("10"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        # demand = 10; on-hand = 3; incoming = 7 → projected = 10 → not short
+        _add_inventory(db, comp.id, Decimal("3"))
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        _add_po_line(db, po, comp.id, Decimal("7"))
+
+        result = get_buy_list(db)
+        ids = {i.product_id for i in result.items}
+        assert comp.id not in ids, "Incoming PO should cover the gap"
+
+    def test_partial_incoming_leaves_remainder_short(
+        self, db, make_product, make_bom, make_production_order, make_purchase_order,
+        make_vendor
+    ):
+        """Incoming PO covers part; remainder shows as net_shortage."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA", standard_cost=Decimal("5.00"))
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("20"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        # demand = 20; on-hand = 0; incoming = 8 → projected = 8 → short = 12
+        vendor = make_vendor()
+        po = make_purchase_order(vendor_id=vendor.id, status="ordered")
+        _add_po_line(db, po, comp.id, Decimal("10"), qty_received=Decimal("2"))
+
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        assert item.net_shortage == Decimal("12")
+        assert item.incoming_qty == Decimal("8")
+
+
+class TestSafetyStockFloor:
+    """Safety stock is added to the netting equation."""
+
+    def test_safety_stock_increases_shortage(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """Safety stock of N means we need N extra units beyond gross demand."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA",
+            standard_cost=Decimal("1.00"),
+            safety_stock=Decimal("5"),
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("10"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        # demand = 10; on-hand = 8; projected = 8
+        # net = max(0, 10 - 8 + 5) = 7
+        _add_inventory(db, comp.id, Decimal("8"))
+
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        assert item.net_shortage == Decimal("7"), (
+            f"Expected net_shortage=7 (safety_stock=5), got {item.net_shortage}"
+        )
+
+
+class TestMinOrderQty:
+    """Suggested qty is max(net_shortage, min_order_qty)."""
+
+    def test_min_order_qty_floors_suggested_qty(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """If shortage < min_order_qty, suggested_qty = min_order_qty."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA",
+            standard_cost=Decimal("2.00"),
+            min_order_qty=Decimal("50"),
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("3"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        # demand = 3; on-hand = 0; shortage = 3 < min_order_qty = 50
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        assert item.net_shortage == Decimal("3")
+        assert item.suggested_qty == Decimal("50"), (
+            f"Expected suggested_qty=50 (min_order_qty), got {item.suggested_qty}"
+        )
+
+    def test_shortage_exceeds_min_order_qty(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """If shortage > min_order_qty, suggested_qty = shortage."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA",
+            standard_cost=Decimal("1.00"),
+            min_order_qty=Decimal("10"),
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("100"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        assert item.suggested_qty == Decimal("100")
+
+
+class TestZeroShortageExclusion:
+    """Components with no shortage are excluded."""
+
+    def test_fully_covered_component_not_in_results(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """A component fully covered by on-hand does not appear."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA")
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("1"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=5)
+        _add_inventory(db, comp.id, Decimal("1000"))
+
+        result = get_buy_list(db)
+        assert all(i.product_id != comp.id for i in result.items)
+
+
+class TestDraftIncomingVisibility:
+    """Draft PO incoming quantity is surfaced in summary and detail."""
+
+    def test_draft_po_counted_in_incoming_and_summary(
+        self, db, make_product, make_bom, make_production_order, make_purchase_order,
+        make_vendor
+    ):
+        """Draft POs appear in incoming_details and contribute to summary.draft_incoming_qty."""
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(
+            item_type="supply", unit="EA", standard_cost=Decimal("3.00")
+        )
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("20"), "unit": "EA"}],
+        )
+        make_production_order(product_id=fg.id, status="released", quantity=1)
+        # Draft PO covers 5 of the 20 needed → comp still short by 15
+        vendor = make_vendor()
+        draft_po = make_purchase_order(vendor_id=vendor.id, status="draft")
+        _add_po_line(db, draft_po, comp.id, Decimal("5"))
+
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None
+        assert item.net_shortage == Decimal("15")
+        # Draft supply should be visible in details
+        draft_details = [d for d in item.incoming_details if d.status == "draft"]
+        assert len(draft_details) == 1
+        assert draft_details[0].quantity == Decimal("5")
+        # Summary tracks draft supply
+        assert result.summary.draft_incoming_qty >= Decimal("5")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestBuyListEndpoint:
+    """Endpoint auth and basic response shape."""
+
+    def test_unauthenticated_returns_401(self, unauthed_client):
+        response = unauthed_client.get("/api/v1/buy-list")
+        assert response.status_code == 401
+
+    def test_authenticated_returns_200(self, client):
+        response = client.get("/api/v1/buy-list")
+        assert response.status_code == 200
+        body = response.json()
+        assert "summary" in body
+        assert "items" in body
+        assert isinstance(body["items"], list)
+
+    def test_vendor_filter_accepted(self, client):
+        """vendor_id filter is accepted without error (may return empty list)."""
+        response = client.get("/api/v1/buy-list?vendor_id=9999")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["items"] == []

--- a/frontend/src/components/purchasing/BuyListTab.jsx
+++ b/frontend/src/components/purchasing/BuyListTab.jsx
@@ -1,0 +1,444 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useApi } from "../../hooks/useApi";
+
+/**
+ * BuyListTab — consolidated buy list (HARD-7, Layer 1 live view).
+ *
+ * Answers "across ALL open demand, what do I buy, how much, by when?"
+ *
+ * Per-row "Create PO" navigates to /admin/purchasing?create_po=true&product_id=X&quantity=Y
+ * so the existing POCreateModal pre-fills vendor + suggested qty without
+ * any modification to purchase_order_service (human commits the PO).
+ */
+export default function BuyListTab() {
+  const api = useApi();
+  const navigate = useNavigate();
+
+  const [buyList, setBuyList] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [expandedRows, setExpandedRows] = useState(new Set());
+
+  const fetchBuyList = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get("/api/v1/buy-list");
+      setBuyList(data);
+    } catch (err) {
+      setError(err.message || "Failed to load buy list");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchBuyList();
+  }, []);
+
+  const toggleRow = (productId) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(productId)) {
+        next.delete(productId);
+      } else {
+        next.add(productId);
+      }
+      return next;
+    });
+  };
+
+  const handleCreatePO = (item) => {
+    // Navigate to the Purchasing page with URL params that pre-fill POCreateModal.
+    // This reuses the existing create_po param flow already in AdminPurchasing.jsx.
+    const params = new URLSearchParams({
+      tab: "orders",
+      create_po: "true",
+      product_id: String(item.product_id),
+      quantity: String(item.suggested_qty),
+    });
+    navigate(`/admin/purchasing?${params.toString()}`);
+  };
+
+  const formatQty = (qty) => {
+    const n = parseFloat(qty);
+    if (Number.isInteger(n)) return n.toLocaleString();
+    return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  };
+
+  const formatCurrency = (val) => {
+    const n = parseFloat(val);
+    return n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+  };
+
+  const formatDate = (d) => {
+    if (!d) return "—";
+    return new Date(d).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-6 text-red-400">
+        <p className="font-semibold mb-1">Failed to load buy list</p>
+        <p className="text-sm">{error}</p>
+        <button
+          onClick={fetchBuyList}
+          className="mt-3 px-3 py-1.5 bg-red-600/20 hover:bg-red-600/40 rounded text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!buyList) return null;
+
+  const { summary, items } = buyList;
+
+  return (
+    <div className="space-y-6">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
+          <div className="text-3xl font-bold text-red-400">
+            {summary.components_short}
+          </div>
+          <div className="text-sm text-gray-400 mt-1">Components Short</div>
+        </div>
+        <div className="bg-orange-500/10 border border-orange-500/30 rounded-xl p-4">
+          <div className="text-2xl font-bold text-orange-400">
+            {formatCurrency(summary.total_estimated_buy_value)}
+          </div>
+          <div className="text-sm text-gray-400 mt-1">Est. Buy Value</div>
+        </div>
+        <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4">
+          <div className="text-3xl font-bold text-blue-400">
+            {summary.open_sales_orders_included}
+          </div>
+          <div className="text-sm text-gray-400 mt-1">Open Sales Orders</div>
+        </div>
+        <div className="bg-purple-500/10 border border-purple-500/30 rounded-xl p-4">
+          <div className="text-3xl font-bold text-purple-400">
+            {summary.open_production_orders_included}
+          </div>
+          <div className="text-sm text-gray-400 mt-1">Open Work Orders</div>
+        </div>
+      </div>
+
+      {/* Draft-supply transparency notice */}
+      {summary.draft_incoming_qty > 0 && (
+        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl p-4 flex items-start gap-3">
+          <svg
+            className="w-5 h-5 text-yellow-400 mt-0.5 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <p className="text-yellow-300 text-sm">
+            <strong>
+              {formatQty(summary.draft_incoming_qty)} units
+            </strong>{" "}
+            of incoming supply shown below are on <strong>draft</strong> POs
+            — uncommitted. Rows marked "(draft)" in the Incoming column may
+            still be short if those POs are not placed.
+          </p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {items.length === 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-12 text-center">
+          <svg
+            className="w-12 h-12 text-green-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <h3 className="text-lg font-semibold text-white mb-2">
+            All components covered
+          </h3>
+          <p className="text-gray-400 text-sm">
+            No shortages detected across open sales and production orders.
+          </p>
+          <button
+            onClick={fetchBuyList}
+            className="mt-4 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 rounded text-sm text-gray-300"
+          >
+            Refresh
+          </button>
+        </div>
+      )}
+
+      {/* Buy list table */}
+      {items.length > 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+          <div className="flex items-center justify-between p-4 border-b border-gray-800">
+            <h3 className="text-sm font-semibold text-white">
+              Components to Buy ({items.length})
+            </h3>
+            <button
+              onClick={fetchBuyList}
+              className="text-xs text-gray-400 hover:text-white flex items-center gap-1"
+            >
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+              Refresh
+            </button>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-400 border-b border-gray-800">
+                  <th className="px-4 py-3 font-medium w-6" />
+                  <th className="px-4 py-3 font-medium">Component</th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    Gross Demand
+                  </th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    On Hand
+                  </th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    Incoming
+                  </th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    Net Short
+                  </th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    Suggest Qty
+                  </th>
+                  <th className="px-4 py-3 font-medium">Vendor</th>
+                  <th className="px-4 py-3 font-medium text-right">
+                    Est. Value
+                  </th>
+                  <th className="px-4 py-3 font-medium">Need By</th>
+                  <th className="px-4 py-3 font-medium" />
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item) => {
+                  const isExpanded = expandedRows.has(item.product_id);
+                  const hasDraft = item.incoming_details?.some(
+                    (d) => d.status === "draft"
+                  );
+
+                  return (
+                    <>
+                      <tr
+                        key={item.product_id}
+                        className="border-b border-gray-800/50 bg-red-500/5 hover:bg-red-500/10 transition-colors"
+                      >
+                        {/* Expand toggle */}
+                        <td className="px-4 py-3">
+                          {item.incoming_details?.length > 0 && (
+                            <button
+                              onClick={() => toggleRow(item.product_id)}
+                              className="text-gray-500 hover:text-gray-300"
+                            >
+                              <svg
+                                className={`w-4 h-4 transition-transform ${
+                                  isExpanded ? "rotate-90" : ""
+                                }`}
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M9 5l7 7-7 7"
+                                />
+                              </svg>
+                            </button>
+                          )}
+                        </td>
+
+                        {/* SKU / name */}
+                        <td className="px-4 py-3">
+                          <div className="font-mono text-white text-xs">
+                            {item.sku}
+                          </div>
+                          <div className="text-gray-400 text-xs mt-0.5 truncate max-w-[180px]">
+                            {item.name}
+                          </div>
+                        </td>
+
+                        {/* Gross demand */}
+                        <td className="px-4 py-3 text-right text-gray-300">
+                          {formatQty(item.gross_demand)}{" "}
+                          <span className="text-gray-500 text-xs">
+                            {item.unit}
+                          </span>
+                        </td>
+
+                        {/* On hand */}
+                        <td className="px-4 py-3 text-right text-gray-300">
+                          {formatQty(item.on_hand)}
+                        </td>
+
+                        {/* Incoming */}
+                        <td className="px-4 py-3 text-right">
+                          <span
+                            className={
+                              hasDraft
+                                ? "text-yellow-400"
+                                : "text-blue-400"
+                            }
+                          >
+                            {formatQty(item.incoming_qty)}
+                          </span>
+                          {hasDraft && (
+                            <span className="ml-1 text-yellow-500 text-xs">
+                              ⚠ draft
+                            </span>
+                          )}
+                        </td>
+
+                        {/* Net short — highlighted */}
+                        <td className="px-4 py-3 text-right">
+                          <span className="font-semibold text-red-400">
+                            {formatQty(item.net_shortage)}{" "}
+                            <span className="text-xs font-normal">
+                              {item.unit}
+                            </span>
+                          </span>
+                        </td>
+
+                        {/* Suggested qty */}
+                        <td className="px-4 py-3 text-right text-white font-medium">
+                          {formatQty(item.suggested_qty)}{" "}
+                          <span className="text-gray-500 text-xs font-normal">
+                            {item.unit}
+                          </span>
+                        </td>
+
+                        {/* Vendor */}
+                        <td className="px-4 py-3">
+                          {item.preferred_vendor_name ? (
+                            <span className="text-gray-300">
+                              {item.preferred_vendor_name}
+                            </span>
+                          ) : (
+                            <span className="text-gray-600 italic text-xs">
+                              No vendor
+                            </span>
+                          )}
+                        </td>
+
+                        {/* Estimated value */}
+                        <td className="px-4 py-3 text-right text-gray-300">
+                          {formatCurrency(item.estimated_buy_value)}
+                        </td>
+
+                        {/* Need by */}
+                        <td className="px-4 py-3 text-gray-400">
+                          {formatDate(item.earliest_need)}
+                        </td>
+
+                        {/* Create PO button */}
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => handleCreatePO(item)}
+                            className="px-2.5 py-1 bg-blue-600/80 hover:bg-blue-600 rounded text-white text-xs font-medium whitespace-nowrap"
+                            title={`Create PO for ${item.sku} — ${formatQty(item.suggested_qty)} ${item.unit}${item.preferred_vendor_name ? " from " + item.preferred_vendor_name : ""}`}
+                          >
+                            + Create PO
+                          </button>
+                        </td>
+                      </tr>
+
+                      {/* Expanded incoming PO detail */}
+                      {isExpanded && item.incoming_details?.length > 0 && (
+                        <tr
+                          key={`${item.product_id}-detail`}
+                          className="border-b border-gray-800/50 bg-gray-800/30"
+                        >
+                          <td colSpan={11} className="px-10 py-3">
+                            <div className="text-xs text-gray-400 mb-2 font-medium uppercase tracking-wide">
+                              Open PO Supply
+                            </div>
+                            <div className="space-y-1">
+                              {item.incoming_details.map((d) => (
+                                <div
+                                  key={d.purchase_order_id}
+                                  className="flex items-center gap-4 text-xs"
+                                >
+                                  <span className="font-mono text-blue-300">
+                                    {d.po_number}
+                                  </span>
+                                  <span className="text-gray-300">
+                                    {formatQty(d.quantity)} {item.unit}
+                                  </span>
+                                  <span
+                                    className={`px-1.5 py-0.5 rounded text-xs ${
+                                      d.status === "draft"
+                                        ? "bg-yellow-500/20 text-yellow-400"
+                                        : d.status === "shipped"
+                                        ? "bg-green-500/20 text-green-400"
+                                        : "bg-blue-500/20 text-blue-400"
+                                    }`}
+                                  >
+                                    {d.status === "draft"
+                                      ? "draft (uncommitted)"
+                                      : d.status}
+                                  </span>
+                                  {d.expected_date && (
+                                    <span className="text-gray-500">
+                                      due {formatDate(d.expected_date)}
+                                    </span>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminPurchasing.jsx
+++ b/frontend/src/pages/admin/AdminPurchasing.jsx
@@ -11,6 +11,7 @@ import ReceiveModal from "../../components/purchasing/ReceiveModal";
 import PurchaseOrdersTab from "../../components/purchasing/PurchaseOrdersTab";
 import VendorsTab from "../../components/purchasing/VendorsTab";
 import LowStockTab from "../../components/purchasing/LowStockTab";
+import BuyListTab from "../../components/purchasing/BuyListTab";
 
 export default function AdminPurchasing() {
   const api = useApi();
@@ -626,10 +627,20 @@ export default function AdminPurchasing() {
             </span>
           )}
         </button>
+        <button
+          onClick={() => setActiveTab("buy-list")}
+          className={`pb-2 px-1 text-sm font-medium transition-colors ${
+            activeTab === "buy-list"
+              ? "text-red-400 border-b-2 border-red-400"
+              : "text-gray-400 hover:text-white"
+          }`}
+        >
+          Buy List
+        </button>
       </div>
 
-      {/* Filters - hide on import and low-stock tabs */}
-      {activeTab !== "import" && activeTab !== "low-stock" && (
+      {/* Filters - hide on import, low-stock, and buy-list tabs */}
+      {activeTab !== "import" && activeTab !== "low-stock" && activeTab !== "buy-list" && (
         <div className="flex flex-col sm:flex-row gap-4 bg-gray-900 border border-gray-800 rounded-xl p-4">
           <div className="flex-1">
             <input
@@ -673,7 +684,7 @@ export default function AdminPurchasing() {
         </div>
       )}
 
-      {/* Loading - only show for orders and vendors tabs */}
+      {/* Loading - only show for orders and vendors tabs (buy-list has its own loader) */}
       {loading && (activeTab === "orders" || activeTab === "vendors") && (
         <div className="flex items-center justify-center h-32">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
@@ -748,6 +759,9 @@ export default function AdminPurchasing() {
           onCreatePOFromSelection={handleCreatePOFromSelection}
         />
       )}
+
+      {/* Buy List Tab — HARD-7: computed-on-demand netting across all open demand */}
+      {activeTab === "buy-list" && <BuyListTab />}
 
       {/* Vendor Modal */}
       {showVendorModal && (


### PR DESCRIPTION
## Summary

Implements HARD-7 Layer 1: the **consolidated buy list** — a zero-write, computed-on-demand view that answers "across ALL open demand, what do I buy, how much, and by when?"

### Architecture (owner-approved three-layer design)
- **Layer 1 (this PR)** — live view: open the page, it nets gross demand right then. No stored MRP run artifact to go stale.
- Layer 2 (Plan-and-firm) — follow-up PR
- Layer 3 (event signals) — after HARD-3 follow-up

### What ships
- **`buy_list_service.get_buy_list(db)`** — pure read, zero writes, never calls `run_mrp`
  - Explodes all open SOs + production orders via `MRPService.explode_bom` (routing-first / BOM-fallback, identical semantics to the full engine)
  - Aggregates gross component demand across all orders
  - Nets per component via `supply_netting.get_projected_available` (on-hand − allocated + open POs)
  - Safety-stock floor: `net_shortage = max(0, gross − projected + safety_stock)`
  - Suggested qty: `max(net_shortage, min_order_qty)`
  - Preferred vendor via `Product.preferred_vendor_id` (HARD-13 will add VendorItem pricing later)
  - Earliest-need hint from min(due_date) across demanding orders
  - Single-bucket netting, no time-phasing (per MVP spec)
- **`GET /api/v1/buy-list`** — staff-only (router-level `Depends(get_current_staff_user)`), optional `?vendor_id=N` filter; response: `{summary, items[]}`
- **`supply_netting._OPEN_PO_STATUSES`** — already a named module-level constant as scoped; draft PO status propagates through to `incoming_details[].status` so operators see uncommitted supply labeled `"draft"` 
- **Buy List tab** in Purchasing page (between Low Stock and Import):
  - Summary cards: components short, est. buy value, open SO count, open WO count
  - Draft-supply transparency banner when any incoming qty is on draft POs
  - Per-row: SKU, name, gross demand, on-hand, incoming (yellow + ⚠ if draft), net short, suggested qty, vendor, est. value, need-by date
  - Expand row → shows individual open PO lines with status badges ("draft (uncommitted)" / "ordered" / "shipped")
  - Per-row **"+ Create PO"** button → navigates to `/admin/purchasing?create_po=true&product_id=X&quantity=Y` which pre-fills the existing `POCreateModal` (zero changes to `purchase_order_service`)
- **13 service tests**: multi-order aggregation, on-hand netting, incoming-PO netting, safety-stock, min_order_qty floor, zero-shortage exclusion, draft-PO visibility, endpoint 401/200/vendor-filter

### Layer 2 status
Layer 1 lands cleanly and is the honest MVP per the plan. Layer 2 (Plan-and-firm: generate proposals for human review before any PO is created) is noted as the follow-up.

### Files changed
| File | Role |
|------|------|
| `backend/app/services/buy_list_service.py` | New — netting service |
| `backend/app/schemas/buy_list.py` | New — response schemas |
| `backend/app/api/v1/endpoints/buy_list.py` | New — GET /buy-list endpoint |
| `backend/app/api/v1/__init__.py` | Register router |
| `backend/tests/test_buy_list_service.py` | New — 13 tests |
| `frontend/src/components/purchasing/BuyListTab.jsx` | New — Buy List tab component |
| `frontend/src/pages/admin/AdminPurchasing.jsx` | Add tab + panel |

## Test plan
- [ ] `pytest backend/tests/test_buy_list_service.py` — 13 tests pass
- [ ] `npm run test:unit` — 301 tests pass (no regressions)
- [ ] `npm run build` — clean build
- [ ] Open Purchasing → Buy List tab → shows live shortage data from dev DB
- [ ] Per-row "Create PO" → opens PO modal pre-filled with vendor + qty
- [ ] `GET /api/v1/buy-list` without auth → 401
- [ ] `GET /api/v1/buy-list?vendor_id=1` → filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)