### PR TITLE
feat: SCHED-2 — reschedule & unschedule operations; modal edit mode

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -5,7 +5,7 @@ Manufacturing Orders (MOs) for tracking production of finished goods.
 Supports creation from sales orders, manual entry, and MRP planning.
 """
 from typing import Annotated, List, Optional
-from datetime import date
+from datetime import date, datetime, timezone, timedelta
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -23,6 +23,7 @@ from app.models.production_order import (
 )
 from app.models.work_center import WorkCenter
 from app.models.manufacturing import Resource
+from app.models.printer import Printer
 from app.schemas.production_order import (
     ProductionOrderCreate,
     ProductionOrderUpdate,
@@ -66,8 +67,23 @@ from app.core.status_config import (
     get_allowed_production_order_transitions,
 )
 from app.schemas.blocking_issues import ProductionOrderBlockingIssues
+from app.schemas.resource_scheduling import (
+    RescheduleRequest,
+    RescheduleResponse,
+    UnscheduleResponse,
+    ConflictInfo,
+    SuccessorConflictInfo,
+)
 from app.services.blocking_issues import get_production_order_blocking_issues
 from app.services import production_order_service
+from app.services.resource_scheduling import (
+    find_conflicts,
+    find_next_available_slot,
+    check_predecessor_scheduling,
+    check_successor_scheduling,
+    get_earliest_start_after_predecessors,
+    TERMINAL_STATUSES,
+)
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -817,6 +833,388 @@ async def get_work_center_queues(
         )
         for q in queues
     ]
+
+
+# =============================================================================
+# Reschedule / Unschedule  (SCHED-2)
+# =============================================================================
+
+#: Statuses that allow reschedule / unschedule (op must not have started).
+_RESCHEDULABLE_STATUSES = frozenset({"pending", "queued"})
+
+#: Default duration (minutes) when an operation has no planned time data.
+_DEFAULT_DURATION_MINUTES = 120
+
+
+def _get_op_duration_minutes(op: ProductionOrderOperation) -> int:
+    """Return the best-available estimated duration for an operation."""
+    setup = float(op.planned_setup_minutes or 0)
+    run = float(op.planned_run_minutes or 0)
+    total = setup + run
+    return int(total) if total > 0 else _DEFAULT_DURATION_MINUTES
+
+
+def _append_po_note(order: ProductionOrder, note: str) -> None:
+    """
+    Append a timestamped note to production order notes.
+
+    Reuses the same pattern as production_order_service.complete_production_order
+    and accept_short_production_order — timestamp prefix, newline separator.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    if order.notes:
+        order.notes = f"{order.notes}\n[{ts}] {note}"
+    else:
+        order.notes = f"[{ts}] {note}"
+
+
+@router.post(
+    "/{order_id}/operations/{op_id}/reschedule",
+    response_model=RescheduleResponse,
+    status_code=200,
+)
+async def reschedule_operation(
+    order_id: int,
+    op_id: int,
+    request: RescheduleRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> RescheduleResponse:
+    """
+    Reschedule a scheduled operation — move it to a new resource and/or time.
+
+    **Allowed statuses**: ``pending`` or ``queued`` (not yet started).
+
+    At least one of ``resource_id`` or ``scheduled_start`` must be provided.
+    ``scheduled_end`` is optional; if omitted it is recomputed from the
+    operation's planned duration (setup + run, defaulting to 120 min).
+
+    Validates:
+    1. Resource / printer exists (when provided).
+    2. No time conflicts on the target resource (``exclude_operation_id`` so
+       the operation doesn't conflict with its own current slot).
+    3. Predecessor sequence constraints (lower-sequence sibling ops).
+    4. Successor implications — if moving this op later would violate a
+       SUCCESSOR's existing scheduled_start, surfaces a 400 with
+       ``conflict_type="successor"`` + per-successor ``earliest_valid_start``
+       so the operator can fix the succession order.
+
+    On success: writes an audit note to the production order's notes field and
+    returns the new scheduled times.
+    """
+    # --- Validate PO + op ---
+    po = db.get(ProductionOrder, order_id)
+    if not po:
+        raise HTTPException(status_code=404, detail="Production order not found")
+
+    op = db.get(ProductionOrderOperation, op_id)
+    if not op:
+        raise HTTPException(status_code=404, detail="Operation not found")
+    if op.production_order_id != order_id:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Operation {op_id} does not belong to production order {order_id}",
+        )
+
+    if op.status not in _RESCHEDULABLE_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Operation {op_id} has status '{op.status}'; "
+                f"only pending/queued operations can be rescheduled"
+            ),
+        )
+
+    # --- At least one change required ---
+    if request.resource_id is None and request.scheduled_start is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide at least one of resource_id or scheduled_start",
+        )
+
+    # --- Resolve target resource / printer ---
+    # Start from the operation's current values and overlay the request.
+    new_resource_id: Optional[int] = request.resource_id
+    is_printer: bool = request.is_printer if request.is_printer is not None else False
+
+    if new_resource_id is None:
+        # Keep current resource / printer
+        if op.printer_id is not None:
+            new_resource_id = op.printer_id
+            is_printer = True
+        elif op.resource_id is not None:
+            new_resource_id = op.resource_id
+            is_printer = False
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="Operation has no current resource; provide resource_id",
+            )
+    else:
+        # Validate the supplied resource exists
+        if is_printer:
+            res_obj = db.get(Printer, new_resource_id)
+            if not res_obj:
+                raise HTTPException(status_code=404, detail="Printer not found")
+        else:
+            res_obj = db.get(Resource, new_resource_id)
+            if not res_obj:
+                raise HTTPException(status_code=404, detail="Resource not found")
+
+    # --- Resolve start / end times ---
+    duration_minutes = _get_op_duration_minutes(op)
+
+    if request.scheduled_start is not None:
+        new_start = request.scheduled_start
+    else:
+        # Keep current start
+        if op.scheduled_start is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Operation has no current start time; provide scheduled_start",
+            )
+        new_start = op.scheduled_start
+        # Normalize naive DB timestamp to UTC-aware
+        if new_start.tzinfo is None:
+            new_start = new_start.replace(tzinfo=timezone.utc)
+
+    if request.scheduled_end is not None:
+        new_end = request.scheduled_end
+    else:
+        new_end = new_start + timedelta(minutes=duration_minutes)
+
+    if new_end <= new_start:
+        raise HTTPException(
+            status_code=422,
+            detail="scheduled_end must be after scheduled_start",
+        )
+
+    # --- Conflict check (exclude self so we don't block on our own current slot) ---
+    resource_conflicts = find_conflicts(
+        db=db,
+        resource_id=new_resource_id,
+        start_time=new_start,
+        end_time=new_end,
+        exclude_operation_id=op_id,
+        is_printer=is_printer,
+    )
+
+    if resource_conflicts:
+        earliest = get_earliest_start_after_predecessors(
+            db=db, operation=op, after=new_start
+        )
+        next_start = find_next_available_slot(
+            db=db,
+            resource_id=new_resource_id,
+            duration_minutes=duration_minutes,
+            after=earliest,
+            is_printer=is_printer,
+        )
+        conflict_details = [
+            ConflictInfo(
+                operation_id=c.id,
+                production_order_id=c.production_order_id,
+                production_order_code=c.production_order.code if c.production_order else None,
+                operation_code=c.operation_code,
+                scheduled_start=c.scheduled_start,
+                scheduled_end=c.scheduled_end,
+            )
+            for c in resource_conflicts
+        ]
+        return RescheduleResponse(
+            success=False,
+            message=f"Scheduling conflict with {len(resource_conflicts)} existing operation(s)",
+            conflicts=conflict_details,
+            conflict_type="resource",
+            next_available_start=next_start,
+            next_available_end=next_start + timedelta(minutes=duration_minutes),
+        )
+
+    # --- Predecessor check ---
+    try:
+        seq_error = check_predecessor_scheduling(db, op, new_start)
+    except Exception:
+        seq_error = None  # never raises in current impl; guard for safety
+
+    if seq_error:
+        # Check if any predecessor is unscheduled
+        has_unscheduled_pred = (
+            db.query(ProductionOrderOperation.id)
+            .filter(
+                ProductionOrderOperation.production_order_id == op.production_order_id,
+                ProductionOrderOperation.sequence < op.sequence,
+                ProductionOrderOperation.id != op.id,
+                ProductionOrderOperation.status.notin_(list(TERMINAL_STATUSES)),
+                ProductionOrderOperation.scheduled_end.is_(None),
+            )
+            .first()
+        ) is not None
+
+        earliest = None
+        next_start = None
+        if not has_unscheduled_pred:
+            earliest = get_earliest_start_after_predecessors(
+                db=db, operation=op, after=new_start
+            )
+            next_start = find_next_available_slot(
+                db=db,
+                resource_id=new_resource_id,
+                duration_minutes=duration_minutes,
+                after=earliest,
+                is_printer=is_printer,
+            )
+        return RescheduleResponse(
+            success=False,
+            message=seq_error,
+            conflicts=[],
+            conflict_type="predecessor",
+            earliest_valid_start=earliest,
+            next_available_start=next_start,
+            next_available_end=(
+                next_start + timedelta(minutes=duration_minutes)
+                if next_start is not None else None
+            ),
+        )
+
+    # --- Successor implication check ---
+    successor_violations = check_successor_scheduling(db, op, new_end)
+    if successor_violations:
+        succ_details = [
+            SuccessorConflictInfo(
+                operation_id=s.id,
+                operation_code=s.operation_code,
+                operation_name=s.operation_name,
+                sequence=s.sequence,
+                scheduled_start=s.scheduled_start,
+                earliest_valid_start=new_end,
+            )
+            for s in successor_violations
+        ]
+        return RescheduleResponse(
+            success=False,
+            message=(
+                f"Moving this operation would violate {len(successor_violations)} "
+                f"successor operation(s) that are already scheduled"
+            ),
+            conflict_type="successor",
+            successor_conflicts=succ_details,
+        )
+
+    # --- Apply the reschedule ---
+    old_resource_desc = (
+        f"printer_id={op.printer_id}" if op.printer_id
+        else f"resource_id={op.resource_id}"
+    )
+    old_start_str = (
+        op.scheduled_start.isoformat() if op.scheduled_start else "unscheduled"
+    )
+
+    if is_printer:
+        op.printer_id = new_resource_id
+        op.resource_id = None
+    else:
+        op.resource_id = new_resource_id
+        op.printer_id = None
+
+    op.scheduled_start = new_start
+    op.scheduled_end = new_end
+    if op.status == "pending":
+        op.status = "queued"
+
+    # Audit trail — append a timestamped note to the production order
+    new_resource_desc = f"printer_id={new_resource_id}" if is_printer else f"resource_id={new_resource_id}"
+    _append_po_note(
+        po,
+        f"Operation {op.sequence} ({op.operation_code}) rescheduled by "
+        f"{current_user.email}: "
+        f"{old_resource_desc} {old_start_str} → "
+        f"{new_resource_desc} {new_start.isoformat()}",
+    )
+
+    db.flush()
+    db.commit()
+
+    return RescheduleResponse(
+        success=True,
+        operation_id=op_id,
+        scheduled_start=op.scheduled_start,
+        scheduled_end=op.scheduled_end,
+    )
+
+
+@router.post(
+    "/{order_id}/operations/{op_id}/unschedule",
+    response_model=UnscheduleResponse,
+    status_code=200,
+)
+async def unschedule_operation(
+    order_id: int,
+    op_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> UnscheduleResponse:
+    """
+    Unschedule an operation — clear its times and resource, return to pending.
+
+    **Allowed statuses**: ``pending`` or ``queued`` (not yet started).
+
+    Writes an audit note to the production order's notes field.
+    """
+    po = db.get(ProductionOrder, order_id)
+    if not po:
+        raise HTTPException(status_code=404, detail="Production order not found")
+
+    op = db.get(ProductionOrderOperation, op_id)
+    if not op:
+        raise HTTPException(status_code=404, detail="Operation not found")
+    if op.production_order_id != order_id:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Operation {op_id} does not belong to production order {order_id}",
+        )
+
+    if op.status not in _RESCHEDULABLE_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Operation {op_id} has status '{op.status}'; "
+                f"only pending/queued operations can be unscheduled"
+            ),
+        )
+
+    old_resource_desc = (
+        f"printer_id={op.printer_id}" if op.printer_id
+        else (f"resource_id={op.resource_id}" if op.resource_id else "no resource")
+    )
+    old_start_str = (
+        op.scheduled_start.isoformat() if op.scheduled_start else "unscheduled"
+    )
+
+    # Clear schedule
+    op.scheduled_start = None
+    op.scheduled_end = None
+    op.resource_id = None
+    op.printer_id = None
+    op.status = "pending"
+
+    # Audit trail
+    _append_po_note(
+        po,
+        f"Operation {op.sequence} ({op.operation_code}) unscheduled by "
+        f"{current_user.email}: cleared {old_resource_desc} @ {old_start_str}",
+    )
+
+    db.flush()
+    db.commit()
+
+    return UnscheduleResponse(
+        success=True,
+        operation_id=op_id,
+        message=(
+            f"Operation {op.sequence} ({op.operation_code}) unscheduled; "
+            f"returned to pending"
+        ),
+    )
 
 
 # =============================================================================

--- a/backend/app/schemas/resource_scheduling.py
+++ b/backend/app/schemas/resource_scheduling.py
@@ -86,3 +86,66 @@ class NextAvailableSlotResponse(BaseModel):
     """Response with next available time slot."""
     next_available: datetime
     suggested_end: datetime  # Based on requested duration
+
+
+# ---------------------------------------------------------------------------
+# SCHED-2: Reschedule / Unschedule
+# ---------------------------------------------------------------------------
+
+class RescheduleRequest(BaseModel):
+    """
+    Request body for POST .../reschedule.
+
+    At least one of resource_id or scheduled_start must be provided.
+    scheduled_end is optional — if omitted the endpoint recomputes it from
+    the operation's planned duration (setup + run minutes, defaulting to
+    120 min when not set).
+    """
+
+    resource_id: Optional[int] = None
+    is_printer: Optional[bool] = None  # True when resource_id refers to a Printer
+    scheduled_start: Optional[datetime] = None
+    scheduled_end: Optional[datetime] = None
+
+
+class SuccessorConflictInfo(BaseModel):
+    """A successor operation whose existing schedule would be violated."""
+
+    operation_id: int
+    operation_code: Optional[str] = None
+    operation_name: Optional[str] = None
+    sequence: int
+    scheduled_start: Optional[datetime] = None
+    # earliest_valid_start = the proposed reschedule end — the soonest the
+    # successor can now validly start, mirroring the predecessor-conflict shape.
+    earliest_valid_start: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class RescheduleResponse(BaseModel):
+    """Response from a reschedule operation."""
+
+    success: bool
+    operation_id: Optional[int] = None
+    scheduled_start: Optional[datetime] = None
+    scheduled_end: Optional[datetime] = None
+    message: Optional[str] = None
+    # Conflict fields — same shape as ScheduleOperationResponse so the modal
+    # can reuse its existing conflict/suggestion affordances.
+    conflicts: List[ConflictInfo] = Field(default_factory=list)
+    conflict_type: Optional[Literal["predecessor", "resource", "successor"]] = None
+    earliest_valid_start: Optional[datetime] = None
+    next_available_start: Optional[datetime] = None
+    next_available_end: Optional[datetime] = None
+    # Successor violations (when conflict_type == "successor")
+    successor_conflicts: List[SuccessorConflictInfo] = Field(default_factory=list)
+
+
+class UnscheduleResponse(BaseModel):
+    """Response from an unschedule operation."""
+
+    success: bool
+    operation_id: int
+    message: str

--- a/backend/app/services/resource_scheduling.py
+++ b/backend/app/services/resource_scheduling.py
@@ -342,6 +342,50 @@ def get_earliest_start_after_predecessors(
     return earliest
 
 
+def check_successor_scheduling(
+    db: Session,
+    operation: ProductionOrderOperation,
+    scheduled_end: datetime,
+) -> Optional[List["ProductionOrderOperation"]]:
+    """
+    Check that moving this operation's end time doesn't violate any SUCCESSOR's
+    existing scheduled start.
+
+    A successor is any higher-sequence sibling on the same PO that:
+    - Is NOT in a terminal status, AND
+    - Has an existing scheduled_start set (is already scheduled), AND
+    - Its scheduled_start < our new scheduled_end  (i.e. we'd push past it)
+
+    Returns:
+        None if no violations, or a list of impacted successor operations.
+
+    Note: this is a WARNING surface — the endpoint converts these into a 400
+    with successor conflict details + earliest_valid_start so the operator can
+    fix the successor scheduling order.
+    """
+    successors = db.query(ProductionOrderOperation).filter(
+        ProductionOrderOperation.production_order_id == operation.production_order_id,
+        ProductionOrderOperation.sequence > operation.sequence,
+        ProductionOrderOperation.id != operation.id,
+        ProductionOrderOperation.status.notin_(TERMINAL_STATUSES),
+        ProductionOrderOperation.scheduled_start.isnot(None),
+    ).order_by(ProductionOrderOperation.sequence).all()
+
+    violated: List[ProductionOrderOperation] = []
+    for succ in successors:
+        succ_start = succ.scheduled_start
+        end = scheduled_end
+        # Normalize timezone — DB stores naive UTC, caller may pass tz-aware
+        if succ_start.tzinfo is None and end.tzinfo is not None:
+            succ_start = succ_start.replace(tzinfo=timezone.utc)
+        elif succ_start.tzinfo is not None and end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        if end > succ_start:
+            violated.append(succ)
+
+    return violated if violated else None
+
+
 def schedule_operation(
     db: Session,
     operation: ProductionOrderOperation,

--- a/backend/tests/api/v1/test_reschedule_unschedule.py
+++ b/backend/tests/api/v1/test_reschedule_unschedule.py
@@ -1,0 +1,517 @@
+"""
+Tests for SCHED-2: reschedule and unschedule operation endpoints.
+
+POST /api/v1/production-orders/{id}/operations/{op_id}/reschedule
+POST /api/v1/production-orders/{id}/operations/{op_id}/unschedule
+
+Coverage:
+- reschedule validates conflicts excluding self
+- predecessor violation surfaces with earliest_valid_start
+- successor violation surfaces with per-successor earliest_valid_start
+- unschedule only works for pre-start statuses
+- audit notes written on both actions
+- endpoints require authentication (401 when not logged in)
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrderOperation
+
+BASE_URL = "/api/v1/production-orders"
+
+
+def _uid():
+    return uuid.uuid4().hex[:6]
+
+
+def _make_printer(db, work_center_id, status="idle"):
+    uid = _uid()
+    printer = Printer(
+        code=f"PRT-{uid}",
+        name=f"Test Printer {uid}",
+        model="X1C",
+        brand="bambulab",
+        work_center_id=work_center_id,
+        status=status,
+        active=True,
+    )
+    db.add(printer)
+    db.flush()
+    return printer
+
+
+def _make_operation(db, production_order_id, work_center_id, sequence=10, status="pending", **kwargs):
+    operation = ProductionOrderOperation(
+        production_order_id=production_order_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_code=kwargs.pop("operation_code", f"OP-{sequence}"),
+        operation_name=kwargs.pop("operation_name", f"Op-{sequence}"),
+        planned_run_minutes=kwargs.pop("planned_run_minutes", 60),
+        status=status,
+        **kwargs,
+    )
+    db.add(operation)
+    db.flush()
+    return operation
+
+
+# ---------------------------------------------------------------------------
+# Authentication guard
+# ---------------------------------------------------------------------------
+
+class TestRescheduleAuth:
+    def test_reschedule_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(
+            f"{BASE_URL}/1/operations/1/reschedule",
+            json={"scheduled_start": datetime.now(timezone.utc).isoformat()},
+        )
+        assert resp.status_code == 401
+
+    def test_unschedule_requires_auth(self, unauthed_client):
+        resp = unauthed_client.post(f"{BASE_URL}/1/operations/1/unschedule")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Reschedule — happy path
+# ---------------------------------------------------------------------------
+
+class TestRescheduleHappy:
+    def test_reschedule_move_to_new_start(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Rescheduling an already-queued op to a new start time succeeds."""
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        new_start = now + timedelta(hours=4)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/reschedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": new_start.isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["operation_id"] == op.id
+        assert "scheduled_start" in data
+
+    def test_reschedule_writes_audit_note(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Rescheduling appends a timestamped note to production order notes."""
+        from app.models.production_order import ProductionOrder
+
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        new_start = now + timedelta(hours=6)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/reschedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": new_start.isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        db.expire_all()
+        refreshed_po = db.get(ProductionOrder, po.id)
+        assert refreshed_po.notes is not None
+        assert "rescheduled" in refreshed_po.notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# Reschedule — conflict: excludes self
+# ---------------------------------------------------------------------------
+
+class TestRescheduleExcludesSelf:
+    def test_rescheduling_to_same_slot_does_not_self_conflict(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """
+        Rescheduling op to the same time slot on the same printer must not
+        report a conflict with itself.  (exclude_operation_id must be passed.)
+        """
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        # "Reschedule" to the same slot — should succeed (no self-conflict)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/reschedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": now.isoformat(),
+                "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["success"] is True
+
+    def test_reschedule_into_another_ops_slot_returns_conflict(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """
+        Moving op into a slot occupied by a DIFFERENT op on the same printer
+        must return success=False with conflict_type="resource".
+        """
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        po2 = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        # op1 on printer, scheduled 1h from now
+        op1 = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now + timedelta(hours=1),
+            scheduled_end=now + timedelta(hours=2),
+        )
+
+        # op2 on po2 — initially pending
+        op2 = _make_operation(
+            db, po2.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        # Try to move op2 into op1's slot
+        resp = client.post(
+            f"{BASE_URL}/{po2.id}/operations/{op2.id}/reschedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": (now + timedelta(hours=1)).isoformat(),
+                "scheduled_end": (now + timedelta(hours=2)).isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "resource"
+        assert len(data["conflicts"]) > 0
+        assert data["conflicts"][0]["operation_id"] == op1.id
+
+
+# ---------------------------------------------------------------------------
+# Reschedule — predecessor violation
+# ---------------------------------------------------------------------------
+
+class TestReschedulePredecessorViolation:
+    def test_predecessor_violation_returns_earliest_valid_start(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """
+        Rescheduling OP020 to start before OP010 ends returns conflict_type=predecessor
+        and earliest_valid_start >= pred scheduled_end.
+        """
+        wc = make_work_center()
+        printer_a = _make_printer(db, wc.id)
+        printer_b = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        pred_end = now + timedelta(hours=3)
+
+        # OP010 — predecessor, scheduled on printer_a
+        _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer_a.id,
+            scheduled_start=now,
+            scheduled_end=pred_end,
+        )
+
+        # OP020 — needs to start BEFORE pred_end → predecessor violation
+        op2 = _make_operation(
+            db, po.id, wc.id,
+            sequence=20, status="queued",
+            printer_id=printer_b.id,
+            scheduled_start=pred_end,
+            scheduled_end=pred_end + timedelta(hours=1),
+        )
+        db.commit()
+
+        # Try to move OP020 to start 1h from now (before pred ends at +3h)
+        too_early = now + timedelta(hours=1)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op2.id}/reschedule",
+            json={
+                "resource_id": printer_b.id,
+                "is_printer": True,
+                "scheduled_start": too_early.isoformat(),
+                "scheduled_end": (too_early + timedelta(hours=1)).isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "predecessor"
+        # earliest_valid_start is present and >= pred_end
+        assert data["earliest_valid_start"] is not None
+        evs = datetime.fromisoformat(data["earliest_valid_start"])
+        if evs.tzinfo is None:
+            evs = evs.replace(tzinfo=timezone.utc)
+        assert evs >= pred_end
+
+
+# ---------------------------------------------------------------------------
+# Reschedule — successor violation
+# ---------------------------------------------------------------------------
+
+class TestRescheduleSuccessorViolation:
+    def test_successor_violation_surfaces_with_earliest_valid_start(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """
+        Moving OP010 later so it now overlaps OP020's existing scheduled_start
+        returns conflict_type=successor with per-successor earliest_valid_start.
+        """
+        wc = make_work_center()
+        printer_a = _make_printer(db, wc.id)
+        printer_b = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        # OP010 — currently scheduled 0→1h on printer_a
+        op1 = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer_a.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+
+        # OP020 — successor, scheduled 1h→2h on printer_b
+        op2 = _make_operation(
+            db, po.id, wc.id,
+            sequence=20, status="queued",
+            printer_id=printer_b.id,
+            scheduled_start=now + timedelta(hours=1),
+            scheduled_end=now + timedelta(hours=2),
+        )
+        db.commit()
+
+        # Try to move OP010 to 0.5h→1.5h — its new end (1.5h) > OP020 start (1h)
+        new_start = now + timedelta(minutes=30)
+        new_end = now + timedelta(hours=1, minutes=30)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op1.id}/reschedule",
+            json={
+                "resource_id": printer_a.id,
+                "is_printer": True,
+                "scheduled_start": new_start.isoformat(),
+                "scheduled_end": new_end.isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is False
+        assert data["conflict_type"] == "successor"
+        assert len(data["successor_conflicts"]) > 0
+        sc = data["successor_conflicts"][0]
+        assert sc["operation_id"] == op2.id
+        # earliest_valid_start for the successor == our proposed new_end
+        assert sc["earliest_valid_start"] is not None
+        evs = datetime.fromisoformat(sc["earliest_valid_start"])
+        if evs.tzinfo is None:
+            evs = evs.replace(tzinfo=timezone.utc)
+        assert evs == new_end
+
+
+# ---------------------------------------------------------------------------
+# Unschedule — happy path
+# ---------------------------------------------------------------------------
+
+class TestUnscheduleHappy:
+    def test_unschedule_queued_op_returns_to_pending(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Unscheduling a queued op clears times + resource and returns to pending."""
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        resp = client.post(f"{BASE_URL}/{po.id}/operations/{op.id}/unschedule")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+
+        db.expire_all()
+        db.refresh(op)
+        assert op.status == "pending"
+        assert op.scheduled_start is None
+        assert op.scheduled_end is None
+        assert op.printer_id is None
+        assert op.resource_id is None
+
+    def test_unschedule_pending_op_succeeds(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Unscheduling a pending (already unscheduled) op also succeeds."""
+        wc = make_work_center()
+        po = make_production_order(product_id=make_product().id)
+
+        op = _make_operation(db, po.id, wc.id, sequence=10, status="pending")
+        db.commit()
+
+        resp = client.post(f"{BASE_URL}/{po.id}/operations/{op.id}/unschedule")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["success"] is True
+
+    def test_unschedule_writes_audit_note(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Unscheduling appends a timestamped note to production order notes."""
+        from app.models.production_order import ProductionOrder
+
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status="queued",
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        resp = client.post(f"{BASE_URL}/{po.id}/operations/{op.id}/unschedule")
+        assert resp.status_code == 200, resp.text
+
+        db.expire_all()
+        refreshed_po = db.get(ProductionOrder, po.id)
+        assert refreshed_po.notes is not None
+        assert "unscheduled" in refreshed_po.notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unschedule — blocked on started / finished ops
+# ---------------------------------------------------------------------------
+
+class TestUnschedulePreStartOnly:
+    @pytest.mark.parametrize("bad_status", ["running", "complete", "cancelled", "skipped"])
+    def test_unschedule_blocks_non_pre_start_statuses(
+        self, client, db, make_product, make_production_order, make_work_center, bad_status
+    ):
+        """Unschedule must be rejected for ops that have started or finished."""
+        wc = make_work_center()
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status=bad_status,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        resp = client.post(f"{BASE_URL}/{po.id}/operations/{op.id}/unschedule")
+        assert resp.status_code == 400, f"Expected 400 for status={bad_status}, got {resp.status_code}"
+
+    @pytest.mark.parametrize("bad_status", ["running", "complete", "cancelled", "skipped"])
+    def test_reschedule_blocks_non_pre_start_statuses(
+        self, client, db, make_product, make_production_order, make_work_center, bad_status
+    ):
+        """Reschedule must also be rejected for ops that have started or finished."""
+        wc = make_work_center()
+        printer = _make_printer(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        op = _make_operation(
+            db, po.id, wc.id,
+            sequence=10, status=bad_status,
+            printer_id=printer.id,
+            scheduled_start=now,
+            scheduled_end=now + timedelta(hours=1),
+        )
+        db.commit()
+
+        new_start = now + timedelta(hours=4)
+        resp = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/reschedule",
+            json={
+                "resource_id": printer.id,
+                "is_printer": True,
+                "scheduled_start": new_start.isoformat(),
+            },
+        )
+        assert resp.status_code == 400, f"Expected 400 for status={bad_status}, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Not found guards
+# ---------------------------------------------------------------------------
+
+class TestRescheduleNotFound:
+    def test_reschedule_unknown_po(self, client):
+        resp = client.post(
+            f"{BASE_URL}/999999/operations/1/reschedule",
+            json={"scheduled_start": datetime.now(timezone.utc).isoformat()},
+        )
+        assert resp.status_code == 404
+
+    def test_unschedule_unknown_po(self, client):
+        resp = client.post(f"{BASE_URL}/999999/operations/1/unschedule")
+        assert resp.status_code == 404

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -232,6 +232,92 @@ function ScheduleSuccess({ operationCode, nextOperation, onNext }) {
 }
 
 /**
+ * Unschedule confirmation inline panel.
+ */
+function UnscheduleConfirm({ onConfirm, onCancel, submitting }) {
+  return (
+    <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+      <p className="text-amber-300 font-medium text-sm">
+        Unschedule this operation?
+      </p>
+      <p className="text-amber-400/70 text-sm mt-1">
+        The operation will return to pending and its time slot will be freed.
+      </p>
+      <div className="flex gap-3 mt-3">
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={submitting}
+          className="px-4 py-1.5 bg-amber-600 text-white text-sm rounded-lg hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {submitting ? "Unscheduling..." : "Confirm Unschedule"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-1.5 text-gray-400 hover:text-white text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Successor conflict banner — shown when moving an op would violate a
+ * downstream op's existing schedule.
+ */
+function SuccessorConflictAlert({ successorConflicts }) {
+  if (!successorConflicts || successorConflicts.length === 0) return null;
+  return (
+    <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-4">
+      <div className="flex items-start gap-3">
+        <svg
+          className="w-5 h-5 text-orange-400 flex-shrink-0 mt-0.5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <div className="flex-1">
+          <h4 className="text-orange-400 font-medium">Successor Conflict</h4>
+          <p className="text-sm text-orange-400/70 mt-1">
+            Moving this operation would violate existing schedules of:
+          </p>
+          <ul className="mt-2 space-y-1">
+            {successorConflicts.map((sc, idx) => (
+              <li key={idx} className="text-sm text-orange-300">
+                - Seq {sc.sequence} ({sc.operation_code || "Operation"})
+                {sc.scheduled_start && (
+                  <span className="text-orange-400/50">
+                    {" "}currently at {formatTime(sc.scheduled_start)}
+                  </span>
+                )}
+                {sc.earliest_valid_start && (
+                  <span className="text-orange-300">
+                    {" "}— earliest valid start: {formatTime(sc.earliest_valid_start)}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-orange-400/50 mt-2">
+            Reschedule the successor operations first, or choose an earlier end time.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
  * Main modal component
  */
 export default function OperationSchedulerModal({
@@ -253,10 +339,20 @@ export default function OperationSchedulerModal({
   const [serverConflicts, setServerConflicts] = useState([]);
   // Predecessor-specific conflict state
   const [predecessorConflict, setPredecessorConflict] = useState(null); // { message, earliestValidStart }
+  // Successor conflict state
+  const [successorConflicts, setSuccessorConflicts] = useState([]);
   const [justScheduled, setJustScheduled] = useState(null); // op code of just-scheduled op
   const [nextPendingOp, setNextPendingOp] = useState(null); // next op to schedule
   // Defensive: keep modal alive even if parent unmounts/remounts during conflicts
   const [forceOpen, setForceOpen] = useState(false);
+  // Unschedule confirm state
+  const [showUnscheduleConfirm, setShowUnscheduleConfirm] = useState(false);
+
+  // Derived: is this an already-scheduled op? → edit mode.
+  const isEditMode =
+    currentOp != null &&
+    (currentOp.status === "queued" ||
+      (currentOp.scheduled_start != null && currentOp.status !== "pending"));
 
   // Sync external operation prop into internal state.
   // Depends on isOpen too: if the same operation is clicked twice, the prop
@@ -311,12 +407,30 @@ export default function OperationSchedulerModal({
     }
   }, [isOpen, startTime]);
 
-  // Pre-select resource if operation already has one
+  // Pre-select resource if operation already has one (covers both resource and printer)
   useEffect(() => {
-    if (isOpen && currentOp?.resource_id) {
-      setResourceId(String(currentOp.resource_id));
+    if (isOpen && currentOp) {
+      if (currentOp.printer_id) {
+        setResourceId(String(currentOp.printer_id));
+      } else if (currentOp.resource_id) {
+        setResourceId(String(currentOp.resource_id));
+      }
     }
   }, [isOpen, currentOp]);
+
+  // In edit mode: prefill times from the operation's existing schedule.
+  // We do NOT auto-suggest a new slot when already scheduled — the operator
+  // chose this slot and we should show it rather than immediately replacing it.
+  useEffect(() => {
+    if (isOpen && isEditMode && currentOp?.scheduled_start) {
+      const start = new Date(currentOp.scheduled_start);
+      setStartTime(start.toISOString().slice(0, 16));
+      if (currentOp.scheduled_end) {
+        const end = new Date(currentOp.scheduled_end);
+        setEndTime(end.toISOString().slice(0, 16));
+      }
+    }
+  }, [isOpen, isEditMode, currentOp?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Check compatibility when resource changes
   useEffect(() => {
@@ -353,9 +467,11 @@ export default function OperationSchedulerModal({
     return () => { cancelled = true; };
   }, [resourceId, productionOrder?.id, resources]);
 
-  // Auto-suggest next available slot when resource is selected
+  // Auto-suggest next available slot when resource is selected — skip in edit mode
+  // because the operator can see the current slot and change it deliberately.
   useEffect(() => {
     if (!resourceId || estimatedMinutes <= 0) return;
+    if (isEditMode) return;
 
     const selectedRes = resources.find((r) => String(r.id) === resourceId);
     if (!selectedRes) return;
@@ -428,6 +544,8 @@ export default function OperationSchedulerModal({
     setNextAvailableStart(null);
     setNextAvailableEnd(null);
     setPredecessorConflict(null);
+    setSuccessorConflicts([]);
+    setShowUnscheduleConfirm(false);
   };
 
   const handleSubmit = async (e) => {
@@ -455,10 +573,14 @@ export default function OperationSchedulerModal({
     setServerConflicts([]);
     setNextAvailableStart(null);
     setNextAvailableEnd(null);
+    setSuccessorConflicts([]);
+
+    // Choose endpoint: reschedule for already-scheduled ops, schedule for new.
+    const endpoint = isEditMode ? "reschedule" : "schedule";
 
     try {
       const res = await fetch(
-        `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${currentOp.id}/schedule`,
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${currentOp.id}/${endpoint}`,
         {
           method: "POST",
           credentials: "include",
@@ -477,7 +599,7 @@ export default function OperationSchedulerModal({
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.detail || "Failed to schedule operation");
+        throw new Error(data.detail || `Failed to ${isEditMode ? "reschedule" : "schedule"} operation`);
       }
 
       if (data.success === false) {
@@ -489,10 +611,17 @@ export default function OperationSchedulerModal({
             earliestValidStart: data.earliest_valid_start,
           });
           setServerConflicts([]);
+          setSuccessorConflicts([]);
+        } else if (data.conflict_type === "successor") {
+          // Successor violation — show orange banner with per-successor details
+          setSuccessorConflicts(data.successor_conflicts || []);
+          setServerConflicts([]);
+          setPredecessorConflict(null);
         } else {
           // Resource conflict — show red banner with conflicting ops
           setServerConflicts(data.conflicts || []);
           setPredecessorConflict(null);
+          setSuccessorConflicts([]);
         }
         if (data.next_available_start) {
           setNextAvailableStart(data.next_available_start);
@@ -504,11 +633,20 @@ export default function OperationSchedulerModal({
       }
 
       onScheduled?.();
-      const scheduledCode = `${currentOp.sequence} — ${currentOp.operation_code}`;
-      const nextOp = await fetchNextPendingOp(currentOp.id);
-      setJustScheduled(scheduledCode);
-      setNextPendingOp(nextOp || null);
-      resetFormState();
+      const actionLabel = isEditMode ? "rescheduled" : "scheduled";
+      const scheduledCode = `${currentOp.sequence} — ${currentOp.operation_code} (${actionLabel})`;
+      // In edit mode, don't advance to next op — the operator was editing, not
+      // sequentially scheduling. Just show success and close.
+      if (isEditMode) {
+        setJustScheduled(scheduledCode);
+        setNextPendingOp(null);
+        resetFormState();
+      } else {
+        const nextOp = await fetchNextPendingOp(currentOp.id);
+        setJustScheduled(scheduledCode);
+        setNextPendingOp(nextOp || null);
+        resetFormState();
+      }
     } catch (err) {
       setError(err.message);
     } finally {
@@ -536,10 +674,39 @@ export default function OperationSchedulerModal({
     }
     setServerConflicts([]);
     setPredecessorConflict(null);
+    setSuccessorConflicts([]);
     setNextAvailableStart(null);
     setNextAvailableEnd(null);
     setError(null);
     setForceOpen(false);
+  };
+
+  const handleUnscheduleConfirmed = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/operations/${currentOp.id}/unschedule`,
+        {
+          method: "POST",
+          credentials: "include",
+        },
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.detail || "Failed to unschedule operation");
+      }
+      onScheduled?.();
+      const unscheduledCode = `${currentOp.sequence} — ${currentOp.operation_code} (unscheduled)`;
+      setJustScheduled(unscheduledCode);
+      setNextPendingOp(null);
+      resetFormState();
+    } catch (err) {
+      setError(err.message);
+      setShowUnscheduleConfirm(false);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   // Close with full reset — used by X button, Done button, and advance
@@ -557,7 +724,15 @@ export default function OperationSchedulerModal({
   // user needs to explicitly resolve or dismiss them, not lose their work
   // by accidentally clicking outside.
   const handleAutoClose = () => {
-    if (serverConflicts.length > 0 || conflicts.length > 0 || predecessorConflict || error || compatWarning) {
+    if (
+      serverConflicts.length > 0 ||
+      conflicts.length > 0 ||
+      predecessorConflict ||
+      successorConflicts.length > 0 ||
+      error ||
+      compatWarning ||
+      showUnscheduleConfirm
+    ) {
       return;
     }
     handleClose();
@@ -566,17 +741,19 @@ export default function OperationSchedulerModal({
   const effectiveOpen = isOpen || forceOpen;
   if (!effectiveOpen) return null;
 
+  const modalTitle = isEditMode ? "Edit Schedule" : "Schedule Operation";
+
   return (
     <Modal
       isOpen={effectiveOpen}
       onClose={handleAutoClose}
-      title="Schedule Operation"
+      title={modalTitle}
       disableClose={submitting}
       className="w-full max-w-lg mx-4"
     >
       {/* Header */}
       <div className="flex items-center justify-between p-6 border-b border-gray-800">
-        <h2 className="text-xl font-semibold text-white">Schedule Operation</h2>
+        <h2 className="text-xl font-semibold text-white">{modalTitle}</h2>
         <button
           onClick={handleClose}
           className="text-gray-400 hover:text-white transition-colors"
@@ -708,8 +885,13 @@ export default function OperationSchedulerModal({
               />
             )}
 
+            {/* Successor conflict banner */}
+            {successorConflicts.length > 0 && (
+              <SuccessorConflictAlert successorConflicts={successorConflicts} />
+            )}
+
             {/* Resource conflict alert (live check or server response) */}
-            {!predecessorConflict && (
+            {!predecessorConflict && successorConflicts.length === 0 && (
               checking ? (
                 <div className="text-sm text-gray-500 flex items-center gap-2">
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
@@ -726,36 +908,66 @@ export default function OperationSchedulerModal({
             )}
 
             {/* Error message (only for non-conflict errors) */}
-            {error && !predecessorConflict && !serverConflicts.length && (
+            {error && !predecessorConflict && !serverConflicts.length && successorConflicts.length === 0 && (
               <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
                 <p className="text-red-400 text-sm">{error}</p>
               </div>
             )}
 
+            {/* Unschedule confirm panel (edit mode only) */}
+            {isEditMode && showUnscheduleConfirm && (
+              <UnscheduleConfirm
+                onConfirm={handleUnscheduleConfirmed}
+                onCancel={() => setShowUnscheduleConfirm(false)}
+                submitting={submitting}
+              />
+            )}
+
             <hr className="border-gray-800" />
 
             {/* Actions */}
-            <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={handleClose}
-                className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
-              >
-                Done
-              </button>
-              <button
-                type="submit"
-                disabled={
-                  submitting ||
-                  hasConflicts ||
-                  !!compatWarning ||
-                  !resourceId ||
-                  !startTime
-                }
-                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {submitting ? "Scheduling..." : "Schedule"}
-              </button>
+            <div className="flex justify-between gap-3">
+              {/* Left: Unschedule button (edit mode only) */}
+              <div>
+                {isEditMode && !showUnscheduleConfirm && (
+                  <button
+                    type="button"
+                    onClick={() => setShowUnscheduleConfirm(true)}
+                    disabled={submitting}
+                    className="px-4 py-2 text-amber-400 hover:text-amber-300 transition-colors disabled:opacity-50"
+                  >
+                    Unschedule
+                  </button>
+                )}
+              </div>
+
+              {/* Right: Done + Schedule/Reschedule */}
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+                >
+                  Done
+                </button>
+                {!showUnscheduleConfirm && (
+                  <button
+                    type="submit"
+                    disabled={
+                      submitting ||
+                      hasConflicts ||
+                      !!compatWarning ||
+                      !resourceId ||
+                      !startTime
+                    }
+                    className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {submitting
+                      ? isEditMode ? "Rescheduling..." : "Scheduling..."
+                      : isEditMode ? "Reschedule" : "Schedule"}
+                  </button>
+                )}
+              </div>
             </div>
           </form>
         )}

--- a/frontend/src/components/production/__tests__/OperationSchedulerModal.test.jsx
+++ b/frontend/src/components/production/__tests__/OperationSchedulerModal.test.jsx
@@ -10,6 +10,9 @@
  *     error when both startTime and endTime are present).
  *  4. Predecessor conflict — amber "Sequence Constraint" banner with "Use this
  *     time" button; clicking it sets the start field and clears the banner.
+ *  5. Edit mode — already-scheduled op shows "Edit Schedule" title, "Reschedule"
+ *     submit button, and "Unschedule" action with confirm.
+ *  6. Successor conflict — orange banner with per-successor details.
  */
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -86,6 +89,22 @@ const secondOp = {
   planned_setup_minutes: '5.00',
   planned_run_minutes: '88.00',
   status: 'pending',
+}
+
+// An already-scheduled op — edit mode
+const scheduledOp = {
+  id: 50,
+  sequence: 10,
+  operation_code: 'PRINT',
+  operation_name: 'FDM Print',
+  work_center_id: 1,
+  resource_id: null,
+  printer_id: 7,
+  planned_setup_minutes: '3.00',
+  planned_run_minutes: '120.00',
+  status: 'queued',
+  scheduled_start: '2026-06-11T10:00:00Z',
+  scheduled_end: '2026-06-11T12:03:00Z',
 }
 
 const productionOrder = { id: 1, code: 'PO-2026-000001' }
@@ -312,5 +331,167 @@ describe('OperationSchedulerModal — predecessor conflict suggestion', () => {
     const dtInput = filledInputs.find((el) => el.type === 'datetime-local')
     expect(dtInput).toBeDefined()
     expect(dtInput.value).not.toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. Edit mode — already-scheduled op
+// ---------------------------------------------------------------------------
+describe('OperationSchedulerModal — edit mode (already scheduled op)', () => {
+  const PRINTER = { id: 7, code: 'PRINTER-01', name: 'Bambu X1C', is_printer: true }
+
+  it('shows "Edit Schedule" title for a queued operation', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+    // Modal renders the title in both sr-only span and h2 — use getAllByText
+    const titles = screen.getAllByText('Edit Schedule')
+    expect(titles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows "Reschedule" submit button for a queued operation', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+    expect(screen.getByRole('button', { name: /^Reschedule$/i })).toBeInTheDocument()
+  })
+
+  it('shows "Unschedule" action button for a queued operation', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+    expect(screen.getByRole('button', { name: /^Unschedule$/i })).toBeInTheDocument()
+  })
+
+  it('prefills start time from existing scheduled_start', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+    await act(async () => { vi.runAllTimers() })
+
+    // The start input should be prefilled from scheduled_start
+    const dtInputs = screen.getAllByDisplayValue(/.+/).filter((el) => el.type === 'datetime-local')
+    expect(dtInputs.length).toBeGreaterThanOrEqual(1)
+    // At least one must have a non-empty value matching the scheduled time
+    expect(dtInputs.some((el) => el.value !== '')).toBe(true)
+  })
+
+  it('clicking "Unschedule" shows confirm panel', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+
+    const unscheduleBtn = screen.getByRole('button', { name: /^Unschedule$/i })
+    await act(async () => { fireEvent.click(unscheduleBtn) })
+
+    // Confirm panel text must appear
+    expect(screen.getByText(/Unschedule this operation\?/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Confirm Unschedule/i })).toBeInTheDocument()
+  })
+
+  it('clicking Cancel in confirm panel hides it', async () => {
+    _mockResources = [PRINTER]
+    await act(async () => { renderModal(scheduledOp) })
+
+    const unscheduleBtn = screen.getByRole('button', { name: /^Unschedule$/i })
+    await act(async () => { fireEvent.click(unscheduleBtn) })
+
+    expect(screen.getByText(/Unschedule this operation\?/i)).toBeInTheDocument()
+
+    const cancelBtn = screen.getByRole('button', { name: /^Cancel$/i })
+    await act(async () => { fireEvent.click(cancelBtn) })
+
+    expect(screen.queryByText(/Unschedule this operation\?/i)).not.toBeInTheDocument()
+    // Unschedule button reappears
+    expect(screen.getByRole('button', { name: /^Unschedule$/i })).toBeInTheDocument()
+  })
+
+  it('calls reschedule endpoint (not schedule) on submit in edit mode', async () => {
+    _mockResources = [PRINTER]
+    const fetchSpy = vi.fn().mockImplementation((url, opts) => {
+      if (typeof url === 'string' && url.includes('check-resource-compatibility')) {
+        return Promise.resolve({ ok: true, json: async () => ({ compatible: true, reason: null }) })
+      }
+      if (typeof url === 'string' && url.includes('reschedule') && opts?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, operation_id: scheduledOp.id }) })
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await act(async () => { renderModal(scheduledOp) })
+    await act(async () => { vi.runAllTimers() })
+
+    const select = screen.getByRole('combobox')
+    await act(async () => {
+      fireEvent.change(select, { target: { value: String(PRINTER.id) } })
+    })
+    await act(async () => { vi.runAllTimers() })
+
+    const submitBtn = screen.getByRole('button', { name: /^Reschedule$/i })
+    await act(async () => { fireEvent.click(submitBtn) })
+    await act(async () => { vi.runAllTimers() })
+
+    // Check that fetch was called with /reschedule
+    const rescheduleCalls = fetchSpy.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/reschedule')
+    )
+    expect(rescheduleCalls.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. Successor conflict — orange banner
+// ---------------------------------------------------------------------------
+describe('OperationSchedulerModal — successor conflict', () => {
+  const PRINTER = { id: 7, code: 'PRINTER-01', name: 'Bambu X1C', is_printer: true }
+
+  const nextStart = '2026-06-11T18:00:00Z'
+  const nextEnd   = '2026-06-11T19:33:00Z'
+
+  function stubSuccessorConflict() {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url, opts) => {
+      if (typeof url === 'string' && url.includes('check-resource-compatibility')) {
+        return Promise.resolve({ ok: true, json: async () => ({ compatible: true, reason: null }) })
+      }
+      if (typeof url === 'string' && url.includes('reschedule') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            success: false,
+            conflict_type: 'successor',
+            message: 'Moving this operation would violate 1 successor operation(s)',
+            successor_conflicts: [
+              {
+                operation_id: 99,
+                operation_code: 'POST',
+                operation_name: 'Post-processing',
+                sequence: 20,
+                scheduled_start: nextStart,
+                earliest_valid_start: nextEnd,
+              },
+            ],
+          }),
+        })
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) })
+    }))
+  }
+
+  it('renders Successor Conflict banner after successor violation', async () => {
+    _mockResources = [PRINTER]
+    stubSuccessorConflict()
+
+    await act(async () => { renderModal(scheduledOp) })
+    await act(async () => { vi.runAllTimers() })
+
+    const select = screen.getByRole('combobox')
+    await act(async () => {
+      fireEvent.change(select, { target: { value: String(PRINTER.id) } })
+    })
+    await act(async () => { vi.runAllTimers() })
+
+    const submitBtn = screen.getByRole('button', { name: /^Reschedule$/i })
+    await act(async () => { fireEvent.click(submitBtn) })
+    await act(async () => { vi.runAllTimers() })
+
+    expect(screen.getByText('Successor Conflict')).toBeInTheDocument()
+    // Should show per-successor details
+    expect(screen.getByText(/POST/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- **`POST …/operations/{op_id}/reschedule`** — move a scheduled operation to a new resource and/or time; validates resource conflicts (self-excluded), predecessor sequence constraints with `earliest_valid_start` suggestion, and new successor implications (if moving this op later would violate a successor's existing schedule, returns `conflict_type="successor"` with per-successor `earliest_valid_start`). Conflict response shape mirrors #721.
- **`POST …/operations/{op_id}/unschedule`** — clears `scheduled_start/end/resource/printer`, returns op to `pending`. Both endpoints are pre-start only (`pending` or `queued`).
- **Audit trail** — timestamped note appended to `ProductionOrder.notes` on both actions (reuses the same pattern as `complete_production_order`/`accept_short` — no new table; no production-order-specific event model exists).
- **`OperationSchedulerModal`** — already-scheduled ops open in EDIT mode: title → "Edit Schedule", times prefilled, submit → "Reschedule" (calls `/reschedule`), new "Unschedule" button with inline confirm. Successor conflict banner (orange) added alongside existing resource/predecessor banners from #721.
- **Successor checking** — `check_successor_scheduling()` added to `resource_scheduling.py` (additive-only, no existing function changed).

## Test plan

- [ ] Backend: `pytest tests/api/v1/test_reschedule_unschedule.py` → 21 tests covering auth guard, happy paths, self-exclusion, resource conflict, predecessor + successor violations with `earliest_valid_start`, unschedule pre-start guard, audit notes
- [ ] Existing scheduling tests: `pytest tests/api/v1/test_operation_status_scheduling.py` → 6 tests still pass
- [ ] Frontend: `vitest run` on `OperationSchedulerModal.test.jsx` → 17 tests (7 new: edit mode prefill, Reschedule/Unschedule buttons, confirm/cancel, endpoint routing, successor banner)
- [ ] Frontend build: passes clean
- [ ] Ruff: no new E712 or other violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)