### PR TITLE
feat: one-click earliest-valid-start for predecessor conflicts; local-time conflict copy

### DIFF
--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -532,7 +532,9 @@ def schedule_operation_endpoint(
             is_printer=request.is_printer,
         )
     except SequenceError as e:
-        # Return same shape as a conflict so the frontend gets a suggested slot
+        # Pure predecessor violation — no resource conflict.
+        # earliest_valid_start = the latest predecessor end (absolute floor).
+        # next_available_start = earliest slot on the resource at or after that floor.
         earliest = get_earliest_start_after_predecessors(
             db=db,
             operation=op,
@@ -549,14 +551,16 @@ def schedule_operation_endpoint(
             success=False,
             message=str(e),
             conflicts=[],
+            conflict_type="predecessor",
+            earliest_valid_start=earliest,
             next_available_start=next_start,
             next_available_end=next_start + timedelta(minutes=duration_minutes),
         )
 
     if not success:
-        # Calculate next available slot for this resource, accounting for
+        # Resource conflict — calculate next available slot accounting for
         # both resource conflicts AND predecessor sequence constraints.
-        # Floor: can't start before all predecessors are done
+        # Floor: can't start before all predecessors are done.
         earliest = get_earliest_start_after_predecessors(
             db=db,
             operation=op,
@@ -587,6 +591,7 @@ def schedule_operation_endpoint(
             success=False,
             message=f"Scheduling conflict with {len(conflicts)} existing operation(s)",
             conflicts=conflict_details,
+            conflict_type="resource",
             next_available_start=next_start,
             next_available_end=suggested_end,
         )

--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -533,20 +533,38 @@ def schedule_operation_endpoint(
         )
     except SequenceError as e:
         # Pure predecessor violation — no resource conflict.
-        # earliest_valid_start = the latest predecessor end (absolute floor).
-        # next_available_start = earliest slot on the resource at or after that floor.
-        earliest = get_earliest_start_after_predecessors(
-            db=db,
-            operation=op,
-            after=request.scheduled_start,
-        )
-        next_start = find_next_available_slot(
-            db=db,
-            resource_id=request.resource_id,
-            duration_minutes=duration_minutes,
-            after=earliest,
-            is_printer=request.is_printer,
-        )
+        # Only offer a suggested start when ALL predecessors are scheduled
+        # (have a scheduled_end).  If any predecessor is unscheduled we cannot
+        # compute a meaningful floor; returning a suggestion would be misleading
+        # because the operator must schedule the predecessor first.
+        has_unscheduled_pred = (
+            db.query(ProductionOrderOperation.id)
+            .filter(
+                ProductionOrderOperation.production_order_id == op.production_order_id,
+                ProductionOrderOperation.sequence < op.sequence,
+                ProductionOrderOperation.id != op.id,
+                ProductionOrderOperation.status.notin_(["complete", "skipped", "cancelled"]),
+                ProductionOrderOperation.scheduled_end.is_(None),
+            )
+            .first()
+        ) is not None
+
+        earliest = None
+        next_start = None
+        if not has_unscheduled_pred:
+            # All predecessors are scheduled — compute the floor and suggest a slot
+            earliest = get_earliest_start_after_predecessors(
+                db=db,
+                operation=op,
+                after=request.scheduled_start,
+            )
+            next_start = find_next_available_slot(
+                db=db,
+                resource_id=request.resource_id,
+                duration_minutes=duration_minutes,
+                after=earliest,
+                is_printer=request.is_printer,
+            )
         return ScheduleOperationResponse(
             success=False,
             message=str(e),
@@ -554,7 +572,10 @@ def schedule_operation_endpoint(
             conflict_type="predecessor",
             earliest_valid_start=earliest,
             next_available_start=next_start,
-            next_available_end=next_start + timedelta(minutes=duration_minutes),
+            next_available_end=(
+                next_start + timedelta(minutes=duration_minutes)
+                if next_start is not None else None
+            ),
         )
 
     if not success:

--- a/backend/app/schemas/resource_scheduling.py
+++ b/backend/app/schemas/resource_scheduling.py
@@ -64,6 +64,14 @@ class ScheduleOperationResponse(BaseModel):
     conflicts: List[ConflictInfo] = Field(default_factory=list)
     next_available_start: Optional[datetime] = None
     next_available_end: Optional[datetime] = None
+    # Predecessor-specific fields
+    # conflict_type is "resource" when blocked by another op on the same
+    # resource, "predecessor" when blocked purely by sequence constraints.
+    conflict_type: Optional[str] = None
+    # earliest_valid_start is the latest predecessor scheduled_end — the
+    # absolute floor for this operation regardless of resource availability.
+    # Present only for predecessor conflicts (conflict_type == "predecessor").
+    earliest_valid_start: Optional[datetime] = None
 
 
 class NextAvailableSlotRequest(BaseModel):

--- a/backend/app/schemas/resource_scheduling.py
+++ b/backend/app/schemas/resource_scheduling.py
@@ -2,7 +2,7 @@
 Schemas for resource scheduling.
 """
 from datetime import datetime
-from typing import Optional, List
+from typing import Literal, Optional, List
 from pydantic import BaseModel, Field
 
 
@@ -67,7 +67,7 @@ class ScheduleOperationResponse(BaseModel):
     # Predecessor-specific fields
     # conflict_type is "resource" when blocked by another op on the same
     # resource, "predecessor" when blocked purely by sequence constraints.
-    conflict_type: Optional[str] = None
+    conflict_type: Optional[Literal["predecessor", "resource"]] = None
     # earliest_valid_start is the latest predecessor scheduled_end — the
     # absolute floor for this operation regardless of resource availability.
     # Present only for predecessor conflicts (conflict_type == "predecessor").

--- a/backend/app/services/resource_scheduling.py
+++ b/backend/app/services/resource_scheduling.py
@@ -299,11 +299,9 @@ def check_predecessor_scheduling(
                 start = start.replace(tzinfo=timezone.utc)
 
             if pred_end > start:
-                pred_end_fmt = pred_end.strftime("%b %d %Y at %I:%M %p UTC")
-                start_fmt = start.strftime("%b %d %Y at %I:%M %p UTC")
                 return (
                     f"Operation {pred.sequence} ({pred.operation_name or pred.operation_code}) "
-                    f"runs until {pred_end_fmt}, after your requested start of {start_fmt}"
+                    f"must finish before this operation can start"
                 )
 
     return None

--- a/backend/tests/api/v1/test_operation_status_scheduling.py
+++ b/backend/tests/api/v1/test_operation_status_scheduling.py
@@ -161,10 +161,14 @@ class TestScheduleOperationPredecessorResponse:
         assert data["earliest_valid_start"] is not None
 
         # earliest_valid_start must be >= the predecessor's scheduled_end
-        def _naive(dt):
-            return dt.replace(tzinfo=None) if dt.tzinfo else dt
+        def _to_utc(dt):
+            return (
+                dt.replace(tzinfo=timezone.utc)
+                if dt.tzinfo is None
+                else dt.astimezone(timezone.utc)
+            )
         earliest = datetime.fromisoformat(data["earliest_valid_start"])
-        assert _naive(earliest) >= _naive(pred_end)
+        assert _to_utc(earliest) >= _to_utc(pred_end)
 
     def test_predecessor_violation_next_available_start_present(
         self, client, db, make_product, make_production_order, make_work_center
@@ -214,12 +218,16 @@ class TestScheduleOperationPredecessorResponse:
         data = response.json()
         assert data["next_available_start"] is not None
 
-        def _naive(dt):
-            return dt.replace(tzinfo=None) if dt.tzinfo else dt
+        def _to_utc(dt):
+            return (
+                dt.replace(tzinfo=timezone.utc)
+                if dt.tzinfo is None
+                else dt.astimezone(timezone.utc)
+            )
 
         earliest = datetime.fromisoformat(data["earliest_valid_start"])
         next_avail = datetime.fromisoformat(data["next_available_start"])
-        assert _naive(next_avail) >= _naive(earliest)
+        assert _to_utc(next_avail) >= _to_utc(earliest)
 
     def test_unscheduled_predecessor_suppresses_suggestion(
         self, client, db, make_product, make_production_order, make_work_center

--- a/backend/tests/api/v1/test_operation_status_scheduling.py
+++ b/backend/tests/api/v1/test_operation_status_scheduling.py
@@ -94,38 +94,47 @@ class TestNextAvailableSlotEndpoint:
 
 
 class TestScheduleOperationPredecessorResponse:
-    """Verify predecessor violation returns earliest_valid_start >= predecessor end."""
+    """Verify predecessor violation returns earliest_valid_start >= predecessor end.
+
+    Key design constraint in schedule_operation():
+      1. find_conflicts() runs FIRST.  If there is a resource conflict the function
+         returns (False, conflicts) immediately — SequenceError is never raised.
+      2. check_predecessor_scheduling() only runs when the resource is free.
+
+    So to test a pure predecessor violation we must use a DIFFERENT (free) printer
+    for OP020 than the one OP010 is locked to.
+    """
 
     def test_predecessor_violation_returns_earliest_valid_start(
         self, client, db, make_product, make_production_order, make_work_center
     ):
         """
-        Scheduling OP020 while OP010 isn't finished should return:
-          success=False, conflict_type="predecessor",
-          earliest_valid_start >= OP010's scheduled_end.
+        OP020 scheduled on a free printer while OP010 (different printer) isn't
+        finished → conflict_type="predecessor", earliest_valid_start >= pred end.
         """
         work_center = make_work_center()
-        printer = _make_printer(db, work_center.id)
+        # Two printers: printer_a is busy with OP010; printer_b is free for OP020
+        printer_a = _make_printer(db, work_center.id)
+        printer_b = _make_printer(db, work_center.id)
         product = make_product()
         po = make_production_order(product_id=product.id)
 
         now = datetime.now(timezone.utc).replace(microsecond=0)
         pred_end = now + timedelta(hours=3)
 
-        # OP010 — predecessor, already scheduled (queued), ends in 3 hours
-        pred_op = _make_operation(
+        # OP010 — predecessor, scheduled on printer_a (locked for 3h)
+        _make_operation(
             db,
             po.id,
             work_center.id,
             sequence=10,
             status="queued",
-            printer_id=printer.id,
+            printer_id=printer_a.id,
             scheduled_start=now,
             scheduled_end=pred_end,
         )
-        assert pred_op.id  # flush succeeded
 
-        # OP020 — the op we want to schedule too early
+        # OP020 — the op we want to schedule on the FREE printer_b
         op = _make_operation(
             db,
             po.id,
@@ -134,11 +143,11 @@ class TestScheduleOperationPredecessorResponse:
             status="pending",
         )
 
-        # Try to schedule OP020 starting NOW — before OP010 ends
+        # Try to schedule OP020 on printer_b starting NOW (before OP010 ends)
         response = client.post(
             f"{BASE_URL}/{po.id}/operations/{op.id}/schedule",
             json={
-                "resource_id": printer.id,
+                "resource_id": printer_b.id,
                 "is_printer": True,
                 "scheduled_start": now.isoformat(),
                 "scheduled_end": (now + timedelta(hours=1)).isoformat(),
@@ -152,32 +161,37 @@ class TestScheduleOperationPredecessorResponse:
         assert data["earliest_valid_start"] is not None
 
         # earliest_valid_start must be >= the predecessor's scheduled_end
+        def _naive(dt):
+            return dt.replace(tzinfo=None) if dt.tzinfo else dt
         earliest = datetime.fromisoformat(data["earliest_valid_start"])
-        assert earliest >= pred_end.replace(tzinfo=None) or earliest >= pred_end
+        assert _naive(earliest) >= _naive(pred_end)
 
     def test_predecessor_violation_next_available_start_present(
         self, client, db, make_product, make_production_order, make_work_center
     ):
         """next_available_start must be present and >= earliest_valid_start."""
         work_center = make_work_center()
-        printer = _make_printer(db, work_center.id)
+        printer_a = _make_printer(db, work_center.id)
+        printer_b = _make_printer(db, work_center.id)
         product = make_product()
         po = make_production_order(product_id=product.id)
 
         now = datetime.now(timezone.utc).replace(microsecond=0)
         pred_end = now + timedelta(hours=2)
 
+        # OP010 on printer_a
         _make_operation(
             db,
             po.id,
             work_center.id,
             sequence=10,
             status="queued",
-            printer_id=printer.id,
+            printer_id=printer_a.id,
             scheduled_start=now,
             scheduled_end=pred_end,
         )
 
+        # OP020 to be scheduled on free printer_b
         op = _make_operation(
             db,
             po.id,
@@ -189,7 +203,7 @@ class TestScheduleOperationPredecessorResponse:
         response = client.post(
             f"{BASE_URL}/{po.id}/operations/{op.id}/schedule",
             json={
-                "resource_id": printer.id,
+                "resource_id": printer_b.id,
                 "is_printer": True,
                 "scheduled_start": now.isoformat(),
                 "scheduled_end": (now + timedelta(hours=1)).isoformat(),
@@ -200,12 +214,11 @@ class TestScheduleOperationPredecessorResponse:
         data = response.json()
         assert data["next_available_start"] is not None
 
-        earliest = datetime.fromisoformat(data["earliest_valid_start"])
-        next_avail = datetime.fromisoformat(data["next_available_start"])
-        # next_available_start must be at or after the predecessor end
-        # (normalise tz for comparison)
         def _naive(dt):
             return dt.replace(tzinfo=None) if dt.tzinfo else dt
+
+        earliest = datetime.fromisoformat(data["earliest_valid_start"])
+        next_avail = datetime.fromisoformat(data["next_available_start"])
         assert _naive(next_avail) >= _naive(earliest)
 
     def test_resource_conflict_uses_resource_conflict_type(
@@ -221,7 +234,7 @@ class TestScheduleOperationPredecessorResponse:
         po2 = make_production_order(product_id=product.id)
 
         now = datetime.now(timezone.utc).replace(microsecond=0)
-        # Occupy the printer for 2 hours on PO1
+        # Occupy the printer for 2 hours on PO1's single op
         _make_operation(
             db,
             po1.id,
@@ -233,7 +246,7 @@ class TestScheduleOperationPredecessorResponse:
             scheduled_end=now + timedelta(hours=2),
         )
 
-        # Single op on PO2 — no predecessors
+        # Single op on PO2 — no predecessors within this PO
         op2 = _make_operation(
             db,
             po2.id,
@@ -242,7 +255,7 @@ class TestScheduleOperationPredecessorResponse:
             status="pending",
         )
 
-        # Try to schedule PO2's op in the same window
+        # Try to schedule PO2's op in the same window — resource conflict, no predecessor
         response = client.post(
             f"{BASE_URL}/{po2.id}/operations/{op2.id}/schedule",
             json={
@@ -257,5 +270,5 @@ class TestScheduleOperationPredecessorResponse:
         data = response.json()
         assert data["success"] is False
         assert data["conflict_type"] == "resource"
-        # No predecessor constraint
+        # No predecessor constraint — earliest_valid_start should be absent
         assert data.get("earliest_valid_start") is None

--- a/backend/tests/api/v1/test_operation_status_scheduling.py
+++ b/backend/tests/api/v1/test_operation_status_scheduling.py
@@ -221,6 +221,52 @@ class TestScheduleOperationPredecessorResponse:
         next_avail = datetime.fromisoformat(data["next_available_start"])
         assert _naive(next_avail) >= _naive(earliest)
 
+    def test_unscheduled_predecessor_suppresses_suggestion(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """When a predecessor has no scheduled_end, no suggestion is offered."""
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+
+        # OP010 — pending and NOT YET SCHEDULED (no scheduled_start/end)
+        _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=10,
+            status="pending",
+        )
+
+        op = _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=20,
+            status="pending",
+        )
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/schedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": now.isoformat(),
+                "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "predecessor"
+        # No suggestion — operator must schedule OP010 first
+        assert data.get("earliest_valid_start") is None
+        assert data.get("next_available_start") is None
+        assert data.get("next_available_end") is None
+
     def test_resource_conflict_uses_resource_conflict_type(
         self, client, db, make_product, make_production_order, make_work_center
     ):

--- a/backend/tests/api/v1/test_operation_status_scheduling.py
+++ b/backend/tests/api/v1/test_operation_status_scheduling.py
@@ -91,3 +91,171 @@ class TestNextAvailableSlotEndpoint:
         )
 
         assert response.status_code == 401
+
+
+class TestScheduleOperationPredecessorResponse:
+    """Verify predecessor violation returns earliest_valid_start >= predecessor end."""
+
+    def test_predecessor_violation_returns_earliest_valid_start(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """
+        Scheduling OP020 while OP010 isn't finished should return:
+          success=False, conflict_type="predecessor",
+          earliest_valid_start >= OP010's scheduled_end.
+        """
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        pred_end = now + timedelta(hours=3)
+
+        # OP010 — predecessor, already scheduled (queued), ends in 3 hours
+        pred_op = _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=10,
+            status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=pred_end,
+        )
+        assert pred_op.id  # flush succeeded
+
+        # OP020 — the op we want to schedule too early
+        op = _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=20,
+            status="pending",
+        )
+
+        # Try to schedule OP020 starting NOW — before OP010 ends
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/schedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": now.isoformat(),
+                "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "predecessor"
+        assert data["earliest_valid_start"] is not None
+
+        # earliest_valid_start must be >= the predecessor's scheduled_end
+        earliest = datetime.fromisoformat(data["earliest_valid_start"])
+        assert earliest >= pred_end.replace(tzinfo=None) or earliest >= pred_end
+
+    def test_predecessor_violation_next_available_start_present(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """next_available_start must be present and >= earliest_valid_start."""
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        pred_end = now + timedelta(hours=2)
+
+        _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=10,
+            status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=pred_end,
+        )
+
+        op = _make_operation(
+            db,
+            po.id,
+            work_center.id,
+            sequence=20,
+            status="pending",
+        )
+
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/schedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": now.isoformat(),
+                "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["next_available_start"] is not None
+
+        earliest = datetime.fromisoformat(data["earliest_valid_start"])
+        next_avail = datetime.fromisoformat(data["next_available_start"])
+        # next_available_start must be at or after the predecessor end
+        # (normalise tz for comparison)
+        def _naive(dt):
+            return dt.replace(tzinfo=None) if dt.tzinfo else dt
+        assert _naive(next_avail) >= _naive(earliest)
+
+    def test_resource_conflict_uses_resource_conflict_type(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Pure resource conflict (no predecessors) uses conflict_type='resource'."""
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+
+        # Two separate POs so there's no predecessor relationship
+        po1 = make_production_order(product_id=product.id)
+        po2 = make_production_order(product_id=product.id)
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        # Occupy the printer for 2 hours on PO1
+        _make_operation(
+            db,
+            po1.id,
+            work_center.id,
+            sequence=10,
+            status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=2),
+        )
+
+        # Single op on PO2 — no predecessors
+        op2 = _make_operation(
+            db,
+            po2.id,
+            work_center.id,
+            sequence=10,
+            status="pending",
+        )
+
+        # Try to schedule PO2's op in the same window
+        response = client.post(
+            f"{BASE_URL}/{po2.id}/operations/{op2.id}/schedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": now.isoformat(),
+                "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "resource"
+        # No predecessor constraint
+        assert data.get("earliest_valid_start") is None

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -132,12 +132,18 @@ function PredecessorAlert({
               <span className="font-medium">{formatTime(earliestValidStart)}</span>
             </p>
           )}
-          <SlotSuggestion
-            label="Earliest valid start"
-            nextAvailableStart={nextAvailableStart}
-            nextAvailableEnd={nextAvailableEnd}
-            onUseSlot={onUseSlot}
-          />
+          {nextAvailableStart ? (
+            <SlotSuggestion
+              label="Earliest valid start"
+              nextAvailableStart={nextAvailableStart}
+              nextAvailableEnd={nextAvailableEnd}
+              onUseSlot={onUseSlot}
+            />
+          ) : (
+            <p className="text-xs text-amber-400/50 mt-2">
+              Schedule the predecessor operation first, then retry.
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -10,7 +10,29 @@ import { formatDuration, formatTime } from "../../utils/formatting";
 import Modal from "../Modal";
 
 /**
- * Conflict alert banner with next-available slot suggestion
+ * Shared slot suggestion pill — used by both conflict alert banners.
+ */
+function SlotSuggestion({ label, nextAvailableStart, nextAvailableEnd, onUseSlot }) {
+  if (!nextAvailableStart) return null;
+  return (
+    <div className="mt-3 p-2 bg-blue-500/10 border border-blue-500/30 rounded">
+      <p className="text-sm text-blue-300">
+        {label}: {formatTime(nextAvailableStart)}
+        {nextAvailableEnd ? ` – ${formatTime(nextAvailableEnd)}` : ""}
+      </p>
+      <button
+        type="button"
+        onClick={() => onUseSlot(nextAvailableStart, nextAvailableEnd)}
+        className="mt-1 text-sm text-blue-400 hover:text-blue-300 underline"
+      >
+        Use this time
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Conflict alert banner with next-available slot suggestion (resource conflicts)
  */
 function ConflictAlert({
   conflicts,
@@ -37,7 +59,7 @@ function ConflictAlert({
           />
         </svg>
         <div className="flex-1">
-          <h4 className="text-red-400 font-medium">Conflict Detected</h4>
+          <h4 className="text-red-400 font-medium">Resource Conflict</h4>
           <p className="text-sm text-red-400/70 mt-1">
             This time slot overlaps with:
           </p>
@@ -49,32 +71,73 @@ function ConflictAlert({
                 {conflict.scheduled_start && (
                   <span className="text-red-400/50">
                     {" "}
-                    ({formatTime(conflict.scheduled_start)} -{" "}
+                    ({formatTime(conflict.scheduled_start)} –{" "}
                     {formatTime(conflict.scheduled_end)})
                   </span>
                 )}
               </li>
             ))}
           </ul>
-          {nextAvailableStart ? (
-            <div className="mt-3 p-2 bg-blue-500/10 border border-blue-500/30 rounded">
-              <p className="text-sm text-blue-300">
-                Next available slot: {formatTime(nextAvailableStart)} -{" "}
-                {formatTime(nextAvailableEnd)}
-              </p>
-              <button
-                type="button"
-                onClick={() => onUseSlot(nextAvailableStart, nextAvailableEnd)}
-                className="mt-1 text-sm text-blue-400 hover:text-blue-300 underline"
-              >
-                Use suggested time
-              </button>
-            </div>
-          ) : (
+          <SlotSuggestion
+            label="Earliest available slot"
+            nextAvailableStart={nextAvailableStart}
+            nextAvailableEnd={nextAvailableEnd}
+            onUseSlot={onUseSlot}
+          />
+          {!nextAvailableStart && (
             <p className="text-xs text-red-400/50 mt-2">
               Adjust the start time or select a different resource.
             </p>
           )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Predecessor sequence violation banner with earliest-valid-start suggestion.
+ */
+function PredecessorAlert({
+  message,
+  earliestValidStart,
+  nextAvailableStart,
+  nextAvailableEnd,
+  onUseSlot,
+}) {
+  if (!message) return null;
+
+  return (
+    <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+      <div className="flex items-start gap-3">
+        <svg
+          className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <div className="flex-1">
+          <h4 className="text-amber-400 font-medium">Sequence Constraint</h4>
+          <p className="text-sm text-amber-400/70 mt-1">{message}</p>
+          {earliestValidStart && (
+            <p className="text-sm text-amber-300 mt-1">
+              Predecessor finishes:{" "}
+              <span className="font-medium">{formatTime(earliestValidStart)}</span>
+            </p>
+          )}
+          <SlotSuggestion
+            label="Earliest valid start"
+            nextAvailableStart={nextAvailableStart}
+            nextAvailableEnd={nextAvailableEnd}
+            onUseSlot={onUseSlot}
+          />
         </div>
       </div>
     </div>
@@ -182,6 +245,8 @@ export default function OperationSchedulerModal({
   const [nextAvailableStart, setNextAvailableStart] = useState(null);
   const [nextAvailableEnd, setNextAvailableEnd] = useState(null);
   const [serverConflicts, setServerConflicts] = useState([]);
+  // Predecessor-specific conflict state
+  const [predecessorConflict, setPredecessorConflict] = useState(null); // { message, earliestValidStart }
   const [justScheduled, setJustScheduled] = useState(null); // op code of just-scheduled op
   const [nextPendingOp, setNextPendingOp] = useState(null); // next op to schedule
   // Defensive: keep modal alive even if parent unmounts/remounts during conflicts
@@ -356,6 +421,7 @@ export default function OperationSchedulerModal({
     setServerConflicts([]);
     setNextAvailableStart(null);
     setNextAvailableEnd(null);
+    setPredecessorConflict(null);
   };
 
   const handleSubmit = async (e) => {
@@ -410,7 +476,18 @@ export default function OperationSchedulerModal({
 
       if (data.success === false) {
         setForceOpen(true);
-        setServerConflicts(data.conflicts || []);
+        if (data.conflict_type === "predecessor") {
+          // Predecessor sequence violation — show amber banner with earliest-valid-start
+          setPredecessorConflict({
+            message: data.message,
+            earliestValidStart: data.earliest_valid_start,
+          });
+          setServerConflicts([]);
+        } else {
+          // Resource conflict — show red banner with conflicting ops
+          setServerConflicts(data.conflicts || []);
+          setPredecessorConflict(null);
+        }
         if (data.next_available_start) {
           setNextAvailableStart(data.next_available_start);
           setNextAvailableEnd(data.next_available_end);
@@ -452,6 +529,7 @@ export default function OperationSchedulerModal({
       setEndTime(new Date(suggestedEnd).toISOString().slice(0, 16));
     }
     setServerConflicts([]);
+    setPredecessorConflict(null);
     setNextAvailableStart(null);
     setNextAvailableEnd(null);
     setError(null);
@@ -473,7 +551,7 @@ export default function OperationSchedulerModal({
   // user needs to explicitly resolve or dismiss them, not lose their work
   // by accidentally clicking outside.
   const handleAutoClose = () => {
-    if (serverConflicts.length > 0 || conflicts.length > 0 || error || compatWarning) {
+    if (serverConflicts.length > 0 || conflicts.length > 0 || predecessorConflict || error || compatWarning) {
       return;
     }
     handleClose();
@@ -613,23 +691,36 @@ export default function OperationSchedulerModal({
             {/* Compatibility warning */}
             <CompatibilityWarning reason={compatWarning} />
 
-            {/* Conflict alert (live check) */}
-            {checking ? (
-              <div className="text-sm text-gray-500 flex items-center gap-2">
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
-                Checking for conflicts...
-              </div>
-            ) : (
-              <ConflictAlert
-                conflicts={conflicts?.length > 0 ? conflicts : serverConflicts}
+            {/* Predecessor sequence violation banner */}
+            {predecessorConflict && (
+              <PredecessorAlert
+                message={predecessorConflict.message}
+                earliestValidStart={predecessorConflict.earliestValidStart}
                 nextAvailableStart={nextAvailableStart}
                 nextAvailableEnd={nextAvailableEnd}
                 onUseSlot={handleUseSuggestedSlot}
               />
             )}
 
-            {/* Error message */}
-            {error && (
+            {/* Resource conflict alert (live check or server response) */}
+            {!predecessorConflict && (
+              checking ? (
+                <div className="text-sm text-gray-500 flex items-center gap-2">
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
+                  Checking for conflicts...
+                </div>
+              ) : (
+                <ConflictAlert
+                  conflicts={conflicts?.length > 0 ? conflicts : serverConflicts}
+                  nextAvailableStart={nextAvailableStart}
+                  nextAvailableEnd={nextAvailableEnd}
+                  onUseSlot={handleUseSuggestedSlot}
+                />
+              )
+            )}
+
+            {/* Error message (only for non-conflict errors) */}
+            {error && !predecessorConflict && !serverConflicts.length && (
               <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
                 <p className="text-red-400 text-sm">{error}</p>
               </div>

--- a/frontend/src/components/production/__tests__/OperationSchedulerModal.test.jsx
+++ b/frontend/src/components/production/__tests__/OperationSchedulerModal.test.jsx
@@ -8,24 +8,38 @@
  *     message and the end-time field label changes to "(enter manually)".
  *  3. Manual end time satisfies submit validation (no "fill in all required fields"
  *     error when both startTime and endTime are present).
+ *  4. Predecessor conflict — amber "Sequence Constraint" banner with "Use this
+ *     time" button; clicking it sets the start field and clears the banner.
  */
 import { render, screen, fireEvent, act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import OperationSchedulerModal from '../OperationSchedulerModal'
 
-// Stub hooks that make network calls
+// ---------------------------------------------------------------------------
+// Module-level mutable state — lets individual tests inject custom resource
+// lists while sharing a single hoisted vi.mock call.
+// ---------------------------------------------------------------------------
+let _mockResources = []
+let _mockConflicts = []
+let _mockChecking = false
+let _mockHasConflicts = false
+
 vi.mock('../../../hooks/useResources', () => ({
-  useResources: () => ({ resources: [], loading: false, error: null }),
+  useResources: () => ({ resources: _mockResources, loading: false, error: null }),
   useResourceConflicts: () => ({
-    conflicts: [],
-    checking: false,
+    conflicts: _mockConflicts,
+    checking: _mockChecking,
     error: null,
-    hasConflicts: false,
+    hasConflicts: _mockHasConflicts,
   }),
 }))
 
 // Silence fetch calls the component may fire (compat check, next-available, etc.)
 beforeEach(() => {
+  _mockResources = []
+  _mockConflicts = []
+  _mockChecking = false
+  _mockHasConflicts = false
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }))
   vi.useFakeTimers({ shouldAdvanceTime: true })
 })
@@ -58,6 +72,19 @@ const zeroDurationOp = {
   resource_id: null,
   planned_setup_minutes: null,
   planned_run_minutes: null,
+  status: 'pending',
+}
+
+// An op in a PO with a predecessor — used for conflict tests
+const secondOp = {
+  id: 44,
+  sequence: 20,
+  operation_code: 'POST',
+  operation_name: 'Post-processing',
+  work_center_id: 1,
+  resource_id: null,
+  planned_setup_minutes: '5.00',
+  planned_run_minutes: '88.00',
   status: 'pending',
 }
 
@@ -177,5 +204,113 @@ describe('OperationSchedulerModal — validation accepts manual end time', () =>
       // Confirm it's a resource-missing error, not end-time-missing
       expect(screen.queryByText(/NaN/)).not.toBeInTheDocument()
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Predecessor conflict — amber "Sequence Constraint" banner
+// ---------------------------------------------------------------------------
+describe('OperationSchedulerModal — predecessor conflict suggestion', () => {
+  const PRINTER = { id: 7, code: 'PRINTER-01', name: 'Bambu X1C', is_printer: true }
+
+  const nextStart = '2026-06-11T18:00:00Z'
+  const nextEnd   = '2026-06-11T19:33:00Z'
+  const earliest  = '2026-06-11T17:30:00Z'
+
+  function stubPredecessorConflict() {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      // Compatibility check → ok, compatible
+      if (typeof url === 'string' && url.includes('check-resource-compatibility')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ compatible: true, reason: null }),
+        })
+      }
+      // next-available → stub a start time
+      if (typeof url === 'string' && url.includes('next-available')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ next_available: nextStart, suggested_end: nextEnd }),
+        })
+      }
+      // Schedule endpoint → predecessor conflict
+      if (typeof url === 'string' && url.includes('/schedule') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            success: false,
+            conflict_type: 'predecessor',
+            message: 'Operation 10 (3D Print) must finish before this operation can start',
+            earliest_valid_start: earliest,
+            next_available_start: nextStart,
+            next_available_end: nextEnd,
+            conflicts: [],
+          }),
+        })
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) })
+    }))
+  }
+
+  it('renders Sequence Constraint banner with "Use this time" after predecessor conflict', async () => {
+    // Provide a resource so the select has an option and submit can reach fetch
+    _mockResources = [PRINTER]
+    stubPredecessorConflict()
+
+    await act(async () => { renderModal(secondOp) })
+    await act(async () => { vi.runAllTimers() })
+
+    // Select the resource
+    const select = screen.getByRole('combobox')
+    await act(async () => {
+      fireEvent.change(select, { target: { value: String(PRINTER.id) } })
+    })
+    await act(async () => { vi.runAllTimers() })
+
+    // Submit the form
+    const submitBtn = screen.getByRole('button', { name: /^Schedule$/i })
+    await act(async () => { fireEvent.click(submitBtn) })
+    await act(async () => { vi.runAllTimers() })
+
+    // Amber banner heading must appear
+    expect(screen.getByText('Sequence Constraint')).toBeInTheDocument()
+    // "Use this time" suggestion button must appear
+    expect(screen.getByRole('button', { name: /Use this time/i })).toBeInTheDocument()
+  })
+
+  it('"Use this time" sets the start-time input and clears the Sequence Constraint banner', async () => {
+    _mockResources = [PRINTER]
+    stubPredecessorConflict()
+
+    await act(async () => { renderModal(secondOp) })
+    await act(async () => { vi.runAllTimers() })
+
+    const select = screen.getByRole('combobox')
+    await act(async () => {
+      fireEvent.change(select, { target: { value: String(PRINTER.id) } })
+    })
+    await act(async () => { vi.runAllTimers() })
+
+    const submitBtn = screen.getByRole('button', { name: /^Schedule$/i })
+    await act(async () => { fireEvent.click(submitBtn) })
+    await act(async () => { vi.runAllTimers() })
+
+    // Banner visible
+    expect(screen.getByText('Sequence Constraint')).toBeInTheDocument()
+
+    // Click "Use this time"
+    const useBtn = screen.getByRole('button', { name: /Use this time/i })
+    await act(async () => { fireEvent.click(useBtn) })
+
+    // Banner must clear
+    expect(screen.queryByText('Sequence Constraint')).not.toBeInTheDocument()
+
+    // A datetime-local input must have a non-empty value (the suggested start).
+    // datetime-local inputs are not matched by role "textbox" in jsdom — query
+    // by display value pattern instead.
+    const filledInputs = screen.getAllByDisplayValue(/.+/)
+    const dtInput = filledInputs.find((el) => el.type === 'datetime-local')
+    expect(dtInput).toBeDefined()
+    expect(dtInput.value).not.toBe('')
   })
 })


### PR DESCRIPTION
## Summary

- **Backend**: `ScheduleOperationResponse` gains `conflict_type` (`"predecessor"` | `"resource"`) and `earliest_valid_start` (the latest predecessor `scheduled_end`, i.e. the absolute floor). Both fields are populated on `SequenceError`; resource-conflict path gains `conflict_type="resource"`.
- **Frontend**: New `PredecessorAlert` component (amber banner) mirrors the existing `ConflictAlert` red banner pattern. When `conflict_type === "predecessor"`, the modal routes to the amber banner showing the predecessor's finish time (formatted local via `formatTime`) and an "Earliest valid start: [time] — [Use this time]" button. Clicking it sets `startTime` and clears the banner — identical UX to the resource-conflict suggestion. Raw UTC strings are removed from the backend message; all time formatting happens client-side via `formatTime`.
- **Tests**: 3 new backend tests verify `conflict_type` and `earliest_valid_start ≥ predecessor_end` for predecessor violations, and `conflict_type="resource"` for pure resource conflicts. 2 new frontend tests verify the amber banner renders after a predecessor response and that "Use this time" populates the field and clears the banner.

## Test plan
- [ ] All 353 frontend unit tests pass (`npm run test:unit`)
- [ ] Frontend build clean (`vite build` zero errors/warnings)
- [ ] Ruff clean on changed backend files
- [ ] Backend tests pass in CI (`filaops_test` DB required)
- [ ] Manual: schedule an op before its predecessor finishes → amber banner with "Use this time" button appears, clicking it sets the start field, re-submitting succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now distinguishes predecessor vs resource scheduling conflicts and returns conflict_type plus predecessor timing suggestions when applicable.
  * Modal supports a "Sequence Constraint" predecessor mode with a suggested slot and "Use this time" action.

* **Bug Fixes**
  * Simplified predecessor violation messaging.

* **UI Improvements**
  * Conflict banners and time-suggestion pill updated; predecessor banner suppresses resource banner when shown.

* **Tests**
  * Expanded backend and frontend tests for predecessor and resource conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->