### PR TITLE
fix: brownfield order data health — legacy WO linkage, fulfillment evidence, guided resolution (LEGACY-1)

### DIFF
--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -1038,6 +1038,48 @@ async def ship_order(
     return result
 
 
+class ResolveLegacyFulfillmentRequest(BaseModel):
+    """Action to resolve a legacy fulfillment mismatch (LEGACY-1)."""
+    action: str  # "close_out" | "reopen"
+
+
+@router.post("/{order_id}/resolve-legacy-fulfillment", response_model=SalesOrderResponse)
+async def resolve_legacy_fulfillment(
+    order_id: int,
+    request: ResolveLegacyFulfillmentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Resolve a brownfield order whose status says shipped/delivered/completed
+    but which has no shipment evidence (legacy data from older FilaOps
+    versions). Admin only.
+
+    - close_out: mark lines shipped and record fulfillment — paperwork only,
+      no inventory movements, no GL entries (goods left long ago).
+    - reopen: set the order back to ready_to_ship so the normal Ship flow
+      (with inventory + GL postings) takes over.
+
+    Returns 409 if the mismatch does not exist (re-validated server-side).
+    """
+    is_admin = getattr(current_user, "account_type", None) == "admin" or getattr(current_user, "is_admin", False)
+    if not is_admin:
+        raise HTTPException(status_code=403, detail="Only administrators can resolve legacy fulfillment")
+
+    order = sales_order_service.resolve_legacy_fulfillment(
+        db,
+        order_id=order_id,
+        action=request.action,
+        user_email=current_user.email,
+        user_id=current_user.id,
+    )
+
+    db.commit()
+    db.refresh(order)
+
+    return build_sales_order_response(order, db)
+
+
 @router.post("/{order_id}/generate-production-orders")
 async def generate_production_orders(
     order_id: int,

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -2885,8 +2885,11 @@ def generate_production_orders(
         producible_line_ids = [line.id for line in producible_lines]
         existing_pos = []
         if producible_line_ids:
+            # Cancelled WOs are not coverage — an order whose WOs were all
+            # cancelled must be able to regenerate them.
             existing_pos = db.query(ProductionOrder).filter(
-                ProductionOrder.sales_order_id == order_id
+                ProductionOrder.sales_order_id == order_id,
+                ProductionOrder.status != "cancelled",
             ).all()
             existing_po_line_ids = {
                 po.sales_order_line_id
@@ -2913,7 +2916,8 @@ def generate_production_orders(
             }
     else:
         existing_pos = db.query(ProductionOrder).filter(
-            ProductionOrder.sales_order_id == order_id
+            ProductionOrder.sales_order_id == order_id,
+            ProductionOrder.status != "cancelled",
         ).all()
 
     if existing_pos and (

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -49,6 +49,19 @@ _MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE = (
     "Shipment GL posting for material-backed sales orders needs raw-material account mapping"
 )
 
+# LEGACY-1: statuses where the order claims goods have left the building.
+# Mirrors SHIPPED_ORDER_STATUSES in frontend/src/pages/admin/OrderDetail.jsx.
+SHIPPED_ORDER_STATUSES = {"shipped", "delivered", "completed"}
+
+# Statuses where material requirements are historical context rather than
+# actionable demand (nothing more will be produced/shipped for this order).
+TERMINAL_ORDER_STATUSES = {"completed", "cancelled", "delivered", "shipped"}
+
+# Order-level fulfillment_status values that count as shipment evidence.
+# Grounded in order_status.py which sets "shipped"/"delivered" on those
+# transitions; "fulfilled" is accepted defensively for older data.
+_SHIPMENT_EVIDENCE_FULFILLMENT_STATUSES = {"shipped", "delivered", "fulfilled"}
+
 
 def _has_material_backed_lines(order: "SalesOrder") -> bool:
     return any(
@@ -2453,6 +2466,16 @@ def get_material_requirements(
     materials_with_incoming = sum(1 for r in requirements if r["has_incoming_supply"])
     materials_covered_by_incoming = sum(1 for r in requirements if r.get("covered_by_incoming"))
 
+    # LEGACY-1: requirements are re-exploded against CURRENT stock on every
+    # call. For terminal (or deliberately short-closed) orders that is
+    # historical context, not an actionable shortage — the goods already
+    # shipped or never will. Flag it so the UI stops raising live shortage
+    # alerts while still showing the data for reference.
+    historical = (
+        order.status in TERMINAL_ORDER_STATUSES
+        or bool(getattr(order, "closed_short", False))
+    )
+
     return {
         "sales_order_id": order.id,
         "order_number": order.order_number,
@@ -2466,6 +2489,7 @@ def get_material_requirements(
             "materials_covered_by_incoming": materials_covered_by_incoming,
             "can_fulfill": materials_short == 0,
             "has_shortages": materials_short > 0,
+            "historical": historical,
         }
     }
 
@@ -2706,6 +2730,126 @@ def ship_order(
 
 
 # =============================================================================
+# Legacy Fulfillment Resolution (LEGACY-1)
+# =============================================================================
+
+def has_shipment_evidence(order: "SalesOrder") -> bool:
+    """
+    True when there is any recorded evidence that goods actually shipped.
+
+    Evidence = order.shipped_at set, OR any line with shipped_quantity > 0,
+    OR order.fulfillment_status in the shipped/delivered set.
+    """
+    if order.shipped_at is not None:
+        return True
+    if (order.fulfillment_status or "") in _SHIPMENT_EVIDENCE_FULFILLMENT_STATUSES:
+        return True
+    for line in (order.lines or []):
+        if (line.shipped_quantity or Decimal("0")) > Decimal("0"):
+            return True
+    return False
+
+
+def resolve_legacy_fulfillment(
+    db: Session,
+    order_id: int,
+    action: str,
+    user_email: str,
+    user_id: Optional[int] = None,
+) -> SalesOrder:
+    """
+    Resolve a legacy fulfillment mismatch on a brownfield order.
+
+    Mismatch = order.status says shipped/delivered/completed, but there is
+    NO shipment evidence (no shipped_at, no shipped quantities, fulfillment
+    still pending). This happens on orders created before FilaOps recorded
+    shipment data properly.
+
+    Actions:
+        close_out: accept the order as fulfilled — paperwork reconciliation
+            only. Sets line shipped quantities, fulfillment_status, and
+            shipped_at, and appends an audit note.
+
+            DESIGN DECISION (owner, LEGACY-1): close_out posts NO inventory
+            movements and NO GL entries. The goods physically left long ago;
+            per the HARD-4c doctrine, current stock truth comes from the
+            inventory ledger + cycle counts, not from retroactive paperwork.
+            Backdating COGS/inventory relief here would corrupt both.
+
+        reopen: production is already complete, so move the order back to
+            ready_to_ship and let the normal Ship flow take over (which DOES
+            post inventory + GL). Invoice/payment are left untouched.
+
+    Raises 409 if the mismatch does not actually exist (re-validated
+    server-side so stale UI cannot mutate healthy orders).
+    """
+    order = get_sales_order_with_lines(db, order_id)
+
+    if order.status not in SHIPPED_ORDER_STATUSES or has_shipment_evidence(order):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "No legacy fulfillment mismatch on this order: it is either "
+                "not in a shipped/delivered/completed status or already has "
+                "shipment evidence recorded."
+            ),
+        )
+
+    now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+
+    if action == "close_out":
+        for line in (order.lines or []):
+            line.shipped_quantity = line.quantity
+        # Grounded enum: order_status.py uses "shipped"/"delivered" as the
+        # shipped-evidence fulfillment statuses (there is no "fulfilled").
+        order.fulfillment_status = (
+            "delivered" if order.status == "delivered" else "shipped"
+        )
+        order.shipped_at = order.actual_completion_date or now
+        audit_note = (
+            f"Legacy fulfillment closed out by {user_email} on {date_str} "
+            f"— no shipment record existed (no inventory or GL impact)"
+        )
+        event_title = "Legacy fulfillment closed out"
+    elif action == "reopen":
+        # Direct assignment (not the transition validator): completed →
+        # ready_to_ship is intentionally outside the normal lifecycle; this
+        # is an admin-gated data repair, and production is already complete.
+        order.status = "ready_to_ship"
+        order.fulfillment_status = "ready"
+        audit_note = (
+            f"Legacy fulfillment reopened (set to ready_to_ship) by "
+            f"{user_email} on {date_str} — no shipment record existed; "
+            f"ship through the normal flow"
+        )
+        event_title = "Legacy fulfillment reopened for shipping"
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="action must be 'close_out' or 'reopen'",
+        )
+
+    order.internal_notes = (
+        f"{order.internal_notes}\n{audit_note}" if order.internal_notes else audit_note
+    )
+    order.updated_at = now
+
+    record_order_event(
+        db=db,
+        order_id=order.id,
+        event_type="legacy_fulfillment_resolved",
+        title=event_title,
+        description=audit_note,
+        user_id=user_id,
+        metadata_key="action",
+        metadata_value=action,
+    )
+
+    return order
+
+
+# =============================================================================
 # Generate Production Orders
 # =============================================================================
 
@@ -2735,19 +2879,37 @@ def generate_production_orders(
 
     # Check for existing production orders
     producible_line_ids: list[int] = []
-    existing_po_line_ids: set[int] = set()
+    covered_line_ids: set[int] = set()
     if order.order_type == "line_item":
-        producible_line_ids = [line.id for line in order.lines if line.product_id]
+        producible_lines = [line for line in order.lines if line.product_id]
+        producible_line_ids = [line.id for line in producible_lines]
         existing_pos = []
         if producible_line_ids:
             existing_pos = db.query(ProductionOrder).filter(
-                ProductionOrder.sales_order_id == order_id,
-                ProductionOrder.sales_order_line_id.in_(producible_line_ids)
+                ProductionOrder.sales_order_id == order_id
             ).all()
             existing_po_line_ids = {
                 po.sales_order_line_id
                 for po in existing_pos
                 if po.sales_order_line_id is not None
+            }
+            # LEGACY-1 fallback: production orders created before line-level
+            # linkage existed have sales_order_line_id = NULL. Treat such a
+            # WO as covering every line with the same product_id — this is a
+            # coverage check (does production exist for this line's product?),
+            # not an assignment, so one NULL-linked WO may cover multiple
+            # lines of its product. Mirrored in hasMainProductWO() in
+            # frontend/src/pages/admin/OrderDetail.jsx — keep in sync.
+            legacy_covered_product_ids = {
+                po.product_id
+                for po in existing_pos
+                if po.sales_order_line_id is None
+            }
+            covered_line_ids = {
+                line.id
+                for line in producible_lines
+                if line.id in existing_po_line_ids
+                or line.product_id in legacy_covered_product_ids
             }
     else:
         existing_pos = db.query(ProductionOrder).filter(
@@ -2756,7 +2918,7 @@ def generate_production_orders(
 
     if existing_pos and (
         order.order_type != "line_item"
-        or len(existing_po_line_ids) == len(producible_line_ids)
+        or len(covered_line_ids) == len(producible_line_ids)
     ):
         return {
             "message": "Production orders already exist",
@@ -2803,7 +2965,9 @@ def generate_production_orders(
             )
 
         for idx, line in enumerate(lines, start=1):
-            if line.id in existing_po_line_ids:
+            # covered_line_ids includes both directly-linked lines and lines
+            # covered by legacy NULL-linked WOs (see coverage check above).
+            if line.id in covered_line_ids:
                 continue
 
             # Skip material-only lines — raw materials don't need production orders

--- a/backend/migrations/versions/091_backfill_legacy_wo_line_links.py
+++ b/backend/migrations/versions/091_backfill_legacy_wo_line_links.py
@@ -1,0 +1,61 @@
+"""backfill legacy production_orders.sales_order_line_id links
+
+Revision ID: 091
+Revises: 090
+Create Date: 2026-06-11
+
+LEGACY-1: Production orders created before sales_order_line_id linkage
+existed (PR #713 gating) have ``sales_order_line_id = NULL`` even though
+they were generated from a specific sales order line. That breaks the
+workflow UI ("Not released" on completed orders) and the existing-PO check
+in ``generate_production_orders``.
+
+This pure data migration backfills the link where it is UNAMBIGUOUS:
+the parent sales order is ``order_type = 'line_item'`` and EXACTLY ONE
+``sales_order_lines`` row on that order has the same ``product_id`` as the
+production order. Rows with zero or multiple candidate lines are left
+NULL (runtime fallback logic handles those).
+
+Idempotent: backfilled rows are no longer NULL, so re-running the UPDATE
+matches nothing. Server-side SQL only — no ORM, no Python row loops.
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "091"
+down_revision = "090"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE production_orders AS po
+        SET sales_order_line_id = candidate.line_id
+        FROM (
+            SELECT
+                po2.id AS po_id,
+                MIN(sol.id) AS line_id
+            FROM production_orders AS po2
+            JOIN sales_orders AS so
+              ON so.id = po2.sales_order_id
+            JOIN sales_order_lines AS sol
+              ON sol.sales_order_id = so.id
+             AND sol.product_id = po2.product_id
+            WHERE po2.sales_order_line_id IS NULL
+              AND so.order_type = 'line_item'
+            GROUP BY po2.id
+            HAVING COUNT(sol.id) = 1
+        ) AS candidate
+        WHERE po.id = candidate.po_id
+        """
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op: once backfilled, the rows are indistinguishable
+    # from organically created line-linked production orders, so we cannot
+    # safely null out only the values this migration set. Reverting would
+    # risk destroying legitimate linkage data.
+    pass

--- a/backend/tests/services/test_legacy_order_health.py
+++ b/backend/tests/services/test_legacy_order_health.py
@@ -1,0 +1,348 @@
+"""
+Tests for LEGACY-1 — brownfield order data health.
+
+Covers:
+- generate_production_orders: legacy NULL-linked WO coverage fallback
+  (pre-#713 production orders have sales_order_line_id = NULL)
+- resolve_legacy_fulfillment: close_out and reopen actions + 409 guard,
+  including the no-inventory / no-GL design decision for close_out
+- get_material_requirements: "historical" summary flag for terminal /
+  short-closed orders
+
+All tests create their own fixtures — no assertions on global counts
+(the dev/CI databases accumulate data across runs).
+"""
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.accounting import GLJournalEntry
+from app.models.inventory import InventoryTransaction
+from app.models.production_order import ProductionOrder
+from app.models.sales_order import SalesOrderLine
+from app.services import sales_order_service
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_order_line(db, sales_order_id, product_id, quantity=1, unit_price=Decimal("10.00")):
+    """Create a SalesOrderLine directly."""
+    line = SalesOrderLine(
+        sales_order_id=sales_order_id,
+        product_id=product_id,
+        quantity=quantity,
+        unit_price=unit_price,
+        total=unit_price * quantity,
+        discount=Decimal("0"),
+        tax_rate=Decimal("0"),
+    )
+    db.add(line)
+    db.flush()
+    return line
+
+
+def _make_legacy_wo(db, *, so_id, product_id, code, status="complete", quantity=1):
+    """Create a production order with NO line linkage (pre-#713 legacy shape)."""
+    po = ProductionOrder(
+        code=code,
+        product_id=product_id,
+        sales_order_id=so_id,
+        sales_order_line_id=None,
+        quantity_ordered=quantity,
+        quantity_completed=quantity,
+        quantity_scrapped=0,
+        status=status,
+        created_by="legacy-test",
+    )
+    db.add(po)
+    db.flush()
+    return po
+
+
+def _make_legacy_completed_order(db, make_sales_order, make_product, *, n_lines=2):
+    """A completed line_item order with legacy NULL-linked complete WOs.
+
+    Mirrors the verified SO-2026-0041 shape: status=completed, lines with
+    shipped_quantity=0, fulfillment_status=pending, shipped_at=None, WOs
+    complete but unlinked.
+    """
+    so = make_sales_order(
+        status="completed",
+        order_type="line_item",
+        fulfillment_status="pending",
+    )
+    lines = []
+    for i in range(n_lines):
+        product = make_product(selling_price=Decimal("10.00"))
+        line = _make_order_line(db, so.id, product.id, quantity=2)
+        lines.append(line)
+        _make_legacy_wo(
+            db,
+            so_id=so.id,
+            product_id=product.id,
+            code=f"WO-LEG-{so.id}-{i}",
+            quantity=2,
+        )
+    db.flush()
+    return so, lines
+
+
+# =============================================================================
+# generate_production_orders — legacy coverage fallback
+# =============================================================================
+
+class TestLegacyWOCoverage:
+    """Legacy NULL-linked WOs must count as line coverage."""
+
+    def test_legacy_null_linked_wos_return_already_exist(
+        self, db, make_sales_order, make_product
+    ):
+        """Completed legacy order with NULL-linked WOs covering all lines
+        returns the friendly 'already exist' message instead of the
+        misleading status-must-be-confirmed 400."""
+        so, _lines = _make_legacy_completed_order(db, make_sales_order, make_product)
+
+        result = sales_order_service.generate_production_orders(
+            db, so.id, "test@filaops.dev"
+        )
+
+        assert result["message"] == "Production orders already exist"
+        assert result["created_orders"] == []
+        assert len(result["existing_orders"]) == 2
+
+    def test_single_legacy_wo_covers_all_lines_of_its_product(
+        self, db, make_sales_order, make_product
+    ):
+        """One NULL-linked WO covers every line of its product (coverage
+        check, not assignment)."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="completed", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+        _make_order_line(db, so.id, product.id, quantity=3)
+        _make_legacy_wo(
+            db, so_id=so.id, product_id=product.id, code=f"WO-LEG-MULTI-{so.id}"
+        )
+
+        result = sales_order_service.generate_production_orders(
+            db, so.id, "test@filaops.dev"
+        )
+        assert result["message"] == "Production orders already exist"
+
+    def test_legacy_wo_does_not_cover_other_products(
+        self, db, make_sales_order, make_product
+    ):
+        """A NULL-linked WO only covers lines with a matching product_id;
+        uncovered lines still get new WOs on a confirmed order."""
+        p1 = make_product(selling_price=Decimal("10.00"))
+        p2 = make_product(selling_price=Decimal("20.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        _make_order_line(db, so.id, p1.id, quantity=1)
+        line2 = _make_order_line(db, so.id, p2.id, quantity=2)
+        _make_legacy_wo(
+            db, so_id=so.id, product_id=p1.id, code=f"WO-LEG-P1-{so.id}", status="draft"
+        )
+
+        result = sales_order_service.generate_production_orders(
+            db, so.id, "test@filaops.dev"
+        )
+
+        assert len(result["created_orders"]) == 1
+        created = db.query(ProductionOrder).filter(
+            ProductionOrder.code == result["created_orders"][0]
+        ).one()
+        assert created.sales_order_line_id == line2.id
+        assert created.product_id == p2.id
+
+    def test_unconfirmed_order_without_any_wos_still_rejected(
+        self, db, make_sales_order, make_product
+    ):
+        """The fallback must not weaken the confirmation gate when no WOs
+        exist at all."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="pending", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.generate_production_orders(
+                db, so.id, "test@filaops.dev"
+            )
+        assert exc_info.value.status_code == 400
+        assert "confirm" in exc_info.value.detail.lower()
+
+
+# =============================================================================
+# resolve_legacy_fulfillment
+# =============================================================================
+
+class TestResolveLegacyFulfillment:
+    """close_out / reopen actions and the server-side mismatch guard."""
+
+    def test_close_out_records_fulfillment_paperwork_only(
+        self, db, make_sales_order, make_product
+    ):
+        so, lines = _make_legacy_completed_order(db, make_sales_order, make_product)
+
+        order = sales_order_service.resolve_legacy_fulfillment(
+            db, order_id=so.id, action="close_out", user_email="admin@filaops.dev"
+        )
+        db.flush()
+
+        assert order.shipped_at is not None
+        assert order.fulfillment_status == "shipped"
+        assert order.status == "completed"  # status untouched
+        for line in lines:
+            db.refresh(line)
+            assert line.shipped_quantity == line.quantity
+        assert "Legacy fulfillment closed out by admin@filaops.dev" in order.internal_notes
+
+        # DESIGN DECISION: paperwork only — no inventory movements, no GL.
+        txns = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "sales_order",
+            InventoryTransaction.reference_id == so.id,
+        ).count()
+        assert txns == 0
+        gl = db.query(GLJournalEntry).filter(
+            GLJournalEntry.source_type == "sales_order",
+            GLJournalEntry.source_id == so.id,
+        ).count()
+        assert gl == 0
+
+    def test_close_out_uses_actual_completion_date_when_present(
+        self, db, make_sales_order, make_product
+    ):
+        completed_at = datetime(2026, 1, 15, 12, 0, 0)
+        so, _ = _make_legacy_completed_order(db, make_sales_order, make_product)
+        so.actual_completion_date = completed_at
+        db.flush()
+
+        order = sales_order_service.resolve_legacy_fulfillment(
+            db, order_id=so.id, action="close_out", user_email="admin@filaops.dev"
+        )
+        assert order.shipped_at == completed_at
+
+    def test_close_out_on_delivered_order_sets_delivered_fulfillment(
+        self, db, make_sales_order, make_product
+    ):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="delivered", order_type="line_item", fulfillment_status="pending"
+        )
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        order = sales_order_service.resolve_legacy_fulfillment(
+            db, order_id=so.id, action="close_out", user_email="admin@filaops.dev"
+        )
+        assert order.fulfillment_status == "delivered"
+
+    def test_reopen_sets_ready_to_ship(self, db, make_sales_order, make_product):
+        so, lines = _make_legacy_completed_order(db, make_sales_order, make_product)
+
+        order = sales_order_service.resolve_legacy_fulfillment(
+            db, order_id=so.id, action="reopen", user_email="admin@filaops.dev"
+        )
+        db.flush()
+
+        assert order.status == "ready_to_ship"
+        assert order.fulfillment_status == "ready"
+        assert order.shipped_at is None
+        for line in lines:
+            db.refresh(line)
+            assert (line.shipped_quantity or Decimal("0")) == Decimal("0")
+        assert "Legacy fulfillment reopened" in order.internal_notes
+
+    def test_409_when_shipment_evidence_exists(
+        self, db, make_sales_order, make_product
+    ):
+        """shipped_at present → not a legacy mismatch → 409."""
+        so, _ = _make_legacy_completed_order(db, make_sales_order, make_product)
+        so.shipped_at = datetime.now(timezone.utc)
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.resolve_legacy_fulfillment(
+                db, order_id=so.id, action="close_out", user_email="admin@filaops.dev"
+            )
+        assert exc_info.value.status_code == 409
+
+    def test_409_when_line_shipped_quantity_present(
+        self, db, make_sales_order, make_product
+    ):
+        so, lines = _make_legacy_completed_order(db, make_sales_order, make_product)
+        lines[0].shipped_quantity = Decimal("1")
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.resolve_legacy_fulfillment(
+                db, order_id=so.id, action="reopen", user_email="admin@filaops.dev"
+            )
+        assert exc_info.value.status_code == 409
+
+    def test_409_when_status_not_in_shipped_set(
+        self, db, make_sales_order, make_product
+    ):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="in_production", order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.resolve_legacy_fulfillment(
+                db, order_id=so.id, action="close_out", user_email="admin@filaops.dev"
+            )
+        assert exc_info.value.status_code == 409
+
+    def test_400_for_unknown_action(self, db, make_sales_order, make_product):
+        so, _ = _make_legacy_completed_order(db, make_sales_order, make_product)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.resolve_legacy_fulfillment(
+                db, order_id=so.id, action="explode", user_email="admin@filaops.dev"
+            )
+        assert exc_info.value.status_code == 400
+
+
+# =============================================================================
+# get_material_requirements — historical flag
+# =============================================================================
+
+class TestHistoricalRequirementsFlag:
+    """Terminal/short-closed orders are flagged historical in the summary."""
+
+    @pytest.mark.parametrize(
+        "status", ["completed", "cancelled", "shipped", "delivered"]
+    )
+    def test_terminal_statuses_are_historical(
+        self, db, make_sales_order, make_product, status
+    ):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status=status, order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        result = sales_order_service.get_material_requirements(db, so.id)
+        assert result["summary"]["historical"] is True
+
+    @pytest.mark.parametrize("status", ["confirmed", "in_production", "pending"])
+    def test_active_statuses_are_not_historical(
+        self, db, make_sales_order, make_product, status
+    ):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status=status, order_type="line_item")
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        result = sales_order_service.get_material_requirements(db, so.id)
+        assert result["summary"]["historical"] is False
+
+    def test_closed_short_order_is_historical(
+        self, db, make_sales_order, make_product
+    ):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="ready_to_ship", order_type="line_item", closed_short=True
+        )
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        result = sales_order_service.get_material_requirements(db, so.id)
+        assert result["summary"]["historical"] is True

--- a/backend/tests/services/test_legacy_order_health.py
+++ b/backend/tests/services/test_legacy_order_health.py
@@ -157,6 +157,32 @@ class TestLegacyWOCoverage:
         assert created.sales_order_line_id == line2.id
         assert created.product_id == p2.id
 
+    def test_cancelled_wos_are_not_coverage(
+        self, db, make_sales_order, make_product
+    ):
+        """Cancelled WOs (linked or legacy NULL-linked) must not block
+        regeneration — an order whose WOs were all cancelled gets new ones."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="confirmed", order_type="line_item")
+        line = _make_order_line(db, so.id, product.id, quantity=2)
+        _make_legacy_wo(
+            db,
+            so_id=so.id,
+            product_id=product.id,
+            code=f"WO-LEG-CANC-{so.id}",
+            status="cancelled",
+        )
+
+        result = sales_order_service.generate_production_orders(
+            db, so.id, "test@filaops.dev"
+        )
+
+        assert len(result["created_orders"]) == 1
+        created = db.query(ProductionOrder).filter(
+            ProductionOrder.code == result["created_orders"][0]
+        ).one()
+        assert created.sales_order_line_id == line.id
+
     def test_unconfirmed_order_without_any_wos_still_rejected(
         self, db, make_sales_order, make_product
     ):

--- a/frontend/src/components/orders/MaterialRequirementsSection.jsx
+++ b/frontend/src/components/orders/MaterialRequirementsSection.jsx
@@ -19,6 +19,11 @@ export default function MaterialRequirementsSection({
     0
   );
   const hasShortages = materialRequirements.some((req) => req.net_shortage > 0);
+  // LEGACY-1: the backend flags terminal/short-closed orders as historical —
+  // requirements are still shown for reference, but stock is not re-checked,
+  // so live shortage alerts would be phantom noise.
+  const isHistorical = Boolean(materialAvailability?.historical);
+  const showShortageAlerts = hasShortages && !isHistorical;
 
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
@@ -36,9 +41,14 @@ export default function MaterialRequirementsSection({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
           Material Requirements
-          {hasShortages && (
+          {showShortageAlerts && (
             <span className="px-2 py-0.5 bg-red-500/20 text-red-400 text-xs rounded-full">
               {materialRequirements.filter((r) => r.net_shortage > 0).length} Shortage{materialRequirements.filter((r) => r.net_shortage > 0).length !== 1 ? "s" : ""}
+            </span>
+          )}
+          {isHistorical && (
+            <span className="px-2 py-0.5 bg-gray-500/20 text-gray-400 text-xs rounded-full">
+              Reference only
             </span>
           )}
         </button>
@@ -72,7 +82,7 @@ export default function MaterialRequirementsSection({
                     <tr
                       key={idx}
                       className={`border-b border-gray-800 ${
-                        req.net_shortage > 0 ? "bg-red-900/20" : ""
+                        req.net_shortage > 0 && !isHistorical ? "bg-red-900/20" : ""
                       }`}
                     >
                       <td className="p-2">
@@ -105,7 +115,9 @@ export default function MaterialRequirementsSection({
                         <span
                           className={
                             req.net_shortage > 0
-                              ? "text-red-400 font-semibold"
+                              ? isHistorical
+                                ? "text-gray-400"
+                                : "text-red-400 font-semibold"
                               : "text-green-400"
                           }
                         >
@@ -114,6 +126,7 @@ export default function MaterialRequirementsSection({
                       </td>
                       <td className="p-2 text-center">
                         {req.net_shortage > 0 &&
+                          !isHistorical &&
                           (req.has_bom ? (
                             <button
                               onClick={() => onCreateWorkOrder(req)}
@@ -136,7 +149,9 @@ export default function MaterialRequirementsSection({
                 <tfoot>
                   <tr className="bg-gray-800 font-semibold">
                     <td colSpan="4" className="p-2 text-right text-white">
-                      {materialAvailability?.has_shortages ? (
+                      {isHistorical ? (
+                        <span className="text-gray-400">Shown for reference</span>
+                      ) : materialAvailability?.has_shortages ? (
                         <span className="text-red-400">
                           {materialAvailability.materials_short} of {materialAvailability.total_materials} materials short
                         </span>
@@ -152,7 +167,7 @@ export default function MaterialRequirementsSection({
                 </tfoot>
               </table>
 
-              {hasShortages && (
+              {showShortageAlerts && (
                 <div className="mt-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
                   <p className="text-red-400 text-sm">
                     Material shortages detected. Create{" "}
@@ -160,6 +175,14 @@ export default function MaterialRequirementsSection({
                     sub-assemblies or{" "}
                     <span className="text-blue-400">Purchase Orders</span> for raw
                     materials.
+                  </p>
+                </div>
+              )}
+              {isHistorical && (
+                <div className="mt-4 p-3 bg-gray-800/60 border border-gray-700 rounded-lg">
+                  <p className="text-gray-400 text-sm">
+                    Order is {(order?.status || "").replace(/_/g, " ")} —
+                    requirements shown for reference; stock is not re-checked.
                   </p>
                 </div>
               )}

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -43,6 +43,14 @@ const formatMoney = (value) => `$${parseFloat(value || 0).toFixed(2)}`;
 const COMPLETE_PRODUCTION_STATUSES = new Set(["complete", "completed", "closed"]);
 const SHIPPED_ORDER_STATUSES = new Set(["shipped", "delivered", "completed"]);
 const UNCONFIRMED_ORDER_STATUSES = new Set(["draft", "pending", "pending_confirmation"]);
+// LEGACY-1: order-level fulfillment_status values that count as shipment
+// evidence (order_status.py sets "shipped"/"delivered"; "fulfilled" is
+// accepted defensively for older data).
+const SHIPMENT_EVIDENCE_FULFILLMENT_STATUSES = new Set([
+  "fulfilled",
+  "shipped",
+  "delivered",
+]);
 
 export default function OrderDetail() {
   const { orderId } = useParams();
@@ -71,13 +79,49 @@ export default function OrderDetail() {
           .map((po) => po.sales_order_line_id)
           .filter((lineId) => lineId !== null && lineId !== undefined)
       );
-      return productLines.every((line) => woLineIds.has(line.id));
+      // LEGACY-1 fallback: WOs created before line-level linkage existed
+      // have sales_order_line_id = null. Treat such a WO as covering every
+      // line with the same product_id (coverage check, not assignment).
+      // Mirrored in generate_production_orders() in
+      // backend/app/services/sales_order_service.py — keep in sync.
+      const legacyCoveredProductIds = new Set(
+        productionOrders
+          .filter(
+            (po) =>
+              po.sales_order_line_id === null ||
+              po.sales_order_line_id === undefined
+          )
+          .map((po) => po.product_id)
+      );
+      return productLines.every(
+        (line) =>
+          woLineIds.has(line.id) || legacyCoveredProductIds.has(line.product_id)
+      );
     }
     if (order?.product_id) {
       return productionOrders.some((po) => po.product_id === order.product_id);
     }
     return false;
   };
+
+  // LEGACY-1: shipment evidence — did anything actually ship?
+  const hasShipmentEvidence = () => {
+    if (!order) return false;
+    if (order.shipped_at) return true;
+    if (SHIPMENT_EVIDENCE_FULFILLMENT_STATUSES.has(order.fulfillment_status)) {
+      return true;
+    }
+    return (order.lines || []).some(
+      (line) => parseFloat(line.shipped_quantity || 0) > 0
+    );
+  };
+
+  // Mismatch: status claims shipped/delivered/completed, but no shipment
+  // was ever recorded — legacy data from an older FilaOps version.
+  const isLegacyFulfillmentMismatch = () =>
+    Boolean(order) &&
+    SHIPPED_ORDER_STATUSES.has(order.status) &&
+    !hasShipmentEvidence();
 
   const [error, setError] = useState(null);
   const [exploding, setExploding] = useState(false);
@@ -147,6 +191,11 @@ export default function OrderDetail() {
 
   // Refresh state
   const [refreshing, setRefreshing] = useState(false);
+
+  // LEGACY-1: legacy fulfillment resolution state
+  // legacyResolveAction is "close_out" | "reopen" | null (null = modal closed)
+  const [legacyResolveAction, setLegacyResolveAction] = useState(null);
+  const [resolvingLegacy, setResolvingLegacy] = useState(false);
 
   // SCHED-3b: guided schedule wizard state
   // wizardPending=true means we're waiting for fetchProductionOrders to
@@ -575,6 +624,31 @@ export default function OrderDetail() {
     }
   };
 
+  // LEGACY-1: resolve a legacy fulfillment mismatch (close_out | reopen)
+  const handleResolveLegacyFulfillment = async () => {
+    if (!legacyResolveAction) return;
+    setResolvingLegacy(true);
+    try {
+      await api.post(
+        `/api/v1/sales-orders/${orderId}/resolve-legacy-fulfillment`,
+        { action: legacyResolveAction }
+      );
+      toast.success(
+        legacyResolveAction === "close_out"
+          ? `Order ${order.order_number} closed out — fulfillment recorded`
+          : `Order ${order.order_number} reopened — ready to ship`
+      );
+      setLegacyResolveAction(null);
+      fetchOrder();
+      fetchProductionOrders();
+      refetchFulfillment();
+    } catch (err) {
+      toast.error(err.message || "Failed to resolve legacy fulfillment");
+    } finally {
+      setResolvingLegacy(false);
+    }
+  };
+
   const handleSaveLineEdit = async (lineId) => {
     if ((editQty === "" && editPrice === "") || !editReason.trim()) return;
     setSavingLineEdit(true);
@@ -835,6 +909,9 @@ export default function OrderDetail() {
     const productionReleased = hasMainProductWO();
     const productionComplete = getProductionComplete();
     const shipped = SHIPPED_ORDER_STATUSES.has(status);
+    // LEGACY-1: "done" requires evidence, not just a status claim.
+    const shipmentEvidence = hasShipmentEvidence();
+    const legacyMismatch = shipped && !shipmentEvidence;
     const noProductionNeeded = !hasOrderProduct();
     const releaseBlockReason = getProductionReleaseBlockReason();
     const shipBlockReason = getShipBlockReason();
@@ -949,16 +1026,20 @@ export default function OrderDetail() {
         title: "Fulfillment",
         Icon: Truck,
         state: getStepState({
-          done: shipped,
+          done: shipped && shipmentEvidence,
           active: canShipOrder(),
-          blocked: !shipped && Boolean(shipBlockReason),
+          blocked: legacyMismatch || (!shipped && Boolean(shipBlockReason)),
         }),
-        meta: shipped
+        meta: legacyMismatch
+          ? "Needs review"
+          : shipped
           ? status.replace(/_/g, " ")
           : productionComplete
           ? "Ready to ship"
           : "Waiting",
-        detail: shipped
+        detail: legacyMismatch
+          ? `Order status says ${status.replace(/_/g, " ")}, but no shipment was recorded.`
+          : shipped
           ? "Shipment is already in progress or complete."
           : shipBlockReason || "Production is complete and materials are clear.",
         action: canShipOrder()
@@ -1064,6 +1145,44 @@ export default function OrderDetail() {
           </button>
         </div>
       </div>
+
+      {/* LEGACY-1: data-health banner for legacy fulfillment mismatch */}
+      {isLegacyFulfillmentMismatch() && (
+        <div className="rounded-xl border border-amber-500/40 bg-amber-950/20 p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400 mt-0.5" />
+              <div>
+                <p className="text-sm font-semibold text-amber-300">
+                  Legacy data issue: no shipment on record
+                </p>
+                <p className="mt-1 text-sm text-amber-200/80">
+                  This order&apos;s status says{" "}
+                  <span className="font-medium capitalize">
+                    {order.status.replace(/_/g, " ")}
+                  </span>
+                  , but no shipment was ever recorded — likely data from an
+                  older FilaOps version.
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2">
+              <button
+                onClick={() => setLegacyResolveAction("close_out")}
+                className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500"
+              >
+                Close Out as Fulfilled
+              </button>
+              <button
+                onClick={() => setLegacyResolveAction("reopen")}
+                className="rounded-lg border border-amber-500/40 bg-gray-800 px-3 py-2 text-sm font-medium text-amber-200 hover:bg-gray-700"
+              >
+                Reopen for Shipping
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Order Workflow */}
       <div className="rounded-xl border border-gray-700 bg-gray-900/60 p-5">
@@ -1794,6 +1913,60 @@ export default function OrderDetail() {
                 className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {closingShort ? "Closing..." : "Close Order Short"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* LEGACY-1: confirm dialog for legacy fulfillment resolution */}
+      {legacyResolveAction && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          onClick={() => !resolvingLegacy && setLegacyResolveAction(null)}
+        >
+          <div
+            className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full mx-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold text-white mb-2">
+              {legacyResolveAction === "close_out"
+                ? "Close Out as Fulfilled"
+                : "Reopen for Shipping"}
+            </h3>
+            {legacyResolveAction === "close_out" ? (
+              <p className="text-gray-400 text-sm mb-4">
+                This records the order as fully shipped (paperwork only). No
+                inventory movements or accounting entries are created — the
+                goods already left under an older FilaOps version. An audit
+                note is added to the order.
+              </p>
+            ) : (
+              <p className="text-gray-400 text-sm mb-4">
+                This sets the order back to Ready to Ship so you can ship it
+                through the normal flow (which records inventory and
+                accounting). Invoice and payment are left untouched. An audit
+                note is added to the order.
+              </p>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setLegacyResolveAction(null)}
+                disabled={resolvingLegacy}
+                className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleResolveLegacyFulfillment}
+                disabled={resolvingLegacy}
+                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {resolvingLegacy
+                  ? "Working..."
+                  : legacyResolveAction === "close_out"
+                  ? "Close Out"
+                  : "Reopen Order"}
               </button>
             </div>
           </div>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -72,10 +72,15 @@ export default function OrderDetail() {
   };
 
   const hasMainProductWO = () => {
+    // Cancelled WOs are not coverage — mirrored in
+    // generate_production_orders() (backend) — keep in sync.
+    const activePOs = productionOrders.filter(
+      (po) => po.status !== "cancelled"
+    );
     const productLines = order?.lines?.filter((line) => line.product_id) || [];
     if (productLines.length > 0) {
       const woLineIds = new Set(
-        productionOrders
+        activePOs
           .map((po) => po.sales_order_line_id)
           .filter((lineId) => lineId !== null && lineId !== undefined)
       );
@@ -85,7 +90,7 @@ export default function OrderDetail() {
       // Mirrored in generate_production_orders() in
       // backend/app/services/sales_order_service.py — keep in sync.
       const legacyCoveredProductIds = new Set(
-        productionOrders
+        activePOs
           .filter(
             (po) =>
               po.sales_order_line_id === null ||
@@ -99,7 +104,7 @@ export default function OrderDetail() {
       );
     }
     if (order?.product_id) {
-      return productionOrders.some((po) => po.product_id === order.product_id);
+      return activePOs.some((po) => po.product_id === order.product_id);
     }
     return false;
   };

--- a/frontend/src/pages/admin/__tests__/OrderDetailLegacyHealth.test.jsx
+++ b/frontend/src/pages/admin/__tests__/OrderDetailLegacyHealth.test.jsx
@@ -1,0 +1,429 @@
+/**
+ * OrderDetailLegacyHealth.test.jsx — LEGACY-1 brownfield order data health
+ *
+ * Tests:
+ * - Step 4 (Fulfillment) "done" requires shipment evidence, not just status
+ * - Step 4 shows blocked + honest copy when status says shipped but nothing
+ *   was recorded
+ * - Legacy NULL-linked WOs count as production coverage (Step 3)
+ * - Amber data-health banner appears only on a legacy fulfillment mismatch
+ * - Banner buttons open a confirm dialog and call the resolve endpoint
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mocks } = vi.hoisted(() => {
+  const mocks = {
+    get: vi.fn(),
+    post: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastInfo: vi.fn(),
+    navigate: vi.fn(),
+  }
+  mocks.api = {
+    get: mocks.get,
+    post: mocks.post,
+  }
+  mocks.toast = {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    info: mocks.toastInfo,
+  }
+  return { mocks }
+})
+
+vi.mock('../../../hooks/useApi', () => ({
+  useApi: () => mocks.api,
+}))
+
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => mocks.toast,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  }
+})
+
+vi.mock('../../../hooks/useFulfillmentStatus', () => ({
+  useFulfillmentStatus: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../components/orders/BlockingIssuesPanel', () => ({
+  default: () => <div data-testid="blocking-issues" />,
+}))
+
+vi.mock('../../../components/orders/FulfillmentProgress', () => ({
+  default: () => <div data-testid="fulfillment-progress" />,
+}))
+
+vi.mock('../../../components/orders/ProductionStatusCards', () => ({
+  ProductionProgressSummary: () => <div data-testid="production-summary" />,
+  ProductionOrderStatusCard: ({ order }) => (
+    <div data-testid={`po-card-${order.id}`}>{order.code}</div>
+  ),
+}))
+
+vi.mock('../../../components/orders/MaterialRequirementsSection', () => ({
+  default: () => <div data-testid="material-req" />,
+}))
+
+vi.mock('../../../components/orders/CapacityRequirementsSection', () => ({
+  default: () => <div data-testid="capacity-req" />,
+}))
+
+vi.mock('../../../components/orders/PaymentsSection', () => ({
+  default: () => <div data-testid="payments-section" />,
+}))
+
+vi.mock('../../../components/orders/ShippingAddressSection', () => ({
+  default: () => <div data-testid="shipping-address" />,
+}))
+
+vi.mock('../../../components/orders/OrderModals', () => ({
+  CancelOrderModal: () => <div data-testid="cancel-modal" />,
+  DeleteOrderModal: () => <div data-testid="delete-modal" />,
+}))
+
+vi.mock('../../../components/payments/RecordPaymentModal', () => ({
+  default: () => <div data-testid="payment-modal" />,
+}))
+
+vi.mock('../../../components/ActivityTimeline', () => ({
+  default: () => <div data-testid="activity-timeline" />,
+}))
+
+vi.mock('../../../components/ShippingTimeline', () => ({
+  default: () => <div data-testid="shipping-timeline" />,
+}))
+
+import OrderDetail from '../OrderDetail'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** SO-2026-0041 shape: completed order, nothing ever shipped. */
+function makeLegacyOrder(overrides = {}) {
+  return {
+    id: 1001,
+    order_number: 'SO-2026-0041',
+    order_type: 'line_item',
+    status: 'completed',
+    fulfillment_status: 'pending',
+    payment_status: 'paid',
+    shipped_at: null,
+    closed_short: false,
+    quantity: 4,
+    total_price: '40.00',
+    grand_total: '40.00',
+    product_id: null,
+    product_name: null,
+    lines: [
+      {
+        id: 101,
+        product_id: 42,
+        product_name: 'Test Widget',
+        product_sku: 'TW-001',
+        quantity: 2,
+        unit_price: '10.00',
+        total: '20.00',
+        shipped_quantity: 0,
+        line_type: 'product',
+      },
+      {
+        id: 102,
+        product_id: 43,
+        product_name: 'Test Gadget',
+        product_sku: 'TG-001',
+        quantity: 2,
+        unit_price: '10.00',
+        total: '20.00',
+        shipped_quantity: 0,
+        line_type: 'product',
+      },
+    ],
+    customer_name: 'ACME Corp',
+    customer_email: 'acme@example.com',
+    ...overrides,
+  }
+}
+
+/** Legacy WOs: complete but sales_order_line_id = null (pre-#713). */
+function makeLegacyWOs() {
+  return [
+    {
+      id: 555,
+      code: 'PO-2026-0055',
+      status: 'complete',
+      product_id: 42,
+      sales_order_line_id: null,
+      quantity_ordered: 2,
+      quantity_completed: 2,
+    },
+    {
+      id: 556,
+      code: 'PO-2026-0056',
+      status: 'complete',
+      product_id: 43,
+      sales_order_line_id: null,
+      quantity_ordered: 2,
+      quantity_completed: 2,
+    },
+  ]
+}
+
+function setupApiMocks({ order, productionOrders = [], invoice = null } = {}) {
+  mocks.get.mockImplementation((path) => {
+    if (path.includes('/api/v1/sales-orders/1001') && !path.includes('material')) {
+      return Promise.resolve(order)
+    }
+    if (path.includes('material-requirements')) {
+      return Promise.resolve({ requirements: [], summary: null })
+    }
+    if (path.includes('/api/v1/production-orders')) {
+      return Promise.resolve({ items: productionOrders })
+    }
+    if (path.includes('/api/v1/payments/order')) {
+      return Promise.resolve({ total_paid: 40, total_due: 0 })
+    }
+    if (path.includes('/api/v1/payments')) {
+      return Promise.resolve({ items: [] })
+    }
+    if (path.includes('/api/v1/invoices')) {
+      return Promise.resolve({ items: invoice ? [invoice] : [] })
+    }
+    return Promise.resolve({})
+  })
+}
+
+function renderOrderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/admin/orders/1001']}>
+      <Routes>
+        <Route path="/admin/orders/:orderId" element={<OrderDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mocks.get.mockReset()
+  mocks.post.mockReset()
+  mocks.toastError.mockReset()
+  mocks.toastSuccess.mockReset()
+  mocks.navigate.mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// Step 4 — shipment evidence
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — Step 4 fulfillment evidence (LEGACY-1)', () => {
+  it('marks Step 4 blocked with honest copy when status is completed but nothing shipped', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.getByText(/order status says completed, but no shipment was recorded/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/needs review/i)).toBeInTheDocument()
+  })
+
+  it('marks Step 4 done when shipped_at evidence exists', async () => {
+    const order = makeLegacyOrder({ shipped_at: '2026-01-15T12:00:00Z' })
+    setupApiMocks({ order, productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.queryByText(/no shipment was recorded/i),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/shipment is already in progress or complete/i),
+    ).toBeInTheDocument()
+  })
+
+  it('marks Step 4 done when a line has shipped_quantity > 0', async () => {
+    const order = makeLegacyOrder()
+    order.lines[0].shipped_quantity = 2
+    setupApiMocks({ order, productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.queryByText(/no shipment was recorded/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('marks Step 4 done when fulfillment_status is shipped', async () => {
+    const order = makeLegacyOrder({ fulfillment_status: 'shipped' })
+    setupApiMocks({ order, productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.queryByText(/no shipment was recorded/i),
+    ).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Step 3 — legacy NULL-linked WO coverage
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — legacy WO coverage fallback (LEGACY-1)', () => {
+  it('treats NULL-linked WOs matching line products as production coverage', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    // Step 3 considers production released → Open Work Order, no misleading block
+    expect(screen.getByRole('button', { name: /open work order/i })).toBeInTheDocument()
+    expect(
+      screen.queryByText(/work orders can only be created while the order is in confirmed status/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT count a NULL-linked WO toward lines of a different product', async () => {
+    // Only one legacy WO (product 42); line for product 43 is uncovered.
+    setupApiMocks({
+      order: makeLegacyOrder(),
+      productionOrders: [makeLegacyWOs()[0]],
+    })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.getByText(/work orders can only be created while the order is in confirmed status; this order is completed/i),
+    ).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Legacy data-health banner + guided resolution
+// ---------------------------------------------------------------------------
+
+describe('OrderDetail — legacy fulfillment banner (LEGACY-1)', () => {
+  it('shows the amber banner when status claims shipped but no evidence exists', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.getByText(/no shipment was ever recorded — likely data from an older filaops version/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /close out as fulfilled/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reopen for shipping/i })).toBeInTheDocument()
+  })
+
+  it('does NOT show the banner when shipment evidence exists', async () => {
+    const order = makeLegacyOrder({ shipped_at: '2026-01-15T12:00:00Z' })
+    setupApiMocks({ order, productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.queryByText(/no shipment was ever recorded/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does NOT show the banner for non-shipped statuses', async () => {
+    const order = makeLegacyOrder({ status: 'in_production' })
+    setupApiMocks({ order, productionOrders: makeLegacyWOs() })
+
+    renderOrderDetail()
+
+    await screen.findByText('Order Workflow')
+    expect(
+      screen.queryByText(/no shipment was ever recorded/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Close Out opens confirm dialog and posts action=close_out', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+    mocks.post.mockResolvedValue({})
+
+    renderOrderDetail()
+
+    const closeOutBtn = await screen.findByRole('button', { name: /close out as fulfilled/i })
+    fireEvent.click(closeOutBtn)
+
+    // Confirm dialog with the no-inventory/no-GL explanation
+    expect(
+      await screen.findByText(/no inventory movements or accounting entries are created/i),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^close out$/i }))
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        '/api/v1/sales-orders/1001/resolve-legacy-fulfillment',
+        { action: 'close_out' },
+      )
+    })
+    await waitFor(() => {
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        expect.stringMatching(/closed out/i),
+      )
+    })
+  })
+
+  it('Reopen opens confirm dialog and posts action=reopen', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+    mocks.post.mockResolvedValue({})
+
+    renderOrderDetail()
+
+    const reopenBtn = await screen.findByRole('button', { name: /reopen for shipping/i })
+    fireEvent.click(reopenBtn)
+
+    expect(
+      await screen.findByText(/sets the order back to ready to ship/i),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /reopen order/i }))
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith(
+        '/api/v1/sales-orders/1001/resolve-legacy-fulfillment',
+        { action: 'reopen' },
+      )
+    })
+  })
+
+  it('shows an error toast and keeps the dialog usable when the resolve call fails', async () => {
+    setupApiMocks({ order: makeLegacyOrder(), productionOrders: makeLegacyWOs() })
+    mocks.post.mockRejectedValue(new Error('No legacy fulfillment mismatch on this order'))
+
+    renderOrderDetail()
+
+    fireEvent.click(await screen.findByRole('button', { name: /close out as fulfilled/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^close out$/i }))
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        'No legacy fulfillment mismatch on this order',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Orders created before production orders carried `sales_order_line_id` (pre-#713) contradict themselves on the Order Detail page. Case study: **SO-2026-0041** (`sales_orders.id=2715`, status=`completed`, 2 lines, 2 complete WOs with NULL line ids, all `shipped_quantity=0`, `fulfillment_status='pending'`, `shipped_at` NULL, invoice paid) showed three contradictions at once:

1. **Workflow Step 3 said "blocked / Not released … order is completed"** even though both WOs exist and are complete. `hasMainProductWO()` (frontend) and the existing-PO check in `generate_production_orders` (backend) both match WOs strictly by `sales_order_line_id`, so NULL-linked legacy WOs matched nothing and the backend fell through to the misleading "must be Confirmed" 400.
2. **Step 4 (Fulfillment) showed DONE purely from order status** (`shipped`/`delivered`/`completed`) even though nothing ever shipped — no `shipped_at`, all line `shipped_quantity=0`.
3. **Material Requirements showed phantom shortages forever**: `get_material_requirements` re-explodes demand and nets against *current* stock regardless of order status, so a completed order keeps screaming about shortages for goods that already left.

## Fixes

### Migration 091 — data backfill (idempotent, server-side SQL)
Backfills `production_orders.sales_order_line_id` where it is NULL, the parent order is `order_type='line_item'`, and **exactly one** line on that order matches the WO's `product_id` (`HAVING COUNT(*) = 1`). Ambiguous rows (0 or >1 candidate lines) stay NULL. Downgrade is a documented no-op — backfilled values are indistinguishable from organic ones, so reverting would risk destroying legitimate links. Single alembic head verified (`091`).

### Runtime legacy-coverage fallback (mirrored both sides)
A line counts as covered if a WO is linked to it by id **or** a NULL-linked WO exists with the same `product_id` (coverage check, not assignment). Applied in `generate_production_orders` (backend) and `hasMainProductWO()` (frontend) with cross-referencing comments to keep them in sync. Legacy orders now get the friendly "Production orders already exist" response.

### Fulfillment step honesty
Step 4 "done" now requires status ∈ shipped-set **and** shipment evidence (`shipped_at` set, any line `shipped_quantity > 0`, or `fulfillment_status` ∈ shipped/delivered — grounded in `order_status.py`, which never writes "fulfilled"; it is accepted defensively). Status without evidence renders the step amber/blocked with "Order status says {status}, but no shipment was recorded."

### Historical requirements guard
`get_material_requirements` adds `summary.historical = true` for terminal statuses (`completed`, `cancelled`, `shipped`, `delivered`) or `closed_short` orders. Requirements are still computed and shown, but `MaterialRequirementsSection` suppresses shortage badges/alerts/action buttons and shows a neutral "requirements shown for reference; stock is not re-checked" note.

### Guided resolution — `POST /api/v1/sales-orders/{id}/resolve-legacy-fulfillment`
Admin-gated (same pattern as sibling endpoints). Server re-validates the mismatch (status ∈ shipped-set AND no evidence) and **409s** otherwise, so a stale UI can never mutate a healthy order. Amber banner on OrderDetail offers both actions with confirm dialogs:

- **`close_out`** — sets each line's `shipped_quantity = quantity`, order `fulfillment_status` to `shipped` (or `delivered` when status is delivered), `shipped_at = actual_completion_date or now`, and appends an audit note to `internal_notes`.
  **Design decision (owner):** close_out posts **NO inventory movements and NO GL entries**. It is paperwork reconciliation for goods that physically left long ago; per the HARD-4c doctrine, current stock truth comes from the inventory ledger + cycle counts. Backdating COGS/inventory relief would corrupt both. Rationale lives in a code comment on `resolve_legacy_fulfillment`.
- **`reopen`** — sets status to `ready_to_ship` (production already complete) so the normal Ship flow (which *does* post inventory + GL) takes over; invoice/payment untouched; audit note appended.

## Tests

- **Backend**: `tests/services/test_legacy_order_health.py` — 20 passed (legacy coverage fallback incl. multi-line/cross-product cases, close_out/reopen incl. no-inventory/no-GL assertions and `actual_completion_date` precedence, 409 guards for evidence/status, 400 unknown action, historical flag across 8 statuses). Targeted existing suites (`TestGenerateProductionOrders`, `TestGetMaterialRequirements*`): 25 passed. Full `test_sales_order_service.py` + `tests/api/v1/test_sales_orders.py` failures (21/10) are pre-existing — verified identical with this branch's changes stashed.
- **Frontend**: `OrderDetailLegacyHealth.test.jsx` — 12 passed (Step-4 evidence on/off, legacy WO coverage incl. non-matching product, banner visibility, both resolve actions through confirm dialog, error path). Full `npm run test:unit`: **417 passed / 46 files**. `npm run build` passes.
- `python -m ruff check app/` clean; boolean filters use `.is_()`; Decimal-only quantity handling.

## Migration note

`091_backfill_legacy_wo_line_links.py` (down_revision `090`) — pure data migration, idempotent, no schema change, safe to run repeatedly. Not run against any database from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can resolve legacy fulfillment mismatches (close out or reopen) from the UI.
  * Material requirements show a “Reference only” historical mode with a badge, gray styling, and suppressed live shortage actions/alerts.
  * UI displays a legacy data-health banner with guided resolution modals.

* **Bug Fixes**
  * Prevented duplicate production orders from legacy unlinked work orders.
  * Improved detection of shipment evidence and fulfillment-step status handling.

* **Chores**
  * Backfill migration to link legacy production orders to sales order lines.

* **Tests**
  * Added comprehensive tests for legacy fulfillment, work-order coverage, and historical flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->