### PR TITLE
fix: restore Delete Order trigger; hide Close Short when already closed

### DIFF
--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -495,7 +495,15 @@ export default function OrderDetail() {
   };
 
   const canCloseShort = () => {
-    return order && ["confirmed", "in_production", "ready_to_ship"].includes(order.status);
+    return (
+      order &&
+      !order.closed_short &&
+      ["confirmed", "in_production", "ready_to_ship"].includes(order.status)
+    );
+  };
+
+  const canDeleteOrder = () => {
+    return order && ["cancelled", "pending"].includes(order.status);
   };
 
   const openCloseShortModal = async () => {
@@ -1086,7 +1094,7 @@ export default function OrderDetail() {
         </div>
 
         {/* Secondary / destructive actions — below workflow steps */}
-        {(order.status === "pending_confirmation" || canCancelOrder() || canCloseShort()) && (
+        {(order.status === "pending_confirmation" || canCancelOrder() || canCloseShort() || canDeleteOrder()) && (
           <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-gray-700/50 pt-4">
             <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
               Order actions:
@@ -1124,6 +1132,14 @@ export default function OrderDetail() {
                 className="rounded-lg bg-amber-700 px-3 py-1.5 text-sm text-white hover:bg-amber-600"
               >
                 Close Short
+              </button>
+            )}
+            {canDeleteOrder() && (
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                className="rounded-lg bg-red-900 px-3 py-1.5 text-sm text-white hover:bg-red-800 border border-red-700"
+              >
+                Delete Order
               </button>
             )}
           </div>

--- a/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
+++ b/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
@@ -9,7 +9,7 @@
  * - closed_short renders correctly depending on production completion
  * - Action surface is singular: state-changing buttons appear in workflow card
  */
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -378,5 +378,99 @@ describe('OrderDetail — closed_short reconcile rendering (PR-8 / issue #680 it
     await screen.findByText('Order Summary')
     expect(screen.getByText(/previously closed short.*fulfilled/i)).toBeInTheDocument()
     expect(screen.queryByText(/^closed short$/i)).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Delete Order button tests (fix: restore trigger removed by PR #713)
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — Delete Order button (PR-713 follow-up)', () => {
+  it('renders Delete Order button for status=pending', async () => {
+    const order = makeOrder({ status: 'pending' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.getByRole('button', { name: /delete order/i })).toBeInTheDocument()
+  })
+
+  it('renders Delete Order button for status=cancelled', async () => {
+    const order = makeOrder({ status: 'cancelled' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.getByRole('button', { name: /delete order/i })).toBeInTheDocument()
+  })
+
+  it('Delete Order button opens the delete confirmation modal', async () => {
+    const order = makeOrder({ status: 'pending' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    const deleteBtn = await screen.findByRole('button', { name: /delete order/i })
+    fireEvent.click(deleteBtn)
+
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument()
+  })
+
+  it('does NOT render Delete Order button for status=confirmed', async () => {
+    const order = makeOrder({ status: 'confirmed' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.queryByRole('button', { name: /delete order/i })).not.toBeInTheDocument()
+  })
+
+  it('does NOT render Delete Order button for status=in_production', async () => {
+    const order = makeOrder({ status: 'in_production' })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.queryByRole('button', { name: /delete order/i })).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Close Short button — hidden when already closed short (fix: canCloseShort guard)
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — Close Short button hidden when already closed short', () => {
+  it('shows Close Short button when order is in_production and NOT closed_short', async () => {
+    const order = makeOrder({ status: 'in_production', closed_short: false })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.getByRole('button', { name: /close short/i })).toBeInTheDocument()
+  })
+
+  it('hides Close Short button when order.closed_short is true', async () => {
+    const order = makeOrder({ status: 'in_production', closed_short: true })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.queryByRole('button', { name: /close short/i })).not.toBeInTheDocument()
+  })
+
+  it('hides Close Short button when status is ready_to_ship and already closed_short', async () => {
+    const order = makeOrder({ status: 'ready_to_ship', closed_short: true })
+    setupApiMocks({ order })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(screen.queryByRole('button', { name: /close short/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
+++ b/frontend/src/pages/admin/__tests__/OrderDetail.test.jsx
@@ -415,7 +415,7 @@ describe('OrderDetail — Delete Order button (PR-713 follow-up)', () => {
     const deleteBtn = await screen.findByRole('button', { name: /delete order/i })
     fireEvent.click(deleteBtn)
 
-    expect(screen.getByTestId('delete-modal')).toBeInTheDocument()
+    expect(await screen.findByTestId('delete-modal')).toBeInTheDocument()
   })
 
   it('does NOT render Delete Order button for status=confirmed', async () => {


### PR DESCRIPTION
## Summary

- **Critical fix**: PR #713's header slim-down removed the only `setShowDeleteConfirm(true)` call, making Delete Order completely unreachable. Added `canDeleteOrder()` that mirrors the backend's exact guard (`deletable_statuses = ["cancelled", "pending"]`) and wired a Delete Order button into the secondary-actions row with red/destructive styling consistent with other destructive actions on the page.
- **UX nit**: `canCloseShort()` was missing a `!order.closed_short` check, allowing the Close Short button to appear for orders that had already been closed short. The backend returns 400 on the duplicate; now the button correctly hides itself.

## Backend-verified delete-eligible statuses

`["cancelled", "pending"]` — sourced directly from `sales_order_service.delete_sales_order()` (`deletable_statuses` list, line 2134). Note: the order lifecycle default is `status="pending"` (not `"draft"`) per `create_sales_order`.

## Test plan

- [x] `Delete Order button renders for status=pending`
- [x] `Delete Order button renders for status=cancelled`
- [x] `Delete Order button opens the delete confirmation modal (fireEvent.click)`
- [x] `Delete Order button NOT rendered for status=confirmed`
- [x] `Delete Order button NOT rendered for status=in_production`
- [x] `Close Short button renders when in_production and closed_short=false`
- [x] `Close Short button hidden when order.closed_short=true`
- [x] `Close Short button hidden when ready_to_ship and closed_short=true`
- [x] All 344 existing unit tests still pass
- [x] `npm run build` clean (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Delete Order" button to the Order actions toolbar for eligible orders, enabling deletion of pending and cancelled orders through a confirmation modal.

* **Bug Fixes**
  * Improved "Close Short" button behavior to prevent operations when the order is already marked as closed short.
  * Enhanced order action toolbar to display appropriate options based on current order status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->