### PR TITLE
fix(orders): PR-8 expanded — one action surface, backend-aligned gating, closed_short reconcile

### DIFF
--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -2767,7 +2767,10 @@ def generate_production_orders(
     if order.status != "confirmed":
         raise HTTPException(
             status_code=400,
-            detail="Confirm the sales order before generating production orders"
+            detail=(
+                f"Work orders can only be generated while the order is in Confirmed status; "
+                f"this order is {order.status.replace('_', ' ')}."
+            )
         )
 
     created_orders = []

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -2802,6 +2802,7 @@ class TestCopyRoutingToOperations:
         assert len(ops) == 1
         assert ops[0].planned_run_minutes == 120.0  # 30 * 4
 
+
     def test_create_production_orders_with_routing_for_quote_based(
         self, db, make_product, make_bom, make_sales_order
     ):
@@ -2837,3 +2838,205 @@ class TestCopyRoutingToOperations:
             ProductionOrderOperation.production_order_id == po.id
         ).all()
         assert len(ops) == 1
+
+# =============================================================================
+# PR-8: generate_production_orders -- error copy (issue #680 item 3)
+# =============================================================================
+
+class TestGenerateProductionOrdersErrorCopy:
+    """Verify error messages name the actual blocking rule."""
+
+    def test_error_names_current_status_not_confirmed(self, db, make_sales_order, make_product):
+        """400 detail names the actual status, not a generic confirm-first message."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="in_production", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        assert "in production" in detail.lower()
+        assert "confirmed" in detail.lower()
+
+    def test_error_names_ready_to_ship_status(self, db, make_sales_order, make_product):
+        """400 detail names ready to ship for a closed-short order."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="ready_to_ship", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        assert "ready to ship" in detail.lower()
+        assert "confirmed" in detail.lower()
+
+    def test_confirmed_order_succeeds(self, db, make_sales_order, make_product):
+        """Confirmed order with producible lines creates work orders successfully."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=2)
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 1
+
+
+# =============================================================================
+# PR-8: line linkage on generate_production_orders paths (issue #680 item 1)
+# =============================================================================
+
+class TestGenerateProductionOrdersLineLinkage:
+    """sales_order_line_id is set on all line_item creation paths."""
+
+    def test_line_item_wo_carries_line_id(self, db, make_sales_order, make_product):
+        """WOs created for line_item orders must have sales_order_line_id set."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        line = _make_order_line(db, so.id, product.id, quantity=3)
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 1
+
+        po = db.query(ProductionOrder).filter(
+            ProductionOrder.code == result["created_orders"][0]
+        ).first()
+        assert po is not None
+        assert po.sales_order_line_id == line.id
+
+    def test_multi_line_each_wo_carries_its_line_id(self, db, make_sales_order, make_product):
+        """Each WO carries the ID of its specific line."""
+        p1 = make_product(selling_price=Decimal("10.00"))
+        p2 = make_product(selling_price=Decimal("20.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        line1 = _make_order_line(db, so.id, p1.id, quantity=1)
+        line2 = _make_order_line(db, so.id, p2.id, quantity=2)
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 2
+
+        linked_pos = db.query(ProductionOrder).filter(
+            ProductionOrder.sales_order_id == so.id
+        ).all()
+        linked_line_ids = {po.sales_order_line_id for po in linked_pos}
+        assert line1.id in linked_line_ids
+        assert line2.id in linked_line_ids
+
+    def test_quote_based_wo_has_null_line_id(self, db, make_sales_order, make_product):
+        """quote_based orders have no line items -- NULL is the correct value."""
+        from datetime import datetime, timezone, timedelta
+        from app.models.quote import Quote
+
+        product = make_product(selling_price=Decimal("10.00"))
+        quote = Quote(
+            user_id=1,
+            quote_number="Q-TEST-LINELINK-001",
+            product_name="Test Widget",
+            quantity=2,
+            material_type="PLA",
+            total_price=Decimal("20.00"),
+            unit_price=Decimal("10.00"),
+            file_format=".stl",
+            file_size_bytes=1000,
+            status="accepted",
+            product_id=product.id,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+        )
+        db.add(quote)
+        db.flush()
+
+        so = make_sales_order(
+            status="confirmed",
+            order_type="quote_based",
+            product_id=product.id,
+            quote_id=quote.id,
+            quantity=2,
+        )
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 1
+
+        po = db.query(ProductionOrder).filter(
+            ProductionOrder.code == result["created_orders"][0]
+        ).first()
+        assert po is not None
+        # quote_based orders have no lines -- NULL is correct
+        assert po.sales_order_line_id is None
+
+
+# =============================================================================
+# PR-8: closed_short reconcile (issue #680 item 2)
+# =============================================================================
+
+class TestClosedShortReconcile:
+    """closed_short flag is preserved as audit record after demand is subsequently met."""
+
+    def test_closed_short_flag_preserved_when_production_completes(
+        self, db, make_sales_order, make_product
+    ):
+        """closed_short=True remains after all WOs complete -- it is an audit record.
+
+        The UI surfaces Previously Closed Short - Fulfilled when all WOs are complete.
+        The flag must NOT be cleared so the close-short action is preserved for audit.
+        """
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="ready_to_ship",
+            order_type="line_item",
+            closed_short=True,
+        )
+        line = _make_order_line(db, so.id, product.id, quantity=2)
+
+        po = ProductionOrder(
+            code="PO-CLSHRT-RECN-001",
+            product_id=product.id,
+            sales_order_id=so.id,
+            sales_order_line_id=line.id,
+            quantity_ordered=2,
+            quantity_completed=2,
+            quantity_scrapped=0,
+            status="complete",
+            created_by="test",
+        )
+        db.add(po)
+        db.flush()
+
+        db.refresh(so)
+        assert so.closed_short is True
+
+    def test_closed_short_is_set_by_close_short_action(
+        self, db, make_sales_order, make_product
+    ):
+        """close_short service function sets closed_short=True and transitions to ready_to_ship."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="in_production",
+            order_type="line_item",
+        )
+        line = _make_order_line(db, so.id, product.id, quantity=5)
+
+        po = ProductionOrder(
+            code="PO-CLSHRT-SET-001",
+            product_id=product.id,
+            sales_order_id=so.id,
+            sales_order_line_id=line.id,
+            quantity_ordered=5,
+            quantity_completed=3,
+            quantity_scrapped=0,
+            status="complete",
+            created_by="test",
+        )
+        db.add(po)
+        db.flush()
+
+        sales_order_service.close_short_sales_order(
+            db, so.id, user_id=1, reason="Not enough material to complete full run"
+        )
+        db.flush()
+        db.refresh(so)
+
+        assert so.closed_short is True
+        assert so.status == "ready_to_ship"
+        assert so.close_short_reason is not None

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -114,8 +114,12 @@ export default function OrderDetail() {
     if (!order) return "Order is still loading";
     if (!hasOrderProduct()) return "Order must have a product line";
     if (hasMainProductWO()) return "Production order already exists";
-    if (UNCONFIRMED_ORDER_STATUSES.has(order.status)) {
-      return "Order must be confirmed before production release";
+    // Mirror the backend rule exactly: status must be "confirmed" (not merely past-unconfirmed)
+    if (order.status !== "confirmed") {
+      if (UNCONFIRMED_ORDER_STATUSES.has(order.status)) {
+        return "Order must be confirmed before production release";
+      }
+      return `Work orders can only be created while the order is in Confirmed status; this order is ${order.status.replace(/_/g, " ")}.`;
     }
     if (!isBillingReleaseSatisfied()) {
       return "Create/send an invoice or record payment before production release";
@@ -1015,51 +1019,6 @@ export default function OrderDetail() {
           >
             Print Packing Slip
           </button>
-          {!SHIPPED_ORDER_STATUSES.has(order.status) && (
-            <button
-              onClick={() => navigate(`/admin/shipping?orderId=${order.id}`)}
-              disabled={!canShipOrder()}
-              className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-              title={getShipBlockReason() || "Ship order"}
-            >
-              Ship Order
-            </button>
-          )}
-          {(order.status === "pending" || order.status === "pending_confirmation") && (
-            <>
-              <button
-                onClick={handleConfirmOrder}
-                disabled={confirmingOrder}
-                className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg disabled:opacity-50"
-              >
-                {confirmingOrder ? "Confirming..." : "Confirm Order"}
-              </button>
-              {order.status === "pending_confirmation" && (
-                <button
-                  onClick={() => setShowRejectModal(true)}
-                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg"
-                >
-                  Reject Order
-                </button>
-              )}
-            </>
-          )}
-          {canCancelOrder() && (
-            <button
-              onClick={() => setShowCancelModal(true)}
-              className="px-4 py-2 bg-yellow-600 hover:bg-yellow-500 text-white rounded-lg"
-            >
-              Cancel Order
-            </button>
-          )}
-          {canCloseShort() && (
-            <button
-              onClick={openCloseShortModal}
-              className="px-4 py-2 bg-amber-600 hover:bg-amber-500 text-white rounded-lg"
-            >
-              Close Short
-            </button>
-          )}
         </div>
       </div>
 
@@ -1125,9 +1084,53 @@ export default function OrderDetail() {
             );
           })}
         </div>
+
+        {/* Secondary / destructive actions — below workflow steps */}
+        {(order.status === "pending_confirmation" || canCancelOrder() || canCloseShort()) && (
+          <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-gray-700/50 pt-4">
+            <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              Order actions:
+            </span>
+            {(order.status === "pending" || order.status === "pending_confirmation") && (
+              <>
+                <button
+                  onClick={handleConfirmOrder}
+                  disabled={confirmingOrder}
+                  className="rounded-lg bg-green-700 px-3 py-1.5 text-sm text-white hover:bg-green-600 disabled:opacity-50"
+                >
+                  {confirmingOrder ? "Confirming..." : "Confirm Order"}
+                </button>
+                {order.status === "pending_confirmation" && (
+                  <button
+                    onClick={() => setShowRejectModal(true)}
+                    className="rounded-lg bg-red-700 px-3 py-1.5 text-sm text-white hover:bg-red-600"
+                  >
+                    Reject Order
+                  </button>
+                )}
+              </>
+            )}
+            {canCancelOrder() && (
+              <button
+                onClick={() => setShowCancelModal(true)}
+                className="rounded-lg bg-yellow-700 px-3 py-1.5 text-sm text-white hover:bg-yellow-600"
+              >
+                Cancel Order
+              </button>
+            )}
+            {canCloseShort() && (
+              <button
+                onClick={openCloseShortModal}
+                className="rounded-lg bg-amber-700 px-3 py-1.5 text-sm text-white hover:bg-amber-600"
+              >
+                Close Short
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
-      {/* Quick Actions Panel */}
+      {/* Quick Actions \u2014 idempotent tools only (links + checks) */}
       <div className="bg-gradient-to-r from-blue-900/20 to-cyan-900/20 border border-blue-500/30 rounded-xl p-6">
         <h2 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1166,16 +1169,6 @@ export default function OrderDetail() {
                 >
                   Open Invoice
                 </button>
-                {orderInvoice.status === "draft" && (
-                  <button
-                    onClick={handleSendOrderInvoice}
-                    disabled={sendingInvoice}
-                    title="Marks this invoice as sent in FilaOps. This does not email the customer."
-                    className="rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
-                  >
-                    {sendingInvoice ? "Marking..." : "Mark Sent"}
-                  </button>
-                )}
                 <button
                   onClick={handleDownloadOrderInvoice}
                   className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600"
@@ -1186,18 +1179,7 @@ export default function OrderDetail() {
             </div>
           </div>
         )}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          <button
-            onClick={handleCreateProductionOrder}
-            disabled={!canGenerateProductionOrder()}
-            className="px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
-            title={getProductionReleaseBlockReason() || "Generate production order"}
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-            </svg>
-            {hasMainProductWO() ? "WO Exists" : "Generate Production Order"}
-          </button>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <button
             onClick={handleCheckAvailability}
             disabled={checkingAvailability || productionOrders.length === 0}
@@ -1218,18 +1200,6 @@ export default function OrderDetail() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
               </svg>
               View in Production
-            </button>
-          )}
-          {canGenerateInvoice() && (
-            <button
-              onClick={handleGenerateInvoice}
-              disabled={generatingInvoice}
-              className="px-4 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              {generatingInvoice ? "Creating..." : "Create Invoice"}
             </button>
           )}
         </div>
@@ -1312,12 +1282,18 @@ export default function OrderDetail() {
           </div>
           <div>
             <div className="text-sm text-gray-400">Status</div>
-            <div className="text-white font-medium flex items-center gap-2">
-              {order.status}
+            <div className="text-white font-medium flex items-center gap-2 capitalize">
+              {order.status?.replace(/_/g, " ") || "unknown"}
               {order.closed_short && (
-                <span className="px-2 py-0.5 text-xs rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30">
-                  Closed Short
-                </span>
+                getProductionComplete() ? (
+                  <span className="px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
+                    Previously Closed Short — Fulfilled
+                  </span>
+                ) : (
+                  <span className="px-2 py-0.5 text-xs rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                    Closed Short
+                  </span>
+                )
               )}
             </div>
           </div>

--- a/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
+++ b/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
@@ -1,0 +1,382 @@
+/**
+ * OrderDetail.test.jsx — PR-8 workflow gating tests
+ *
+ * Tests:
+ * - Workflow card shows "Create Work Orders" only when status === "confirmed"
+ * - Workflow card blocks "Create Work Orders" for non-confirmed statuses
+ * - Header only contains Refresh and Print Packing Slip
+ * - Order Summary shows humanized status (no raw snake_case)
+ * - closed_short renders correctly depending on production completion
+ * - Action surface is singular: state-changing buttons appear in workflow card
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => {
+  const mocks = {
+    get: vi.fn(),
+    post: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastInfo: vi.fn(),
+    navigate: vi.fn(),
+  }
+  mocks.api = {
+    get: mocks.get,
+    post: mocks.post,
+  }
+  mocks.toast = {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    info: mocks.toastInfo,
+  }
+  return { mocks }
+})
+
+vi.mock('../../../hooks/useApi', () => ({
+  useApi: () => mocks.api,
+}))
+
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => mocks.toast,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  }
+})
+
+vi.mock('../../../hooks/useFulfillmentStatus', () => ({
+  useFulfillmentStatus: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../components/orders/BlockingIssuesPanel', () => ({
+  default: () => <div data-testid="blocking-issues" />,
+}))
+
+vi.mock('../../../components/orders/FulfillmentProgress', () => ({
+  default: () => <div data-testid="fulfillment-progress" />,
+}))
+
+vi.mock('../../../components/orders/ProductionStatusCards', () => ({
+  ProductionProgressSummary: () => <div data-testid="production-summary" />,
+  ProductionOrderStatusCard: ({ order }) => (
+    <div data-testid={`po-card-${order.id}`}>{order.code}</div>
+  ),
+}))
+
+vi.mock('../../../components/orders/MaterialRequirementsSection', () => ({
+  default: () => <div data-testid="material-req" />,
+}))
+
+vi.mock('../../../components/orders/CapacityRequirementsSection', () => ({
+  default: () => <div data-testid="capacity-req" />,
+}))
+
+vi.mock('../../../components/orders/PaymentsSection', () => ({
+  default: () => <div data-testid="payments-section" />,
+}))
+
+vi.mock('../../../components/orders/ShippingAddressSection', () => ({
+  default: () => <div data-testid="shipping-address" />,
+}))
+
+vi.mock('../../../components/orders/OrderModals', () => ({
+  CancelOrderModal: () => <div data-testid="cancel-modal" />,
+  DeleteOrderModal: () => <div data-testid="delete-modal" />,
+}))
+
+vi.mock('../../../components/payments/RecordPaymentModal', () => ({
+  default: () => <div data-testid="payment-modal" />,
+}))
+
+vi.mock('../../../components/ActivityTimeline', () => ({
+  default: () => <div data-testid="activity-timeline" />,
+}))
+
+vi.mock('../../../components/ShippingTimeline', () => ({
+  default: () => <div data-testid="shipping-timeline" />,
+}))
+
+import OrderDetail from '../OrderDetail'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOrder(overrides = {}) {
+  return {
+    id: 1001,
+    order_number: 'SO-2026-001',
+    order_type: 'line_item',
+    status: 'confirmed',
+    payment_status: 'pending',
+    closed_short: false,
+    quantity: 5,
+    total_price: '50.00',
+    grand_total: '50.00',
+    product_id: null,
+    product_name: null,
+    lines: [
+      {
+        id: 101,
+        product_id: 42,
+        product_name: 'Test Widget',
+        product_sku: 'TW-001',
+        quantity: 5,
+        unit_price: '10.00',
+        total: '50.00',
+        shipped_quantity: 0,
+        line_type: 'product',
+      },
+    ],
+    customer_name: 'ACME Corp',
+    customer_email: 'acme@example.com',
+    ...overrides,
+  }
+}
+
+function setupApiMocks({ order, productionOrders = [], invoice = null } = {}) {
+  mocks.get.mockImplementation((path) => {
+    if (path.includes('/api/v1/sales-orders/1001') && !path.includes('material')) {
+      return Promise.resolve(order)
+    }
+    if (path.includes('material-requirements')) {
+      return Promise.resolve({ requirements: [], summary: null })
+    }
+    if (path.includes('/api/v1/production-orders')) {
+      return Promise.resolve({ items: productionOrders })
+    }
+    if (path.includes('/api/v1/payments/order')) {
+      return Promise.resolve({ total_paid: 0, total_due: 50 })
+    }
+    if (path.includes('/api/v1/payments')) {
+      return Promise.resolve({ items: [] })
+    }
+    if (path.includes('/api/v1/invoices')) {
+      return Promise.resolve({ items: invoice ? [invoice] : [] })
+    }
+    return Promise.resolve({})
+  })
+}
+
+function renderOrderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/orders/1001']}>
+      <Routes>
+        <Route path="/admin/orders/:orderId" element={<OrderDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mocks.get.mockReset()
+  mocks.post.mockReset()
+  mocks.toastError.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.navigate.mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// Workflow gating tests
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — workflow gating (PR-8 / issue #680 item 3)', () => {
+  it('shows Create Work Orders button when status is confirmed, billing satisfied, no WOs exist', async () => {
+    // Billing must be satisfied for the production step to offer Create Work Orders
+    const order = makeOrder({
+      status: 'confirmed',
+      payment_status: 'paid',  // billing satisfied
+    })
+    setupApiMocks({ order, productionOrders: [] })
+
+    renderOrderDetail()
+
+    expect(await screen.findByText('Order Workflow')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create work orders/i })).toBeInTheDocument()
+  })
+
+  it('does NOT show Create Work Orders button when status is in_production', async () => {
+    const order = makeOrder({ status: 'in_production' })
+    setupApiMocks({
+      order,
+      productionOrders: [],  // no WOs, but status is past confirmed
+    })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    const createWOButtons = screen.queryAllByRole('button', { name: /create work orders/i })
+    expect(createWOButtons).toHaveLength(0)
+  })
+
+  it('does NOT show Create Work Orders button when status is ready_to_ship', async () => {
+    const order = makeOrder({ status: 'ready_to_ship', closed_short: true })
+    setupApiMocks({ order, productionOrders: [] })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    const createWOButtons = screen.queryAllByRole('button', { name: /create work orders/i })
+    expect(createWOButtons).toHaveLength(0)
+  })
+
+  it('shows Open Work Order when WOs exist', async () => {
+    const order = makeOrder({ status: 'in_production' })
+    const productionOrders = [
+      {
+        id: 555,
+        code: 'PO-2026-0055',
+        status: 'draft',
+        product_id: 42,
+        sales_order_line_id: 101,
+        quantity_ordered: 5,
+        quantity_completed: 0,
+      },
+    ]
+    setupApiMocks({ order, productionOrders })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.getByRole('button', { name: /open work order/i })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Header tests
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — header (PR-8 slim)', () => {
+  it('header contains Refresh and Print Packing Slip only', async () => {
+    const order = makeOrder({ status: 'confirmed' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+
+    // Must have Refresh
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+    // Must have Print Packing Slip
+    expect(screen.getByRole('button', { name: /print packing slip/i })).toBeInTheDocument()
+    // Must NOT have Ship Order in header (it's in workflow card step 4)
+    const shipButtons = screen.queryAllByRole('button', { name: /^ship order$/i })
+    // Ship Order only appears in the workflow card action, not a second time in header
+    // The workflow card renders it as a button only when shipping is ready
+    // (confirmed status means production not complete, so no ship button should appear in workflow either)
+    expect(shipButtons).toHaveLength(0)
+  })
+
+  it('Confirm Order appears in workflow secondary actions, not header', async () => {
+    const order = makeOrder({ status: 'pending' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+
+    // Confirm appears in the secondary actions row below workflow card
+    const confirmBtns = screen.getAllByRole('button', { name: /confirm order/i })
+    // Should be in the workflow secondary row (not the header area)
+    expect(confirmBtns.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Order Summary humanization tests
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — Order Summary status humanization (PR-8)', () => {
+  it('renders status without underscores in Order Summary', async () => {
+    const order = makeOrder({ status: 'in_production' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Summary')
+    // The Status row in Order Summary must show humanized text
+    const statusLabel = screen.getByText('Status')
+    const statusCell = statusLabel.closest('div').parentElement
+    expect(statusCell).toHaveTextContent('in production')
+    expect(screen.queryByText('in_production')).not.toBeInTheDocument()
+  })
+
+  it('renders ready_to_ship as readable text in Order Summary', async () => {
+    const order = makeOrder({ status: 'ready_to_ship' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Summary')
+    const statusLabel = screen.getByText('Status')
+    const statusCell = statusLabel.closest('div').parentElement
+    expect(statusCell).toHaveTextContent('ready to ship')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// closed_short reconcile tests
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — closed_short reconcile rendering (PR-8 / issue #680 item 2)', () => {
+  it('shows Closed Short badge when closed_short=true and production not complete', async () => {
+    const order = makeOrder({
+      status: 'ready_to_ship',
+      closed_short: true,
+    })
+    const productionOrders = [
+      {
+        id: 556,
+        code: 'PO-2026-0056',
+        status: 'draft',  // not complete
+        product_id: 42,
+        sales_order_line_id: 101,
+        quantity_ordered: 5,
+        quantity_completed: 0,
+      },
+    ]
+    setupApiMocks({ order, productionOrders })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Summary')
+    expect(screen.getByText('Closed Short')).toBeInTheDocument()
+    expect(screen.queryByText(/previously closed short/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Previously Closed Short - Fulfilled badge when all WOs are complete', async () => {
+    const order = makeOrder({
+      status: 'ready_to_ship',
+      closed_short: true,
+    })
+    const productionOrders = [
+      {
+        id: 557,
+        code: 'PO-2026-0057',
+        status: 'complete',  // complete!
+        product_id: 42,
+        sales_order_line_id: 101,
+        quantity_ordered: 5,
+        quantity_completed: 5,
+      },
+    ]
+    setupApiMocks({ order, productionOrders })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Summary')
+    expect(screen.getByText(/previously closed short.*fulfilled/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^closed short$/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the mechanical parts of issue #680 (PR-8 expanded UX GTM readiness):

**Scope 1 — One canonical action surface (OrderDetail)**
- Header slimmed to: order identity, status badge, Refresh, Print Packing Slip. All state-changing operations (Confirm, Reject, Cancel, Ship Order, Close Short) moved to a secondary-actions row inside the workflow card so there is one place to look.
- Quick Actions panel keeps only idempotent/read-only tools: Check Material Availability, View in Production, Open Invoice, Download PDF.

**Scope 2 — Workflow gating aligned with backend**
- `getProductionReleaseBlockReason()` now mirrors the exact backend rule: `status === "confirmed"` exactly (not "past-unconfirmed"). Orders in `in_production`, `ready_to_ship`, etc. now show a clear blocking message instead of letting the button appear and fail at the API with an opaque 400.

**Scope 3 — Backend error copy**
- `generate_production_orders` 400 detail now names the actual rule and the current status in plain English: `"Work orders can only be generated while the order is in Confirmed status; this order is in production."` (underscores replaced with spaces).

**Scope 3 — Order Summary humanization**
- Status cell in Order Summary shows `status.replace(/_/g, " ")` with CSS `capitalize` — no raw `in_production` visible to users.

**Scope 4 — Line linkage audit**
- Audited all production-order creation paths in `sales_order_service.py`, `quote_conversion_service.py`, `production_order_service.py`, `scrap_service.py`, `mrp.py`, `fulfillment_queue.py`, `order_status.py`. All `line_item`-type paths already set `sales_order_line_id=line.id` correctly. `quote_based` and MRP paths correctly leave it NULL (no line context). No fixes needed.

**Scope 5 — closed_short reconcile**
- Decision: preserve `closed_short=True` as an immutable audit record. No DB migration or flag-clearing. UI detects coverage: when `closed_short=true` AND all production orders are `complete`, the badge renders as "Previously Closed Short — Fulfilled" (emerald) instead of "Closed Short" (amber).

**Scope 5 supplementary-WO path — explicitly SKIPPED** (needs owner sign-off per task spec).

## Tests added

**Backend** (`test_sales_order_service.py`):
- `TestGenerateProductionOrdersErrorCopy` — verifies humanized message for `in_production`, `ready_to_ship`, and that `confirmed` succeeds.
- `TestGenerateProductionOrdersLineLinkage` — verifies `line_item` WO carries correct `sales_order_line_id`, multi-line each gets the right ID, and `quote_based` gets NULL.
- `TestClosedShortReconcile` — verifies flag is preserved after WO completes, and `close_short_sales_order` sets it correctly.

**Frontend** (`OrderDetail.test.jsx`, 10 tests):
- Workflow gating: confirmed+billing shows Create Work Orders; `in_production` and `ready_to_ship` do not; WO exists shows Open Work Order.
- Header: only Refresh and Print Packing Slip present.
- Status humanization: `in_production` → "in production" in Order Summary.
- closed_short reconcile: incomplete WO → "Closed Short" badge; complete WO → "Previously Closed Short — Fulfilled" badge.

## Test plan

- [ ] All 10 frontend unit tests pass (`npm run test:unit`)
- [ ] All 8 backend tests pass (`pytest backend/tests/services/test_sales_order_service.py -k "ErrorCopy or LineLinkage or ClosedShort"`)
- [ ] `npm run build` clean (no type/import errors)
- [ ] Ruff clean on `sales_order_service.py` (`python -m ruff check --select E712`)
- [ ] Manual: open a `confirmed` order with a product line and payment — "Create Work Orders" appears in workflow card step 3
- [ ] Manual: open an `in_production` order — "Create Work Orders" NOT visible; tooltip explains status rule
- [ ] Manual: open a `closed_short` order where WO is complete — see "Previously Closed Short — Fulfilled" badge
- [ ] Manual: trigger the 400 from generate_production_orders on a non-confirmed order — new error message shown

Closes mechanical part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)