### PR TITLE
feat: dispatch service — suggest-and-confirm engine (SCHED-1)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -40,6 +40,7 @@ from app.api.v1.endpoints import (
     price_levels,
     system_settings,
     system_license,
+    dispatch,
 )
 from app.api.v1.endpoints.admin import router as admin_router
 from app.api.v1.endpoints.test import test_endpoints_enabled
@@ -251,6 +252,9 @@ router.include_router(
     prefix="/command-center",
     tags=["command-center"]
 )
+
+# Dispatch (suggest-and-confirm scheduling engine — SCHED-1)
+router.include_router(dispatch.router)
 
 # License activation is a PRO feature
 

--- a/backend/app/api/v1/endpoints/dispatch.py
+++ b/backend/app/api/v1/endpoints/dispatch.py
@@ -1,0 +1,94 @@
+"""
+Dispatch endpoints — suggest-and-confirm engine.  SCHED-1.
+
+Routes:
+  GET  /api/v1/dispatch/suggestions  — ranked suggestions for idle printers
+  POST /api/v1/dispatch/assign       — commit an assignment
+
+Both routes are staff-gated (admin or operator) following the pattern
+established in mrp.py (``get_current_staff_user`` dependency on the router).
+"""
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.deps import get_current_staff_user, get_db
+from app.models.user import User
+from app.schemas.dispatch import AssignRequest, AssignResponse, DispatchSuggestionsResponse
+from app.services.dispatch_service import dispatch_operation, get_dispatch_suggestions
+from app.services.resource_scheduling import SequenceError
+
+router = APIRouter(
+    prefix="/dispatch",
+    tags=["dispatch"],
+    dependencies=[Depends(get_current_staff_user)],
+)
+
+
+@router.get("/suggestions", response_model=DispatchSuggestionsResponse)
+async def get_suggestions(
+    printer_id: Optional[int] = Query(
+        None,
+        description="Filter to a single printer (by Printer.id). "
+        "Omit to get suggestions for all idle printers.",
+    ),
+    db: Session = Depends(get_db),
+) -> DispatchSuggestionsResponse:
+    """
+    Return ranked dispatch suggestions for idle, available printers.
+
+    For each eligible printer (active, not in maintenance status), returns:
+    - ``top_suggestion``: the highest-priority candidate operation
+    - ``runners_up``: up to 2 alternative candidates
+
+    Each suggestion carries:
+    - Order / operation details (code, product, qty, due date, priority)
+    - ``why``: human-readable rank factors so the operator can trust the ranking
+    - ``maintenance_warning``: non-null when maintenance is due before the job
+      would finish (the operator decides whether to proceed)
+
+    ZERO writes — safe to poll frequently.
+    """
+    return get_dispatch_suggestions(db, printer_id=printer_id)
+
+
+@router.post("/assign", response_model=AssignResponse, status_code=200)
+async def assign_operation(
+    request: AssignRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+) -> AssignResponse:
+    """
+    Commit a dispatch assignment.
+
+    Validates:
+    1. Operation exists and is in ``pending`` status.
+    2. Printer exists and is not in maintenance status.
+    3. Material-machine compatibility (e.g. ABS requires enclosed printer).
+    4. No scheduling conflicts via the existing conflict-detection engine.
+    5. Predecessor operations are satisfied (sequence constraints).
+
+    On success: sets ``operation.status = 'queued'``, records
+    ``scheduled_start = now`` and ``scheduled_end = now + estimated_duration``.
+
+    Status note: ``queued`` means assigned to a specific printer + time slot,
+    ready to run, but NOT yet started.  The operator starts it via the
+    operation-status endpoint.
+    """
+    try:
+        result = dispatch_operation(
+            db=db,
+            operation_id=request.operation_id,
+            printer_id=request.printer_id,
+            user=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except SequenceError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    db.commit()
+    return result

--- a/backend/app/schemas/dispatch.py
+++ b/backend/app/schemas/dispatch.py
@@ -1,0 +1,104 @@
+"""
+Pydantic schemas for the dispatch (suggest-and-confirm) engine.
+
+SCHED-1: Dispatch service brain — read-only ranking + single assign action.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PrinterInfo(BaseModel):
+    """Minimal printer descriptor in a suggestion."""
+
+    model_config = {"from_attributes": True}
+
+    id: int
+    code: str
+    name: str
+    model: str
+    status: Optional[str] = None
+
+
+class DispatchSuggestion(BaseModel):
+    """
+    A single ranked suggestion: one operation on one printer.
+
+    ``why`` contains human-readable rank factors so the operator can
+    understand why this job rose to the top, e.g.::
+
+        ["priority 1 (highest)", "due 2026-06-12", "FIFO"]
+
+    ``maintenance_warning`` is present when the printer's latest
+    ``MaintenanceLog.next_due_at`` falls before ``now + estimated_duration``.
+    The operator still decides — dispatch never silently skips.
+    """
+
+    production_order_id: int
+    production_order_code: str
+    product_name: str
+    operation_id: int
+    operation_code: Optional[str] = None
+    operation_name: Optional[str] = None
+    quantity: str  # Decimal serialised as str to avoid float drift
+    due_date: Optional[date] = None
+    priority: int
+    estimated_duration_minutes: int = Field(
+        description="Best-available duration: planned_setup + planned_run, "
+        "or DEFAULT_DURATION_MINUTES if no routing data"
+    )
+    why: List[str] = Field(
+        default_factory=list,
+        description="Human-readable rank factors (priority, due date, FIFO)",
+    )
+    maintenance_warning: Optional[str] = Field(
+        default=None,
+        description="Non-None when maintenance is due before the job would finish",
+    )
+
+
+class PrinterDispatchResult(BaseModel):
+    """Top suggestion + up to 2 runners-up for one printer."""
+
+    printer: PrinterInfo
+    top_suggestion: Optional[DispatchSuggestion] = None
+    runners_up: List[DispatchSuggestion] = Field(default_factory=list)
+
+
+class DispatchSuggestionsResponse(BaseModel):
+    """Response envelope for GET /api/v1/dispatch/suggestions."""
+
+    results: List[PrinterDispatchResult]
+    generated_at: datetime
+
+
+class AssignRequest(BaseModel):
+    """
+    Request body for POST /api/v1/dispatch/assign.
+
+    Commits a suggestion: validates compatibility + conflicts via the
+    existing engine, then calls schedule_operation(now → now+duration).
+    """
+
+    operation_id: int = Field(description="ProductionOrderOperation.id to assign")
+    printer_id: int = Field(description="Printer.id to assign the operation to")
+
+
+class AssignResponse(BaseModel):
+    """Response for a successful assignment."""
+
+    operation_id: int
+    printer_id: int
+    printer_code: str
+    production_order_code: str
+    scheduled_start: datetime
+    scheduled_end: datetime
+    # Status the operation was moved to after assignment
+    # Semantics: schedule_operation() sets status='queued'.
+    # The operation is QUEUED (assigned to a specific printer and time slot)
+    # but NOT yet started. The operator/printer starts it via the existing
+    # operation-status endpoint (POST /production-orders/{id}/operations/{op_id}/start).
+    operation_status: str

--- a/backend/app/services/dispatch_service.py
+++ b/backend/app/services/dispatch_service.py
@@ -1,0 +1,496 @@
+"""
+Dispatch Service — suggest-and-confirm engine.  SCHED-1.
+
+Two public functions:
+- ``get_dispatch_suggestions(db, printer_id=None)`` — ZERO writes.
+  For each idle+available printer (skips status="maintenance") rank
+  candidate work and return the top suggestion + up to 2 runners-up.
+
+- ``dispatch_operation(db, operation_id, printer_id, user)`` — single
+  write.  Validates via the existing scheduling engine, then calls
+  ``schedule_operation`` to commit the assignment.
+
+Status semantics after assign
+------------------------------
+``schedule_operation()`` (resource_scheduling.py) sets the operation
+status to ``'queued'`` — meaning: assigned to a specific printer and
+time slot, materials allocated, ready to run, but NOT yet started.
+The printer operator starts it via the existing operation-status
+endpoint (POST /production-orders/{id}/operations/{op_id}/start).
+This is intentional: assigning ≠ starting.  The PO status is left
+untouched here; it transitions to ``in_progress`` when the first
+operation actually starts.
+
+Maintenance warning heuristic
+-------------------------------
+We compare ``printer.maintenance_logs[-1].next_due_at`` (latest log by
+performed_at) against ``now + estimated_duration``.  If due before job
+end → add ``maintenance_warning``.  This is a heuristic (not a hard
+block); the operator decides.  SCHED-7 will replace this with real
+maintenance-window rows.
+
+Default duration
+----------------
+``DEFAULT_DURATION_MINUTES = 120`` (2 hours) is used when an operation
+has no ``planned_run_minutes`` and no routing back-reference with time
+data.  This constant is intentional and documented; callers may pass
+an explicit duration.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from datetime import date
+from sqlalchemy.orm import Session
+
+from app.models.maintenance import MaintenanceLog
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+from app.schemas.dispatch import (
+    AssignResponse,
+    DispatchSuggestion,
+    DispatchSuggestionsResponse,
+    PrinterDispatchResult,
+    PrinterInfo,
+)
+from app.services.resource_compatibility_service import is_machine_compatible
+from app.services.resource_scheduling import (
+    SequenceError as SequenceError,  # re-exported for callers (endpoint catches it)
+    check_predecessor_scheduling,
+    schedule_operation,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Fall-back duration (minutes) when no routing/planned time data exists.
+DEFAULT_DURATION_MINUTES: int = 120
+
+#: How many runners-up to include per printer.
+MAX_RUNNERS_UP: int = 2
+
+#: Printer statuses that make a printer ineligible for dispatch.
+SKIP_STATUSES: frozenset[str] = frozenset({"maintenance"})
+
+#: Production order statuses whose operations are candidates for dispatch.
+DISPATCHABLE_ORDER_STATUSES: frozenset[str] = frozenset({"released"})
+
+#: Operation statuses that are candidates (not yet assigned to a resource).
+DISPATCHABLE_OP_STATUSES: frozenset[str] = frozenset({"pending"})
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    """Return current UTC time (tz-aware)."""
+    return datetime.now(timezone.utc)
+
+
+def _get_idle_printers(db: Session, printer_id: Optional[int] = None) -> List[Printer]:
+    """
+    Return printers eligible for dispatch.
+
+    Eligibility: active=True AND status NOT IN SKIP_STATUSES.
+    Optionally filter to a single printer_id.
+
+    Note: "idle" in the printer model means the printer is not running a job.
+    We match status values 'idle', 'offline', and None (unknown) — any status
+    except explicit 'maintenance'.  If the printer is offline we still surface
+    suggestions so the operator can pre-assign; the actual job won't start
+    until connectivity returns.
+    """
+    query = db.query(Printer).filter(
+        Printer.active.is_(True),
+        Printer.status.notin_(SKIP_STATUSES),
+    )
+    if printer_id is not None:
+        query = query.filter(Printer.id == printer_id)
+    return query.all()
+
+
+def _get_operation_duration_minutes(op: ProductionOrderOperation) -> int:
+    """
+    Best-available estimated duration for an operation (minutes).
+
+    Priority:
+    1. planned_setup_minutes + planned_run_minutes on the PO operation row
+       (copied from routing when the WO was released).
+    2. DEFAULT_DURATION_MINUTES (documented constant, not a silent magic number).
+    """
+    setup = float(op.planned_setup_minutes or 0)
+    run = float(op.planned_run_minutes or 0)
+    total = setup + run
+    return int(total) if total > 0 else DEFAULT_DURATION_MINUTES
+
+
+def _get_maintenance_warning(
+    db: Session,
+    printer: Printer,
+    duration_minutes: int,
+) -> Optional[str]:
+    """
+    Return a maintenance warning string if the printer's latest next_due_at
+    falls before now + duration, else None.
+    """
+    latest_log: Optional[MaintenanceLog] = (
+        db.query(MaintenanceLog)
+        .filter(MaintenanceLog.printer_id == printer.id)
+        .order_by(MaintenanceLog.performed_at.desc())
+        .first()
+    )
+    if latest_log is None or latest_log.next_due_at is None:
+        return None
+
+    job_end = _now_utc() + timedelta(minutes=duration_minutes)
+
+    # MaintenanceLog.next_due_at is stored as naive UTC (DateTime, no tz).
+    next_due = latest_log.next_due_at
+    if next_due.tzinfo is None:
+        next_due = next_due.replace(tzinfo=timezone.utc)
+
+    if next_due <= job_end:
+        return (
+            f"Maintenance due {next_due.strftime('%Y-%m-%d %H:%M UTC')} — "
+            f"before this job would finish"
+        )
+    return None
+
+
+def _predecessors_satisfied(
+    db: Session,
+    op: ProductionOrderOperation,
+) -> bool:
+    """
+    Return True if all predecessors of *op* within its PO are in terminal
+    status or have a scheduled_end before now.
+
+    We reuse ``check_predecessor_scheduling`` with a proposed start of now.
+    Any non-None return means predecessors block this op.
+    """
+    error = check_predecessor_scheduling(db, op, _now_utc())
+    return error is None
+
+
+def _build_why(order: ProductionOrder, is_fifo: bool) -> List[str]:
+    """Build the human-readable rank-factor list for a suggestion."""
+    factors: List[str] = []
+
+    # Priority factor (1 = highest)
+    if order.priority == 1:
+        factors.append("priority 1 (highest)")
+    else:
+        factors.append(f"priority {order.priority}")
+
+    # Due-date factor
+    if order.due_date is not None:
+        factors.append(f"due {order.due_date.isoformat()}")
+    else:
+        factors.append("no due date")
+
+    # FIFO marker — present for all candidates, the label helps the operator
+    # understand they came from oldest-first within same priority+due
+    if is_fifo:
+        factors.append("FIFO")
+
+    return factors
+
+
+def _rank_candidates(
+    db: Session,
+    printer: Printer,
+) -> List[tuple[ProductionOrderOperation, ProductionOrder]]:
+    """
+    Build and sort the ranked list of (op, order) candidates for *printer*.
+
+    Ranking: priority ASC (1 first), due_date ASC NULLs last, created_at ASC.
+    Filters:
+    - Order must be in DISPATCHABLE_ORDER_STATUSES.
+    - Op must be in DISPATCHABLE_OP_STATUSES (pending, not yet queued/running).
+    - Op's work center must match one of the work center IDs associated with
+      this printer (via Printer.work_center_id).
+    - All predecessors within the PO must be satisfied.
+    - is_machine_compatible must be True.
+    """
+    # Build base query: released POs joined to pending ops.
+    # We filter ops that are not yet assigned (printer_id IS NULL AND resource_id IS NULL)
+    # so we don't suggest already-scheduled work.
+    rows = (
+        db.query(ProductionOrderOperation, ProductionOrder)
+        .join(
+            ProductionOrder,
+            ProductionOrderOperation.production_order_id == ProductionOrder.id,
+        )
+        .filter(
+            ProductionOrder.status.in_(DISPATCHABLE_ORDER_STATUSES),
+            ProductionOrderOperation.status.in_(DISPATCHABLE_OP_STATUSES),
+            # Not already scheduled
+            ProductionOrderOperation.scheduled_start.is_(None),
+            ProductionOrderOperation.printer_id.is_(None),
+        )
+        .order_by(
+            # Nulls last for due_date: use CASE or Python sort
+            ProductionOrder.priority.asc(),
+            ProductionOrder.created_at.asc(),
+        )
+        .all()
+    )
+
+    # Work-center filter: printer.work_center_id (nullable) constrains which
+    # ops can run on this printer.  If the printer has no work center set, we
+    # accept any op (fallback for un-configured printers).
+    printer_wc_id: Optional[int] = printer.work_center_id
+
+    # Python-side sort for due_date NULLs-last (SQL portability) plus
+    # stable multi-key sort: priority ASC, due_date ASC (NULLs last), created_at ASC.
+    #
+    # DB stores created_at as TIMESTAMP WITHOUT TIME ZONE (naive UTC).
+    # Use a naive sentinel so we never get tz-aware vs naive comparison errors.
+    _far_future = date(9999, 12, 31)
+    _epoch_naive = datetime.min  # naive — matches DB column type
+
+    def _sort_key(row: tuple) -> tuple:
+        op, order = row
+        due = order.due_date if order.due_date is not None else _far_future
+        raw_created = order.created_at or _epoch_naive
+        # Normalise: strip tz from aware datetimes so comparison is always naive
+        created = raw_created.replace(tzinfo=None) if getattr(raw_created, "tzinfo", None) else raw_created
+        return (order.priority, due, created)
+
+    rows.sort(key=_sort_key)
+
+    candidates: list[tuple[ProductionOrderOperation, ProductionOrder]] = []
+    for op, order in rows:
+        # Work-center match
+        if printer_wc_id is not None and op.work_center_id != printer_wc_id:
+            continue
+
+        # Material-machine compatibility
+        is_compat, _reason = is_machine_compatible(db, printer, order)
+        if not is_compat:
+            continue
+
+        # Predecessor gate
+        if not _predecessors_satisfied(db, op):
+            continue
+
+        candidates.append((op, order))
+
+    return candidates
+
+
+def _make_suggestion(
+    db: Session,
+    op: ProductionOrderOperation,
+    order: ProductionOrder,
+    printer: Printer,
+    is_fifo: bool,
+) -> DispatchSuggestion:
+    duration = _get_operation_duration_minutes(op)
+    maint_warning = _get_maintenance_warning(db, printer, duration)
+
+    return DispatchSuggestion(
+        production_order_id=order.id,
+        production_order_code=order.code,
+        product_name=order.product.name if order.product else "N/A",
+        operation_id=op.id,
+        operation_code=op.operation_code,
+        operation_name=op.operation_name,
+        quantity=str(order.quantity_ordered),
+        due_date=order.due_date,
+        priority=order.priority,
+        estimated_duration_minutes=duration,
+        why=_build_why(order, is_fifo),
+        maintenance_warning=maint_warning,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_dispatch_suggestions(
+    db: Session,
+    printer_id: Optional[int] = None,
+) -> DispatchSuggestionsResponse:
+    """
+    For each idle+available printer, rank candidate work and return the top
+    suggestion + up to MAX_RUNNERS_UP runners-up.
+
+    ZERO writes.  Safe to call as frequently as the polling cadence requires.
+
+    Args:
+        db: Database session (read-only usage — no flush/commit).
+        printer_id: If provided, only consider this specific printer.
+
+    Returns:
+        DispatchSuggestionsResponse with one PrinterDispatchResult per
+        eligible printer.
+    """
+    printers = _get_idle_printers(db, printer_id=printer_id)
+    results: List[PrinterDispatchResult] = []
+
+    for printer in printers:
+        candidates = _rank_candidates(db, printer)
+
+        printer_info = PrinterInfo(
+            id=printer.id,
+            code=printer.code,
+            name=printer.name,
+            model=printer.model,
+            status=printer.status,
+        )
+
+        if not candidates:
+            results.append(
+                PrinterDispatchResult(
+                    printer=printer_info,
+                    top_suggestion=None,
+                    runners_up=[],
+                )
+            )
+            continue
+
+        # First candidate is FIFO (relative to sorted order) — only the first
+        # gets the "FIFO" label in why[]; the others just show their factors.
+        top_op, top_order = candidates[0]
+        top = _make_suggestion(db, top_op, top_order, printer, is_fifo=True)
+
+        runners: List[DispatchSuggestion] = []
+        for op, order in candidates[1 : 1 + MAX_RUNNERS_UP]:
+            runners.append(_make_suggestion(db, op, order, printer, is_fifo=False))
+
+        results.append(
+            PrinterDispatchResult(
+                printer=printer_info,
+                top_suggestion=top,
+                runners_up=runners,
+            )
+        )
+
+    return DispatchSuggestionsResponse(
+        results=results,
+        generated_at=_now_utc(),
+    )
+
+
+def dispatch_operation(
+    db: Session,
+    operation_id: int,
+    printer_id: int,
+    user,
+) -> AssignResponse:
+    """
+    Commit an assignment: validate compatibility + conflicts via the existing
+    engine, then call ``schedule_operation(now → now+duration)``.
+
+    This is the only write path in the dispatch service.
+
+    Args:
+        db: Database session.  Caller is responsible for commit/rollback.
+        operation_id: ProductionOrderOperation.id to assign.
+        printer_id: Printer.id to assign to.
+        user: Authenticated user (for future audit trail; not written here).
+
+    Returns:
+        AssignResponse with scheduled times and the resulting operation status.
+
+    Raises:
+        ValueError: If the operation or printer is not found, if the printer
+            is not eligible (maintenance status), if the operation is not in
+            a dispatchable status, or if material-machine compatibility fails.
+        SequenceError: If predecessor operations would be violated.
+        RuntimeError: If schedule_operation reports a conflict.
+    """
+    op: Optional[ProductionOrderOperation] = db.get(
+        ProductionOrderOperation, operation_id
+    )
+    if op is None:
+        raise ValueError(f"Operation {operation_id} not found")
+
+    if op.status not in DISPATCHABLE_OP_STATUSES:
+        raise ValueError(
+            f"Operation {operation_id} has status '{op.status}'; "
+            f"only {sorted(DISPATCHABLE_OP_STATUSES)} can be dispatched"
+        )
+
+    printer: Optional[Printer] = db.get(Printer, printer_id)
+    if printer is None:
+        raise ValueError(f"Printer {printer_id} not found")
+
+    if printer.status in SKIP_STATUSES:
+        raise ValueError(
+            f"Printer {printer.code} has status '{printer.status}' "
+            f"and cannot accept new assignments"
+        )
+
+    # Load the production order
+    order: Optional[ProductionOrder] = db.get(
+        ProductionOrder, op.production_order_id
+    )
+    if order is None:
+        raise ValueError(
+            f"Production order not found for operation {operation_id}"
+        )
+
+    if order.status not in DISPATCHABLE_ORDER_STATUSES:
+        raise ValueError(
+            f"Production order {order.code} has status '{order.status}'; "
+            f"only {sorted(DISPATCHABLE_ORDER_STATUSES)} orders can be dispatched"
+        )
+
+    # Material-machine compatibility check
+    is_compat, reason = is_machine_compatible(db, printer, order)
+    if not is_compat:
+        raise ValueError(
+            f"Printer {printer.code} is not compatible with order {order.code}: {reason}"
+        )
+
+    # Calculate times
+    duration = _get_operation_duration_minutes(op)
+    now = _now_utc()
+    scheduled_start = now
+    scheduled_end = now + timedelta(minutes=duration)
+
+    # Delegate to the existing scheduling engine.
+    # schedule_operation handles:
+    #   1. Conflict detection (raises SequenceError if predecessor violated;
+    #      returns (False, conflicts) if time conflict)
+    #   2. Sets op.printer_id, op.scheduled_start, op.scheduled_end
+    #   3. Sets op.status = 'queued'
+    success, conflicts = schedule_operation(
+        db=db,
+        operation=op,
+        resource_id=printer_id,
+        scheduled_start=scheduled_start,
+        scheduled_end=scheduled_end,
+        is_printer=True,
+    )
+
+    if not success:
+        conflict_codes = [
+            f"op#{c.id}({c.operation_code or c.operation_name or '?'})"
+            for c in conflicts
+        ]
+        raise RuntimeError(
+            f"Scheduling conflict on printer {printer.code}: "
+            f"{', '.join(conflict_codes)}"
+        )
+
+    # schedule_operation calls db.flush() but not commit — caller commits.
+    db.flush()
+
+    return AssignResponse(
+        operation_id=op.id,
+        printer_id=printer.id,
+        printer_code=printer.code,
+        production_order_code=order.code,
+        scheduled_start=scheduled_start,
+        scheduled_end=scheduled_end,
+        operation_status=op.status,  # 'queued' per schedule_operation semantics
+    )

--- a/backend/app/services/dispatch_service.py
+++ b/backend/app/services/dispatch_service.py
@@ -42,6 +42,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from datetime import date
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.models.maintenance import MaintenanceLog
@@ -104,9 +105,16 @@ def _get_idle_printers(db: Session, printer_id: Optional[int] = None) -> List[Pr
     suggestions so the operator can pre-assign; the actual job won't start
     until connectivity returns.
     """
+    # status.notin_(SKIP_STATUSES) excludes NULLs in SQL — printers with
+    # status=None (newly registered, unknown) would be silently skipped.
+    # We want to include them (they may be online but un-polled).
+    # Use explicit OR to keep NULL-status printers in scope.
     query = db.query(Printer).filter(
         Printer.active.is_(True),
-        Printer.status.notin_(SKIP_STATUSES),
+        or_(
+            Printer.status.is_(None),
+            Printer.status.notin_(SKIP_STATUSES),
+        ),
     )
     if printer_id is not None:
         query = query.filter(Printer.id == printer_id)
@@ -422,6 +430,12 @@ def dispatch_operation(
     printer: Optional[Printer] = db.get(Printer, printer_id)
     if printer is None:
         raise ValueError(f"Printer {printer_id} not found")
+
+    if not printer.active:
+        raise ValueError(
+            f"Printer {printer.code} (id={printer_id}) is inactive "
+            f"and cannot accept new assignments"
+        )
 
     if printer.status in SKIP_STATUSES:
         raise ValueError(

--- a/backend/tests/api/test_dispatch_endpoints.py
+++ b/backend/tests/api/test_dispatch_endpoints.py
@@ -1,0 +1,224 @@
+"""
+API-level tests for the dispatch endpoints.  SCHED-1.
+
+Covers:
+- GET /api/v1/dispatch/suggestions returns 401 for unauthenticated requests
+- GET /api/v1/dispatch/suggestions returns 200 for authenticated staff
+- POST /api/v1/dispatch/assign returns 401 for unauthenticated requests
+- POST /api/v1/dispatch/assign happy-path assigns operation (200)
+- POST /api/v1/dispatch/assign 400 for maintenance-status printer
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _make_printer(db, *, status: str = "idle", work_center_id=None) -> Printer:
+    p = Printer(
+        code=f"PRT-{_uid()}",
+        name=f"Printer {_uid()}",
+        model="X1C",
+        brand="bambulab",
+        status=status,
+        active=True,
+        work_center_id=work_center_id,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_wo(db, product_id: int, status: str = "released") -> ProductionOrder:
+    wo = ProductionOrder(
+        code=f"WO-{_uid()}",
+        product_id=product_id,
+        quantity_ordered=Decimal("5"),
+        status=status,
+        priority=2,
+        source="manual",
+    )
+    db.add(wo)
+    db.flush()
+    return wo
+
+
+def _make_op(db, wo_id: int, work_center_id: int) -> ProductionOrderOperation:
+    op = ProductionOrderOperation(
+        production_order_id=wo_id,
+        work_center_id=work_center_id,
+        sequence=10,
+        operation_code=f"OP-{_uid()}",
+        operation_name="Print",
+        planned_setup_minutes=Decimal("0"),
+        planned_run_minutes=Decimal("60"),
+        status="pending",
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/dispatch/suggestions
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSuggestionsEndpoint:
+
+    def test_unauthenticated_returns_401(self, unauthed_client):
+        resp = unauthed_client.get("/api/v1/dispatch/suggestions")
+        assert resp.status_code == 401
+
+    def test_authenticated_returns_200(self, client):
+        resp = client.get("/api/v1/dispatch/suggestions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "results" in data
+        assert "generated_at" in data
+
+    def test_with_printer_id_filter(self, client, db, make_product, make_work_center):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        resp = client.get(f"/api/v1/dispatch/suggestions?printer_id={printer.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "results" in data
+        # Should only have results for this specific printer (or empty)
+        for result in data["results"]:
+            assert result["printer"]["id"] == printer.id
+
+    def test_suggestions_response_shape(self, client, db, make_product, make_work_center):
+        """Response has expected schema fields."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        resp = client.get(f"/api/v1/dispatch/suggestions?printer_id={printer.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert len(data["results"]) >= 1
+        result = next(r for r in data["results"] if r["printer"]["id"] == printer.id)
+
+        # Shape checks
+        assert "printer" in result
+        assert "top_suggestion" in result
+        assert "runners_up" in result
+
+        if result["top_suggestion"] is not None:
+            ts = result["top_suggestion"]
+            assert "production_order_code" in ts
+            assert "product_name" in ts
+            assert "operation_id" in ts
+            assert "priority" in ts
+            assert "why" in ts
+            assert isinstance(ts["why"], list)
+            assert "estimated_duration_minutes" in ts
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/dispatch/assign
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAssignEndpoint:
+
+    def test_unauthenticated_returns_401(self, unauthed_client):
+        resp = unauthed_client.post(
+            "/api/v1/dispatch/assign",
+            json={"operation_id": 1, "printer_id": 1},
+        )
+        assert resp.status_code == 401
+
+    def test_assign_happy_path_returns_200(
+        self, client, db, make_product, make_work_center
+    ):
+        """Successful assign returns 200 with scheduled times and queued status."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id, status="released")
+        op = _make_op(db, wo.id, wc.id)
+
+        resp = client.post(
+            "/api/v1/dispatch/assign",
+            json={"operation_id": op.id, "printer_id": printer.id},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        assert data["operation_id"] == op.id
+        assert data["printer_id"] == printer.id
+        assert data["printer_code"] == printer.code
+        assert data["production_order_code"] == wo.code
+        assert data["operation_status"] == "queued"
+        assert "scheduled_start" in data
+        assert "scheduled_end" in data
+
+    def test_assign_maintenance_printer_returns_400(
+        self, client, db, make_product, make_work_center
+    ):
+        """Assigning to a maintenance-status printer returns 400."""
+        wc = make_work_center()
+        product = make_product()
+        maint_printer = _make_printer(db, status="maintenance", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id, status="released")
+        op = _make_op(db, wo.id, wc.id)
+
+        resp = client.post(
+            "/api/v1/dispatch/assign",
+            json={"operation_id": op.id, "printer_id": maint_printer.id},
+        )
+        assert resp.status_code == 400
+        assert "maintenance" in resp.json()["detail"].lower()
+
+    def test_assign_nonexistent_operation_returns_400(
+        self, client, db, make_work_center
+    ):
+        wc = make_work_center()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        resp = client.post(
+            "/api/v1/dispatch/assign",
+            json={"operation_id": 999_999, "printer_id": printer.id},
+        )
+        assert resp.status_code == 400
+
+    def test_assign_draft_order_returns_400(
+        self, client, db, make_product, make_work_center
+    ):
+        """Draft production orders cannot be dispatched."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id, status="draft")
+        op = _make_op(db, wo.id, wc.id)
+
+        resp = client.post(
+            "/api/v1/dispatch/assign",
+            json={"operation_id": op.id, "printer_id": printer.id},
+        )
+        assert resp.status_code == 400

--- a/backend/tests/services/test_dispatch_service.py
+++ b/backend/tests/services/test_dispatch_service.py
@@ -1,0 +1,685 @@
+"""
+Tests for app/services/dispatch_service.py — SCHED-1.
+
+Covers (per plan):
+- ranking order: priority beats due date beats FIFO (created_at)
+- maintenance-status printers are skipped
+- maintenance-due warning present/absent
+- incompatible material excluded
+- predecessor-not-ready excluded
+- assign path validates conflicts
+- assign sets status to 'queued'
+- Decimal discipline (quantity serialised as str, no float drift)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.models.maintenance import MaintenanceLog
+from app.models.manufacturing import Resource
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+from app.services.dispatch_service import (
+    DEFAULT_DURATION_MINUTES,
+    dispatch_operation,
+    get_dispatch_suggestions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / factories
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_printer(db, *, status: str = "idle", work_center_id=None, model: str = "X1C") -> Printer:
+    uid = _uid()
+    p = Printer(
+        code=f"PRT-{uid}",
+        name=f"Printer {uid}",
+        model=model,
+        brand="bambulab",
+        status=status,
+        active=True,
+        work_center_id=work_center_id,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_resource(db, work_center_id) -> Resource:
+    uid = _uid()
+    r = Resource(
+        work_center_id=work_center_id,
+        code=f"RES-{uid}",
+        name=f"Resource {uid}",
+        status="available",
+        is_active=True,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _make_wo(
+    db,
+    product_id: int,
+    *,
+    status: str = "released",
+    priority: int = 3,
+    due_date=None,
+    created_at=None,
+) -> ProductionOrder:
+    uid = _uid()
+    wo = ProductionOrder(
+        code=f"WO-{uid}",
+        product_id=product_id,
+        quantity_ordered=Decimal("10"),
+        status=status,
+        priority=priority,
+        due_date=due_date,
+        source="manual",
+    )
+    if created_at is not None:
+        wo.created_at = created_at
+    db.add(wo)
+    db.flush()
+    return wo
+
+
+def _make_op(
+    db,
+    wo_id: int,
+    work_center_id: int,
+    *,
+    sequence: int = 10,
+    status: str = "pending",
+    planned_run_minutes: float = 60.0,
+) -> ProductionOrderOperation:
+    op = ProductionOrderOperation(
+        production_order_id=wo_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_code=f"OP-{_uid()}",
+        operation_name="Print",
+        planned_setup_minutes=Decimal("0"),
+        planned_run_minutes=Decimal(str(planned_run_minutes)),
+        status=status,
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+def _make_maintenance_log(
+    db,
+    printer_id: int,
+    *,
+    next_due_at=None,
+    performed_at=None,
+) -> MaintenanceLog:
+    log = MaintenanceLog(
+        printer_id=printer_id,
+        maintenance_type="routine",
+        performed_at=performed_at or _now(),
+        next_due_at=next_due_at,
+    )
+    db.add(log)
+    db.flush()
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_dispatch_suggestions — read-only path
+# ---------------------------------------------------------------------------
+
+
+class TestGetDispatchSuggestions:
+    """Tests for the read-only suggestion path."""
+
+    def test_no_printers_returns_empty(self, db, make_product, make_work_center):
+        """With no active printers in DB, results is empty."""
+        resp = get_dispatch_suggestions(db)
+        # Results may contain printers from other tests due to non-isolated DB;
+        # we at least verify the response shape is correct.
+        assert hasattr(resp, "results")
+        assert hasattr(resp, "generated_at")
+
+    def test_maintenance_status_printer_skipped(
+        self, db, make_product, make_work_center
+    ):
+        """Printers with status='maintenance' are excluded from suggestions."""
+        wc = make_work_center()
+        product = make_product()
+        maint_printer = _make_printer(db, status="maintenance", work_center_id=wc.id)
+        idle_printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        # Create a released WO with a pending op tied to the wc
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db)
+
+        # The maintenance printer should not appear in results
+        result_printer_ids = {r.printer.id for r in resp.results}
+        assert maint_printer.id not in result_printer_ids
+
+        # The idle printer should appear
+        assert idle_printer.id in result_printer_ids
+
+    def test_priority_beats_due_date(self, db, make_product, make_work_center):
+        """Priority 1 surfaces before priority 3, even if priority-3 has earlier due date."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        # WO-A: priority 3, due yesterday (earlier due)
+        wo_a = _make_wo(
+            db,
+            product.id,
+            priority=3,
+            due_date=date.today() - timedelta(days=1),
+        )
+        _make_op(db, wo_a.id, wc.id)
+
+        # WO-B: priority 1, due next week (later due)
+        wo_b = _make_wo(
+            db,
+            product.id,
+            priority=1,
+            due_date=date.today() + timedelta(days=7),
+        )
+        _make_op(db, wo_b.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        assert len(resp.results) == 1
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        # Priority 1 (WO-B) must win over priority 3 (WO-A)
+        assert result.top_suggestion.production_order_id == wo_b.id
+
+        # WO-A should appear in runners_up
+        runner_ids = [r.production_order_id for r in result.runners_up]
+        assert wo_a.id in runner_ids
+
+    def test_due_date_beats_fifo(self, db, make_product, make_work_center):
+        """Same priority: earlier due date beats later-created order."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        now = _now()
+        # WO-old: created first (FIFO advantage), due far future
+        wo_old = _make_wo(
+            db,
+            product.id,
+            priority=2,
+            due_date=date.today() + timedelta(days=30),
+            created_at=now - timedelta(hours=2),
+        )
+        _make_op(db, wo_old.id, wc.id)
+
+        # WO-urgent: created later, due tomorrow
+        wo_urgent = _make_wo(
+            db,
+            product.id,
+            priority=2,
+            due_date=date.today() + timedelta(days=1),
+            created_at=now - timedelta(hours=1),
+        )
+        _make_op(db, wo_urgent.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        assert len(resp.results) == 1
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        # Due-tomorrow must beat created-first
+        assert result.top_suggestion.production_order_id == wo_urgent.id
+
+    def test_fifo_tiebreaker(self, db, make_product, make_work_center):
+        """Same priority + same due date: older created_at wins."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        due = date.today() + timedelta(days=5)
+
+        now = _now()
+        wo_first = _make_wo(
+            db, product.id, priority=2, due_date=due, created_at=now - timedelta(hours=3)
+        )
+        _make_op(db, wo_first.id, wc.id)
+
+        wo_second = _make_wo(
+            db, product.id, priority=2, due_date=due, created_at=now - timedelta(hours=1)
+        )
+        _make_op(db, wo_second.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        assert len(resp.results) == 1
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        assert result.top_suggestion.production_order_id == wo_first.id
+
+    def test_why_contains_priority_and_due(self, db, make_product, make_work_center):
+        """'why' list includes priority, due date, and FIFO labels."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        due = date.today() + timedelta(days=3)
+
+        wo = _make_wo(db, product.id, priority=1, due_date=due)
+        _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+        assert result.top_suggestion is not None
+
+        why = result.top_suggestion.why
+        assert any("priority 1" in w for w in why)
+        assert any(due.isoformat() in w for w in why)
+        assert any("FIFO" in w for w in why)
+
+    def test_no_suggestion_when_no_released_orders(
+        self, db, make_product, make_work_center
+    ):
+        """Draft orders should not appear in suggestions."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id, status="draft")
+        _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+        # No released orders → no suggestion
+        assert result.top_suggestion is None
+
+    def test_maintenance_due_warning_present(self, db, make_product, make_work_center):
+        """maintenance_warning is set when next_due_at < now + duration."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        # Log: next maintenance due in 30 minutes (before a 60-min job finishes)
+        _make_maintenance_log(
+            db,
+            printer.id,
+            next_due_at=_now() + timedelta(minutes=30),
+        )
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        assert result.top_suggestion.maintenance_warning is not None
+        assert "maintenance due" in result.top_suggestion.maintenance_warning.lower()
+
+    def test_maintenance_due_warning_absent(self, db, make_product, make_work_center):
+        """maintenance_warning is None when next_due_at is well after job end."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        # Next maintenance in 2 weeks — well after a 60-min job
+        _make_maintenance_log(
+            db,
+            printer.id,
+            next_due_at=_now() + timedelta(days=14),
+        )
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        assert result.top_suggestion.maintenance_warning is None
+
+    def test_maintenance_no_log_no_warning(self, db, make_product, make_work_center):
+        """No MaintenanceLog rows → no maintenance_warning."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        assert result.top_suggestion.maintenance_warning is None
+
+    def test_incompatible_material_excluded(
+        self, db, make_product, make_work_center
+    ):
+        """ABS job on open-frame printer is excluded from candidates."""
+        from app.models.material import MaterialType
+        from app.models.bom import BOM, BOMLine
+
+        wc = make_work_center()
+        # Open-frame printer (no enclosure — X1C actually has one in real life
+        # but we use model="A1" so machine_has_enclosure returns False)
+        printer = _make_printer(
+            db, status="idle", work_center_id=wc.id, model="A1"
+        )
+
+        # ABS material type — requires enclosure
+        abs_type = MaterialType(
+            code=f"ABS-{_uid()}",
+            name="ABS",
+            base_material="ABS",
+            density=Decimal("1.04"),
+            base_price_per_kg=Decimal("25.00"),
+            requires_enclosure=True,
+            active=True,
+            is_customer_visible=True,
+        )
+        db.add(abs_type)
+        db.flush()
+
+        # Product that is itself an ABS material
+        abs_product = make_product(
+            item_type="supply",
+            unit="G",
+            is_raw_material=True,
+            material_type_id=abs_type.id,
+        )
+        # Finished-good product for the WO
+        fg = make_product()
+
+        wo = _make_wo(db, fg.id)
+        _make_op(db, wo.id, wc.id)
+
+        # Associate ABS component via BOM so is_machine_compatible sees it
+        bom = BOM(
+            product_id=fg.id,
+            name=f"BOM-{_uid()}",
+            active=True,
+        )
+        db.add(bom)
+        db.flush()
+        db.add(BOMLine(
+            bom_id=bom.id,
+            component_id=abs_product.id,
+            quantity=Decimal("100"),
+            unit="G",
+        ))
+        # Link BOM to WO
+        wo.bom_id = bom.id
+        db.flush()
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        # ABS on open-frame printer must be excluded
+        assert result.top_suggestion is None
+
+    def test_predecessor_not_ready_excluded(
+        self, db, make_product, make_work_center
+    ):
+        """Op with pending predecessor (not yet scheduled) is excluded."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+
+        # Op-10 (predecessor) — pending, not scheduled
+        _make_op(db, wo.id, wc.id, sequence=10, status="pending")
+
+        # Op-20 (successor) — also pending, but predecessor blocks it
+        _make_op(db, wo.id, wc.id, sequence=20, status="pending")
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        # Op-20 is blocked by Op-10; only Op-10 should be suggested
+        assert result.top_suggestion is not None
+        # Top must be Op-10 (the first sequence) not Op-20
+        # We can verify no suggestion refers to sequence=20 among top+runners_up
+        suggested_op_ids = set()
+        if result.top_suggestion:
+            suggested_op_ids.add(result.top_suggestion.operation_id)
+        for r in result.runners_up:
+            suggested_op_ids.add(r.operation_id)
+
+        ops_in_suggestions = (
+            db.query(ProductionOrderOperation)
+            .filter(ProductionOrderOperation.id.in_(suggested_op_ids))
+            .all()
+        )
+        for op in ops_in_suggestions:
+            assert op.sequence != 20, (
+                "Op with sequence=20 should not appear — predecessor not satisfied"
+            )
+
+    def test_runners_up_capped_at_two(self, db, make_product, make_work_center):
+        """runners_up contains at most MAX_RUNNERS_UP (2) entries."""
+        from app.services.dispatch_service import MAX_RUNNERS_UP
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        for i in range(5):
+            wo = _make_wo(db, product.id, priority=3)
+            _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert len(result.runners_up) <= MAX_RUNNERS_UP
+
+    def test_quantity_is_decimal_string(self, db, make_product, make_work_center):
+        """quantity in suggestion is a string representation (no float drift)."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        qty = result.top_suggestion.quantity
+        # Must be a string (not float)
+        assert isinstance(qty, str)
+        # Must be parse-able as Decimal without losing precision
+        Decimal(qty)
+
+    def test_default_duration_used_when_no_planned_minutes(
+        self, db, make_product, make_work_center
+    ):
+        """When planned_run_minutes = 0, DEFAULT_DURATION_MINUTES is applied."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        # planned_run_minutes defaults to 60 in _make_op;
+        # set it to 0 to trigger the default path
+        op = ProductionOrderOperation(
+            production_order_id=wo.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code=f"OP-{_uid()}",
+            operation_name="Print",
+            planned_setup_minutes=Decimal("0"),
+            planned_run_minutes=Decimal("0"),
+            status="pending",
+        )
+        db.add(op)
+        db.flush()
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        result = resp.results[0]
+
+        assert result.top_suggestion is not None
+        assert result.top_suggestion.estimated_duration_minutes == DEFAULT_DURATION_MINUTES
+
+
+# ---------------------------------------------------------------------------
+# Tests: dispatch_operation — write path
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchOperation:
+    """Tests for the write/assign path."""
+
+    def test_assigns_operation_and_sets_queued(
+        self, db, make_product, make_work_center
+    ):
+        """Successful assign sets op.status='queued' and records scheduled times."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        from datetime import datetime as _dt, timezone as _tz
+        before = _dt.now(_tz.utc)
+
+        result = dispatch_operation(db, op.id, printer.id, user)
+
+        assert result.operation_status == "queued"
+        assert result.printer_id == printer.id
+        assert result.printer_code == printer.code
+        assert result.production_order_code == wo.code
+
+        # Scheduled times should be set
+        assert result.scheduled_start >= before
+        assert result.scheduled_end > result.scheduled_start
+
+        # Verify DB-side
+        db.expire(op)
+        assert op.status == "queued"
+        assert op.printer_id == printer.id
+        assert op.scheduled_start is not None
+
+    def test_assign_rejects_maintenance_printer(
+        self, db, make_product, make_work_center
+    ):
+        """dispatch_operation raises ValueError for a printer in maintenance."""
+        wc = make_work_center()
+        product = make_product()
+        maint_printer = _make_printer(db, status="maintenance", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(ValueError, match="maintenance"):
+            dispatch_operation(db, op.id, maint_printer.id, user)
+
+    def test_assign_rejects_non_pending_operation(
+        self, db, make_product, make_work_center
+    ):
+        """dispatch_operation raises ValueError if op is already queued/running."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id, status="queued")  # already queued
+
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(ValueError, match="queued"):
+            dispatch_operation(db, op.id, printer.id, user)
+
+    def test_assign_rejects_non_released_order(
+        self, db, make_product, make_work_center
+    ):
+        """dispatch_operation raises ValueError if WO is draft (not released)."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        wo = _make_wo(db, product.id, status="draft")
+        op = _make_op(db, wo.id, wc.id)
+
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(ValueError, match="draft"):
+            dispatch_operation(db, op.id, printer.id, user)
+
+    def test_assign_validates_conflicts(self, db, make_product, make_work_center):
+        """dispatch_operation raises RuntimeError when a time conflict exists."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+
+        now = _now()
+        # Pre-schedule op-A on the printer to create a conflict
+        wo_a = _make_wo(db, product.id)
+        op_a = ProductionOrderOperation(
+            production_order_id=wo_a.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code=f"OP-A-{_uid()}",
+            operation_name="Print A",
+            planned_setup_minutes=Decimal("0"),
+            planned_run_minutes=Decimal("120"),
+            status="queued",
+            printer_id=printer.id,
+            scheduled_start=now - timedelta(minutes=10),
+            scheduled_end=now + timedelta(minutes=110),
+        )
+        db.add(op_a)
+        db.flush()
+
+        # Try to dispatch op-B to the same printer in the overlapping slot
+        wo_b = _make_wo(db, product.id)
+        op_b = _make_op(db, wo_b.id, wc.id, planned_run_minutes=60)
+
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(RuntimeError, match="conflict"):
+            dispatch_operation(db, op_b.id, printer.id, user)
+
+    def test_assign_missing_operation_raises_value_error(
+        self, db, make_work_center
+    ):
+        wc = make_work_center()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(ValueError, match="not found"):
+            dispatch_operation(db, 999_999, printer.id, user)
+
+    def test_assign_missing_printer_raises_value_error(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+        user = db.query(__import__("app.models.user", fromlist=["User"]).User).filter_by(id=1).first()
+
+        with pytest.raises(ValueError, match="not found"):
+            dispatch_operation(db, op.id, 999_999, user)


### PR DESCRIPTION
## Summary

- **New service** `backend/app/services/dispatch_service.py`: `get_dispatch_suggestions()` (zero-write ranking) + `dispatch_operation()` (single assign action). Reuses `resource_scheduling`, `resource_compatibility_service` — no new scheduling math.
- **Schemas** `backend/app/schemas/dispatch.py`: `PrinterInfo`, `DispatchSuggestion` (with `why[]` rank factors + `maintenance_warning`), `PrinterDispatchResult`, `DispatchSuggestionsResponse`, `AssignRequest`, `AssignResponse`.
- **Endpoints** `backend/app/api/v1/endpoints/dispatch.py`: staff-gated `GET /api/v1/dispatch/suggestions` + `POST /api/v1/dispatch/assign`. Registered in `api/v1/__init__.py`.
- **31 tests** covering: ranking order (priority > due date > FIFO), maintenance-status skip, maintenance-due warning present/absent, incompatible material excluded, predecessor-not-ready excluded, assign conflict validation, 401/200 auth.

## Status semantics

`dispatch_operation()` calls `schedule_operation()` from the existing engine which sets `op.status = 'queued'` — meaning assigned to a specific printer + time slot, ready to run, **not yet started**. The printer operator starts it via the existing operation-status endpoint. This is intentional: assigning ≠ starting.

## Design decisions

- `DEFAULT_DURATION_MINUTES = 120`: documented constant used when no `planned_run_minutes`/`planned_setup_minutes` data exists on the operation row.
- Maintenance warning is a **heuristic warn**, never a silent skip — operator decides. Compares `MaintenanceLog.next_due_at` (latest log by `performed_at`) against `now + estimated_duration`.
- Ranking uses Python-side sort with NULLs-last for `due_date` (SQL portability). Timezone normalisation matches the pattern established in `resource_scheduling.py`.
- `resource_scheduling.py` is **read-only** for this PR (no changes). `SequenceError` is re-exported for callers.

## Test plan

- [x] `python -m ruff check` — all new files pass
- [x] `python -m pytest tests/services/test_dispatch_service.py tests/api/test_dispatch_endpoints.py` — 31/31 passed
- [ ] CI must pass all existing suites (no regressions)
- [ ] CodeRabbit / Copilot review triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dispatch suggestions endpoint to recommend ranked printer assignments for pending operations (optional printer filtering).
  * Added dispatch assign endpoint to confirm and schedule assignments, enforcing staff authentication and eligibility checks (printer status, operation/order validity, conflict detection).
* **Tests**
  * Added comprehensive tests for dispatch suggestions and assign flows, including authorization, validation, ranking, scheduling, and edge cases (maintenance, incompatibility, conflicts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->