### PR TITLE
feat: nav regroup (MONEY group, flow-ordered SALES) and CommandCenter landing (PR-13)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -155,8 +155,18 @@ export default function App() {
 
                   {/* ERP Admin Panel */}
                   <Route path="/admin" element={<AdminLayout />}>
+                    {/* CommandCenter is the /admin index (PR-13) */}
                     <Route
                       index
+                      element={
+                        <Suspense fallback={<PageLoader />}>
+                          <CommandCenter />
+                        </Suspense>
+                      }
+                    />
+                    {/* Analytics (previously Dashboard) lives at /admin/dashboard */}
+                    <Route
+                      path="dashboard"
                       element={
                         <Suspense fallback={<PageLoader />}>
                           <AdminDashboard />
@@ -393,13 +403,10 @@ export default function App() {
                         </Suspense>
                       }
                     />
+                    {/* Redirect legacy /admin/command-center bookmarks to the index */}
                     <Route
                       path="command-center"
-                      element={
-                        <Suspense fallback={<PageLoader />}>
-                          <CommandCenter />
-                        </Suspense>
-                      }
+                      element={<Navigate to="/admin" replace />}
                     />
                     <Route
                       path="access-requests"

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -293,22 +293,21 @@ const InventoryIcon = () => (
   </svg>
 );
 
-// TODO: Re-enable when Pro analytics are implemented
-// const AnalyticsIcon = () => (
-//   <svg
-//     className="w-5 h-5"
-//     fill="none"
-//     stroke="currentColor"
-//     viewBox="0 0 24 24"
-//   >
-//     <path
-//       strokeLinecap="round"
-//       strokeLinejoin="round"
-//       strokeWidth={2}
-//       d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-//     />
-//   </svg>
-// );
+const AnalyticsIcon = () => (
+  <svg
+    className="w-5 h-5"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+    />
+  </svg>
+);
 
 const AccountingIcon = () => (
   <svg
@@ -417,27 +416,40 @@ const CommandCenterIcon = () => (
 
 const navGroups = [
   {
-    label: null, // No header for dashboard
+    label: null, // No header — home screen entry
     items: [
-      { path: "/admin", label: "Dashboard", icon: DashboardIcon, end: true },
       {
-        path: "/admin/command-center",
+        path: "/admin",
         label: "Command Center",
         icon: CommandCenterIcon,
+        end: true,
+      },
+      {
+        path: "/admin/dashboard",
+        label: "Analytics",
+        icon: AnalyticsIcon,
       },
     ],
   },
   {
     label: "SALES",
     items: [
-      { path: "/admin/orders", label: "Orders", icon: OrdersIcon },
-      { path: "/admin/quotes", label: "Quotes", icon: QuotesIcon },
       {
-        path: "/admin/payments",
-        label: "Payments",
-        icon: PaymentsIcon,
+        path: "/admin/customers",
+        label: "Customers",
+        icon: CustomersIcon,
         adminOnly: true,
       },
+      { path: "/admin/quotes", label: "Quotes", icon: QuotesIcon },
+      { path: "/admin/orders", label: "Orders", icon: OrdersIcon },
+      { path: "/admin/shipping", label: "Shipping", icon: ShippingIcon },
+      { path: "/admin/messages", label: "Messages", icon: MessagesIcon },
+    ],
+  },
+  {
+    label: "MONEY",
+    adminOnly: true,
+    items: [
       {
         path: "/admin/invoices",
         label: "Invoices",
@@ -445,47 +457,15 @@ const navGroups = [
         adminOnly: true,
       },
       {
-        path: "/admin/customers",
-        label: "Customers",
-        icon: CustomersIcon,
-        adminOnly: true,
-      },
-      { path: "/admin/messages", label: "Messages", icon: MessagesIcon },
-    ],
-  },
-  {
-    label: "INVENTORY",
-    items: [
-      { path: "/admin/items", label: "Items", icon: ItemsIcon },
-      {
-        path: "/admin/materials/import",
-        label: "Import Materials",
-        icon: MaterialImportIcon,
-        adminOnly: true,
-      },
-      { path: "/admin/bom", label: "Bill of Materials", icon: BOMIcon },
-      {
-        path: "/admin/locations",
-        label: "Locations",
-        icon: InventoryIcon,
+        path: "/admin/payments",
+        label: "Payments",
+        icon: PaymentsIcon,
         adminOnly: true,
       },
       {
-        path: "/admin/inventory/transactions",
-        label: "Transactions",
-        icon: InventoryIcon,
-        adminOnly: true,
-      },
-      {
-        path: "/admin/inventory/cycle-count",
-        label: "Cycle Count",
-        icon: InventoryIcon,
-        adminOnly: true,
-      },
-      {
-        path: "/admin/spools",
-        label: "Material Spools",
-        icon: InventoryIcon,
+        path: "/admin/accounting",
+        label: "Accounting",
+        icon: AccountingIcon,
         adminOnly: true,
       },
     ],
@@ -508,8 +488,49 @@ const navGroups = [
         proOnly: true,
         feature: "bambu_integration",
       },
+      {
+        path: "/admin/spools",
+        label: "Material Spools",
+        icon: InventoryIcon,
+        adminOnly: true,
+      },
+    ],
+  },
+  {
+    label: "INVENTORY",
+    items: [
+      { path: "/admin/items", label: "Items", icon: ItemsIcon },
+      { path: "/admin/bom", label: "Bill of Materials", icon: BOMIcon },
+      {
+        path: "/admin/locations",
+        label: "Locations",
+        icon: InventoryIcon,
+        adminOnly: true,
+      },
+      {
+        path: "/admin/inventory/transactions",
+        label: "Transactions",
+        icon: InventoryIcon,
+        adminOnly: true,
+      },
+      {
+        path: "/admin/inventory/cycle-count",
+        label: "Cycle Count",
+        icon: InventoryIcon,
+        adminOnly: true,
+      },
+    ],
+  },
+  {
+    label: "PURCHASING",
+    items: [
       { path: "/admin/purchasing", label: "Purchasing", icon: PurchasingIcon },
-      { path: "/admin/shipping", label: "Shipping", icon: ShippingIcon },
+      {
+        path: "/admin/materials/import",
+        label: "Import Materials",
+        icon: MaterialImportIcon,
+        adminOnly: true,
+      },
     ],
   },
   {
@@ -558,27 +579,15 @@ const navGroups = [
     adminOnly: true,
     items: [
       {
-        path: "/admin/accounting",
-        label: "Accounting",
-        icon: AccountingIcon,
-        adminOnly: true,
-      },
-      {
-        path: "/admin/orders/import",
-        label: "Import Orders",
-        icon: MaterialImportIcon,
-        adminOnly: true,
-      },
-      {
         path: "/admin/users",
         label: "Team Members",
         icon: CustomersIcon,
         adminOnly: true,
       },
       {
-        path: "/admin/scrap-reasons",
-        label: "Scrap Reasons",
-        icon: SettingsIcon,
+        path: "/admin/security",
+        label: "Security Audit",
+        icon: QualityIcon,
         adminOnly: true,
       },
       {
@@ -594,9 +603,21 @@ const navGroups = [
         adminOnly: true,
       },
       {
-        path: "/admin/security",
-        label: "Security Audit",
-        icon: QualityIcon,
+        path: "/admin/license",
+        label: "License",
+        icon: SettingsIcon,
+        adminOnly: true,
+      },
+      {
+        path: "/admin/orders/import",
+        label: "Import Orders",
+        icon: MaterialImportIcon,
+        adminOnly: true,
+      },
+      {
+        path: "/admin/scrap-reasons",
+        label: "Scrap Reasons",
+        icon: SettingsIcon,
         adminOnly: true,
       },
     ],

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -20,9 +20,9 @@ function SummarySkeleton() {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="bg-gray-800 rounded-xl p-4 animate-pulse">
-          <div className="h-4 bg-gray-700 rounded w-20 mb-2" />
-          <div className="h-8 bg-gray-700 rounded w-12" />
+        <div key={i} className="bg-[var(--color-surface-raised,theme(colors.gray.800))] rounded-xl p-4 animate-pulse">
+          <div className="h-4 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded w-20 mb-2" />
+          <div className="h-8 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded w-12" />
         </div>
       ))}
     </div>
@@ -36,12 +36,12 @@ function ActionItemsSkeleton() {
   return (
     <div className="space-y-3">
       {[1, 2, 3].map((i) => (
-        <div key={i} className="bg-gray-800 rounded-lg p-4 animate-pulse">
+        <div key={i} className="bg-[var(--color-surface-raised,theme(colors.gray.800))] rounded-lg p-4 animate-pulse">
           <div className="flex gap-3">
-            <div className="w-5 h-5 bg-gray-700 rounded-full" />
+            <div className="w-5 h-5 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded-full" />
             <div className="flex-1">
-              <div className="h-4 bg-gray-700 rounded w-1/3 mb-2" />
-              <div className="h-3 bg-gray-700 rounded w-2/3" />
+              <div className="h-4 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded w-1/3 mb-2" />
+              <div className="h-3 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded w-2/3" />
             </div>
           </div>
         </div>
@@ -119,31 +119,36 @@ export default function CommandCenter() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white p-6">
+    <div className="space-y-8">
       {/* Header */}
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Command Center</h1>
-          <p className="text-gray-400 text-sm mt-1">{today}</p>
+          <h1 className="text-2xl font-bold text-white">Command Center</h1>
+          <p className="text-[var(--color-text-muted,theme(colors.gray.400))] text-sm mt-1">{today}</p>
         </div>
-        <button
-          onClick={handleRefresh}
-          disabled={refreshing}
-          className={`
-            flex items-center gap-2 px-4 py-2 bg-gray-800 rounded-lg
-            hover:bg-gray-700 transition-colors disabled:opacity-50
-          `}
-        >
-          <svg
-            className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+        <div className="flex items-center gap-3">
+          <a
+            href="/admin/dashboard"
+            className="text-sm text-blue-400 hover:text-blue-300 transition-colors"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-          Refresh
-        </button>
+            Analytics →
+          </a>
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="flex items-center gap-2 px-4 py-2 bg-[var(--color-surface-raised,theme(colors.gray.800))] rounded-lg hover:bg-[var(--color-surface-hover,theme(colors.gray.700))] transition-colors disabled:opacity-50"
+          >
+            <svg
+              className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Refresh
+          </button>
+        </div>
       </div>
 
       {error ? (
@@ -152,8 +157,8 @@ export default function CommandCenter() {
         <div className="space-y-8">
           {/* Summary Stats */}
           <section>
-            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2 text-white">
+              <svg className="w-5 h-5 text-[var(--color-text-muted,theme(colors.gray.400))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
               Today's Summary
@@ -194,13 +199,13 @@ export default function CommandCenter() {
 
           {/* Action Items */}
           <section>
-            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2 text-white">
+              <svg className="w-5 h-5 text-[var(--color-text-muted,theme(colors.gray.400))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
               Action Items
               {actionItems.length > 0 && (
-                <span className="text-sm font-normal text-gray-400">
+                <span className="text-sm font-normal text-[var(--color-text-muted,theme(colors.gray.400))]">
                   ({actionItems.length})
                 </span>
               )}
@@ -232,22 +237,22 @@ export default function CommandCenter() {
 
           {/* Machine Status */}
           <section>
-            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-              <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2 text-white">
+              <svg className="w-5 h-5 text-[var(--color-text-muted,theme(colors.gray.400))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
               </svg>
               Machines
               {resources.length > 0 && (
-                <span className="text-sm font-normal text-gray-400">
+                <span className="text-sm font-normal text-[var(--color-text-muted,theme(colors.gray.400))]">
                   ({resources.filter(r => r.status === 'running').length}/{resources.length} running)
                 </span>
               )}
             </h2>
             {loading ? (
-              <div className="bg-gray-800 rounded-lg p-8 animate-pulse">
+              <div className="bg-[var(--color-surface-raised,theme(colors.gray.800))] rounded-lg p-8 animate-pulse">
                 <div className="grid grid-cols-4 gap-4">
                   {[1, 2, 3, 4].map((i) => (
-                    <div key={i} className="h-20 bg-gray-700 rounded" />
+                    <div key={i} className="h-20 bg-[var(--color-surface-hover,theme(colors.gray.700))] rounded" />
                   ))}
                 </div>
               </div>
@@ -262,7 +267,7 @@ export default function CommandCenter() {
       )}
 
       {/* Auto-refresh indicator */}
-      <div className="fixed bottom-4 right-4 text-xs text-gray-600">
+      <div className="fixed bottom-4 right-4 text-xs text-[var(--color-text-muted,theme(colors.gray.600))]">
         Auto-refreshes every 60s
       </div>
     </div>

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -171,9 +171,17 @@ export default function AdminDashboard() {
   return (
     <div className="space-y-8">
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-white">Dashboard</h1>
-        <p className="text-gray-400 mt-1">Welcome to the FilaOps Admin Panel</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Analytics</h1>
+          <p className="text-gray-400 mt-1">KPIs and trends for your print farm</p>
+        </div>
+        <Link
+          to="/admin"
+          className="text-sm text-blue-400 hover:text-blue-300 transition-colors"
+        >
+          ← Command Center
+        </Link>
       </div>
 
       {/* Sales Trend Chart - Primary KPI */}
@@ -186,156 +194,7 @@ export default function AdminDashboard() {
         />
       </div>
 
-      {/* Action Items Section */}
-      {(stats?.orders?.overdue > 0 ||
-        stats?.orders?.pending_confirmation > 0 ||
-        stats?.notifications?.unread > 0 ||
-        stats?.inventory?.low_stock_count > 0 ||
-        stats?.production?.ready_to_start > 0 ||
-        stats?.orders?.ready_to_ship > 0 ||
-        stats?.quotes?.pending > 0 ||
-        invoiceSummary?.overdue_count > 0) && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <div className="px-4 py-3 border-b border-gray-800 flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-blue-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-              />
-            </svg>
-            <h3 className="font-semibold text-white">Action Items</h3>
-          </div>
-          <div className="divide-y divide-gray-800">
-            {/* Critical - Overdue */}
-            {stats?.orders?.overdue > 0 && (
-              <Link
-                to="/admin/orders?status=overdue"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-red-500"></span>
-                  <span className="text-white">
-                    {stats.orders.overdue} Overdue Order{stats.orders.overdue !== 1 ? "s" : ""}
-                  </span>
-                </div>
-                <span className="text-xs text-red-400 font-medium">URGENT</span>
-              </Link>
-            )}
-            {/* Critical - Overdue Invoices */}
-            {invoiceSummary?.overdue_count > 0 && (
-              <Link
-                to="/admin/invoices?status=overdue"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-red-500"></span>
-                  <span className="text-white">
-                    {invoiceSummary.overdue_count} Overdue Invoice{invoiceSummary.overdue_count !== 1 ? "s" : ""}
-                  </span>
-                </div>
-                <span className="text-xs text-red-400 font-medium">URGENT</span>
-              </Link>
-            )}
-            {/* Pending Confirmation Orders */}
-            {stats?.orders?.pending_confirmation > 0 && (
-              <Link
-                to="/admin/orders?filter=pending_review"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-purple-500"></span>
-                  <span className="text-white">
-                    {stats.orders.pending_confirmation} Order{stats.orders.pending_confirmation !== 1 ? "s" : ""} Pending Review
-                  </span>
-                </div>
-                <span className="text-xs text-purple-400 font-medium">REVIEW</span>
-              </Link>
-            )}
-            {/* Unread Messages */}
-            {stats?.notifications?.unread > 0 && (
-              <Link
-                to="/admin/messages"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-blue-500"></span>
-                  <span className="text-white">
-                    {stats.notifications.unread} Unread Message{stats.notifications.unread !== 1 ? "s" : ""}
-                  </span>
-                </div>
-                <span className="text-xs text-blue-400">Read</span>
-              </Link>
-            )}
-            {/* Warning - Low Stock */}
-            {stats?.inventory?.low_stock_count > 0 && (
-              <Link
-                to="/admin/purchasing?tab=low-stock"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-yellow-500"></span>
-                  <span className="text-white">
-                    {stats.inventory.low_stock_count} Low Stock Item{stats.inventory.low_stock_count !== 1 ? "s" : ""}
-                  </span>
-                </div>
-                <span className="text-xs text-yellow-400">Reorder needed</span>
-              </Link>
-            )}
-            {/* Action - Quotes */}
-            {stats?.quotes?.pending > 0 && (
-              <Link
-                to="/admin/quotes"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-blue-500"></span>
-                  <span className="text-white">
-                    {stats.quotes.pending} Pending Quote{stats.quotes.pending !== 1 ? "s" : ""}
-                  </span>
-                </div>
-                <span className="text-xs text-blue-400">Respond</span>
-              </Link>
-            )}
-            {/* Ready - Production */}
-            {stats?.production?.ready_to_start > 0 && (
-              <Link
-                to="/admin/production?status=released"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-green-500"></span>
-                  <span className="text-white">
-                    {stats.production.ready_to_start} Order{stats.production.ready_to_start !== 1 ? "s" : ""} Ready to Start
-                  </span>
-                </div>
-                <span className="text-xs text-green-400">Start production</span>
-              </Link>
-            )}
-            {/* Ready - Shipping */}
-            {stats?.orders?.ready_to_ship > 0 && (
-              <Link
-                to="/admin/shipping"
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-800/50 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-2 h-2 rounded-full bg-cyan-500"></span>
-                  <span className="text-white">
-                    {stats.orders.ready_to_ship} Order{stats.orders.ready_to_ship !== 1 ? "s" : ""} Ready to Ship
-                  </span>
-                </div>
-                <span className="text-xs text-cyan-400">Ship</span>
-              </Link>
-            )}
-          </div>
-        </div>
-      )}
+      {/* Action Items removed — CommandCenter is the canonical action-items surface (PR-13) */}
 
       {/* SALES Section */}
       <div>

--- a/frontend/tests/e2e/pages/capture-screenshots.spec.ts
+++ b/frontend/tests/e2e/pages/capture-screenshots.spec.ts
@@ -49,7 +49,8 @@ async function screenshot(page: Page, name: string) {
 
 // Pages to capture
 const PAGES = [
-  { url: '/admin', name: 'dashboard-page', title: 'Dashboard' },
+  { url: '/admin', name: 'command-center-page', title: 'Command Center' },
+  { url: '/admin/dashboard', name: 'analytics-page', title: 'Analytics' },
   { url: '/admin/quotes', name: 'quotes-page', title: 'Quotes' },
   { url: '/admin/orders', name: 'orders-page', title: 'Orders' },
   { url: '/admin/customers', name: 'customers-page', title: 'Customers' },

--- a/frontend/tests/e2e/pages/sop-comprehensive.spec.ts
+++ b/frontend/tests/e2e/pages/sop-comprehensive.spec.ts
@@ -790,15 +790,15 @@ test.describe('SOP-SET-001: System Settings', () => {
 });
 
 // =============================================================================
-// Dashboard Tests
+// Command Center Tests (was: Dashboard Tests — /admin now loads CommandCenter per PR-13)
 // =============================================================================
 test.describe('Dashboard Verification', () => {
-  test('DASH-01: Verify Dashboard and capture screenshot', async ({ authPage: page }) => {
+  test('DASH-01: Verify Command Center and capture screenshot', async ({ authPage: page }) => {
     await page.goto('/admin');
     await page.waitForLoadState('networkidle');
 
     // Capture screenshot for SOP documentation
-    await captureScreenshot(page, 'dashboard-page');
+    await captureScreenshot(page, 'command-center-page');
 
     // Check for stat cards
     const statCards = page.locator('[class*="stat"], [class*="card"]');
@@ -857,17 +857,19 @@ test.describe('Sidebar Navigation', () => {
     await page.waitForLoadState('networkidle');
 
     const expectedLinks = [
-      'Dashboard',
-      'Orders',
-      'Quotes',
+      'Command Center',
+      'Analytics',
       'Customers',
-      'Items',
+      'Quotes',
+      'Orders',
+      'Shipping',
+      'Invoices',
+      'Payments',
       'Production',
+      'Work Centers & Routings',
+      'Items',
       'Bill of Materials',
       'Purchasing',
-      'Work Centers & Routings',
-      'Shipping',
-      'Payments',
       'Settings',
     ];
 


### PR DESCRIPTION
## Summary

Implements PR-13 from the UX GTM-Readiness plan: restructures admin navigation, promotes CommandCenter to the `/admin` landing page, and removes the duplicated Action Items panel from AdminDashboard.

**Decision on partial edit:** The prior agent's edit to `AdminLayout.jsx` was coherent and complete — the navGroups array was fully restructured. Built on it without resetting.

## Before → After group structure

| Before | After |
|--------|-------|
| _(none)_ Dashboard, Command Center | _(none)_ Command Center, Analytics |
| SALES: Orders, Quotes, Payments, Invoices, Customers, Messages | **SALES**: Customers, Quotes, Orders, Shipping, Messages |
| INVENTORY: Items, Import Materials, BOM, Locations, Transactions, Spools | **MONEY** _(new, adminOnly)_: Invoices, Payments, Accounting |
| OPERATIONS: Production, Work Centers & Routings, Printers, Bambuddy, Purchasing, Shipping | **OPERATIONS**: Production, Work Centers & Routings, Printers, Bambuddy (PRO), Material Spools |
| ADMIN: Accounting, Import Orders, Users, Scrap Reasons, Settings, Integrations, Security | **INVENTORY**: Items, BOM, Locations, Transactions, Cycle Count |
| B2B PORTAL + QUALITY unchanged | **PURCHASING**: Purchasing, Import Materials |
| | **ADMIN**: Users, Security, Settings, Integrations, License, Import Orders, Scrap Reasons |
| | **B2B PORTAL** + **QUALITY** unchanged |

## Changes

- **AdminLayout.jsx** — Restructured `navGroups`; un-commented `AnalyticsIcon`; renamed Dashboard nav entry to "Analytics"
- **App.jsx** — `CommandCenter` is the `index` route for `/admin`; `AdminDashboard` moved to `/admin/dashboard`; `/admin/command-center` redirects to `/admin` for bookmark compatibility
- **CommandCenter.jsx** — Dropped `min-h-screen p-6 bg-gray-900` standalone wrapper (was double-padding inside AdminLayout); migrated hardcoded gray tokens to CSS-variable fallbacks; added "Analytics →" cross-link
- **AdminDashboard.jsx** — Removed duplicate Action Items panel (CommandCenter is canonical); renamed page title to "Analytics"; added "← Command Center" cross-link
- **E2E tests** — Updated nav link assertions in `sop-comprehensive.spec.ts`; updated page list/titles in `capture-screenshots.spec.ts`

## Verification

- `npm run test:unit` — 39 test files, 314 tests, all passed ✅
- `npm run build` — Clean build, no warnings ✅
- All old routes still resolve (no broken bookmarks) ✅
- Role/PRO/adminOnly filtering on all nav items preserved ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)