### PR TITLE
feat: cycle count variance review before posting (HARD-16)

### DIFF
--- a/backend/app/services/inventory_transaction_service.py
+++ b/backend/app/services/inventory_transaction_service.py
@@ -261,8 +261,14 @@ def get_inventory_summary(
     for inv in items:
         product = inv.product
         location = inv.location
-        # Best available unit cost: standard > average > last; None if all null
-        raw_cost = product.standard_cost or product.average_cost or product.last_cost
+        # Best available unit cost: standard > average > last; None if all null.
+        # Use explicit is-None checks — Decimal("0") is falsy and should not fall through.
+        if product.standard_cost is not None:
+            raw_cost = product.standard_cost
+        elif product.average_cost is not None:
+            raw_cost = product.average_cost
+        else:
+            raw_cost = product.last_cost
         unit_cost = float(raw_cost) if raw_cost is not None else None
         result.append({
             "inventory_id": inv.id,

--- a/backend/app/services/inventory_transaction_service.py
+++ b/backend/app/services/inventory_transaction_service.py
@@ -261,6 +261,9 @@ def get_inventory_summary(
     for inv in items:
         product = inv.product
         location = inv.location
+        # Best available unit cost: standard > average > last; None if all null
+        raw_cost = product.standard_cost or product.average_cost or product.last_cost
+        unit_cost = float(raw_cost) if raw_cost is not None else None
         result.append({
             "inventory_id": inv.id,
             "product_id": product.id,
@@ -277,6 +280,7 @@ def get_inventory_summary(
                 if inv.available_quantity
                 else float(inv.on_hand_quantity) - float(inv.allocated_quantity)
             ),
+            "unit_cost": unit_cost,
             "last_counted": inv.last_counted.isoformat() if inv.last_counted else None,
         })
 

--- a/docs/user-guide/inventory.md
+++ b/docs/user-guide/inventory.md
@@ -182,9 +182,13 @@ Navigate to **Inventory > Cycle Count** in the sidebar.
 graph LR
     A[Filter items to count] --> B[Count physical stock]
     B --> C[Enter counted quantities]
-    C --> D[Review variances]
-    D --> E[Submit count]
-    E --> F[System records adjustments]
+    C --> D[Review variances in table]
+    D --> E[Submit Count]
+    E --> F[Review variance summary]
+    F --> G{Correct?}
+    G -- Yes --> H[Confirm & Post]
+    G -- No --> D
+    H --> I[System records adjustments + GL entries]
 ```
 
 When you submit a cycle count, FilaOps automatically creates inventory adjustment transactions for every item where the counted quantity differs from the system quantity. These adjustments include the reason you selected and create corresponding accounting entries.
@@ -247,26 +251,39 @@ As you enter quantities, FilaOps highlights variances in real time:
 
 For each item with a variance, you can optionally select a **per-item reason** from the dropdown. If you don't, the default reason from the top of the page is used.
 
-#### Step 5: Submit the Count
+#### Step 5: Review the Variance Summary
 
-When you've finished entering all quantities, click **Submit Count**.
+When you've finished entering all quantities, click **Submit Count**. FilaOps opens a
+**Variance Review** panel before writing anything. The review shows:
 
-FilaOps processes the count and shows a results summary:
-
-- **Total Items** — How many items were included in the count
-- **Successful** (green) — Items processed without errors
-- **Failed** (red) — Items that couldn't be processed (rare, usually a system error)
-
-Below the summary, a **variance details table** shows every item that had a variance:
+- A summary line: **N adjustments, total variance value $X (▲ $Y up / ▼ $Z down)**
+- Items counted at system quantity (zero variance) are collapsed into a single note —
+  they require no adjustment and are not listed individually.
+- A per-item table for every item that *will* be adjusted:
 
 | Column | What It Shows |
 |--------|--------------|
 | **SKU** | Item part number |
 | **Name** | Item name |
-| **Previous** | What the system quantity was before the count |
-| **Counted** | What you entered |
-| **Variance** | The difference |
-| **Status** | OK (green) or FAILED (red) |
+| **System Qty** | Quantity the system had recorded |
+| **Counted Qty** | What you entered |
+| **Variance** | The difference (green = found more, red = found less) |
+| **Unit Cost** | Cost used to calculate the dollar impact |
+| **Variance Value** | `variance × unit cost` — the GL dollar amount |
+| **Reason** | The reason that will be recorded on the transaction |
+
+From this screen you have two options:
+
+- **Go Back** — dismiss the review and return to your entries (nothing is written;
+  all your counts are preserved so you can correct any mistakes).
+- **Confirm & Post** — post all adjustments immediately. Inventory quantities and
+  GL journal entries are written at this point.
+
+After a successful post, the page shows a results summary:
+
+- **Total Items** — How many items were included in the count
+- **Successful** (green) — Items processed without errors
+- **Failed** (red) — Items that couldn't be processed (rare, usually a system error)
 
 !!! info "Accounting impact"
     Every cycle count variance creates a journal entry in your general ledger. Positive variances debit Inventory and credit the Inventory Adjustment expense account. Negative variances do the opposite. This keeps your books in sync with physical reality.
@@ -313,6 +330,6 @@ With inventory tracking in place, you can automate replenishment and plan ahead:
 | Record an adjustment | **Inventory > Transactions** > **+ New Transaction** > Type: Adjustment |
 | Add a new spool | **Inventory > Spools** > **+ Add Spool** |
 | Update spool weight | **Inventory > Spools** > **Edit** on the spool row |
-| Run a cycle count | **Inventory > Cycle Count** > Fill quantities > **Submit Count** |
+| Run a cycle count | **Inventory > Cycle Count** > Fill quantities > **Submit Count** > review variances > **Confirm & Post** |
 | Filter by location | Use the Location dropdown on any inventory page |
 | Check stock levels | **Inventory > Items** > Look at stock status colors |

--- a/frontend/src/pages/admin/AdminCycleCount.jsx
+++ b/frontend/src/pages/admin/AdminCycleCount.jsx
@@ -2,6 +2,141 @@ import { useState, useEffect, useCallback } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 
+// ---------------------------------------------------------------------------
+// Variance review modal — shown BEFORE any writes
+// ---------------------------------------------------------------------------
+function VarianceReviewModal({ reviewItems, noVarianceCount, countReference, submitting, onConfirm, onBack }) {
+  const totalAdjustments = reviewItems.filter((r) => r.variance !== 0).length;
+  const totalVarianceValue = reviewItems.reduce((acc, r) => acc + r.varianceValue, 0);
+  const upValue = reviewItems.filter((r) => r.variance > 0).reduce((acc, r) => acc + r.varianceValue, 0);
+  const downValue = reviewItems.filter((r) => r.variance < 0).reduce((acc, r) => acc + Math.abs(r.varianceValue), 0);
+
+  const fmtQty = (v) =>
+    v.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  const fmtCurrency = (v) =>
+    v != null
+      ? `$${Math.abs(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : "—";
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-800 flex-shrink-0">
+          <h2 className="text-xl font-bold text-white">Review Variance Before Posting</h2>
+          <p className="text-sm text-gray-400 mt-1">
+            Review every adjustment below. Once you confirm, inventory and GL entries will be written immediately.
+          </p>
+        </div>
+
+        {/* Summary row */}
+        <div className="px-6 py-3 bg-gray-800/50 border-b border-gray-800 flex-shrink-0">
+          <div className="flex flex-wrap gap-6 text-sm">
+            <span className="text-gray-300">
+              <span className="font-semibold text-white">{totalAdjustments}</span> adjustment{totalAdjustments !== 1 ? "s" : ""}
+            </span>
+            <span className="text-gray-300">
+              Total variance value:{" "}
+              <span className={`font-semibold ${totalVarianceValue > 0 ? "text-green-400" : totalVarianceValue < 0 ? "text-red-400" : "text-white"}`}>
+                {totalVarianceValue >= 0 ? "+" : "−"}{fmtCurrency(totalVarianceValue)}
+              </span>
+            </span>
+            {upValue > 0 && (
+              <span className="text-green-400 text-xs">
+                ▲ {fmtCurrency(upValue)} up
+              </span>
+            )}
+            {downValue > 0 && (
+              <span className="text-red-400 text-xs">
+                ▼ {fmtCurrency(downValue)} down
+              </span>
+            )}
+            {noVarianceCount > 0 && (
+              <span className="text-gray-500 text-xs">
+                {noVarianceCount} item{noVarianceCount !== 1 ? "s" : ""} counted at system qty — no adjustment
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Variance table */}
+        <div className="overflow-y-auto flex-1">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-800/80 sticky top-0">
+              <tr>
+                <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase">SKU</th>
+                <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase hidden sm:table-cell">Name</th>
+                <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">System Qty</th>
+                <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Counted Qty</th>
+                <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Variance</th>
+                <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Unit Cost</th>
+                <th className="text-right py-2 px-4 text-xs font-medium text-gray-400 uppercase">Variance Value</th>
+                <th className="text-left py-2 px-4 text-xs font-medium text-gray-400 uppercase hidden md:table-cell">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reviewItems.map((r) => (
+                <tr key={r.product_id} className="border-t border-gray-800">
+                  <td className="py-2 px-4 font-mono text-white text-xs">{r.product_sku}</td>
+                  <td className="py-2 px-4 text-gray-400 hidden sm:table-cell">{r.product_name}</td>
+                  <td className="py-2 px-4 text-right text-gray-400">{fmtQty(r.systemQty)}</td>
+                  <td className="py-2 px-4 text-right text-white">{fmtQty(r.countedQty)}</td>
+                  <td
+                    className={`py-2 px-4 text-right font-medium ${
+                      r.variance > 0 ? "text-green-400" : r.variance < 0 ? "text-red-400" : "text-gray-500"
+                    }`}
+                  >
+                    {r.variance > 0 ? "+" : ""}{fmtQty(r.variance)}
+                  </td>
+                  <td className="py-2 px-4 text-right text-gray-400">
+                    {r.unitCost != null ? fmtCurrency(r.unitCost) : <span className="text-gray-600">—</span>}
+                  </td>
+                  <td
+                    className={`py-2 px-4 text-right font-medium ${
+                      r.varianceValue > 0 ? "text-green-400" : r.varianceValue < 0 ? "text-red-400" : "text-gray-500"
+                    }`}
+                  >
+                    {r.varianceValue !== 0 ? (
+                      <>
+                        {r.varianceValue > 0 ? "+" : "−"}
+                        {fmtCurrency(r.varianceValue)}
+                      </>
+                    ) : (
+                      <span className="text-gray-600">—</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-4 text-gray-400 text-xs hidden md:table-cell">{r.reason}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-800 flex justify-end gap-3 flex-shrink-0">
+          <button
+            onClick={onBack}
+            disabled={submitting}
+            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50"
+          >
+            Go Back
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={submitting}
+            className="px-5 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-semibold disabled:opacity-50"
+          >
+            {submitting ? "Posting…" : `Confirm & Post ${totalAdjustments} Adjustment${totalAdjustments !== 1 ? "s" : ""}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
 export default function AdminCycleCount() {
   const api = useApi();
   const [inventoryItems, setInventoryItems] = useState([]);
@@ -22,6 +157,8 @@ export default function AdminCycleCount() {
   const [countReference, setCountReference] = useState(
     `Cycle Count ${new Date().toISOString().split("T")[0]}`
   );
+  // Review modal state: null = hidden, array of review rows = visible
+  const [reviewRows, setReviewRows] = useState(null);
   const toast = useToast();
 
   // Common cycle count adjustment reasons (required for accounting audit trail)
@@ -123,23 +260,52 @@ export default function AdminCycleCount() {
     });
   };
 
-  const handleSubmit = async () => {
-    // Build items array from entries that have changes
+  // Build review rows (items with variance) + no-variance count.
+  // Called when user clicks "Submit Count".
+  const buildReviewData = () => {
+    const withVariance = [];
+    let noVarianceCount = 0;
+
+    for (const [productId, value] of Object.entries(countEntries)) {
+      if (value === "" || value === undefined) continue;
+      const item = inventoryItems.find((i) => i.product_id === parseInt(productId));
+      if (!item) continue;
+      const countedQty = parseFloat(value);
+      const variance = countedQty - item.on_hand_quantity;
+
+      if (variance === 0) {
+        noVarianceCount += 1;
+        continue;
+      }
+
+      const unitCost = item.unit_cost ?? null;
+      const varianceValue = unitCost != null ? variance * unitCost : 0;
+
+      withVariance.push({
+        product_id: item.product_id,
+        product_sku: item.product_sku,
+        product_name: item.product_name,
+        systemQty: item.on_hand_quantity,
+        countedQty,
+        variance,
+        unitCost,
+        varianceValue,
+        reason: getItemReason(item.product_id),
+      });
+    }
+
+    return { withVariance, noVarianceCount };
+  };
+
+  // Open the review modal (no writes yet)
+  const handleOpenReview = () => {
     const items = [];
     for (const [productId, value] of Object.entries(countEntries)) {
       if (value === "" || value === undefined) continue;
       const item = inventoryItems.find((i) => i.product_id === parseInt(productId));
       if (!item) continue;
       if (parseFloat(value) === item.on_hand_quantity) continue;
-
-      // Get reason for this item (required for accounting audit trail)
-      const reason = getItemReason(parseInt(productId));
-
-      items.push({
-        product_id: parseInt(productId),
-        counted_quantity: parseFloat(value),
-        reason: reason, // Required field for GL journal entry
-      });
+      items.push(item);
     }
 
     if (items.length === 0) {
@@ -147,10 +313,40 @@ export default function AdminCycleCount() {
       return;
     }
 
-    // Validate all items have reasons
-    const missingReason = items.some((i) => !i.reason || i.reason.trim() === "");
+    // Validate all variance items have reasons
+    const missingReason = items.some((item) => {
+      const reason = getItemReason(item.product_id);
+      return !reason || reason.trim() === "";
+    });
     if (missingReason) {
       toast.error("All items must have a reason for accounting compliance");
+      return;
+    }
+
+    const { withVariance, noVarianceCount } = buildReviewData();
+    setReviewRows({ withVariance, noVarianceCount });
+  };
+
+  // Actual post — only called after the user clicks Confirm in the modal
+  const handleConfirmPost = async () => {
+    const items = [];
+    for (const [productId, value] of Object.entries(countEntries)) {
+      if (value === "" || value === undefined) continue;
+      const item = inventoryItems.find((i) => i.product_id === parseInt(productId));
+      if (!item) continue;
+      if (parseFloat(value) === item.on_hand_quantity) continue;
+
+      const reason = getItemReason(parseInt(productId));
+      items.push({
+        product_id: parseInt(productId),
+        counted_quantity: parseFloat(value),
+        reason,
+      });
+    }
+
+    if (items.length === 0) {
+      setReviewRows(null);
+      toast.warning("No changes to submit");
       return;
     }
 
@@ -167,6 +363,7 @@ export default function AdminCycleCount() {
         }
       );
 
+      setReviewRows(null);
       setResults(data);
       const message = `Cycle count complete: ${data.successful} items updated, ${data.failed} failed`;
       if (data.failed > 0) {
@@ -175,7 +372,6 @@ export default function AdminCycleCount() {
         toast.success(message);
       }
 
-      // Clear entries and refresh
       setCountEntries({});
       setReasonEntries({});
       fetchInventorySummary();
@@ -211,8 +407,20 @@ export default function AdminCycleCount() {
 
   return (
     <div className="space-y-6">
+      {/* Variance review modal — blocks any write until confirmed */}
+      {reviewRows && (
+        <VarianceReviewModal
+          reviewItems={reviewRows.withVariance}
+          noVarianceCount={reviewRows.noVarianceCount}
+          countReference={countReference}
+          submitting={submitting}
+          onConfirm={handleConfirmPost}
+          onBack={() => setReviewRows(null)}
+        />
+      )}
+
       {/* Header */}
-      <div className="flex justify-between items-start">
+      <div className="flex justify-between items-start flex-wrap gap-3">
         <div>
           <h1 className="text-2xl font-bold text-white">Cycle Count</h1>
           <p className="text-gray-400 mt-1">
@@ -227,28 +435,22 @@ export default function AdminCycleCount() {
             Clear All
           </button>
           <button
-            onClick={setAllToCurrentQuantity}
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
-          >
-            Fill Current Qty
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={submitting || !hasChanges()}
+            onClick={handleOpenReview}
+            disabled={!hasChanges()}
             className={`px-4 py-2 rounded-lg font-medium ${
               hasChanges()
                 ? "bg-blue-600 text-white hover:bg-blue-700"
                 : "bg-gray-700 text-gray-400 cursor-not-allowed"
             }`}
           >
-            {submitting ? "Submitting..." : "Submit Count"}
+            Submit Count
           </button>
         </div>
       </div>
 
-      {/* Count Reference & Default Reason */}
+      {/* Count Reference, Default Reason & Fill Current Qty */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="flex items-center gap-4">
             <label className="text-sm font-medium text-gray-400 whitespace-nowrap">
               Count Reference:
@@ -277,6 +479,19 @@ export default function AdminCycleCount() {
                 </option>
               ))}
             </select>
+          </div>
+          {/* Fill Current Qty moved here — away from Submit to prevent fat-finger */}
+          <div className="flex items-center">
+            <button
+              onClick={setAllToCurrentQuantity}
+              className="px-4 py-2 bg-gray-700 text-gray-300 rounded-lg hover:bg-gray-600 text-sm border border-gray-600"
+              title="Pre-fill every row with the current system quantity — only change items that differ"
+            >
+              Fill Current Qty
+            </button>
+            <span className="ml-2 text-xs text-gray-500">
+              Pre-fills all rows; only change items that differ
+            </span>
           </div>
         </div>
         <p className="text-xs text-gray-500 mt-2">
@@ -534,6 +749,7 @@ export default function AdminCycleCount() {
                           value={countEntries[item.product_id] ?? ""}
                           onChange={(e) =>
                             handleCountChange(item.product_id, e.target.value)
+
                           }
                           placeholder={item.on_hand_quantity.toString()}
                           className={`w-full bg-gray-800 border rounded-lg px-3 py-1.5 text-white text-right ${
@@ -607,10 +823,11 @@ export default function AdminCycleCount() {
         <ol className="text-sm text-gray-400 space-y-1 list-decimal list-inside">
           <li>Filter items by location or category to focus your count</li>
           <li>Set a default reason (required for accounting audit trail)</li>
+          <li>Optionally click "Fill Current Qty" to pre-fill all rows, then change only items that differ</li>
           <li>Enter the physical count quantity for each item</li>
-          <li>Items with variances will be highlighted - override reason per item if needed</li>
-          <li>Click "Submit Count" to create adjustment transactions + GL journal entries</li>
-          <li>Review the results summary to see all changes made</li>
+          <li>Items with variances will be highlighted — override reason per item if needed</li>
+          <li>Click "Submit Count" to open a variance review showing every adjustment and total dollar impact</li>
+          <li>Review the list, then click "Confirm &amp; Post" — adjustments and GL journal entries are written at that point</li>
         </ol>
         <p className="text-xs text-gray-500 mt-3">
           Note: All adjustments create GL journal entries (DR/CR Inventory Adjustment expense account 5030).

--- a/frontend/src/pages/admin/AdminCycleCount.jsx
+++ b/frontend/src/pages/admin/AdminCycleCount.jsx
@@ -20,7 +20,11 @@ function VarianceReviewModal({ reviewItems, noVarianceCount, countReference, sub
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+      <div
+        role="dialog"
+        aria-label="Review Variance Before Posting"
+        className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col"
+      >
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-800 flex-shrink-0">
           <h2 className="text-xl font-bold text-white">Review Variance Before Posting</h2>

--- a/frontend/src/pages/admin/__tests__/AdminCycleCount.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminCycleCount.test.jsx
@@ -1,0 +1,417 @@
+/**
+ * AdminCycleCount — HARD-16 tests
+ *
+ * Verifies that:
+ * 1. Clicking "Submit Count" opens a variance review modal (does NOT post immediately)
+ * 2. Review shows correct per-item variances, variance values, and totals
+ * 3. "Confirm & Post" fires the batch submit API call
+ * 4. "Go Back" dismisses the modal and preserves entered quantities
+ * 5. Items counted at system qty (zero variance) are summarised, not listed in review
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mocks } = vi.hoisted(() => {
+  const mocks = {
+    get: vi.fn(),
+    post: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastWarning: vi.fn(),
+  }
+  mocks.api = { get: mocks.get, post: mocks.post }
+  mocks.toast = {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  }
+  return { mocks }
+})
+
+vi.mock('../../../hooks/useApi', () => ({ useApi: () => mocks.api }))
+vi.mock('../../../components/Toast', () => ({ useToast: () => mocks.toast }))
+
+import AdminCycleCount from '../AdminCycleCount'
+
+// ---------------------------------------------------------------------------
+// Sample inventory data
+// ---------------------------------------------------------------------------
+const ITEM_A = {
+  inventory_id: 1,
+  product_id: 101,
+  product_sku: 'MAT-PLA-BLK',
+  product_name: 'PLA Black 1kg',
+  category_name: 'Filament',
+  unit: 'G',
+  location_id: 1,
+  location_name: 'Main Warehouse',
+  on_hand_quantity: 1000,
+  allocated_quantity: 0,
+  available_quantity: 1000,
+  unit_cost: 0.02,          // $0.02/g → variance value = variance × 0.02
+  last_counted: null,
+}
+
+const ITEM_B = {
+  inventory_id: 2,
+  product_id: 102,
+  product_sku: 'MAT-PETG-CLR',
+  product_name: 'PETG Clear 1kg',
+  category_name: 'Filament',
+  unit: 'G',
+  location_id: 1,
+  location_name: 'Main Warehouse',
+  on_hand_quantity: 500,
+  allocated_quantity: 0,
+  available_quantity: 500,
+  unit_cost: 0.025,
+  last_counted: null,
+}
+
+// Item with no unit cost
+const ITEM_C = {
+  inventory_id: 3,
+  product_id: 103,
+  product_sku: 'PKG-BOX-SM',
+  product_name: 'Small Box',
+  category_name: 'Packaging',
+  unit: 'EA',
+  location_id: 1,
+  location_name: 'Main Warehouse',
+  on_hand_quantity: 50,
+  allocated_quantity: 0,
+  available_quantity: 50,
+  unit_cost: null,
+  last_counted: null,
+}
+
+const INVENTORY_RESPONSE = {
+  items: [ITEM_A, ITEM_B, ITEM_C],
+  total: 3,
+  limit: 500,
+  offset: 0,
+}
+
+const BATCH_RESPONSE = {
+  total_items: 1,
+  successful: 1,
+  failed: 0,
+  count_reference: 'Cycle Count 2026-06-10',
+  results: [
+    {
+      product_id: 101,
+      product_sku: 'MAT-PLA-BLK',
+      product_name: 'PLA Black 1kg',
+      previous_quantity: 1000,
+      counted_quantity: 1200,
+      variance: 200,
+      success: true,
+      error: null,
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminCycleCount />
+    </MemoryRouter>,
+  )
+}
+
+function setupGetMock() {
+  mocks.get.mockImplementation((path) => {
+    if (path.includes('inventory-summary')) return Promise.resolve(INVENTORY_RESPONSE)
+    if (path.includes('locations')) return Promise.resolve([{ id: 1, name: 'Main Warehouse' }])
+    if (path.includes('categories')) return Promise.resolve([{ id: 1, name: 'Filament' }])
+    return Promise.resolve([])
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  mocks.get.mockReset()
+  mocks.post.mockReset()
+  mocks.toastError.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.toastWarning.mockReset()
+  setupGetMock()
+})
+
+describe('AdminCycleCount — initial render', () => {
+  it('renders the page heading', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Cycle Count')).toBeInTheDocument())
+  })
+
+  it('shows Submit Count button disabled when no entries', async () => {
+    renderPage()
+    await waitFor(() => expect(mocks.get).toHaveBeenCalled())
+    const btn = screen.getByRole('button', { name: /submit count/i })
+    expect(btn).toBeDisabled()
+  })
+
+  it('Fill Current Qty is in the header panel (not adjacent to Submit Count)', async () => {
+    renderPage()
+    await waitFor(() => expect(mocks.get).toHaveBeenCalled())
+
+    // Both buttons must exist
+    expect(screen.getByRole('button', { name: /fill current qty/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /submit count/i })).toBeInTheDocument()
+
+    // Fill Current Qty should NOT appear inside the same flex container as Submit Count.
+    // We verify this by checking that Fill Current Qty is in the config panel (contains
+    // the Count Reference label), while Submit Count is in the page header.
+    const fillBtn = screen.getByRole('button', { name: /fill current qty/i })
+    const submitBtn = screen.getByRole('button', { name: /submit count/i })
+    // They must NOT share the same direct parent element
+    expect(fillBtn.parentElement).not.toBe(submitBtn.parentElement)
+  })
+})
+
+describe('AdminCycleCount — review modal opens on Submit Count', () => {
+  it('does NOT call api.post when Submit Count is clicked — opens review modal instead', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    // Enter a variance for item A (1200 vs system 1000)
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    // Click Submit Count
+    const submitBtn = screen.getByRole('button', { name: /submit count/i })
+    fireEvent.click(submitBtn)
+
+    // api.post must NOT have been called yet
+    expect(mocks.post).not.toHaveBeenCalled()
+
+    // Review modal must be visible
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows correct variance and variance value in the review modal', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    // ITEM_A: system 1000, count 1200 → variance +200, value = 200 × 0.02 = $4.00
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // SKU appears in the review table
+    expect(screen.getAllByText('MAT-PLA-BLK').length).toBeGreaterThan(0)
+    // Variance value: $4.00 (200 × 0.02) — may appear in both the summary and table
+    expect(screen.getAllByText(/\$4\.00/).length).toBeGreaterThan(0)
+    // Summary: 1 adjustment
+    expect(screen.getByText(/1 adjustment/i)).toBeInTheDocument()
+  })
+
+  it('shows zero-variance item count in review modal summary', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    // Item A: variance (+200)
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+    // Item B: counted at system qty (no variance)
+    fireEvent.change(inputs[1], { target: { value: '500' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // Modal summary must mention the zero-variance item
+    expect(screen.getByText(/1 item counted at system qty/i)).toBeInTheDocument()
+    // Only 1 adjustment row (item A)
+    expect(screen.getByText(/1 adjustment/i)).toBeInTheDocument()
+  })
+
+  it('does NOT show zero-variance items in the review table rows', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } }) // variance
+    fireEvent.change(inputs[1], { target: { value: '500' } })  // no variance
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // MAT-PLA-BLK (variance) should appear in the table
+    expect(screen.getAllByText('MAT-PLA-BLK').length).toBeGreaterThan(0)
+    // MAT-PETG-CLR (no variance) should NOT appear in the review table
+    // (it appears in the main page table but not in the modal)
+    // The modal renders inside a portal/fixed container with a heading; we check
+    // that PETG-CLR does not appear at all after the modal is open (main table
+    // scrolls behind modal; since it's still in DOM, we check role-specifically)
+    // We just confirm the count in review: only 1 data row (1 adjustment)
+    const reviewHeading = screen.getByText(/review variance before posting/i)
+    const modal = reviewHeading.closest('[class*="fixed"]') ||
+                  reviewHeading.closest('div')
+    // The SKU MAT-PETG-CLR should not appear in the modal
+    expect(modal.textContent).not.toContain('MAT-PETG-CLR')
+  })
+
+  it('shows — for variance value when item has no unit cost', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('PKG-BOX-SM')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    // Item C (index 2): system 50, count 60 → variance +10, no cost → value —
+    fireEvent.change(inputs[2], { target: { value: '60' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // The modal renders em-dash placeholders (—) for unit cost and variance value
+    // when the item has no unit cost set. We can query them by text directly.
+    // There should be at least one — element visible in the modal area.
+    const dashCells = screen.getAllByText('—')
+    expect(dashCells.length).toBeGreaterThan(0)
+  })
+})
+
+describe('AdminCycleCount — Go Back preserves entries', () => {
+  it('dismisses the review modal when Go Back is clicked, entries intact', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // Click Go Back
+    fireEvent.click(screen.getByRole('button', { name: /go back/i }))
+
+    // Modal should be gone
+    await waitFor(() =>
+      expect(screen.queryByText(/review variance before posting/i)).not.toBeInTheDocument()
+    )
+
+    // The entered value must still be in the input
+    expect(inputs[0].value).toBe('1200')
+
+    // api.post was never called
+    expect(mocks.post).not.toHaveBeenCalled()
+  })
+})
+
+describe('AdminCycleCount — Confirm & Post fires the submit call', () => {
+  it('calls api.post with correct payload when Confirm & Post is clicked', async () => {
+    mocks.post.mockResolvedValue(BATCH_RESPONSE)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    // Click the confirm button
+    fireEvent.click(screen.getByRole('button', { name: /confirm & post/i }))
+
+    await waitFor(() => expect(mocks.post).toHaveBeenCalledOnce())
+
+    const [url, body] = mocks.post.mock.calls[0]
+    expect(url).toBe('/api/v1/admin/inventory/transactions/batch')
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0].product_id).toBe(101)
+    expect(body.items[0].counted_quantity).toBe(1200)
+    expect(body.items[0].reason).toBe('Physical count variance')
+  })
+
+  it('shows success toast after successful post', async () => {
+    mocks.post.mockResolvedValue(BATCH_RESPONSE)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm & post/i }))
+
+    await waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        expect.stringContaining('Cycle count complete')
+      )
+    )
+  })
+
+  it('closes the modal after a successful post', async () => {
+    mocks.post.mockResolvedValue(BATCH_RESPONSE)
+
+    renderPage()
+    await waitFor(() => expect(screen.getByText('MAT-PLA-BLK')).toBeInTheDocument())
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.change(inputs[0], { target: { value: '1200' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /submit count/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm & post/i }))
+
+    await waitFor(() =>
+      expect(screen.queryByText(/review variance before posting/i)).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe('AdminCycleCount — no changes guard', () => {
+  it('shows warning toast when Submit Count is clicked with no changes', async () => {
+    renderPage()
+    await waitFor(() => expect(mocks.get).toHaveBeenCalled())
+
+    // Force enable the button by temporarily mocking hasChanges — instead, just
+    // directly call handleSubmit via the button (it's disabled when no changes,
+    // so we verify the button is disabled)
+    const btn = screen.getByRole('button', { name: /submit count/i })
+    expect(btn).toBeDisabled()
+    // No post, no modal
+    expect(mocks.post).not.toHaveBeenCalled()
+    expect(screen.queryByText(/review variance before posting/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/AdminCycleCount.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminCycleCount.test.jsx
@@ -8,7 +8,7 @@
  * 4. "Go Back" dismisses the modal and preserves entered quantities
  * 5. Items counted at system qty (zero variance) are summarised, not listed in review
  */
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -258,19 +258,13 @@ describe('AdminCycleCount — review modal opens on Submit Count', () => {
       expect(screen.getByText(/review variance before posting/i)).toBeInTheDocument()
     )
 
-    // MAT-PLA-BLK (variance) should appear in the table
-    expect(screen.getAllByText('MAT-PLA-BLK').length).toBeGreaterThan(0)
+    // Use the dialog role to scope assertions to the modal
+    const reviewDialog = screen.getByRole('dialog', { name: /review variance before posting/i })
+
+    // MAT-PLA-BLK (variance) should appear in the review table
+    expect(within(reviewDialog).getByText('MAT-PLA-BLK')).toBeInTheDocument()
     // MAT-PETG-CLR (no variance) should NOT appear in the review table
-    // (it appears in the main page table but not in the modal)
-    // The modal renders inside a portal/fixed container with a heading; we check
-    // that PETG-CLR does not appear at all after the modal is open (main table
-    // scrolls behind modal; since it's still in DOM, we check role-specifically)
-    // We just confirm the count in review: only 1 data row (1 adjustment)
-    const reviewHeading = screen.getByText(/review variance before posting/i)
-    const modal = reviewHeading.closest('[class*="fixed"]') ||
-                  reviewHeading.closest('div')
-    // The SKU MAT-PETG-CLR should not appear in the modal
-    expect(modal.textContent).not.toContain('MAT-PETG-CLR')
+    expect(within(reviewDialog).queryByText('MAT-PETG-CLR')).not.toBeInTheDocument()
   })
 
   it('shows — for variance value when item has no unit cost', async () => {


### PR DESCRIPTION
## Summary

- **Variance review gate**: clicking "Submit Count" now opens a review modal before any writes. Shows per-item rows (SKU, system qty, counted qty, variance, unit cost, variance value) and a summary line (`N adjustments, total $X — $Y up / $Z down`). Items counted at system qty are collapsed to a note. Nothing is written until the operator clicks **Confirm & Post**.
- **Fill Current Qty relocated**: moved from the header action bar (where it sat next to Submit Count) into the Count Reference / Default Reason config panel with a subtler style and inline hint, eliminating the fat-finger risk identified in HARD-16.
- **Backend: `unit_cost` in inventory summary**: `GET /inventory-summary` now returns `unit_cost` (best available: standard > average > last, null if absent). No schema change; additive field only. Submit/post path is unchanged.
- **Docs**: `inventory.md` Step 5 expanded to describe the review panel, Mermaid flow updated, quick-reference table row updated.
- **Tests**: 13 new Vitest component tests (`AdminCycleCount.test.jsx`) — review opens without posting, correct variance/dollar values, zero-variance items collapsed, Go Back preserves entries, Confirm & Post fires the correct payload.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/admin/AdminCycleCount.jsx` | Add `VarianceReviewModal` component; wire review gate; relocate Fill Current Qty |
| `frontend/src/pages/admin/__tests__/AdminCycleCount.test.jsx` | New — 13 component tests |
| `backend/app/services/inventory_transaction_service.py` | Add `unit_cost` to `get_inventory_summary` return dict |
| `docs/user-guide/inventory.md` | Update Step 5, Mermaid diagram, quick-reference row |

## Test plan

- [x] `npm run test:unit --prefix frontend -- --run` → 314/314 pass (13 new)
- [x] `npm run build --prefix frontend` → clean build
- [x] `ruff check backend/app/services/inventory_transaction_service.py` → all checks passed
- [ ] CI green

## Out of scope (per plan)

The backend batch-post endpoint (`/batch`) is intentionally unchanged — HARD-4a is the canonical poster consolidation work. This PR only adds the front-end gate and the additive `unit_cost` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cycle count workflow now includes a pre-submission variance review step. Users can review per-item adjustments with unit costs and variance values before confirming to post adjustments and GL entries.

* **Documentation**
  * Updated inventory cycle count documentation to reflect the new variance review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->