### PR TITLE
feat: Scheduler (Gantt) view — machine lanes × time axis (SCHED-5)

### DIFF
--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -33,6 +33,218 @@ from app.services.resource_compatibility_service import (
 router = APIRouter()
 
 
+@router.get("/board")
+async def get_scheduler_board(
+    start_date: datetime = Query(..., description="Window start (ISO 8601)"),
+    end_date: datetime = Query(..., description="Window end (ISO 8601)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    SCHED-5: One-call payload for the Scheduler (Gantt) view.
+
+    Returns every machine lane (machine-type Resources + Printers) with the
+    operations scheduled on it inside the window, plus the unscheduled-orders
+    work queue. Operations may be scheduled against either a Resource
+    (scheduler modal path, op.resource_id) or a Printer (dispatch path,
+    op.printer_id) — the two are distinct models with no FK between them, so
+    lanes are keyed "resource-{id}" / "printer-{id}".
+
+    Read-only; one query per concern (no per-lane N+1).
+    """
+    from sqlalchemy.orm import joinedload
+
+    from app.models.printer import Printer
+    from app.models.production_order import ProductionOrderOperation
+    from app.services.resource_scheduling import TERMINAL_STATUSES
+
+    # Scheduled_* columns are timezone-naive UTC, but values still in the
+    # session identity map (or from other DBs) may carry tzinfo. Normalize
+    # BOTH the window and every op timestamp to naive UTC so Python-side
+    # clipping never mixes aware and naive datetimes.
+    def _naive_utc(dt: datetime) -> datetime:
+        if dt.tzinfo is not None:
+            return dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+
+    start_date = _naive_utc(start_date)
+    end_date = _naive_utc(end_date)
+
+    if end_date <= start_date:
+        raise HTTPException(status_code=422, detail="end_date must be after start_date")
+
+    window_hours = (end_date - start_date).total_seconds() / 3600
+
+    # --- Lanes -----------------------------------------------------------
+    resources = (
+        db.query(Resource)
+        .join(WorkCenter, Resource.work_center_id == WorkCenter.id)
+        .filter(
+            Resource.is_active.is_(True),
+            WorkCenter.center_type == "machine",
+        )
+        .order_by(WorkCenter.code, Resource.code)
+        .all()
+    )
+    printers = db.query(Printer).order_by(Printer.code).all()
+
+    # --- Scheduled operations in window (single query) --------------------
+    ops = (
+        db.query(ProductionOrderOperation)
+        .options(
+            joinedload(ProductionOrderOperation.production_order)
+            .joinedload(ProductionOrder.product)
+        )
+        .filter(
+            ProductionOrderOperation.status.notin_(TERMINAL_STATUSES),
+            ProductionOrderOperation.scheduled_start.isnot(None),
+            ProductionOrderOperation.scheduled_end.isnot(None),
+            ProductionOrderOperation.scheduled_start < end_date,
+            ProductionOrderOperation.scheduled_end > start_date,
+            or_(
+                ProductionOrderOperation.resource_id.isnot(None),
+                ProductionOrderOperation.printer_id.isnot(None),
+            ),
+        )
+        .order_by(ProductionOrderOperation.scheduled_start)
+        .all()
+    )
+
+    def _op_block(op) -> dict:
+        po = op.production_order
+        return {
+            "id": op.id,
+            "operation_code": op.operation_code,
+            "operation_name": op.operation_name,
+            "sequence": op.sequence,
+            "status": op.status,
+            "scheduled_start": op.scheduled_start.isoformat(),
+            "scheduled_end": op.scheduled_end.isoformat(),
+            "planned_setup_minutes": (
+                str(op.planned_setup_minutes)
+                if op.planned_setup_minutes is not None
+                else "0"
+            ),
+            "planned_run_minutes": (
+                str(op.planned_run_minutes)
+                if op.planned_run_minutes is not None
+                else "0"
+            ),
+            "production_order_id": po.id if po else None,
+            "production_order_code": po.code if po else None,
+            "production_order_status": po.status if po else None,
+            "product_name": po.product.name if po and po.product else None,
+            "quantity": float(po.quantity_ordered) if po else None,
+        }
+
+    ops_by_lane: dict[str, list] = {}
+    for op in ops:
+        if op.printer_id is not None:
+            key = f"printer-{op.printer_id}"
+        else:
+            key = f"resource-{op.resource_id}"
+        ops_by_lane.setdefault(key, []).append(op)
+
+    def _lane(kind: str, obj, work_center_code: Optional[str]) -> dict:
+        key = f"{kind}-{obj.id}"
+        lane_ops = ops_by_lane.get(key, [])
+        # Utilization = scheduled time clipped to the window / window length
+        busy_hours = 0.0
+        for op in lane_ops:
+            clip_start = max(_naive_utc(op.scheduled_start), start_date)
+            clip_end = min(_naive_utc(op.scheduled_end), end_date)
+            busy_hours += max(0.0, (clip_end - clip_start).total_seconds() / 3600)
+        utilization = (busy_hours / window_hours * 100) if window_hours > 0 else 0.0
+        return {
+            "key": key,
+            "kind": kind,
+            "id": obj.id,
+            "code": obj.code,
+            "name": obj.name,
+            "status": obj.status or "unknown",
+            "work_center_code": work_center_code,
+            "utilization_percent": round(min(utilization, 100.0), 1),
+            "operations": [_op_block(op) for op in lane_ops],
+        }
+
+    lanes = [
+        _lane("resource", r, r.work_center.code if r.work_center else None)
+        for r in resources
+    ]
+    lanes += [_lane("printer", p, None) for p in printers]
+
+    # --- Unscheduled work queue (single query) -----------------------------
+    unscheduled_ops = (
+        db.query(ProductionOrderOperation)
+        .options(
+            joinedload(ProductionOrderOperation.production_order)
+            .joinedload(ProductionOrder.product)
+        )
+        .join(
+            ProductionOrder,
+            ProductionOrderOperation.production_order_id == ProductionOrder.id,
+        )
+        .filter(
+            ProductionOrder.status.in_(["released", "scheduled", "in_progress"]),
+            ProductionOrderOperation.status.notin_(TERMINAL_STATUSES),
+            ProductionOrderOperation.scheduled_start.is_(None),
+        )
+        .order_by(
+            ProductionOrder.priority,
+            ProductionOrder.due_date.asc().nullslast(),
+            ProductionOrderOperation.sequence,
+        )
+        .all()
+    )
+
+    unscheduled_by_po: dict[int, dict] = {}
+    for op in unscheduled_ops:
+        po = op.production_order
+        if po.id not in unscheduled_by_po:
+            unscheduled_by_po[po.id] = {
+                "production_order_id": po.id,
+                "production_order_code": po.code,
+                "production_order_status": po.status,
+                "product_name": po.product.name if po.product else None,
+                "quantity": float(po.quantity_ordered or 0),
+                "priority": po.priority,
+                "due_date": po.due_date.isoformat() if po.due_date else None,
+                "unscheduled_operation_count": 0,
+                # First unscheduled op (lowest sequence) — click target for
+                # the scheduler modal.
+                "first_unscheduled_operation": _op_unscheduled_block(op),
+            }
+        unscheduled_by_po[po.id]["unscheduled_operation_count"] += 1
+
+    return {
+        "start": start_date.isoformat(),
+        "end": end_date.isoformat(),
+        "lanes": lanes,
+        "unscheduled": list(unscheduled_by_po.values()),
+    }
+
+
+def _op_unscheduled_block(op) -> dict:
+    """Minimal operation payload the OperationSchedulerModal needs."""
+    return {
+        "id": op.id,
+        "operation_code": op.operation_code,
+        "operation_name": op.operation_name,
+        "sequence": op.sequence,
+        "status": op.status,
+        "planned_setup_minutes": (
+            str(op.planned_setup_minutes)
+            if op.planned_setup_minutes is not None
+            else "0"
+        ),
+        "planned_run_minutes": (
+            str(op.planned_run_minutes)
+            if op.planned_run_minutes is not None
+            else "0"
+        ),
+    }
+
+
 @router.post("/capacity/check", response_model=CapacityCheckResponse)
 async def check_capacity(
     request: CapacityCheckRequest,

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -118,8 +118,11 @@ async def get_scheduler_board(
             "operation_name": op.operation_name,
             "sequence": op.sequence,
             "status": op.status,
-            "scheduled_start": op.scheduled_start.isoformat(),
-            "scheduled_end": op.scheduled_end.isoformat(),
+            # Normalize through _naive_utc so every serialized timestamp is a
+            # naive-UTC string, matching the window echo and the frontend's
+            # parseDateTime convention (appends 'Z' to naive strings).
+            "scheduled_start": _naive_utc(op.scheduled_start).isoformat(),
+            "scheduled_end": _naive_utc(op.scheduled_end).isoformat(),
             "planned_setup_minutes": (
                 str(op.planned_setup_minutes)
                 if op.planned_setup_minutes is not None

--- a/backend/tests/api/test_scheduling_board.py
+++ b/backend/tests/api/test_scheduling_board.py
@@ -1,0 +1,280 @@
+"""
+API tests for GET /api/v1/scheduling/board (SCHED-5 Gantt view).
+
+Covers:
+- 401 unauthenticated
+- 422 inverted window
+- lanes include machine-type resources and printers
+- operations land in the correct lane (resource_id vs printer_id)
+- window filtering (ops outside the window excluded)
+- utilization is clipped to the window
+- unscheduled queue lists orders with unscheduled non-terminal ops,
+  including the first unscheduled op as the modal click target
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.models.manufacturing import Resource
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _make_machine_resource(db, work_center_id) -> Resource:
+    r = Resource(
+        code=f"MCH-{_uid()}",
+        name=f"Machine {_uid()}",
+        work_center_id=work_center_id,
+        status="available",
+        is_active=True,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _make_printer(db) -> Printer:
+    p = Printer(
+        code=f"PRT-{_uid()}",
+        name=f"Printer {_uid()}",
+        model="P1S",
+        brand="bambulab",
+        status="idle",
+        active=True,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_wo(db, product_id, status="released") -> ProductionOrder:
+    wo = ProductionOrder(
+        code=f"WO-{_uid()}",
+        product_id=product_id,
+        quantity_ordered=Decimal("5"),
+        status=status,
+        priority=2,
+        source="manual",
+    )
+    db.add(wo)
+    db.flush()
+    return wo
+
+
+def _make_op(
+    db,
+    wo_id,
+    work_center_id,
+    *,
+    resource_id=None,
+    printer_id=None,
+    start=None,
+    end=None,
+    status="queued",
+    sequence=10,
+) -> ProductionOrderOperation:
+    op = ProductionOrderOperation(
+        production_order_id=wo_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_code=f"OP-{_uid()}",
+        operation_name="Print",
+        planned_setup_minutes=Decimal("0"),
+        planned_run_minutes=Decimal("60"),
+        status=status,
+        resource_id=resource_id,
+        printer_id=printer_id,
+        scheduled_start=start,
+        scheduled_end=end,
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+def _window():
+    start = datetime(2026, 6, 15, 0, 0, tzinfo=timezone.utc)
+    return start, start + timedelta(days=1)
+
+
+def _board(client, start, end):
+    resp = client.get(
+        "/api/v1/scheduling/board",
+        params={"start_date": start.isoformat(), "end_date": end.isoformat()},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestSchedulingBoardEndpoint:
+
+    def test_unauthenticated_returns_401(self, unauthed_client):
+        start, end = _window()
+        resp = unauthed_client.get(
+            "/api/v1/scheduling/board",
+            params={"start_date": start.isoformat(), "end_date": end.isoformat()},
+        )
+        assert resp.status_code == 401
+
+    def test_inverted_window_returns_422(self, client):
+        start, end = _window()
+        resp = client.get(
+            "/api/v1/scheduling/board",
+            params={"start_date": end.isoformat(), "end_date": start.isoformat()},
+        )
+        assert resp.status_code == 422
+
+    def test_lanes_include_machine_resources_and_printers(
+        self, client, db, make_work_center
+    ):
+        wc = make_work_center(center_type="machine")
+        resource = _make_machine_resource(db, wc.id)
+        printer = _make_printer(db)
+
+        start, end = _window()
+        data = _board(client, start, end)
+
+        keys = {lane["key"] for lane in data["lanes"]}
+        assert f"resource-{resource.id}" in keys
+        assert f"printer-{printer.id}" in keys
+        kinds = {lane["key"]: lane["kind"] for lane in data["lanes"]}
+        assert kinds[f"resource-{resource.id}"] == "resource"
+        assert kinds[f"printer-{printer.id}"] == "printer"
+
+    def test_ops_land_in_correct_lane(
+        self, client, db, make_work_center, make_product
+    ):
+        wc = make_work_center(center_type="machine")
+        resource = _make_machine_resource(db, wc.id)
+        printer = _make_printer(db)
+        product = make_product()
+        wo = _make_wo(db, product.id)
+
+        start, end = _window()
+        op_res = _make_op(
+            db, wo.id, wc.id,
+            resource_id=resource.id,
+            start=start + timedelta(hours=2),
+            end=start + timedelta(hours=5),
+        )
+        op_prt = _make_op(
+            db, wo.id, wc.id,
+            printer_id=printer.id,
+            start=start + timedelta(hours=6),
+            end=start + timedelta(hours=8),
+            sequence=20,
+        )
+
+        data = _board(client, start, end)
+        by_key = {lane["key"]: lane for lane in data["lanes"]}
+
+        res_ops = {o["id"] for o in by_key[f"resource-{resource.id}"]["operations"]}
+        prt_ops = {o["id"] for o in by_key[f"printer-{printer.id}"]["operations"]}
+        assert op_res.id in res_ops
+        assert op_prt.id in prt_ops
+        assert op_res.id not in prt_ops
+
+        block = next(
+            o for o in by_key[f"resource-{resource.id}"]["operations"]
+            if o["id"] == op_res.id
+        )
+        assert block["production_order_code"] == wo.code
+        assert block["status"] == "queued"
+
+    def test_window_excludes_outside_ops(
+        self, client, db, make_work_center, make_product
+    ):
+        wc = make_work_center(center_type="machine")
+        resource = _make_machine_resource(db, wc.id)
+        product = make_product()
+        wo = _make_wo(db, product.id)
+
+        start, end = _window()
+        # Entirely before the window
+        op_before = _make_op(
+            db, wo.id, wc.id,
+            resource_id=resource.id,
+            start=start - timedelta(hours=10),
+            end=start - timedelta(hours=8),
+        )
+        # Straddles the window start — must be included
+        op_straddle = _make_op(
+            db, wo.id, wc.id,
+            resource_id=resource.id,
+            start=start - timedelta(hours=1),
+            end=start + timedelta(hours=1),
+            sequence=20,
+        )
+
+        data = _board(client, start, end)
+        by_key = {lane["key"]: lane for lane in data["lanes"]}
+        ids = {o["id"] for o in by_key[f"resource-{resource.id}"]["operations"]}
+        assert op_straddle.id in ids
+        assert op_before.id not in ids
+
+    def test_utilization_clipped_to_window(
+        self, client, db, make_work_center, make_product
+    ):
+        wc = make_work_center(center_type="machine")
+        resource = _make_machine_resource(db, wc.id)
+        product = make_product()
+        wo = _make_wo(db, product.id)
+
+        start, end = _window()  # 24h window
+        # 6h inside the window (2h of it spills past the end and is clipped)
+        _make_op(
+            db, wo.id, wc.id,
+            resource_id=resource.id,
+            start=end - timedelta(hours=4),
+            end=end + timedelta(hours=2),
+        )
+
+        data = _board(client, start, end)
+        lane = next(
+            ln for ln in data["lanes"] if ln["key"] == f"resource-{resource.id}"
+        )
+        # 4 clipped hours / 24 = 16.7%
+        assert lane["utilization_percent"] == 16.7
+
+    def test_unscheduled_queue(self, client, db, make_work_center, make_product):
+        wc = make_work_center(center_type="machine")
+        product = make_product()
+        wo = _make_wo(db, product.id, status="released")
+        op1 = _make_op(db, wo.id, wc.id, status="pending", sequence=10)
+        _make_op(db, wo.id, wc.id, status="pending", sequence=20)
+        # Terminal op without schedule must NOT count
+        _make_op(db, wo.id, wc.id, status="complete", sequence=30)
+
+        start, end = _window()
+        data = _board(client, start, end)
+
+        entry = next(
+            (
+                u for u in data["unscheduled"]
+                if u["production_order_id"] == wo.id
+            ),
+            None,
+        )
+        assert entry is not None
+        assert entry["production_order_code"] == wo.code
+        assert entry["unscheduled_operation_count"] == 2
+        assert entry["first_unscheduled_operation"]["id"] == op1.id
+
+    def test_draft_orders_not_in_unscheduled_queue(
+        self, client, db, make_work_center, make_product
+    ):
+        wc = make_work_center(center_type="machine")
+        product = make_product()
+        wo = _make_wo(db, product.id, status="draft")
+        _make_op(db, wo.id, wc.id, status="pending")
+
+        start, end = _window()
+        data = _board(client, start, end)
+        ids = {u["production_order_id"] for u in data["unscheduled"]}
+        assert wo.id not in ids

--- a/frontend/src/components/production/SchedulerBoard.jsx
+++ b/frontend/src/components/production/SchedulerBoard.jsx
@@ -19,23 +19,30 @@
  *   refreshSignal — increment to force a refetch (parent bumps it after the
  *     modal schedules/reschedules something).
  */
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useApi } from "../../hooks/useApi";
 import { parseDateTime } from "../../utils/formatting";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+/**
+ * Local midnight N days after the given date. Uses calendar arithmetic
+ * (Date handles month/year rollover) — NOT millisecond math, which lands
+ * an hour off on DST transition days (23h/25h days).
+ */
+function addDays(d, n) {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + n);
+}
 
 /** Window [start, end) for the given anchor date + view mode, local time. */
 export function getWindow(anchor, viewMode) {
   const d = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate());
   if (viewMode === "day") {
-    return { start: d, end: new Date(d.getTime() + DAY_MS) };
+    return { start: d, end: addDays(d, 1) };
   }
   if (viewMode === "week") {
     // Monday-start week
     const dow = (d.getDay() + 6) % 7;
-    const monday = new Date(d.getTime() - dow * DAY_MS);
-    return { start: monday, end: new Date(monday.getTime() + 7 * DAY_MS) };
+    const monday = addDays(d, -dow);
+    return { start: monday, end: addDays(monday, 7) };
   }
   // month
   const first = new Date(d.getFullYear(), d.getMonth(), 1);
@@ -63,10 +70,14 @@ export function getTicks(start, end, viewMode) {
     }
     return ticks;
   }
-  const days = Math.round((end.getTime() - start.getTime()) / DAY_MS);
-  const labelEvery = viewMode === "week" ? 1 : days > 20 ? 5 : 2;
-  for (let i = 0; i < days; i++) {
-    const t = new Date(start.getTime() + i * DAY_MS);
+  // Walk day-by-day with calendar arithmetic so each tick lands on local
+  // midnight even across DST transitions.
+  const labelEveryFor = (days) => (viewMode === "week" ? 1 : days > 20 ? 5 : 2);
+  const totalDays = Math.round(
+    (end.getTime() - start.getTime()) / (24 * 3600 * 1000)
+  );
+  const labelEvery = labelEveryFor(totalDays);
+  for (let i = 0, t = start; t < end; i++, t = addDays(start, i)) {
     const label =
       i % labelEvery === 0
         ? t.toLocaleDateString(undefined, {
@@ -153,7 +164,12 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
 
   const { start, end } = useMemo(() => getWindow(anchor, viewMode), [anchor, viewMode]);
 
+  // Guards against out-of-order responses: rapid view/date changes can have
+  // several /board requests in flight, and only the latest may paint.
+  const fetchSeq = useRef(0);
+
   const fetchBoard = useCallback(async () => {
+    const seq = ++fetchSeq.current;
     setLoading(true);
     setError(null);
     try {
@@ -162,11 +178,13 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
         end_date: end.toISOString(),
       });
       const data = await api.get(`/api/v1/scheduling/board?${params}`);
+      if (seq !== fetchSeq.current) return; // stale response — a newer fetch won
       setBoard(data);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err.message || "Failed to load schedule");
     } finally {
-      setLoading(false);
+      if (seq === fetchSeq.current) setLoading(false);
     }
   }, [api, start, end]);
 
@@ -181,9 +199,9 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
 
   const shift = (dir) => {
     if (viewMode === "day") {
-      setAnchor((a) => new Date(a.getTime() + dir * DAY_MS));
+      setAnchor((a) => addDays(a, dir));
     } else if (viewMode === "week") {
-      setAnchor((a) => new Date(a.getTime() + dir * 7 * DAY_MS));
+      setAnchor((a) => addDays(a, dir * 7));
     } else {
       setAnchor((a) => new Date(a.getFullYear(), a.getMonth() + dir, 1));
     }

--- a/frontend/src/components/production/SchedulerBoard.jsx
+++ b/frontend/src/components/production/SchedulerBoard.jsx
@@ -1,0 +1,471 @@
+/**
+ * SchedulerBoard — the Scheduler (Gantt) view for AdminProduction (SCHED-5).
+ *
+ * Machine lanes × time axis. Day / Week / Month windows, date navigation,
+ * scheduled-operation blocks (click → OperationSchedulerModal in edit mode),
+ * running operations highlighted, maintenance/offline lanes tinted, and an
+ * Unscheduled Orders work queue whose items open the scheduler modal for
+ * their first unscheduled operation.
+ *
+ * READ-ONLY by design: no drag-and-drop in v1 (deferred per plan v3).
+ *
+ * Data: GET /api/v1/scheduling/board?start_date&end_date — one call returns
+ * all lanes (machine Resources + Printers; operations may be scheduled on
+ * either) plus the unscheduled queue. See scheduling.py::get_scheduler_board.
+ *
+ * Props:
+ *   onScheduleOperation(operation, productionOrder) — open the scheduler
+ *     modal (parent owns the modal instance so Queue view can share it).
+ *   refreshSignal — increment to force a refetch (parent bumps it after the
+ *     modal schedules/reschedules something).
+ */
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useApi } from "../../hooks/useApi";
+import { parseDateTime } from "../../utils/formatting";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Window [start, end) for the given anchor date + view mode, local time. */
+export function getWindow(anchor, viewMode) {
+  const d = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate());
+  if (viewMode === "day") {
+    return { start: d, end: new Date(d.getTime() + DAY_MS) };
+  }
+  if (viewMode === "week") {
+    // Monday-start week
+    const dow = (d.getDay() + 6) % 7;
+    const monday = new Date(d.getTime() - dow * DAY_MS);
+    return { start: monday, end: new Date(monday.getTime() + 7 * DAY_MS) };
+  }
+  // month
+  const first = new Date(d.getFullYear(), d.getMonth(), 1);
+  const next = new Date(d.getFullYear(), d.getMonth() + 1, 1);
+  return { start: first, end: next };
+}
+
+/** Percent position of time t inside [start, end], clamped to [0, 100]. */
+export function pctOf(t, start, end) {
+  const span = end.getTime() - start.getTime();
+  if (span <= 0) return 0;
+  const raw = ((t.getTime() - start.getTime()) / span) * 100;
+  return Math.max(0, Math.min(100, raw));
+}
+
+/** Tick marks for the window: { pct, label } */
+export function getTicks(start, end, viewMode) {
+  const ticks = [];
+  if (viewMode === "day") {
+    for (let h = 0; h < 24; h += 2) {
+      const t = new Date(start.getTime() + h * 3600 * 1000);
+      const label =
+        h === 0 ? "12 AM" : h < 12 ? `${h} AM` : h === 12 ? "12 PM" : `${h - 12} PM`;
+      ticks.push({ pct: pctOf(t, start, end), label });
+    }
+    return ticks;
+  }
+  const days = Math.round((end.getTime() - start.getTime()) / DAY_MS);
+  const labelEvery = viewMode === "week" ? 1 : days > 20 ? 5 : 2;
+  for (let i = 0; i < days; i++) {
+    const t = new Date(start.getTime() + i * DAY_MS);
+    const label =
+      i % labelEvery === 0
+        ? t.toLocaleDateString(undefined, {
+            weekday: viewMode === "week" ? "short" : undefined,
+            month: "numeric",
+            day: "numeric",
+          })
+        : "";
+    ticks.push({ pct: pctOf(t, start, end), label });
+  }
+  return ticks;
+}
+
+const BLOCK_STYLES = {
+  in_progress: "bg-green-600/80 border-green-400 text-white",
+  queued: "bg-blue-600/70 border-blue-400 text-white",
+  scheduled: "bg-blue-600/70 border-blue-400 text-white",
+  pending: "bg-gray-600/70 border-gray-500 text-gray-200",
+  on_hold: "bg-amber-600/70 border-amber-400 text-white",
+};
+
+const LANE_STATUS_STYLES = {
+  maintenance: "text-amber-400",
+  offline: "text-gray-500",
+  busy: "text-green-400",
+  printing: "text-green-400",
+  available: "text-blue-300",
+  idle: "text-blue-300",
+};
+
+function toLocalDateInput(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function OperationBlock({ op, windowStart, windowEnd, onClick }) {
+  // Backend sends naive-UTC timestamps; parseDateTime appends 'Z' so the
+  // block lands at the right LOCAL position (same convention as formatTime).
+  const start = parseDateTime(op.scheduled_start);
+  const end = parseDateTime(op.scheduled_end);
+  const left = pctOf(start, windowStart, windowEnd);
+  const right = pctOf(end, windowStart, windowEnd);
+  const width = Math.max(right - left, 0.6);
+  const style = BLOCK_STYLES[op.status] || BLOCK_STYLES.pending;
+
+  const fmt = (d) =>
+    d.toLocaleString(undefined, {
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+  return (
+    <button
+      type="button"
+      data-testid={`gantt-block-${op.id}`}
+      onClick={onClick}
+      title={`${op.production_order_code} · ${op.operation_name || op.operation_code}\n${
+        op.product_name || ""
+      }\n${fmt(start)} → ${fmt(end)} · ${op.status.replace(/_/g, " ")}`}
+      className={`absolute top-1.5 bottom-1.5 rounded border px-1 overflow-hidden text-left transition-opacity hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-white/60 ${style}`}
+      style={{ left: `${left}%`, width: `${width}%` }}
+    >
+      <span className="block text-[10px] font-medium leading-tight truncate">
+        {op.production_order_code}
+      </span>
+      <span className="block text-[9px] opacity-80 leading-tight truncate">
+        {op.operation_name || op.operation_code}
+      </span>
+    </button>
+  );
+}
+
+export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 }) {
+  const api = useApi();
+  const [viewMode, setViewMode] = useState("day");
+  const [anchor, setAnchor] = useState(() => new Date());
+  const [board, setBoard] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const { start, end } = useMemo(() => getWindow(anchor, viewMode), [anchor, viewMode]);
+
+  const fetchBoard = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        start_date: start.toISOString(),
+        end_date: end.toISOString(),
+      });
+      const data = await api.get(`/api/v1/scheduling/board?${params}`);
+      setBoard(data);
+    } catch (err) {
+      setError(err.message || "Failed to load schedule");
+    } finally {
+      setLoading(false);
+    }
+  }, [api, start, end]);
+
+  useEffect(() => {
+    fetchBoard();
+  }, [fetchBoard, refreshSignal]);
+
+  const ticks = useMemo(() => getTicks(start, end, viewMode), [start, end, viewMode]);
+
+  const now = new Date();
+  const nowPct = now >= start && now <= end ? pctOf(now, start, end) : null;
+
+  const shift = (dir) => {
+    if (viewMode === "day") {
+      setAnchor((a) => new Date(a.getTime() + dir * DAY_MS));
+    } else if (viewMode === "week") {
+      setAnchor((a) => new Date(a.getTime() + dir * 7 * DAY_MS));
+    } else {
+      setAnchor((a) => new Date(a.getFullYear(), a.getMonth() + dir, 1));
+    }
+  };
+
+  const handleBlockClick = (op) => {
+    // The modal derives edit-mode from the op's status/scheduled_start.
+    onScheduleOperation?.(
+      {
+        id: op.id,
+        operation_code: op.operation_code,
+        operation_name: op.operation_name,
+        sequence: op.sequence,
+        status: op.status,
+        scheduled_start: op.scheduled_start,
+        scheduled_end: op.scheduled_end,
+        planned_setup_minutes: op.planned_setup_minutes,
+        planned_run_minutes: op.planned_run_minutes,
+      },
+      { id: op.production_order_id, code: op.production_order_code }
+    );
+  };
+
+  const handleUnscheduledClick = (item) => {
+    onScheduleOperation?.(item.first_unscheduled_operation, {
+      id: item.production_order_id,
+      code: item.production_order_code,
+    });
+  };
+
+  const lanes = board?.lanes || [];
+  const unscheduled = board?.unscheduled || [];
+
+  return (
+    <div className="space-y-4" data-testid="scheduler-board">
+      {/* Header: title + controls */}
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <h2 className="text-xl font-semibold text-white">Production Scheduler</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={viewMode}
+            onChange={(e) => setViewMode(e.target.value)}
+            className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-3 py-1.5"
+            aria-label="View mode"
+          >
+            <option value="day">Day View</option>
+            <option value="week">Week View</option>
+            <option value="month">Month View</option>
+          </select>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => shift(-1)}
+              className="px-2 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+              aria-label="Previous"
+            >
+              ‹
+            </button>
+            <input
+              type="date"
+              value={toLocalDateInput(anchor)}
+              onChange={(e) => {
+                const [y, m, d] = e.target.value.split("-").map(Number);
+                if (y && m && d) setAnchor(new Date(y, m - 1, d));
+              }}
+              className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-2 py-1.5"
+            />
+            <button
+              type="button"
+              onClick={() => shift(1)}
+              className="px-2 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+              aria-label="Next"
+            >
+              ›
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setAnchor(new Date())}
+            className="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+          >
+            Today
+          </button>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-4 text-xs text-gray-400">
+        <span className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-sm bg-blue-600/70 border border-blue-400" />
+          Scheduled
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-sm bg-green-600/80 border border-green-400" />
+          Running
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-sm bg-amber-600/70 border border-amber-400" />
+          On hold
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-0.5 h-3 bg-red-500" />
+          Now
+        </span>
+      </div>
+
+      {error && (
+        <div className="p-3 bg-red-900/20 border border-red-500/30 rounded-lg text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-4">
+        {/* Gantt table */}
+        <div className="xl:col-span-3 bg-gray-900 border border-gray-800 rounded-xl overflow-x-auto">
+          {loading && !board ? (
+            <div className="h-48 flex items-center justify-center">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500" />
+            </div>
+          ) : lanes.length === 0 ? (
+            <div className="p-8 text-center text-gray-500 text-sm">
+              No machines found. Add printers or machine work-center resources to
+              see the schedule.
+            </div>
+          ) : (
+            <table className="w-full min-w-[640px]">
+              <thead>
+                <tr className="border-b border-gray-800">
+                  <th className="text-left p-3 text-xs font-semibold text-gray-400 uppercase tracking-wider w-44">
+                    Machine
+                  </th>
+                  <th className="p-0 relative h-8">
+                    {/* Time axis labels */}
+                    <div className="absolute inset-0">
+                      {ticks.map((t, i) => (
+                        <span
+                          key={i}
+                          className="absolute top-1/2 -translate-y-1/2 text-[10px] font-normal text-gray-500 whitespace-nowrap"
+                          style={{ left: `${t.pct}%` }}
+                        >
+                          {t.label}
+                        </span>
+                      ))}
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {lanes.map((lane) => {
+                  const laneStatus =
+                    LANE_STATUS_STYLES[lane.status] || "text-gray-400";
+                  const laneTint =
+                    lane.status === "maintenance"
+                      ? "bg-amber-950/20"
+                      : lane.status === "offline"
+                      ? "bg-gray-950/40"
+                      : "";
+                  return (
+                    <tr
+                      key={lane.key}
+                      className={`border-b border-gray-800/60 ${laneTint}`}
+                      data-testid={`gantt-lane-${lane.key}`}
+                    >
+                      <td className="p-3 align-middle">
+                        <div className="text-sm text-white font-medium truncate">
+                          {lane.code}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className={`text-xs capitalize ${laneStatus}`}>
+                            {lane.status}
+                          </span>
+                          {lane.work_center_code && (
+                            <span className="text-[10px] text-gray-600">
+                              {lane.work_center_code}
+                            </span>
+                          )}
+                        </div>
+                        {/* Utilization bar */}
+                        <div
+                          className="mt-1.5 h-1 bg-gray-800 rounded overflow-hidden"
+                          title={`${lane.utilization_percent}% booked in window`}
+                        >
+                          <div
+                            className={`h-full ${
+                              lane.utilization_percent > 85
+                                ? "bg-red-500/80"
+                                : lane.utilization_percent > 60
+                                ? "bg-amber-500/80"
+                                : "bg-blue-500/70"
+                            }`}
+                            style={{ width: `${lane.utilization_percent}%` }}
+                          />
+                        </div>
+                      </td>
+                      <td className="p-0 relative h-14">
+                        {/* Vertical gridlines */}
+                        {ticks.map((t, i) => (
+                          <div
+                            key={i}
+                            className="absolute top-0 bottom-0 w-px bg-gray-800/70"
+                            style={{ left: `${t.pct}%` }}
+                          />
+                        ))}
+                        {/* Now line */}
+                        {nowPct !== null && (
+                          <div
+                            className="absolute top-0 bottom-0 w-0.5 bg-red-500/80 z-10 pointer-events-none"
+                            style={{ left: `${nowPct}%` }}
+                            data-testid="now-line"
+                          />
+                        )}
+                        {/* Operation blocks */}
+                        {lane.operations.map((op) => (
+                          <OperationBlock
+                            key={op.id}
+                            op={op}
+                            windowStart={start}
+                            windowEnd={end}
+                            onClick={() => handleBlockClick(op)}
+                          />
+                        ))}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Unscheduled orders work queue */}
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+          <h3 className="text-sm font-semibold text-white mb-3">
+            Unscheduled Orders
+            {unscheduled.length > 0 && (
+              <span className="ml-2 px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded-full">
+                {unscheduled.length}
+              </span>
+            )}
+          </h3>
+          {unscheduled.length === 0 ? (
+            <p className="text-xs text-gray-500">
+              Everything released is on the board. Nice.
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+              {unscheduled.map((item) => (
+                <div
+                  key={item.production_order_id}
+                  className="bg-gray-800 rounded-lg p-2.5 flex items-start justify-between gap-2"
+                  data-testid={`unscheduled-${item.production_order_code}`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-xs font-medium text-white truncate">
+                      {item.production_order_code}
+                    </div>
+                    <div className="text-[11px] text-gray-400 truncate">
+                      {item.product_name}
+                    </div>
+                    <div className="text-[10px] text-gray-500">
+                      Qty {item.quantity}
+                      {item.due_date &&
+                        ` · due ${new Date(item.due_date).toLocaleDateString()}`}
+                      {` · ${item.unscheduled_operation_count} op${
+                        item.unscheduled_operation_count === 1 ? "" : "s"
+                      } to schedule`}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    title="Auto-schedule — pick a slot for the next operation"
+                    onClick={() => handleUnscheduledClick(item)}
+                    className="shrink-0 px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors"
+                  >
+                    ⚡ Schedule
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
+++ b/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
@@ -1,0 +1,240 @@
+/**
+ * SchedulerBoard (SCHED-5) — unit tests.
+ *
+ * Pure helpers (getWindow / pctOf / getTicks) are tested directly;
+ * the component is tested against a mocked /scheduling/board payload.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SchedulerBoard, { getWindow, pctOf, getTicks } from "../SchedulerBoard";
+
+const mocks = vi.hoisted(() => {
+  const get = vi.fn();
+  // Stable object — the real useApi is useMemo'd, so the mock must be
+  // referentially stable too or fetchBoard's deps churn every render.
+  return { get, api: { get } };
+});
+
+vi.mock("../../../hooks/useApi", () => ({
+  useApi: () => mocks.api,
+}));
+
+// Window: the component requests [anchor day 00:00, +24h) in day mode.
+// Build ops relative to "today" so positioning is deterministic.
+const today = new Date();
+const dayStart = new Date(
+  today.getFullYear(), today.getMonth(), today.getDate()
+);
+const at = (h) => new Date(dayStart.getTime() + h * 3600 * 1000).toISOString();
+
+const BOARD = {
+  start: dayStart.toISOString(),
+  end: new Date(dayStart.getTime() + 24 * 3600 * 1000).toISOString(),
+  lanes: [
+    {
+      key: "resource-1",
+      kind: "resource",
+      id: 1,
+      code: "FDM-01",
+      name: "Bambu P1S #1",
+      status: "available",
+      work_center_code: "FDM-POOL",
+      utilization_percent: 25.0,
+      operations: [
+        {
+          id: 11,
+          operation_code: "OP010",
+          operation_name: "3D Print",
+          sequence: 10,
+          status: "queued",
+          scheduled_start: at(2),
+          scheduled_end: at(8),
+          planned_setup_minutes: "0",
+          planned_run_minutes: "360",
+          production_order_id: 100,
+          production_order_code: "PO-2026-0099",
+          production_order_status: "released",
+          product_name: "Headphone Mount",
+          quantity: 10,
+        },
+      ],
+    },
+    {
+      key: "printer-2",
+      kind: "printer",
+      id: 2,
+      code: "PRT-A1",
+      name: "Bambu A1",
+      status: "maintenance",
+      work_center_code: null,
+      utilization_percent: 0,
+      operations: [],
+    },
+  ],
+  unscheduled: [
+    {
+      production_order_id: 200,
+      production_order_code: "PO-2026-0100",
+      production_order_status: "released",
+      product_name: "Cable Organizer",
+      quantity: 20,
+      priority: 2,
+      due_date: null,
+      unscheduled_operation_count: 2,
+      first_unscheduled_operation: {
+        id: 21,
+        operation_code: "OP010",
+        operation_name: "3D Print",
+        sequence: 10,
+        status: "pending",
+        planned_setup_minutes: "0",
+        planned_run_minutes: "120",
+      },
+    },
+  ],
+};
+
+beforeEach(() => {
+  mocks.get.mockReset();
+  mocks.get.mockResolvedValue(BOARD);
+});
+
+describe("helpers", () => {
+  it("getWindow day mode spans exactly the anchor day", () => {
+    const anchor = new Date(2026, 5, 15, 14, 30);
+    const { start, end } = getWindow(anchor, "day");
+    expect(start.getHours()).toBe(0);
+    expect(end.getTime() - start.getTime()).toBe(24 * 3600 * 1000);
+  });
+
+  it("getWindow week mode starts Monday", () => {
+    // 2026-06-17 is a Wednesday
+    const { start, end } = getWindow(new Date(2026, 5, 17), "week");
+    expect(start.getDay()).toBe(1); // Monday
+    expect((end.getTime() - start.getTime()) / 86400000).toBe(7);
+  });
+
+  it("getWindow month mode spans the calendar month", () => {
+    const { start, end } = getWindow(new Date(2026, 5, 17), "month");
+    expect(start.getDate()).toBe(1);
+    expect(start.getMonth()).toBe(5);
+    expect(end.getMonth()).toBe(6);
+  });
+
+  it("pctOf clamps to [0, 100]", () => {
+    const s = new Date(2026, 0, 1);
+    const e = new Date(2026, 0, 2);
+    expect(pctOf(new Date(2025, 11, 31), s, e)).toBe(0);
+    expect(pctOf(new Date(2026, 0, 3), s, e)).toBe(100);
+    expect(pctOf(new Date(2026, 0, 1, 12), s, e)).toBe(50);
+  });
+
+  it("getTicks day mode yields 12 two-hour ticks", () => {
+    const { start, end } = getWindow(new Date(2026, 5, 15), "day");
+    const ticks = getTicks(start, end, "day");
+    expect(ticks).toHaveLength(12);
+    expect(ticks[0].label).toBe("12 AM");
+    expect(ticks[6].label).toBe("12 PM");
+  });
+});
+
+describe("SchedulerBoard", () => {
+  it("renders title, controls, lanes, and machine column", async () => {
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Production Scheduler" })
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("FDM-01")).toBeInTheDocument();
+    });
+
+    // E2E contract: table with Machine header, date input, Today button,
+    // view-mode select containing "Day View"
+    expect(screen.getByText("Machine")).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByLabelText("View mode")).toHaveValue("day");
+    expect(screen.getByText("Day View")).toBeInTheDocument();
+    expect(document.querySelector('input[type="date"]')).toBeTruthy();
+
+    // Lane status text + maintenance lane present
+    expect(screen.getByText("available")).toBeInTheDocument();
+    expect(screen.getByText("maintenance")).toBeInTheDocument();
+  });
+
+  it("renders operation blocks positioned within the lane", async () => {
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+    const block = await screen.findByTestId("gantt-block-11");
+    expect(block).toHaveTextContent("PO-2026-0099");
+    // 2h→8h on a 24h axis = left 8.33%, width 25%
+    expect(parseFloat(block.style.left)).toBeCloseTo(8.33, 1);
+    expect(parseFloat(block.style.width)).toBeCloseTo(25, 1);
+  });
+
+  it("clicking a block opens the scheduler modal in edit mode payload", async () => {
+    const onSchedule = vi.fn();
+    render(<SchedulerBoard onScheduleOperation={onSchedule} />);
+    const block = await screen.findByTestId("gantt-block-11");
+    fireEvent.click(block);
+
+    expect(onSchedule).toHaveBeenCalledTimes(1);
+    const [op, po] = onSchedule.mock.calls[0];
+    expect(op.id).toBe(11);
+    expect(op.scheduled_start).toBe(BOARD.lanes[0].operations[0].scheduled_start);
+    expect(op.status).toBe("queued");
+    expect(po).toEqual({ id: 100, code: "PO-2026-0099" });
+  });
+
+  it("renders the unscheduled queue and schedules its first op on click", async () => {
+    const onSchedule = vi.fn();
+    render(<SchedulerBoard onScheduleOperation={onSchedule} />);
+
+    expect(await screen.findByText("Unscheduled Orders")).toBeInTheDocument();
+    expect(screen.getByText("PO-2026-0100")).toBeInTheDocument();
+    expect(screen.getByText(/2 ops to schedule/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle(/Auto-schedule/));
+    const [op, po] = onSchedule.mock.calls[0];
+    expect(op.id).toBe(21);
+    expect(po).toEqual({ id: 200, code: "PO-2026-0100" });
+  });
+
+  it("switching view mode refetches with a wider window", async () => {
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+    await screen.findByText("FDM-01");
+    const callsBefore = mocks.get.mock.calls.length;
+
+    fireEvent.change(screen.getByLabelText("View mode"), {
+      target: { value: "week" },
+    });
+
+    await waitFor(() => {
+      expect(mocks.get.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+    const lastUrl = mocks.get.mock.calls.at(-1)[0];
+    const params = new URLSearchParams(lastUrl.split("?")[1]);
+    const span =
+      new Date(params.get("end_date")) - new Date(params.get("start_date"));
+    expect(span).toBe(7 * 24 * 3600 * 1000);
+  });
+
+  it("refetches when refreshSignal bumps", async () => {
+    const { rerender } = render(
+      <SchedulerBoard onScheduleOperation={vi.fn()} refreshSignal={0} />
+    );
+    await screen.findByText("FDM-01");
+    const callsBefore = mocks.get.mock.calls.length;
+
+    rerender(<SchedulerBoard onScheduleOperation={vi.fn()} refreshSignal={1} />);
+    await waitFor(() => {
+      expect(mocks.get.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  it("shows the error banner when the fetch fails", async () => {
+    mocks.get.mockRejectedValueOnce(new Error("boom"));
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
+++ b/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
@@ -5,7 +5,7 @@
  * the component is tested against a mocked /scheduling/board payload.
  */
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import SchedulerBoard, { getWindow, pctOf, getTicks } from "../SchedulerBoard";
 
 const mocks = vi.hoisted(() => {
@@ -19,12 +19,13 @@ vi.mock("../../../hooks/useApi", () => ({
   useApi: () => mocks.api,
 }));
 
-// Window: the component requests [anchor day 00:00, +24h) in day mode.
-// Build ops relative to "today" so positioning is deterministic.
-const today = new Date();
-const dayStart = new Date(
-  today.getFullYear(), today.getMonth(), today.getDate()
-);
+// The component anchors to "today" via new Date() at mount, so the clock is
+// FROZEN to a fixed instant (10 AM local on 2026-06-15) in beforeEach —
+// otherwise a suite that crosses midnight would shift the day window out
+// from under the mocked block timestamps. shouldAdvanceTime keeps
+// waitFor/findBy working under fake timers.
+const FROZEN_NOW = new Date(2026, 5, 15, 10, 0, 0);
+const dayStart = new Date(2026, 5, 15);
 const at = (h) => new Date(dayStart.getTime() + h * 3600 * 1000).toISOString();
 
 const BOARD = {
@@ -95,8 +96,14 @@ const BOARD = {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(FROZEN_NOW);
   mocks.get.mockReset();
   mocks.get.mockResolvedValue(BOARD);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("helpers", () => {
@@ -119,6 +126,19 @@ describe("helpers", () => {
     expect(start.getDate()).toBe(1);
     expect(start.getMonth()).toBe(5);
     expect(end.getMonth()).toBe(6);
+  });
+
+  it("getWindow day mode ends at local midnight across DST transitions", () => {
+    // US spring-forward 2026-03-08: the day is 23h long. Millisecond math
+    // (start + 24h) would land at 01:00 on 3/9; calendar math must land
+    // at exactly 00:00 local regardless of the runner's timezone.
+    const { end } = getWindow(new Date(2026, 2, 8), "day");
+    expect(end.getHours()).toBe(0);
+    expect(end.getDate()).toBe(9);
+    // And fall-back (2026-11-01, 25h day) must too.
+    const fall = getWindow(new Date(2026, 10, 1), "day");
+    expect(fall.end.getHours()).toBe(0);
+    expect(fall.end.getDate()).toBe(2);
   });
 
   it("pctOf clamps to [0, 100]", () => {

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import ProductionOrderModal from "../../components/production/ProductionOrderModal";
 import ProductionQueueList from "../../components/production/ProductionQueueList";
 import OperationSchedulerModal from "../../components/production/OperationSchedulerModal";
+import SchedulerBoard from "../../components/production/SchedulerBoard";
 import SplitOrderModal from "../../components/SplitOrderModal";
 import ScrapOrderModal from "../../components/ScrapOrderModal";
 import CompleteOrderModal from "../../components/CompleteOrderModal";
@@ -272,6 +273,13 @@ export default function AdminProduction() {
     productionOrder: null,
   });
 
+  // SCHED-5: Queue list vs Scheduler (Gantt) view
+  const [pageView, setPageView] = useState(
+    searchParams.get("view") === "scheduler" ? "scheduler" : "queue"
+  );
+  // Bumped after the scheduler modal saves so the board refetches.
+  const [boardRefresh, setBoardRefresh] = useState(0);
+
   // Split modal state
   const [showSplitModal, setShowSplitModal] = useState(false);
   const [selectedOrderForSplit, setSelectedOrderForSplit] = useState(null);
@@ -423,14 +431,53 @@ export default function AdminProduction() {
             Track print jobs and production orders
           </p>
         </div>
-        <button
-          onClick={() => { setShowCreateModal(true); setCreateError(null); }}
-          className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500"
-        >
-          + Create Production Order
-        </button>
+        <div className="flex items-center gap-3">
+          {/* SCHED-5: view toggle */}
+          <div className="flex rounded-lg border border-gray-700 overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setPageView("queue")}
+              className={`px-3 py-2 text-sm transition-colors ${
+                pageView === "queue"
+                  ? "bg-gray-700 text-white"
+                  : "bg-gray-900 text-gray-400 hover:text-white"
+              }`}
+            >
+              Queue
+            </button>
+            <button
+              type="button"
+              onClick={() => setPageView("scheduler")}
+              className={`px-3 py-2 text-sm transition-colors ${
+                pageView === "scheduler"
+                  ? "bg-gray-700 text-white"
+                  : "bg-gray-900 text-gray-400 hover:text-white"
+              }`}
+            >
+              Scheduler
+            </button>
+          </div>
+          <button
+            onClick={() => { setShowCreateModal(true); setCreateError(null); }}
+            className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500"
+          >
+            + Create Production Order
+          </button>
+        </div>
       </div>
 
+      {/* SCHED-5: Scheduler (Gantt) view */}
+      {pageView === "scheduler" && (
+        <SchedulerBoard
+          refreshSignal={boardRefresh}
+          onScheduleOperation={(operation, productionOrder) =>
+            setDispatchModal({ isOpen: true, operation, productionOrder })
+          }
+        />
+      )}
+
+      {pageView === "queue" && (
+        <>
       {/* Production Trend Chart */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
         <ProductionChart
@@ -531,6 +578,8 @@ export default function AdminProduction() {
           });
         }}
       />
+        </>
+      )}
 
       {/* Scheduling Modal */}
       {showSchedulingModal && selectedOrderForScheduling && (
@@ -557,6 +606,7 @@ export default function AdminProduction() {
           productionOrder={dispatchModal.productionOrder}
           onScheduled={() => {
             fetchProductionOrders();
+            setBoardRefresh((n) => n + 1);
             setDispatchModal({ isOpen: false, operation: null, productionOrder: null });
           }}
         />

--- a/frontend/src/utils/formatting.js
+++ b/frontend/src/utils/formatting.js
@@ -24,7 +24,7 @@ export function formatDuration(minutes) {
  * @param {string|Date} datetime - ISO datetime string or Date object
  * @returns {Date} Date object
  */
-function parseDateTime(datetime) {
+export function parseDateTime(datetime) {
   if (!datetime) return null;
   if (datetime instanceof Date) return datetime;
 


### PR DESCRIPTION
## Plan v3 Phase A — SCHED-5

The Scheduler tab the E2E spec (`scheduling.spec.ts`) has been describing: machine rows × time axis, day/week/month modes, date navigation, scheduled + running operations as blocks, maintenance-status lanes tinted, click-through to OperationSchedulerModal (edit mode per SCHED-2). READ-ONLY v1 — drag-and-drop explicitly deferred.

### Backend
- `GET /api/v1/scheduling/board?start_date&end_date` — single call returns all lanes + ops + unscheduled queue. Lanes = machine-type Resources **and** Printers (ops schedule against either — `resource_id` via scheduler modal, `printer_id` via dispatch; no FK between the two models, lanes keyed `resource-{id}`/`printer-{id}`).
- Window-clipped utilization per lane; naive/aware datetime normalization (scheduled_* columns are naive UTC).
- Unscheduled queue = released/scheduled/in_progress WOs with non-terminal unscheduled ops, sorted priority → due date, carrying the first unscheduled op as the modal click target.

### Frontend
- `SchedulerBoard.jsx`: table layout satisfying the E2E contract (th Machine, status text per lane, view-mode select with Day/Week/Month View, date input, Today), absolutely-positioned blocks over tick gridlines, now-line, legend, utilization bars (blue→amber→red), Unscheduled Orders panel with ⚡ Schedule.
- `parseDateTime` exported from formatting.js and used for block positioning — naive-UTC strings would otherwise parse as local and shift every block by the UTC offset (the #720/#721 bug class).
- AdminProduction: Queue | Scheduler toggle (`?view=scheduler` deep-linkable); board refetches after the shared scheduler modal saves.

### Tests
- Backend 8/8 (`test_scheduling_board.py`): auth, inverted window 422, lane membership, resource-vs-printer op routing, window straddle/exclusion, clipped utilization, unscheduled queue incl. terminal-op exclusion + draft exclusion.
- Frontend 12/12 (`SchedulerBoard.test.jsx`): pure helpers (window/percent/ticks), E2E-contract elements, block positioning math, click payloads, view-mode refetch span, refreshSignal, error banner. Full suite 429 passed; build green.
- Pre-existing `react-hooks/set-state-in-effect` lint flags match the codebase-wide fetch-in-effect idiom (not a CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Scheduler (Gantt) view for production planning with machine and printer lanes, time-window controls, utilization bars, and a “now” marker.
  * Added an Unscheduled Orders queue with quick-schedule action.
  * Added a view toggle to switch between Queue and Scheduler in Production Admin; board refreshes after scheduling.

* **Tests**
  * End-to-end tests for the scheduling API and SchedulerBoard UI, plus helper unit tests for time-window helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->