### PR TITLE
fix: phase-B sweep — multi-op consumption guard, ghost COGS, buy-list netting, N+1

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -218,8 +218,18 @@ async def get_transactions_as_journal(
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
+    # Exclude unapplied held rows and voided/rejected rows — matching the
+    # same exclusion logic used in get_cogs_summary (~line 486-492).
+    # Held rows (requires_approval=True, approved_by=None) have not yet
+    # affected on_hand; voided rows were explicitly rejected.  Neither
+    # represents a real economic event for the journal.
     query = db.query(InventoryTransaction).filter(
-        InventoryTransaction.created_at >= cutoff
+        InventoryTransaction.created_at >= cutoff,
+        InventoryTransaction.voided_by.is_(None),
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
     ).order_by(InventoryTransaction.created_at.desc())
 
     if order_id:
@@ -339,19 +349,32 @@ async def get_order_cost_breakdown(
 
     po_ids = [po.id for po in production_orders]
 
-    # Get all consumption and scrap transactions
-    # Scrap transactions from failed WOs also count as COGS (materials consumed with no output)
+    # Get all consumption and scrap transactions.
+    # Scrap transactions from failed WOs also count as COGS (materials consumed with no output).
+    # Exclude unapplied held rows and voided/rejected rows — same policy as get_cogs_summary
+    # and get_transactions_as_journal.  Ghost rows from cancelled or rejected transactions
+    # must not inflate the order cost breakdown.
     consumptions = db.query(InventoryTransaction).filter(
         InventoryTransaction.reference_type == 'production_order',
         InventoryTransaction.reference_id.in_(po_ids),
-        InventoryTransaction.transaction_type.in_(['consumption', 'scrap'])
+        InventoryTransaction.transaction_type.in_(['consumption', 'scrap']),
+        InventoryTransaction.voided_by.is_(None),
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
     ).all()
 
-    # Packaging consumptions
+    # Packaging consumptions — same exclusions.
     packaging = db.query(InventoryTransaction).filter(
         InventoryTransaction.reference_type.in_(['shipment', 'consolidated_shipment']),
         InventoryTransaction.reference_id == order_id,
-        InventoryTransaction.transaction_type == 'consumption'
+        InventoryTransaction.transaction_type == 'consumption',
+        InventoryTransaction.voided_by.is_(None),
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
     ).all()
 
     # Calculate costs

--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -219,7 +219,8 @@ async def get_transactions_as_journal(
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
     # Exclude unapplied held rows and voided/rejected rows — matching the
-    # same exclusion logic used in get_cogs_summary (~line 486-492).
+    # same exclusion logic used in get_cogs_summary (see that function for
+    # the canonical rationale).
     # Held rows (requires_approval=True, approved_by=None) have not yet
     # affected on_hand; voided rows were explicitly rejected.  Neither
     # represents a real economic event for the journal.

--- a/backend/app/services/buy_list_service.py
+++ b/backend/app/services/buy_list_service.py
@@ -307,9 +307,13 @@ def get_buy_list(
         if not product:
             continue
 
-        # get_projected_available_bulk guarantees a key for every product_id
-        # in product_ids, so this fallback is a safety net for edge cases where
-        # a product entered demand after the bulk call.
+        # Defensive fallback — get_projected_available_bulk guarantees a key
+        # for every product_id in the product_ids list passed to it (which
+        # equals demand.keys() at call time).  This branch should never
+        # trigger under normal operation; it protects against a future
+        # contract violation by the bulk function rather than any real
+        # demand-race (demand is fully populated before the bulk call and is
+        # not modified after).
         avail = availability_map.get(pid)
         if avail is None:
             avail = get_projected_available(db, pid)

--- a/backend/app/services/buy_list_service.py
+++ b/backend/app/services/buy_list_service.py
@@ -52,7 +52,7 @@ from app.schemas.buy_list import (
     BuyListSummary,
 )
 from app.services.mrp import MRPService
-from app.services.supply_netting import get_projected_available
+from app.services.supply_netting import get_projected_available, get_projected_available_bulk
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -293,6 +293,11 @@ def get_buy_list(
     # ------------------------------------------------------------------ #
     # Step 3: Net each component and build output rows                     #
     # ------------------------------------------------------------------ #
+
+    # Batch-load projected availability for ALL components in two queries
+    # instead of 2·N individual queries.  See supply_netting.get_projected_available_bulk.
+    availability_map = get_projected_available_bulk(db, product_ids)
+
     items: List[BuyListItem] = []
     total_buy_value = Decimal("0")
     total_draft_incoming = Decimal("0")
@@ -302,15 +307,35 @@ def get_buy_list(
         if not product:
             continue
 
-        avail = get_projected_available(db, pid)
+        # get_projected_available_bulk guarantees a key for every product_id
+        # in product_ids, so this fallback is a safety net for edge cases where
+        # a product entered demand after the bulk call.
+        avail = availability_map.get(pid)
+        if avail is None:
+            avail = get_projected_available(db, pid)
 
         safety_stock = Decimal(str(product.safety_stock or 0))
         gross = comp_demand.gross_quantity
-        projected = avail.projected
 
-        # MRP netting formula (same as calculate_net_requirements):
-        # net_shortage = max(0, gross − projected + safety_stock)
-        raw_short = gross - projected + safety_stock
+        # Aggregate MRP netting — net against on_hand + incoming, NOT
+        # available (= on_hand − allocated).
+        #
+        # Why: gross_demand already includes the open WOs that created the
+        # allocated quantities.  Using `available` (on_hand − allocated) would
+        # subtract those allocations from supply while their corresponding WO
+        # demand also appears in gross — double-counting that overstates
+        # shortages.
+        #
+        # Contrast with blocking_issues / per-order checks (e.g. line ~200,
+        # ~541) where `available` IS correct: those check a single order
+        # against current availability and the question is "is there stock free
+        # to fill *this* specific order right now?"  Here we ask "across all
+        # open demand, how much more do we need to buy?" — the allocations are
+        # already captured inside gross_demand.
+        #
+        # Formula: net_shortage = max(0, gross − (on_hand + incoming) + safety_stock)
+        mrp_projected = avail.on_hand + avail.incoming_qty
+        raw_short = gross - mrp_projected + safety_stock
         net_shortage = max(Decimal("0"), raw_short)
 
         if net_shortage <= Decimal("0"):
@@ -374,7 +399,7 @@ def get_buy_list(
                 allocated=avail.allocated,
                 available=avail.available,
                 incoming_qty=avail.incoming_qty,
-                projected=projected,
+                projected=mrp_projected,
                 safety_stock=safety_stock,
                 net_shortage=net_shortage,
                 suggested_qty=suggested_qty,

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -851,7 +851,13 @@ def consume_operation_material(
         The created InventoryTransaction, or None if material was already consumed
     """
 
-    # Skip already consumed materials
+    # Idempotency guard — keyed on THIS material row's status, not the
+    # ledger-level (production_order, component) pair.  The per-row guard is
+    # intentional: the same component can appear in multiple routing operations
+    # (each with its own ProductionOrderOperationMaterial row), and each
+    # occurrence is a legitimate independent consumption.  Using
+    # _consumption_already_posted here would silently suppress all but the
+    # first per-operation consumption of a given component.
     if material.status == 'consumed':
         logger.info(f"Material {material.id} already consumed, skipping")
         return None
@@ -940,9 +946,20 @@ def _consumption_already_posted(
     """Return True if a non-voided consumption transaction already exists for
     this (production_order, component) pair.
 
-    Used by consume_production_materials to prevent double-posting when
-    per-operation consumption (consume_operation_material) already fired for
-    the same component before the BOM-level completion backflush runs.
+    **BOM-BACKFLUSH USE ONLY** — this helper is scoped to the completion
+    backflush path (consume_production_materials).  It MUST NOT be called
+    from consume_operation_material, which uses the per-material-row
+    ``material.status == 'consumed'`` guard instead.  That per-row guard is
+    correct for the per-operation path because the same physical component can
+    legitimately appear in multiple routing operations (each with its own
+    material row), and each occurrence deserves its own consumption
+    transaction.  The ledger-level guard here would erroneously block the
+    second (and later) per-operation consumptions of the same component.
+
+    For the backflush path the opposite semantic is correct: skip the entire
+    BOM line if ANY per-operation consumption already posted for this
+    component — both paths consume the same physical inventory, and the
+    per-operation one wins.
 
     A transaction counts as "already posted" when:
       - reference_type == 'production_order'

--- a/backend/app/services/supply_netting.py
+++ b/backend/app/services/supply_netting.py
@@ -28,7 +28,7 @@ place — this file.
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -156,3 +156,104 @@ def compute_quantity_short(
     qty_required must be a non-negative Decimal.
     """
     return max(Decimal("0"), qty_required - availability.projected)
+
+
+def get_projected_available_bulk(
+    db: Session,
+    product_ids: List[int],
+) -> Dict[int, ProjectedAvailability]:
+    """
+    Batch version of get_projected_available for a list of product IDs.
+
+    Executes exactly two queries regardless of the number of products:
+      1. One grouped Inventory aggregate for on_hand + allocated sums.
+      2. One PurchaseOrderLine + PurchaseOrder join for open-PO supply.
+
+    Returns a dict mapping product_id → ProjectedAvailability.  Products with
+    no inventory row and no open PO are included with all-zero values.
+
+    Use this wherever get_projected_available would be called in a loop to
+    avoid N+1 query patterns (e.g. the buy-list netting loop).
+
+    Note: This function does NOT return per-PO IncomingSupplyDetail sorted by
+    expected_date (that requires the full per-product query).  The bulk path
+    returns detail lists sorted by expected_date per product, which is
+    sufficient for the buy-list use case.
+    """
+    if not product_ids:
+        return {}
+
+    # --- 1. Inventory totals per product ------------------------------------
+    inv_rows = (
+        db.query(
+            Inventory.product_id,
+            func.coalesce(func.sum(Inventory.on_hand_quantity), Decimal("0")).label("on_hand"),
+            func.coalesce(func.sum(Inventory.allocated_quantity), Decimal("0")).label("allocated"),
+        )
+        .filter(Inventory.product_id.in_(product_ids))
+        .group_by(Inventory.product_id)
+        .all()
+    )
+    inv_map: Dict[int, tuple] = {row.product_id: row for row in inv_rows}
+
+    # --- 2. Open PO lines per product ---------------------------------------
+    po_rows = (
+        db.query(PurchaseOrder, PurchaseOrderLine)
+        .join(PurchaseOrderLine, PurchaseOrder.id == PurchaseOrderLine.purchase_order_id)
+        .filter(
+            PurchaseOrderLine.product_id.in_(product_ids),
+            PurchaseOrder.status.in_(_OPEN_PO_STATUSES),
+        )
+        .order_by(
+            PurchaseOrderLine.product_id,
+            PurchaseOrder.expected_date.asc().nullslast(),
+        )
+        .all()
+    )
+
+    # Group PO details by product_id
+    po_details_map: Dict[int, List[IncomingSupplyDetail]] = {pid: [] for pid in product_ids}
+    for po, pol in po_rows:
+        pid = pol.product_id
+        ordered = pol.quantity_ordered or Decimal("0")
+        received = pol.quantity_received or Decimal("0")
+        remaining = Decimal(str(ordered)) - Decimal(str(received))
+        if remaining <= Decimal("0"):
+            continue  # fully received
+        if pid not in po_details_map:
+            po_details_map[pid] = []
+        po_details_map[pid].append(IncomingSupplyDetail(
+            purchase_order_id=po.id,
+            po_number=po.po_number,
+            quantity=remaining,
+            expected_date=po.expected_date,
+            status=po.status,
+        ))
+
+    # --- 3. Assemble results ------------------------------------------------
+    result: Dict[int, ProjectedAvailability] = {}
+    for pid in product_ids:
+        if pid in inv_map:
+            row = inv_map[pid]
+            on_hand = Decimal(str(row.on_hand or 0))
+            allocated = Decimal(str(row.allocated or 0))
+        else:
+            on_hand = Decimal("0")
+            allocated = Decimal("0")
+
+        available = on_hand - allocated
+        details = po_details_map.get(pid, [])
+        incoming_qty = sum((d.quantity for d in details), Decimal("0"))
+        projected = available + incoming_qty
+
+        result[pid] = ProjectedAvailability(
+            product_id=pid,
+            on_hand=on_hand,
+            allocated=allocated,
+            available=available,
+            incoming_qty=incoming_qty,
+            projected=projected,
+            details=details,
+        )
+
+    return result

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -1836,3 +1836,82 @@ class TestAccountingEndpointsExcludeGhostRows:
         assert txn.id not in txn_ids, (
             "Unapplied held consumption row must NOT appear in transactions-journal"
         )
+
+    def test_voided_consumption_absent_from_order_cost_breakdown(
+        self, db, client, make_product, make_sales_order
+    ):
+        """A voided (rejected) consumption row must NOT appear in order-cost-breakdown."""
+        from app.services import inventory_ledger
+
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("10.00"))
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("5.00"))
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="in_progress")
+        po = _make_production_order(db, fg.id, qty_ordered=1, status="in_progress")
+        # Link PO to SO so the endpoint can find it
+        po.sales_order_id = so.id
+        db.flush()
+
+        # Post + void a consumption on the production order
+        txn = inventory_ledger.post(
+            db,
+            product_id=comp.id,
+            location_id=location.id,
+            transaction_type="consumption",
+            quantity_delta=Decimal("-50"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,
+        )
+        inventory_ledger.reject_held_transaction(
+            db, txn, voided_by="staff@test.com", void_reason="test void"
+        )
+        db.flush()
+
+        response = client.get(f"/api/v1/admin/accounting/order-cost-breakdown/{so.id}")
+        assert response.status_code == 200
+        body = response.json()
+        material_items = body["costs"]["materials"]["items"]
+        txn_skus_in_materials = {item["sku"] for item in material_items}
+        # Voided row must not contribute cost
+        assert body["costs"]["materials"]["total"] == 0.0, (
+            "Voided consumption must not inflate material cost"
+        )
+
+    def test_held_unapplied_consumption_absent_from_order_cost_breakdown(
+        self, db, client, make_product, make_sales_order
+    ):
+        """An unapplied held consumption row must NOT appear in order-cost-breakdown."""
+        from app.services import inventory_ledger
+
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("10.00"))
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("5.00"))
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="in_progress")
+        po = _make_production_order(db, fg.id, qty_ordered=1, status="in_progress")
+        po.sales_order_id = so.id
+        db.flush()
+
+        # Post a held (unapplied) consumption — do NOT approve or reject
+        txn = inventory_ledger.post(
+            db,
+            product_id=comp.id,
+            location_id=location.id,
+            transaction_type="consumption",
+            quantity_delta=Decimal("-40"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,
+        )
+        db.flush()
+
+        response = client.get(f"/api/v1/admin/accounting/order-cost-breakdown/{so.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["costs"]["materials"]["total"] == 0.0, (
+            "Unapplied held consumption must not inflate material cost"
+        )

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -20,7 +20,11 @@ from unittest.mock import MagicMock, patch
 from app.models.bom import BOM, BOMLine
 from app.models.inventory import Inventory, InventoryLocation, InventoryTransaction
 from app.models.product import Product
-from app.models.production_order import ProductionOrder
+from app.models.production_order import (
+    ProductionOrder,
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
 from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.traceability import MaterialLot
 from app.services import inventory_service, inventory_transaction_service
@@ -1538,3 +1542,297 @@ class TestCogsExcludesHeldAndVoidedRows:
         )
 
         assert _consumption_already_posted(db, po.id, comp.id) is True
+
+
+# =============================================================================
+# Finding 1 (phase-B sweep): same component at TWO routing operations
+# =============================================================================
+
+def _make_work_center(db, code=None):
+    """Create a minimal WorkCenter for test operations."""
+    import uuid
+    from app.models.work_center import WorkCenter
+    wc = WorkCenter(
+        code=code or f"WC-{uuid.uuid4().hex[:6]}",
+        name="Test Work Center",
+        center_type="production",
+    )
+    db.add(wc)
+    db.flush()
+    return wc
+
+
+def _make_operation(db, production_order_id, work_center_id, sequence=10):
+    """Create a ProductionOrderOperation row."""
+    op = ProductionOrderOperation(
+        production_order_id=production_order_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_name="Test Op",
+        planned_run_minutes=30,
+        status="pending",
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+def _make_op_material(db, operation_id, component_id, qty_required, unit="EA"):
+    """Create a ProductionOrderOperationMaterial row."""
+    mat = ProductionOrderOperationMaterial(
+        production_order_operation_id=operation_id,
+        component_id=component_id,
+        quantity_required=qty_required,
+        unit=unit,
+        status="pending",
+    )
+    db.add(mat)
+    db.flush()
+    return mat
+
+
+class TestMultiOperationSameComponentConsumption:
+    """
+    Regression test for phase-B sweep finding 1:
+
+    When the same component appears in TWO different routing operations,
+    consume_operation_material must fire BOTH consumptions independently
+    (gated by per-material-row status, not the ledger-level guard).
+
+    After both per-op consumptions have run:
+    - Two ledger rows must exist for the component on the PO.
+    - on_hand must be decremented twice.
+    - consume_production_materials (BOM backflush) must post ZERO extra rows.
+    - Calling consume_production_materials a second time must still produce
+      zero rows (double-fire backflush idempotency).
+    """
+
+    def test_two_operations_same_component_both_post(self, db, make_product):
+        """Two op-material rows for the same component each produce a ledger row."""
+        fg = make_product(item_type="finished_good")
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("1.00"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+
+        op1 = _make_operation(db, po.id, wc.id, sequence=10)
+        op2 = _make_operation(db, po.id, wc.id, sequence=20)
+
+        mat1 = _make_op_material(db, op1.id, comp.id, Decimal("5"), unit="EA")
+        mat2 = _make_op_material(db, op2.id, comp.id, Decimal("3"), unit="EA")
+
+        # Both operations complete — each has its own material row
+        txn1 = inventory_service.consume_operation_material(db, mat1, po)
+        txn2 = inventory_service.consume_operation_material(db, mat2, po)
+
+        assert txn1 is not None, "First op-material must produce a transaction"
+        assert txn2 is not None, "Second op-material must ALSO produce a transaction"
+
+        # Two distinct ledger rows for the same component on the same PO
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == comp.id,
+        ).all()
+        assert len(rows) == 2, (
+            f"Expected 2 consumption rows (one per operation), got {len(rows)}"
+        )
+
+        # on_hand decremented by 5 + 3 = 8
+        inv = db.query(Inventory).filter(
+            Inventory.product_id == comp.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert inv.on_hand_quantity == Decimal("992"), (
+            f"Expected on_hand=992 after consuming 8, got {inv.on_hand_quantity}"
+        )
+
+    def test_double_fire_of_same_op_material_posts_once(self, db, make_product):
+        """Calling consume_operation_material on an already-consumed material row
+        must return None (material.status guard) — no duplicate ledger row."""
+        fg = make_product(item_type="finished_good")
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("1.00"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id)
+        mat = _make_op_material(db, op.id, comp.id, Decimal("10"), unit="EA")
+
+        txn_first = inventory_service.consume_operation_material(db, mat, po)
+        txn_second = inventory_service.consume_operation_material(db, mat, po)
+
+        assert txn_first is not None
+        assert txn_second is None, (
+            "Double-fire of same material row must be blocked by status=='consumed'"
+        )
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(rows) == 1
+
+    def test_completion_backflush_posts_nothing_after_per_op_consumption(
+        self, db, make_product
+    ):
+        """After per-operation consumption has already posted for a component,
+        the BOM-level backflush (consume_production_materials) must skip it."""
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("1.00"))
+
+        # BOM line for the component
+        _make_bom_with_lines(db, fg.id, [
+            {"component_id": comp.id, "quantity": Decimal("10"), "unit": "EA",
+             "consume_stage": "production"},
+        ])
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("5000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id)
+        mat = _make_op_material(db, op.id, comp.id, Decimal("10"), unit="EA")
+
+        # Per-operation consumption fires first
+        txn_op = inventory_service.consume_operation_material(db, mat, po)
+        assert txn_op is not None
+
+        # BOM-level backflush must skip (already consumed by per-op)
+        backflush_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert len(backflush_txns) == 0, (
+            "Backflush must post nothing after per-op consumption already ran"
+        )
+
+        # Still only one consumption row in DB
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(rows) == 1
+
+    def test_double_fire_of_backflush_posts_once(self, db, make_product):
+        """Calling consume_production_materials twice must not double-consume
+        (original HARD-11 double-fire guard still holds)."""
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("1.00"))
+
+        _make_bom_with_lines(db, fg.id, [
+            {"component_id": comp.id, "quantity": Decimal("10"), "unit": "EA",
+             "consume_stage": "production"},
+        ])
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("5000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+
+        first = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert len(first) == 1
+
+        second = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert len(second) == 0, "Second backflush call must be idempotent"
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(rows) == 1
+
+
+# =============================================================================
+# Finding 2 (phase-B sweep): voided/held rows excluded from journal + order cost
+# =============================================================================
+
+class TestAccountingEndpointsExcludeGhostRows:
+    """
+    Voided (rejected) and unapplied-held consumption rows must NOT appear
+    in /accounting/transactions-journal or /accounting/order-cost-breakdown/{id}.
+
+    Tests call the endpoints via the TestClient so the full filter chain is
+    exercised exactly as prod code runs it.
+    """
+
+    def _make_po(self, db, product_id):
+        return _make_production_order(db, product_id, qty_ordered=1)
+
+    def test_voided_consumption_absent_from_journal(self, db, client, make_product):
+        """A voided consumption row must NOT appear in the journal."""
+        from app.services import inventory_ledger
+
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("5.00"))
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        po = self._make_po(db, comp.id)
+
+        # Post + void a consumption
+        txn = inventory_ledger.post(
+            db,
+            product_id=comp.id,
+            location_id=location.id,
+            transaction_type="consumption",
+            quantity_delta=Decimal("-50"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,
+        )
+        inventory_ledger.reject_held_transaction(
+            db, txn, voided_by="staff@test.com", void_reason="test"
+        )
+        db.flush()
+
+        response = client.get("/api/v1/admin/accounting/transactions-journal?days=1")
+        assert response.status_code == 200
+        entries = response.json()["entries"]
+        txn_ids = {e["transaction_id"] for e in entries}
+        assert txn.id not in txn_ids, (
+            "Voided consumption row must NOT appear in transactions-journal"
+        )
+
+    def test_held_unapplied_consumption_absent_from_journal(self, db, client, make_product):
+        """An unapplied held consumption row (requires_approval=True, approved_by=None)
+        must NOT appear in the journal."""
+        from app.services import inventory_ledger
+
+        comp = make_product(unit="EA", cost_method="average", average_cost=Decimal("5.00"))
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, comp.id, location.id, Decimal("1000"))
+
+        po = self._make_po(db, comp.id)
+
+        # Post a held (unapplied) consumption — do NOT approve or reject
+        txn = inventory_ledger.post(
+            db,
+            product_id=comp.id,
+            location_id=location.id,
+            transaction_type="consumption",
+            quantity_delta=Decimal("-30"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,
+        )
+        db.flush()
+
+        response = client.get("/api/v1/admin/accounting/transactions-journal?days=1")
+        assert response.status_code == 200
+        entries = response.json()["entries"]
+        txn_ids = {e["transaction_id"] for e in entries}
+        assert txn.id not in txn_ids, (
+            "Unapplied held consumption row must NOT appear in transactions-journal"
+        )

--- a/backend/tests/services/test_supply_netting.py
+++ b/backend/tests/services/test_supply_netting.py
@@ -26,6 +26,7 @@ from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine
 from app.services.supply_netting import (
     compute_quantity_short,
     get_projected_available,
+    get_projected_available_bulk,
 )
 
 
@@ -341,3 +342,118 @@ class TestComputeQuantityShort:
         proj = get_projected_available(db, product.id)
         short = compute_quantity_short(Decimal("10"), proj)
         assert short >= Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# get_projected_available_bulk (N+1 batch path)
+# ---------------------------------------------------------------------------
+
+class TestGetProjectedAvailableBulk:
+    """Batch version returns the same values as per-product calls, in two queries."""
+
+    def test_empty_list_returns_empty_dict(self, db):
+        result = get_projected_available_bulk(db, [])
+        assert result == {}
+
+    def test_missing_product_returns_zeros(self, db, make_product):
+        product = make_product()
+        # No inventory row, no PO
+        result = get_projected_available_bulk(db, [product.id])
+        assert product.id in result
+        a = result[product.id]
+        assert a.on_hand == Decimal("0")
+        assert a.allocated == Decimal("0")
+        assert a.incoming_qty == Decimal("0")
+        assert a.projected == Decimal("0")
+
+    def test_matches_single_call_no_pos(self, db, make_product):
+        product = make_product()
+        _make_inventory(db, product.id, Decimal("300"), allocated=Decimal("50"))
+
+        single = get_projected_available(db, product.id)
+        bulk = get_projected_available_bulk(db, [product.id])
+
+        a = bulk[product.id]
+        assert a.on_hand == single.on_hand
+        assert a.allocated == single.allocated
+        assert a.available == single.available
+        assert a.incoming_qty == single.incoming_qty
+        assert a.projected == single.projected
+
+    def test_matches_single_call_with_open_po(self, db, make_product, make_vendor):
+        product = make_product()
+        vendor = make_vendor()
+        _make_inventory(db, product.id, Decimal("100"))
+        _make_po_with_line(
+            db, vendor.id, product.id,
+            qty_ordered=Decimal("400"), qty_received=Decimal("50"),
+            status="ordered",
+        )
+
+        single = get_projected_available(db, product.id)
+        bulk = get_projected_available_bulk(db, [product.id])
+
+        a = bulk[product.id]
+        assert a.on_hand == single.on_hand
+        assert a.incoming_qty == single.incoming_qty
+        assert a.projected == single.projected
+        assert len(a.details) == len(single.details)
+
+    def test_multiple_products_in_one_call(self, db, make_product, make_vendor):
+        p1 = make_product()
+        p2 = make_product()
+        p3 = make_product()
+        vendor = make_vendor()
+
+        _make_inventory(db, p1.id, Decimal("50"), allocated=Decimal("10"))
+        _make_inventory(db, p2.id, Decimal("200"))
+        # p3 has no inventory
+        _make_po_with_line(
+            db, vendor.id, p2.id,
+            qty_ordered=Decimal("100"), qty_received=Decimal("0"),
+            status="shipped",
+        )
+
+        result = get_projected_available_bulk(db, [p1.id, p2.id, p3.id])
+        assert set(result.keys()) == {p1.id, p2.id, p3.id}
+
+        assert result[p1.id].on_hand == Decimal("50")
+        assert result[p1.id].allocated == Decimal("10")
+        assert result[p1.id].available == Decimal("40")
+        assert result[p1.id].incoming_qty == Decimal("0")
+
+        assert result[p2.id].on_hand == Decimal("200")
+        assert result[p2.id].incoming_qty == Decimal("100")
+        assert result[p2.id].projected == Decimal("300")  # available(200) + incoming(100)
+
+        assert result[p3.id].on_hand == Decimal("0")
+        assert result[p3.id].projected == Decimal("0")
+
+    def test_fully_received_po_excluded_in_bulk(self, db, make_product, make_vendor):
+        product = make_product()
+        vendor = make_vendor()
+        _make_inventory(db, product.id, Decimal("100"))
+        _make_po_with_line(
+            db, vendor.id, product.id,
+            qty_ordered=Decimal("500"), qty_received=Decimal("500"),
+            status="ordered",
+        )
+        result = get_projected_available_bulk(db, [product.id])
+        assert result[product.id].incoming_qty == Decimal("0")
+
+    def test_closed_and_cancelled_pos_excluded_in_bulk(self, db, make_product, make_vendor):
+        product = make_product()
+        vendor = make_vendor()
+        _make_inventory(db, product.id, Decimal("50"))
+        _make_po_with_line(
+            db, vendor.id, product.id,
+            qty_ordered=Decimal("200"), qty_received=Decimal("0"),
+            status="closed",
+        )
+        _make_po_with_line(
+            db, vendor.id, product.id,
+            qty_ordered=Decimal("300"), qty_received=Decimal("0"),
+            status="cancelled",
+        )
+        result = get_projected_available_bulk(db, [product.id])
+        assert result[product.id].incoming_qty == Decimal("0")

--- a/backend/tests/test_buy_list_service.py
+++ b/backend/tests/test_buy_list_service.py
@@ -341,3 +341,95 @@ class TestBuyListEndpoint:
         assert response.status_code == 200
         body = response.json()
         assert body["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Phase-B sweep: Finding 3 — buy-list netting must not double-count allocations
+# ---------------------------------------------------------------------------
+
+class TestBuyListNoDoubleCount:
+    """
+    Regression: open WOs that created allocations must not cause double-counting.
+
+    Scenario:
+    - Component C has on_hand=100, allocated=60 (by an open WO).
+    - The same open WO also generates gross_demand=60 for C via BOM explosion.
+    - Old formula: net = gross − (on_hand − allocated + incoming) + ss
+                       = 60 − (100 − 60 + 0) + 0 = 60 − 40 = 20  ← WRONG
+    - Fixed formula: net = gross − (on_hand + incoming) + ss
+                        = 60 − (100 + 0) + 0 = 0  ← covered, not on buy list
+    """
+
+    def test_component_reserved_by_open_wo_not_double_shorted(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """An open WO's allocations must not generate a false shortage.
+
+        If on_hand fully covers gross demand and the allocations are already
+        captured inside gross_demand, net_shortage must be zero and the
+        component must NOT appear on the buy list.
+        """
+        from app.models.inventory import Inventory as InvModel
+
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA", standard_cost=Decimal("1.00"))
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("3"), "unit": "EA"}],
+        )
+
+        # Open WO for 10 units → gross_demand for comp = 30
+        make_production_order(product_id=fg.id, status="released", quantity=10)
+
+        # on_hand=30, allocated=30 (represents the reservations the WO created)
+        # available = 30 − 30 = 0, but on_hand alone covers the demand
+        inv = InvModel(
+            product_id=comp.id,
+            location_id=1,
+            on_hand_quantity=Decimal("30"),
+            allocated_quantity=Decimal("30"),
+        )
+        db.add(inv)
+        db.flush()
+
+        result = get_buy_list(db)
+        ids = {item.product_id for item in result.items}
+        assert comp.id not in ids, (
+            "Component whose WO-driven allocations match on_hand must NOT appear "
+            "on the buy list (double-count regression)"
+        )
+
+    def test_component_reserved_by_wo_in_gross_demand_shortage_correct(
+        self, db, make_product, make_bom, make_production_order
+    ):
+        """When on_hand is genuinely insufficient (even ignoring allocations),
+        the shortage is computed against on_hand + incoming — not available."""
+        from app.models.inventory import Inventory as InvModel
+
+        fg = make_product(item_type="finished_good", unit="EA", has_bom=True)
+        comp = make_product(item_type="supply", unit="EA", standard_cost=Decimal("2.00"))
+        make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": comp.id, "quantity": Decimal("5"), "unit": "EA"}],
+        )
+
+        # Open WO for 10 → gross_demand = 50
+        make_production_order(product_id=fg.id, status="released", quantity=10)
+
+        # on_hand=30, allocated=30 → available=-0 but on_hand < demand
+        # Fixed: shortage = max(0, 50 − 30) = 20  (not 50 − 0 = 50)
+        inv = InvModel(
+            product_id=comp.id,
+            location_id=1,
+            on_hand_quantity=Decimal("30"),
+            allocated_quantity=Decimal("30"),
+        )
+        db.add(inv)
+        db.flush()
+
+        result = get_buy_list(db)
+        item = next((i for i in result.items if i.product_id == comp.id), None)
+        assert item is not None, "Component with genuine shortage must appear on buy list"
+        assert item.net_shortage == Decimal("20"), (
+            f"Expected net_shortage=20 (50 − 30), got {item.net_shortage}"
+        )


### PR DESCRIPTION
## Summary

Four post-merge review findings from deep-review sweep of PRs #703/#704/#705, verified against origin/main and fixed with targeted regression tests.

### Finding 1 — Multi-operation same-component consumption guard rescoped
- **File:** `backend/app/services/inventory_service.py`
- **Problem:** `_consumption_already_posted` was documented without clearly banning its use inside `consume_operation_material`. If ever accidentally called from the per-op path it would block the second legitimate consumption when the same component appears in multiple routing operations (each with its own `ProductionOrderOperationMaterial` row).
- **Fix:** Added explicit "BOM-BACKFLUSH USE ONLY" docstring on `_consumption_already_posted` and a clarifying comment in `consume_operation_material` explaining why the per-row `material.status == 'consumed'` guard is correct for the per-op path and why the ledger-level guard must NOT be used there.
- **Tests:** `TestMultiOperationSameComponentConsumption` — two-op scenario posts two ledger rows; double-fire of same material row blocked by status; backflush after per-op posts nothing extra; double-fire backflush idempotent.

### Finding 2 — Ghost COGS in journal and order cost breakdown
- **File:** `backend/app/api/v1/endpoints/admin/accounting.py`
- **Problem:** `get_transactions_as_journal` and `get_order_cost_breakdown` lacked the voided/held exclusions that `get_cogs_summary` already had, allowing rejected (voided) consumption rows to inflate the GL journal and per-order cost breakdowns.
- **Fix:** Added `.filter(InventoryTransaction.voided_by.is_(None), ~(requires_approval & approved_by.is_(None)))` to both query sites, matching the exact idiom at ~line 486-492.
- **Tests:** `TestAccountingEndpointsExcludeGhostRows` — voided consumption absent from journal; unapplied held consumption absent from journal.

### Finding 3 — Buy-list netting double-counts WO allocations
- **File:** `backend/app/services/buy_list_service.py`
- **Problem:** Netting used `projected = available + incoming = (on_hand − allocated) + incoming`. Open WOs that created the `allocated` quantity are also in `gross_demand`, so subtracting allocations from supply while their demand is already in gross overstates shortages.
- **Fix:** Changed to `mrp_projected = on_hand + incoming` for the buy-list path with a detailed comment explaining why `available` is correct for per-order blocking-issues checks (single-order availability) but wrong for aggregate MRP netting.
- **Dev-DB delta:** MAT-PLA-BLK 3485→3185 (−300 units), MAT-ABS_BASIC-BLK 1000→500 (−500 units).
- **Tests:** `TestBuyListNoDoubleCount` — WO-driven allocations matching on_hand produce zero shortage; genuine shortage computed against on_hand (not available).

### Finding 4 — N+1 projected-available queries in buy-list netting loop
- **File:** `backend/app/services/supply_netting.py`, `backend/app/services/buy_list_service.py`
- **Fix:** Added `get_projected_available_bulk(db, product_ids)` to `supply_netting.py` — executes exactly two grouped SQL queries regardless of component count. Buy-list netting loop now calls the bulk path instead of `get_projected_available` per component.
- **Note:** `blocking_issues.py` per-component loops (~line 200, ~541) restructuring would change function signatures and require wider refactor — noted as follow-up tech debt per task instructions.
- **Tests:** `TestGetProjectedAvailableBulk` — 7 tests verifying bulk matches per-product calls, handles empty input, multiple products, received/closed/cancelled PO exclusions.

## Test plan

- [x] `pytest tests/ -q -k "buy_list or consumption or inventory_extra or accounting or supply_netting"` — 420 passed, 3 skipped
- [x] Full backend suite — 5366 passed, 13 skipped
- [x] `python -m ruff check app/ --select E712` — all checks passed
- [x] Decimal-only arithmetic in all changed service code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounting reports now exclude held/unapplied and voided inventory rows, improving accuracy of transaction journals and cost breakdowns.
  * Buy list calculations refined with improved availability projections and batch processing efficiency.

* **Tests**
  * Added comprehensive regression tests for multi-operation inventory consumption and buy list netting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->