### PR TITLE
fix: sync op-material allocation with inventory reservations; self-heal stranded WOs (#715)

### DIFF
--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from app.models.inventory import Inventory, InventoryTransaction, InventoryLocation
 from app.models.product import Product
 from app.models.bom import BOM, BOMLine
-from app.models.production_order import ProductionOrder
+from app.models.production_order import ProductionOrder, ProductionOrderOperationMaterial
 from app.models.sales_order import SalesOrder
 from app.models.traceability import MaterialLot, ProductionLotConsumption
 from app.logging_config import get_logger
@@ -647,7 +647,130 @@ def reserve_production_materials(
                 f"for PO#{production_order.code}"
             )
     
+    # Sync op-material rows: distribute reserved qty across op-material rows
+    # for each component, in operation-sequence order, filling each row up to
+    # its quantity_required.  Under partial reservation (HARD-5 shortage path)
+    # we allocate only what was actually reserved.
+    for reservation_info in reservations:
+        component_id = reservation_info["product_id"]
+        qty_reserved = Decimal(str(reservation_info["quantity_reserved"]))
+        _sync_op_material_allocation(db, production_order, component_id, qty_reserved)
+
     return reservations
+
+
+def _sync_op_material_allocation(
+    db: Session,
+    production_order: "ProductionOrder",
+    component_id: int,
+    qty_reserved: "Decimal",
+) -> None:
+    """
+    Distribute *qty_reserved* across the op-material rows for *component_id*
+    on *production_order*, in operation-sequence order.
+
+    Fills each row up to its quantity_required; any remainder spills to the
+    next row.  Excess reservation beyond the total requirement is capped at
+    quantity_required (shouldn't happen in practice, but keeps the column
+    semantically valid).
+
+    This is the single writer of ProductionOrderOperationMaterial.quantity_allocated
+    for the reservation direction.  It is idempotent: calling it twice with the
+    same qty_reserved leaves the rows in the same state.
+    """
+    from app.models.production_order import ProductionOrderOperation
+
+    # Collect op-material rows for this component across all operations,
+    # ordered by operation.sequence then row id for deterministic distribution.
+    rows = (
+        db.query(ProductionOrderOperationMaterial)
+        .join(
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial.production_order_operation_id
+            == ProductionOrderOperation.id,
+        )
+        .filter(
+            ProductionOrderOperation.production_order_id == production_order.id,
+            ProductionOrderOperationMaterial.component_id == component_id,
+        )
+        .order_by(
+            ProductionOrderOperation.sequence,
+            ProductionOrderOperationMaterial.id,
+        )
+        .all()
+    )
+
+    if not rows:
+        return
+
+    remaining = qty_reserved
+    for row in rows:
+        if remaining <= Decimal("0"):
+            row.quantity_allocated = Decimal("0")
+            continue
+        required = Decimal(str(row.quantity_required))
+        alloc = min(remaining, required)
+        row.quantity_allocated = alloc
+        remaining -= alloc
+
+
+def _backfill_op_material_from_ledger(
+    db: Session,
+    production_order: "ProductionOrder",
+) -> None:
+    """
+    Self-heal: rebuild quantity_allocated on op-material rows from the
+    inventory reservation ledger for *production_order*.
+
+    Called at the top of release_production_order when active reservations
+    exist but op-material rows still show quantity_allocated=0.  The heal
+    is idempotent and logged.
+
+    Distribution rule: same as _sync_op_material_allocation — fill each row
+    up to its quantity_required in operation-sequence order per component.
+    """
+    # Sum reservations minus reservation_releases per component
+    from sqlalchemy import func as sqlfunc
+    from sqlalchemy import case
+
+    net_rows = (
+        db.query(
+            InventoryTransaction.product_id,
+            sqlfunc.sum(
+                case(
+                    (InventoryTransaction.transaction_type == "reservation",
+                     InventoryTransaction.quantity),
+                    else_=Decimal("0"),
+                )
+                - case(
+                    (InventoryTransaction.transaction_type == "reservation_release",
+                     InventoryTransaction.quantity),
+                    else_=Decimal("0"),
+                )
+            ).label("net_reserved"),
+        )
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order.id,
+            InventoryTransaction.transaction_type.in_(
+                ["reservation", "reservation_release"]
+            ),
+        )
+        .group_by(InventoryTransaction.product_id)
+        .all()
+    )
+
+    for row in net_rows:
+        qty = max(Decimal("0"), Decimal(str(row.net_reserved)))
+        if qty > Decimal("0"):
+            _sync_op_material_allocation(db, production_order, row.product_id, qty)
+
+    logger.info(
+        "Self-heal: backfilled op-material quantity_allocated from ledger "
+        "for PO#%s (%d component(s))",
+        production_order.code,
+        len(net_rows),
+    )
 
 
 def release_production_reservations(
@@ -722,11 +845,39 @@ def release_production_reservations(
                 "quantity_released": float(release_qty),
                 "new_allocated": float(new_allocated),
             })
-            
+
             logger.info(
                 f"Released reservation of {release_qty} for PO#{production_order.code}"
             )
-    
+
+    # Mirror the release on op-material rows: zero out quantity_allocated for
+    # any rows that are still in a pre-consumption state (pending / allocated).
+    # Rows already consumed retain their quantity_consumed; only the allocation
+    # field is cleared so the two books stay in sync.
+    from app.models.production_order import ProductionOrderOperation
+    unconsumed_rows = (
+        db.query(ProductionOrderOperationMaterial)
+        .join(
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial.production_order_operation_id
+            == ProductionOrderOperation.id,
+        )
+        .filter(
+            ProductionOrderOperation.production_order_id == production_order.id,
+            ProductionOrderOperationMaterial.status.in_(["pending", "allocated"]),
+        )
+        .all()
+    )
+    for row in unconsumed_rows:
+        row.quantity_allocated = Decimal("0")
+
+    if unconsumed_rows:
+        logger.info(
+            "Zeroed quantity_allocated on %d op-material row(s) for PO#%s",
+            len(unconsumed_rows),
+            production_order.code,
+        )
+
     return releases
 
 

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -25,6 +25,7 @@ from app.models.inventory import Inventory
 from app.models.manufacturing import Routing, RoutingOperation, Resource
 from app.models.production_order import ProductionOrderOperationMaterial, ScrapRecord
 from app.models.work_center import WorkCenter
+from app.models.inventory import InventoryTransaction
 from app.models.material_spool import MaterialSpool, ProductionOrderSpool
 from app.services.supply_netting import get_projected_available
 logger = get_logger(__name__)
@@ -330,6 +331,104 @@ def delete_production_order(db: Session, order_id: int) -> None:
 # Status Management
 # =============================================================================
 
+# ---------------------------------------------------------------------------
+# Private helpers for release_production_order
+# ---------------------------------------------------------------------------
+
+def _has_active_reservation(
+    db: Session,
+    production_order_id: int,
+    component_id: int,
+) -> bool:
+    """Return True if there is a net-positive ledger reservation for
+    (production_order_id, component_id), i.e. at least one 'reservation'
+    transaction exists and its quantity exceeds any 'reservation_release'
+    transactions for the same pair.
+    """
+    from sqlalchemy import func as sqlfunc
+    from sqlalchemy import case
+
+    net = (
+        db.query(
+            sqlfunc.coalesce(
+                sqlfunc.sum(
+                    case(
+                        (InventoryTransaction.transaction_type == "reservation",
+                         InventoryTransaction.quantity),
+                        else_=Decimal("0"),
+                    )
+                    - case(
+                        (InventoryTransaction.transaction_type == "reservation_release",
+                         InventoryTransaction.quantity),
+                        else_=Decimal("0"),
+                    )
+                ),
+                Decimal("0"),
+            )
+        )
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order_id,
+            InventoryTransaction.product_id == component_id,
+            InventoryTransaction.transaction_type.in_(
+                ["reservation", "reservation_release"]
+            ),
+        )
+        .scalar()
+    )
+    return (net or Decimal("0")) > Decimal("0")
+
+
+def _maybe_backfill_op_material_allocation(
+    db: Session,
+    order: "ProductionOrder",
+) -> None:
+    """Self-heal: if active ledger reservations exist for *order* but all
+    op-material rows have quantity_allocated=0, rebuild from the ledger.
+
+    This repairs the 17 draft WOs created before fix #715 the moment an
+    operator tries to release them — no data migration needed.  The heal
+    is idempotent: healthy orders (rows already populated) are untouched.
+    """
+    has_op_mats = any(
+        mat
+        for op in order.operations
+        for mat in op.materials
+    )
+    if not has_op_mats:
+        return
+
+    all_zero = all(
+        Decimal(str(mat.quantity_allocated)) == Decimal("0")
+        for op in order.operations
+        for mat in op.materials
+    )
+    if not all_zero:
+        # Already populated — nothing to do.
+        return
+
+    # Check if any active reservation ledger rows exist for this order.
+    has_reservations = (
+        db.query(InventoryTransaction.id)
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == order.id,
+            InventoryTransaction.transaction_type == "reservation",
+        )
+        .first()
+    ) is not None
+
+    if not has_reservations:
+        return
+
+    # Import here to avoid circular dependency at module level.
+    from app.services.inventory_service import _backfill_op_material_from_ledger
+    _backfill_op_material_from_ledger(db, order)
+    # Flush so the gate check below (and any subsequent db.refresh) sees the
+    # updated rows immediately — the surrounding call-site holds the transaction.
+    db.flush()
+
+
 def release_production_order(
     db: Session,
     order_id: int,
@@ -354,27 +453,74 @@ def release_production_order(
             detail=f"Cannot release order in {order.status} status"
         )
 
+    # Self-heal: if the order has active ledger reservations but op-material
+    # rows still show quantity_allocated=0, the reservation sync was skipped
+    # (e.g. orders created before fix #715, or a future code path that calls
+    # reserve_production_materials without the sync step).  Backfill now so
+    # the gate below reads truth rather than always-zero.
+    _maybe_backfill_op_material_allocation(db, order)
+
     # Check material availability unless forced
     if not force:
         blocking_issues = []
         for op in order.operations:
             for mat in op.materials:
                 if mat.quantity_allocated < mat.quantity_required:
-                    shortage = mat.quantity_required - mat.quantity_allocated
-                    component = db.query(Product).filter(Product.id == mat.component_id).first()
-                    blocking_issues.append({
-                        "component_sku": component.sku if component else f"ID:{mat.component_id}",
-                        "operation": op.operation_name,
-                        "shortage": float(shortage),
-                    })
+                    component = db.query(Product).filter(
+                        Product.id == mat.component_id
+                    ).first()
+                    sku = component.sku if component else f"ID:{mat.component_id}"
+                    # Distinguish "never reserved" from "genuinely short"
+                    # by checking whether any active reservations exist for
+                    # this (order, component) pair.
+                    has_any_reservation = _has_active_reservation(
+                        db, order.id, mat.component_id
+                    )
+                    if has_any_reservation:
+                        blocking_issues.append({
+                            "component_sku": sku,
+                            "operation": op.operation_name,
+                            "needed": float(mat.quantity_required),
+                            "reserved": float(mat.quantity_allocated),
+                            "reason": "insufficient_stock",
+                        })
+                    else:
+                        blocking_issues.append({
+                            "component_sku": sku,
+                            "operation": op.operation_name,
+                            "needed": float(mat.quantity_required),
+                            "reserved": 0.0,
+                            "reason": "not_allocated",
+                        })
 
         if blocking_issues:
+            not_allocated = [
+                b for b in blocking_issues if b["reason"] == "not_allocated"
+            ]
+            short = [
+                b for b in blocking_issues if b["reason"] == "insufficient_stock"
+            ]
+
+            if not_allocated and not short:
+                message = (
+                    "Materials not yet allocated — re-run material reservation "
+                    "for this order"
+                )
+            else:
+                parts = []
+                for b in short:
+                    parts.append(
+                        f"Insufficient stock for {b['component_sku']}: "
+                        f"need {b['needed']}, reserved {b['reserved']}"
+                    )
+                message = "; ".join(parts) if parts else "Cannot release: material shortages detected"
+
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "message": "Cannot release: material shortages detected",
+                    "message": message,
                     "shortages": blocking_issues,
-                    "hint": "Use force=true to release anyway"
+                    "hint": "Use force=true to release anyway",
                 }
             )
 

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -30,8 +30,7 @@ from unittest.mock import patch, MagicMock
 
 from fastapi import HTTPException
 
-from app.models import ProductionOrder, Product, BOM
-from app.models.bom import BOMLine
+from app.models import ProductionOrder
 from app.models.manufacturing import Routing, RoutingOperation, RoutingOperationMaterial
 from app.models.production_order import (
     ProductionOrderOperation,
@@ -619,31 +618,45 @@ class TestReleaseProductionOrder:
             svc.release_production_order(db, order.id, "test@filaops.dev")
         assert exc_info.value.status_code == 400
 
-    def test_release_with_material_shortage_blocked(self, db, finished_good, raw_material):
-        """Should block release when materials are short and force=False."""
-        routing, rop = _make_routing_with_operation(db, finished_good)
-        rom = RoutingOperationMaterial(
-            routing_operation_id=rop.id,
-            component_id=raw_material.id,
-            quantity=Decimal("100"),
-            unit="G",
+    def test_release_with_no_reservation_blocked_not_allocated(
+        self, db, finished_good, raw_material
+    ):
+        """Should block release with 'not yet allocated' message when no
+        inventory reservation exists (e.g. allocation step was never run)."""
+        # Create order directly (bypassing service) so no BOM/reservation exists
+        order = _make_production_order(db, finished_good, status="draft")
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=5,
+            planned_run_minutes=Decimal("10"),
+            status="pending",
         )
-        db.add(rom)
+        db.add(op)
         db.flush()
-
-        order = svc.create_production_order(
-            db,
-            product_id=finished_good.id,
-            quantity_ordered=5,
-            created_by="test@filaops.dev",
-            routing_id=routing.id,
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=raw_material.id,
+            quantity_required=Decimal("500"),
+            quantity_allocated=Decimal("0"),
+            unit="G",
+            status="pending",
         )
+        db.add(mat)
+        db.flush()
+        db.expire(order, ["operations"])
 
         with pytest.raises(HTTPException) as exc_info:
             svc.release_production_order(db, order.id, "test@filaops.dev", force=False)
         assert exc_info.value.status_code == 400
         detail = exc_info.value.detail
-        assert "shortages" in detail or "shortage" in str(detail).lower()
+        assert isinstance(detail, dict)
+        assert "shortages" in detail
+        assert any(s["reason"] == "not_allocated" for s in detail["shortages"])
+        assert "not yet allocated" in detail["message"].lower()
 
     def test_release_with_force_overrides_shortage(self, db, finished_good, raw_material):
         """Should release despite shortages when force=True."""
@@ -673,6 +686,273 @@ class TestReleaseProductionOrder:
         order = _make_production_order(db, finished_good, status="draft")
         released = svc.release_production_order(db, order.id, "test@filaops.dev", force=False)
         assert released.status == "released"
+
+    def test_release_after_reservation_syncs_and_passes(
+        self, db, finished_good, raw_material, make_bom
+    ):
+        """reserve then release: op-material rows should be synced, gate passes."""
+        from app.models.inventory import Inventory, InventoryLocation
+        from app.services.inventory_service import reserve_production_materials
+
+        # Give the component plentiful stock
+        location = db.query(InventoryLocation).first()
+        inv = Inventory(
+            product_id=raw_material.id,
+            location_id=location.id,
+            on_hand_quantity=Decimal("10000"),
+            allocated_quantity=Decimal("0"),
+        )
+        db.add(inv)
+        db.flush()
+
+        # BOM: 100 g per unit
+        make_bom(finished_good.id, lines=[
+            {"component_id": raw_material.id, "quantity": Decimal("100"), "unit": "G"},
+        ])
+
+        # Routing + one op-material row
+        routing, rop = _make_routing_with_operation(db, finished_good)
+        rom = RoutingOperationMaterial(
+            routing_operation_id=rop.id,
+            component_id=raw_material.id,
+            quantity=Decimal("100"),
+            unit="G",
+        )
+        db.add(rom)
+        db.flush()
+
+        order = svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=5,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        # Reserve materials — this should sync op-material rows
+        reserve_production_materials(db, order, created_by="test@filaops.dev")
+
+        db.expire(order, ["operations"])
+        for op in order.operations:
+            for mat in op.materials:
+                assert Decimal(str(mat.quantity_allocated)) > Decimal("0"), (
+                    "quantity_allocated should be positive after reservation"
+                )
+
+        # Release should now pass without force
+        released = svc.release_production_order(db, order.id, "test@filaops.dev", force=False)
+        assert released.status == "released"
+
+    def test_release_multi_op_same_component_distribution(
+        self, db, finished_good, raw_material, make_bom
+    ):
+        """Multi-op rows for the same component: qty fills sequentially."""
+        from app.models.inventory import Inventory, InventoryLocation
+        from app.services.inventory_service import reserve_production_materials
+
+        location = db.query(InventoryLocation).first()
+        inv = Inventory(
+            product_id=raw_material.id,
+            location_id=location.id,
+            on_hand_quantity=Decimal("10000"),
+            allocated_quantity=Decimal("0"),
+        )
+        db.add(inv)
+        db.flush()
+
+        # BOM: 200 g per unit (for qty=1 → 200 g total reserved)
+        make_bom(finished_good.id, lines=[
+            {"component_id": raw_material.id, "quantity": Decimal("200"), "unit": "G"},
+        ])
+
+        # Two routing operations, both using raw_material
+        routing = Routing(
+            product_id=finished_good.id,
+            code="RT-MULTI",
+            name="Multi-op routing",
+            is_active=True,
+        )
+        db.add(routing)
+        db.flush()
+
+        from app.models.manufacturing import RoutingOperation, RoutingOperationMaterial
+        rop1 = RoutingOperation(
+            routing_id=routing.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PREP",
+            operation_name="Prep",
+            setup_time_minutes=0,
+            run_time_minutes=Decimal("5"),
+        )
+        rop2 = RoutingOperation(
+            routing_id=routing.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="PRINT",
+            operation_name="Print",
+            setup_time_minutes=0,
+            run_time_minutes=Decimal("30"),
+        )
+        db.add_all([rop1, rop2])
+        db.flush()
+
+        # Each op needs 80 g → total 160 g required; 200 g reserved
+        rom1 = RoutingOperationMaterial(
+            routing_operation_id=rop1.id,
+            component_id=raw_material.id,
+            quantity=Decimal("80"),
+            unit="G",
+        )
+        rom2 = RoutingOperationMaterial(
+            routing_operation_id=rop2.id,
+            component_id=raw_material.id,
+            quantity=Decimal("80"),
+            unit="G",
+        )
+        db.add_all([rom1, rom2])
+        db.flush()
+
+        order = svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=1,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        reserve_production_materials(db, order, created_by="test@filaops.dev")
+        db.expire(order, ["operations"])
+
+        # Collect op-material rows in sequence order
+        rows = sorted(
+            [mat for op in order.operations for mat in op.materials],
+            key=lambda r: (r.operation.sequence, r.id),
+        )
+        assert len(rows) == 2
+
+        # 200 g reserved, row0 needs 80 → 80; row1 needs 80 → 80; 40 g remainder capped
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("80")
+        assert Decimal(str(rows[1].quantity_allocated)) == Decimal("80")
+
+    def test_release_insufficient_stock_error_message(
+        self, db, finished_good, raw_material
+    ):
+        """When stock is genuinely short, error should say 'Insufficient stock for ...'"""
+        from app.models.inventory import InventoryLocation, InventoryTransaction
+
+        location = db.query(InventoryLocation).first()
+
+        order = _make_production_order(db, finished_good, status="draft")
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=Decimal("10"),
+            status="pending",
+        )
+        db.add(op)
+        db.flush()
+
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=raw_material.id,
+            quantity_required=Decimal("500"),
+            quantity_allocated=Decimal("0"),
+            unit="G",
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        # Post a real reservation transaction (simulates reserve_production_materials ran)
+        # but only for 100 g (short by 400 g)
+        txn = InventoryTransaction(
+            product_id=raw_material.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=Decimal("100"),
+            reference_type="production_order",
+            reference_id=order.id,
+            unit="G",
+            notes="Manual test reservation",
+        )
+        db.add(txn)
+        db.flush()
+
+        # Manually set allocated to reflect the partial reservation
+        mat.quantity_allocated = Decimal("100")
+        db.flush()
+        db.expire(order, ["operations"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            svc.release_production_order(db, order.id, "test@filaops.dev", force=False)
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
+        assert any(s["reason"] == "insufficient_stock" for s in detail["shortages"])
+        # Message should contain "Insufficient stock for"
+        assert "insufficient stock for" in detail["message"].lower()
+
+    def test_self_heal_releases_stranded_wo(self, db, finished_good, raw_material):
+        """Stranded WO (op-mats=0 but ledger has reservations) should self-heal
+        and pass the release gate when stock was actually reserved."""
+        from app.models.inventory import InventoryLocation, InventoryTransaction
+
+        location = db.query(InventoryLocation).first()
+
+        # Create order + op-material manually at quantity_allocated=0
+        order = _make_production_order(db, finished_good, status="draft")
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=Decimal("10"),
+            status="pending",
+        )
+        db.add(op)
+        db.flush()
+
+        qty_needed = Decimal("500")
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=raw_material.id,
+            quantity_required=qty_needed,
+            quantity_allocated=Decimal("0"),  # stranded — not synced
+            unit="G",
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        # Post the ledger reservation (simulates pre-fix state)
+        txn = InventoryTransaction(
+            product_id=raw_material.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=qty_needed,
+            reference_type="production_order",
+            reference_id=order.id,
+            unit="G",
+            notes="Pre-fix stranded reservation",
+        )
+        db.add(txn)
+        db.flush()
+        db.expire(order, ["operations"])
+
+        # Release should self-heal and succeed (no force)
+        released = svc.release_production_order(db, order.id, "test@filaops.dev", force=False)
+        assert released.status == "released"
+
+        # Confirm op-material row was backfilled
+        db.refresh(mat)
+        assert Decimal(str(mat.quantity_allocated)) == qty_needed
 
 
 # =============================================================================
@@ -1007,6 +1287,63 @@ class TestCancelProductionOrder:
         order = _make_production_order(db, finished_good, status="scheduled")
         cancelled = svc.cancel_production_order(db, order.id, "test@filaops.dev")
         assert cancelled.status == "cancelled"
+
+    def test_cancel_zeroes_op_material_allocations(self, db, finished_good, raw_material):
+        """Cancelling an order should zero quantity_allocated on pending op-material rows."""
+        from app.models.inventory import InventoryLocation, InventoryTransaction
+
+        location = db.query(InventoryLocation).first()
+
+        order = _make_production_order(db, finished_good, status="draft")
+        op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=Decimal("10"),
+            status="pending",
+        )
+        db.add(op)
+        db.flush()
+
+        qty = Decimal("200")
+        mat = ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=raw_material.id,
+            quantity_required=qty,
+            quantity_allocated=qty,  # simulate post-reservation state
+            unit="G",
+            status="pending",
+        )
+        db.add(mat)
+        db.flush()
+
+        # Post reservation so cancel's release_production_reservations fires
+        txn = InventoryTransaction(
+            product_id=raw_material.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=qty,
+            reference_type="production_order",
+            reference_id=order.id,
+            unit="G",
+            notes="Test reservation for cancel test",
+        )
+        db.add(txn)
+        db.flush()
+        db.expire(order, ["operations"])
+
+        svc.cancel_production_order(db, order.id, "test@filaops.dev")
+
+        # Flush so the SELECT in refresh sees the in-flight zeroing.
+        # (cancel_production_order doesn't commit; the endpoint does.)
+        db.flush()
+        db.refresh(mat)
+        assert Decimal(str(mat.quantity_allocated)) == Decimal("0"), (
+            "quantity_allocated should be zeroed after cancellation"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #715

## Problem

`release_production_order` gated on `ProductionOrderOperationMaterial.quantity_allocated`, but **no code path ever wrote a positive value there**. `reserve_production_materials` updated the inventory side (transactions + `Inventory.allocated_quantity`) but never synced the op-material side. All 17 current draft WOs with routing had 0/N satisfied rows — release without `force=true` was impossible for every routed order.

The contradiction was visible to operators: the Blocking Issues panel (HARD-6 projected math, inventory side) showed materials OK/green, while the release button returned 400 "shortages" — two parallel allocation books, gate reading the one that's always empty.

## Fix

### Scope 1 — Sync the books (forward direction)

`reserve_production_materials` now calls `_sync_op_material_allocation` after posting each component's inventory reservation. Distribution rule: fill each op-material row up to `quantity_required` in operation-sequence order, spilling remainder to the next row. Under partial reservation (HARD-5 shortage flag), only the actually-reserved quantity is allocated.

### Scope 2 — Better error copy

The 400 detail now distinguishes two cases:
- `reason: "not_allocated"` → **"Materials not yet allocated — re-run material reservation for this order"** (no ledger reservation exists at all)
- `reason: "insufficient_stock"` → **"Insufficient stock for {SKU}: need N, reserved M"** (genuine shortage after partial reservation)

Derived cheaply from the ledger (`reservation` minus `reservation_release` per `(production_order, component)` pair).

### Scope 3 — Release-time self-heal (covers 17 stranded WOs, no migration)

`_maybe_backfill_op_material_allocation` runs at the top of `release_production_order`. If active ledger reservations exist for the order but all op-material rows still show `quantity_allocated=0`, it backfills from the ledger using the same distribution rule and flushes.

**Why self-heal beats a one-shot migration script:**
- No migration script means no risk of partial execution, no rollback complexity, no "did it run in prod?" ambiguity
- The self-heal fires automatically the moment an operator releases any of the 17 stranded orders — zero manual steps
- It's idempotent for healthy orders (early-returns if any row is already non-zero)
- It covers any *future* strandings from code paths that might call reserve without the sync (defense in depth)
- The migration would have been dead code after first execution; the self-heal is a permanent correctness guarantee

### Scope 4 — Sync the release direction

`release_production_reservations` now zeroes `quantity_allocated` on unconsumed op-material rows (status `pending`/`allocated`) after posting `reservation_release` transactions. Both books stay matched in cancel/unschedule paths.

## Tests added

| Test | What it proves |
|---|---|
| `test_release_after_reservation_syncs_and_passes` | reserve→rows synced, gate passes without force |
| `test_release_multi_op_same_component_distribution` | fill-then-spill across two ops for same component |
| `test_release_with_no_reservation_blocked_not_allocated` | correct "not yet allocated" error message |
| `test_release_insufficient_stock_error_message` | correct "Insufficient stock for..." error message |
| `test_self_heal_releases_stranded_wo` | op-mats at 0 + ledger reservation → release succeeds, rows backfilled |
| `test_cancel_zeroes_op_material_allocations` | cancel → quantity_allocated zeroed |

Full suite: 5381 passed, 13 skipped (pre-existing), 0 new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved material allocation tracking across production order operations, with automatic recovery for inconsistent states.
  * Fixed production order release to properly clear allocated quantities when canceling.

* **Improvements**
  * Enhanced error messages when releasing production orders, now distinguishing between materials that were never allocated versus insufficient stock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->