### PR TITLE
fix: routing-aware material reservation + release-time self-heal (RESERVE-1)

### DIFF
--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -900,11 +900,20 @@ def _sync_op_material_allocation(
     quantity_required (shouldn't happen in practice, but keeps the column
     semantically valid).
 
+    UNITS: *qty_reserved* arrives in the COMPONENT's inventory unit (that is
+    what reserve_production_materials reserves in), while row.quantity_required
+    is stored in the ROW's unit (copied verbatim from the routing).  Each
+    row's requirement is converted into the component unit for the
+    distribution math, and the allocation is written back in the ROW's unit —
+    quantity_allocated must be comparable to quantity_required because the
+    release gate compares them directly.
+
     This is the single writer of ProductionOrderOperationMaterial.quantity_allocated
     for the reservation direction.  It is idempotent: calling it twice with the
     same qty_reserved leaves the rows in the same state.
     """
     from app.models.production_order import ProductionOrderOperation
+    from app.services.uom_service import convert_quantity_safe
 
     # Collect op-material rows for this component across all operations,
     # ordered by operation.sequence then row id for deterministic distribution.
@@ -929,15 +938,46 @@ def _sync_op_material_allocation(
     if not rows:
         return
 
+    component = db.query(Product).filter(Product.id == component_id).first()
+    component_unit = (
+        (component.unit if component else None) or "EA"
+    ).upper()
+
     remaining = qty_reserved
     for row in rows:
         if remaining <= Decimal("0"):
             row.quantity_allocated = Decimal("0")
             continue
-        required = Decimal(str(row.quantity_required))
-        alloc = min(remaining, required)
-        row.quantity_allocated = alloc
-        remaining -= alloc
+        required_row = Decimal(str(row.quantity_required))
+        row_unit = (row.unit or component_unit).upper()
+        # convert_quantity_safe fast-paths same-unit (the overwhelmingly
+        # common case) and falls back to inline G/KG-style conversion when
+        # the UOM table is unseeded — same resilience as
+        # convert_and_generate_notes on the reservation side.
+        required_comp, converted = convert_quantity_safe(
+            db, required_row, row_unit, component_unit
+        )
+        if not converted:
+            logger.error(
+                "UOM conversion failed distributing reservation for "
+                "component %s on PO#%s (row %s: %s -> %s) — assuming 1:1",
+                component_id,
+                production_order.code,
+                row.id,
+                row_unit,
+                component_unit,
+            )
+            required_comp = required_row
+
+        alloc_comp = min(remaining, required_comp)
+        # Write the allocation back in the ROW's unit via the coverage
+        # ratio — full coverage yields exactly quantity_required with no
+        # round-trip conversion error.
+        if required_comp > Decimal("0"):
+            row.quantity_allocated = (alloc_comp / required_comp) * required_row
+        else:
+            row.quantity_allocated = Decimal("0")
+        remaining -= alloc_comp
 
 
 def _backfill_op_material_from_ledger(

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -498,69 +498,190 @@ def create_inventory_transaction(
     return transaction
 
 
-def reserve_production_materials(
+def _get_net_reserved_by_component(
+    db: Session,
+    production_order_id: int,
+) -> Dict[int, Decimal]:
+    """
+    Net ledger reservations per component for a production order:
+    sum(reservation) - sum(reservation_release), floored at 0.
+
+    Single source for the "how much is already reserved" question used by
+    both the delta-idempotent reservation path (RESERVE-1) and the
+    ledger→row backfill self-heal.
+    """
+    from sqlalchemy import func as sqlfunc
+    from sqlalchemy import case
+
+    net_rows = (
+        db.query(
+            InventoryTransaction.product_id,
+            sqlfunc.sum(
+                case(
+                    (InventoryTransaction.transaction_type == "reservation",
+                     InventoryTransaction.quantity),
+                    else_=Decimal("0"),
+                )
+                - case(
+                    (InventoryTransaction.transaction_type == "reservation_release",
+                     InventoryTransaction.quantity),
+                    else_=Decimal("0"),
+                )
+            ).label("net_reserved"),
+        )
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order_id,
+            InventoryTransaction.transaction_type.in_(
+                ["reservation", "reservation_release"]
+            ),
+        )
+        .group_by(InventoryTransaction.product_id)
+        .all()
+    )
+    return {
+        row.product_id: max(Decimal("0"), Decimal(str(row.net_reserved)))
+        for row in net_rows
+    }
+
+
+def _get_reservation_requirements(
     db: Session,
     production_order: ProductionOrder,
-    created_by: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+) -> Dict[int, Dict[str, Any]]:
     """
-    Reserve (allocate) materials when a production order is scheduled.
-    
-    This increases the allocated_quantity on inventory records, reducing
-    available quantity without actually consuming the materials.
-    
-    Materials are reserved based on BOM quantity * ordered quantity.
-    
-    Args:
-        db: Database session
-        production_order: The production order being scheduled
-        created_by: User scheduling the order
-    
+    Canonical per-component reservation requirements for a production order
+    (RESERVE-1, mirrors the HARD-12 routing-first explosion semantics).
+
+    PRIMARY source — ProductionOrderOperationMaterial rows: when the order
+    has materialized op-material rows (copied from the routing at creation),
+    those rows are the order-specific truth and exactly what the release
+    gate checks.  Rows already include scrap (applied by
+    calculate_required_quantity at copy time) and cost-only routing
+    materials were already excluded by copy_routing_to_operations, so
+    neither is re-applied here.
+
+    FALLBACK — legacy BOM walk: products without routing materials keep the
+    original behavior (active BOM, consume_stage='production', scrap factor
+    applied, cost-only lines skipped).
+
+    The two sources are never mixed: op rows REPLACE the BOM walk entirely,
+    preventing double reservation for mixed-source products.
+
     Returns:
-        List of reservation records with details about what was reserved
+        Dict mapping component_id -> {
+            "component": Product,
+            "quantity": Decimal,  # in the component's inventory unit
+            "unit": str,          # component inventory unit
+            "source": "routing" | "bom",
+        }
     """
-    reservations = []
-    location = get_or_create_default_location(db)
-    
-    # Get BOM for the product
+    from app.models.production_order import ProductionOrderOperation
+
+    requirements: Dict[int, Dict[str, Any]] = {}
+
+    op_rows = (
+        db.query(ProductionOrderOperationMaterial)
+        .join(
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial.production_order_operation_id
+            == ProductionOrderOperation.id,
+        )
+        .filter(
+            ProductionOrderOperation.production_order_id == production_order.id,
+        )
+        .order_by(
+            ProductionOrderOperation.sequence,
+            ProductionOrderOperationMaterial.id,
+        )
+        .all()
+    )
+
+    if op_rows:
+        for row in op_rows:
+            component = db.query(Product).filter(
+                Product.id == row.component_id
+            ).first()
+            if not component:
+                continue
+
+            row_qty = Decimal(str(row.quantity_required or 0))
+            if row_qty <= Decimal("0"):
+                continue
+
+            row_unit = (row.unit or component.unit or "EA").upper()
+            component_unit = (component.unit or "EA").upper()
+
+            try:
+                converted_qty, _ = convert_and_generate_notes(
+                    db=db,
+                    bom_qty=row_qty,
+                    line_unit=row_unit,
+                    component_unit=component_unit,
+                    component_name=component.name,
+                    component_sku=component.sku,
+                    reference_prefix="Reserved for PO#",
+                    reference_code=production_order.code,
+                )
+            except UOMConversionError as e:
+                logger.error(
+                    f"Failed to reserve materials (op-material row {row.id}): {e}"
+                )
+                continue
+
+            entry = requirements.get(row.component_id)
+            if entry:
+                entry["quantity"] += converted_qty
+            else:
+                requirements[row.component_id] = {
+                    "component": component,
+                    "quantity": converted_qty,
+                    "unit": component_unit,
+                    "source": "routing",
+                }
+        return requirements
+
+    # FALLBACK — legacy BOM walk (no op-material rows on this order)
     bom = db.query(BOM).filter(
         BOM.product_id == production_order.product_id,
         BOM.active.is_(True)
     ).first()
-    
+
     if not bom:
-        logger.warning(f"No active BOM found for product {production_order.product_id} - no materials to reserve")
-        return reservations
-    
+        logger.warning(
+            f"No active BOM found for product {production_order.product_id} "
+            f"- no materials to reserve"
+        )
+        return requirements
+
     quantity_ordered = Decimal(str(production_order.quantity_ordered or 0))
-    
-    # Get BOM lines for production consumption
+
     bom_lines = db.query(BOMLine).filter(
         BOMLine.bom_id == bom.id,
         BOMLine.consume_stage == "production",
     ).all()
-    
+
     for line in bom_lines:
         # Skip cost-only items (machine time, overhead)
         if line.is_cost_only:
             continue
-        
+
         # Skip non-inventory items
         component = db.query(Product).filter(Product.id == line.component_id).first()
         if not component:
             continue
-        
+
         # Calculate quantity to reserve (BOM qty per unit * ordered units)
         # Apply scrap factor if any
         base_qty = Decimal(str(line.quantity))
         scrap_factor = Decimal(str(line.scrap_factor or 0)) / Decimal("100")
         qty_with_scrap = base_qty * (Decimal("1") + scrap_factor)
         bom_qty = qty_with_scrap * quantity_ordered
-        
+
         # UOM Conversion: Convert BOM line unit to component's inventory unit
         line_unit = (line.unit or component.unit or "EA").upper()
         component_unit = (component.unit or "EA").upper()
-        
+
         try:
             total_qty, _ = convert_and_generate_notes(
                 db=db,
@@ -575,28 +696,112 @@ def reserve_production_materials(
         except UOMConversionError as e:
             logger.error(f"Failed to reserve materials: {e}")
             continue
-        
+
+        entry = requirements.get(line.component_id)
+        if entry:
+            entry["quantity"] += total_qty
+        else:
+            requirements[line.component_id] = {
+                "component": component,
+                "quantity": total_qty,
+                "unit": component_unit,
+                "source": "bom",
+            }
+
+    return requirements
+
+
+def reserve_production_materials(
+    db: Session,
+    production_order: ProductionOrder,
+    created_by: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Reserve (allocate) materials for a production order.
+
+    This increases the allocated_quantity on inventory records, reducing
+    available quantity without actually consuming the materials.
+
+    RESERVE-1 — requirement source is routing-first: when the order has
+    ProductionOrderOperationMaterial rows (materialized from the routing at
+    creation), those rows drive the reservation; otherwise the legacy
+    active-BOM walk applies.  See _get_reservation_requirements.
+
+    RESERVE-1 — delta idempotency: the function is safely re-runnable.  For
+    each component the net already-reserved quantity (reservation minus
+    reservation_release in the ledger) is subtracted from the requirement
+    and only the shortfall is reserved ("top-up reservation").  Calling it
+    on a fully-reserved order is a no-op apart from re-syncing op-material
+    rows.
+
+    HARD-5: reservations may exceed on_hand (flag, not block) — production
+    legitimately reserves ahead of receipt.
+
+    Args:
+        db: Database session
+        production_order: The production order being scheduled
+        created_by: User scheduling the order
+
+    Returns:
+        List of reservation records with details about what was reserved
+        in THIS call (deltas only; components already fully reserved are
+        omitted).
+    """
+    reservations = []
+    location = get_or_create_default_location(db)
+
+    requirements = _get_reservation_requirements(db, production_order)
+    if not requirements:
+        return reservations
+
+    # Net already-reserved per component from the ledger — only reserve the
+    # delta up to the requirement so re-runs never double-reserve.
+    net_reserved = _get_net_reserved_by_component(db, production_order.id)
+    net_after: Dict[int, Decimal] = {}
+
+    for component_id, req in requirements.items():
+        component = req["component"]
+        component_unit = req["unit"]
+        required_qty = req["quantity"]
+        already_reserved = net_reserved.get(component_id, Decimal("0"))
+        delta_qty = required_qty - already_reserved
+
+        if delta_qty <= Decimal("0"):
+            # Already fully reserved — nothing to add; rows re-synced below.
+            net_after[component_id] = already_reserved
+            logger.info(
+                "Reservation already covers requirement for %s on PO#%s "
+                "(required %s, net reserved %s) — skipping",
+                component.sku,
+                production_order.code,
+                required_qty,
+                already_reserved,
+            )
+            continue
+
+        is_topup = already_reserved > Decimal("0")
+
         # Get or create inventory record
-        inventory = get_or_create_inventory(db, line.component_id, location.id)
+        inventory = get_or_create_inventory(db, component_id, location.id)
 
         # Increase allocated quantity
         current_allocated = Decimal(str(inventory.allocated_quantity))
         current_on_hand = Decimal(str(inventory.on_hand_quantity))
-        new_allocated = current_allocated + total_qty
+        new_allocated = current_allocated + delta_qty
 
         # HARD-5 write-time guard: flag (not block) when reservation would
         # exceed on_hand.  Production is allowed to reserve ahead of receipt,
         # so we log + flag but proceed.  The shortage is visible in the
         # reservation return value so callers/UIs can surface it.
         would_exceed, available_after = check_allocation_guard(
-            current_on_hand, current_allocated, total_qty
+            current_on_hand, current_allocated, delta_qty
         )
         if would_exceed:
             logger.warning(
                 "HARD-5 allocation guard: reserving %s %s of %s for PO#%s "
                 "would exceed on_hand (%s). allocated %s → %s, available_after=%s. "
                 "Proceeding (legitimate ahead-of-receipt reservation).",
-                total_qty,
+                delta_qty,
                 component_unit,
                 component.sku,
                 production_order.code,
@@ -611,15 +816,26 @@ def reserve_production_materials(
 
         # Create reservation transaction for audit trail
         unit_cost = get_effective_cost_per_inventory_unit(component)
-        total_cost = abs(total_qty) * unit_cost if unit_cost else None
+        total_cost = abs(delta_qty) * unit_cost if unit_cost else None
+        if is_topup:
+            notes = (
+                f"Top-up reservation for PO#{production_order.code}: "
+                f"{delta_qty} {component_unit} of {component.name} "
+                f"(net already reserved: {already_reserved} {component_unit})"
+            )
+        else:
+            notes = (
+                f"Reserved for PO#{production_order.code}: "
+                f"{delta_qty} {component_unit} of {component.name}"
+            )
         txn = InventoryTransaction(
-            product_id=line.component_id,
+            product_id=component_id,
             location_id=location.id,
             transaction_type="reservation",
-            quantity=total_qty,
+            quantity=delta_qty,
             reference_type="production_order",
             reference_id=production_order.id,
-            notes=f"Reserved for PO#{production_order.code}: {total_qty} {component_unit} of {component.name}",
+            notes=notes,
             cost_per_unit=unit_cost,
             total_cost=total_cost,
             unit=component_unit,
@@ -628,11 +844,15 @@ def reserve_production_materials(
         )
         db.add(txn)
 
+        net_after[component_id] = already_reserved + delta_qty
+
         reservation_info = {
-            "product_id": line.component_id,
+            "product_id": component_id,
             "product_sku": component.sku,
             "product_name": component.name,
-            "quantity_reserved": float(total_qty),
+            "quantity_reserved": float(delta_qty),
+            "already_reserved": float(already_reserved),
+            "is_topup": is_topup,
             "unit": component_unit,
             "on_hand": float(current_on_hand),
             "allocated_after": float(new_allocated),
@@ -641,20 +861,26 @@ def reserve_production_materials(
         }
         reservations.append(reservation_info)
 
-        if not would_exceed:
+        if is_topup:
             logger.info(
-                f"Reserved {total_qty} {component_unit} of {component.sku} "
+                f"Top-up reservation: {delta_qty} {component_unit} of "
+                f"{component.sku} for PO#{production_order.code} "
+                f"(already reserved {already_reserved})"
+            )
+        elif not would_exceed:
+            logger.info(
+                f"Reserved {delta_qty} {component_unit} of {component.sku} "
                 f"for PO#{production_order.code}"
             )
-    
-    # Sync op-material rows: distribute reserved qty across op-material rows
-    # for each component, in operation-sequence order, filling each row up to
-    # its quantity_required.  Under partial reservation (HARD-5 shortage path)
-    # we allocate only what was actually reserved.
-    for reservation_info in reservations:
-        component_id = reservation_info["product_id"]
-        qty_reserved = Decimal(str(reservation_info["quantity_reserved"]))
-        _sync_op_material_allocation(db, production_order, component_id, qty_reserved)
+
+    # Sync op-material rows: distribute the TOTAL net reserved quantity
+    # (prior reservations + this run's delta) across op-material rows for
+    # each component, in operation-sequence order, filling each row up to
+    # its quantity_required.  Under partial reservation (HARD-5 shortage
+    # path or UOM-skipped top-up) we allocate only what was actually
+    # reserved.
+    for component_id, qty_net in net_after.items():
+        _sync_op_material_allocation(db, production_order, component_id, qty_net)
 
     return reservations
 
@@ -730,46 +956,17 @@ def _backfill_op_material_from_ledger(
     up to its quantity_required in operation-sequence order per component.
     """
     # Sum reservations minus reservation_releases per component
-    from sqlalchemy import func as sqlfunc
-    from sqlalchemy import case
+    net_reserved = _get_net_reserved_by_component(db, production_order.id)
 
-    net_rows = (
-        db.query(
-            InventoryTransaction.product_id,
-            sqlfunc.sum(
-                case(
-                    (InventoryTransaction.transaction_type == "reservation",
-                     InventoryTransaction.quantity),
-                    else_=Decimal("0"),
-                )
-                - case(
-                    (InventoryTransaction.transaction_type == "reservation_release",
-                     InventoryTransaction.quantity),
-                    else_=Decimal("0"),
-                )
-            ).label("net_reserved"),
-        )
-        .filter(
-            InventoryTransaction.reference_type == "production_order",
-            InventoryTransaction.reference_id == production_order.id,
-            InventoryTransaction.transaction_type.in_(
-                ["reservation", "reservation_release"]
-            ),
-        )
-        .group_by(InventoryTransaction.product_id)
-        .all()
-    )
-
-    for row in net_rows:
-        qty = max(Decimal("0"), Decimal(str(row.net_reserved)))
+    for component_id, qty in net_reserved.items():
         if qty > Decimal("0"):
-            _sync_op_material_allocation(db, production_order, row.product_id, qty)
+            _sync_op_material_allocation(db, production_order, component_id, qty)
 
     logger.info(
         "Self-heal: backfilled op-material quantity_allocated from ledger "
         "for PO#%s (%d component(s))",
         production_order.code,
-        len(net_rows),
+        len(net_reserved),
     )
 
 

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -429,6 +429,63 @@ def _maybe_backfill_op_material_allocation(
     db.flush()
 
 
+def _maybe_reserve_missing_materials(
+    db: Session,
+    order: "ProductionOrder",
+    user_email: str,
+) -> None:
+    """RESERVE-1 level-2 self-heal: reserve at release time when reservation
+    never ran or under-ran.
+
+    Level 1 (_maybe_backfill_op_material_allocation) only repairs ledger↔row
+    desync — it cannot help when the ledger itself has no (or insufficient)
+    reservations.  That happens for brownfield orders whose creation-time
+    reservation walked an empty/production-line-less BOM while the materials
+    actually live on the routing (op-material rows).
+
+    If any op-material row still shows quantity_allocated < quantity_required
+    after level 1, the net ledger reservation for that component is missing
+    or short, so run reserve_production_materials — it is delta-safe
+    (RESERVE-1) and tops up only the shortfall.  HARD-5 semantics are
+    preserved: zero-stock components reserve ahead of receipt (flag, not
+    block) and release proceeds.
+    """
+    rows = [mat for op in order.operations for mat in op.materials]
+    if not rows:
+        return
+
+    shortfall_rows = [
+        mat for mat in rows
+        if Decimal(str(mat.quantity_allocated or 0))
+        < Decimal(str(mat.quantity_required or 0))
+    ]
+    if not shortfall_rows:
+        return
+
+    never_ran = all(
+        Decimal(str(mat.quantity_allocated or 0)) == Decimal("0")
+        for mat in rows
+    )
+    if never_ran:
+        logger.info(
+            "RESERVE-1 self-heal: reservation had never run for PO#%s — "
+            "reserving at release",
+            order.code,
+        )
+    else:
+        logger.info(
+            "RESERVE-1 self-heal: reservation under-ran for PO#%s "
+            "(%d op-material row(s) short) — topping up at release",
+            order.code,
+            len(shortfall_rows),
+        )
+
+    from app.services.inventory_service import reserve_production_materials
+    reserve_production_materials(db, order, created_by=user_email)
+    # Flush so the gate re-check reads the updated rows.
+    db.flush()
+
+
 def release_production_order(
     db: Session,
     order_id: int,
@@ -453,15 +510,22 @@ def release_production_order(
             detail=f"Cannot release order in {order.status} status"
         )
 
-    # Self-heal: if the order has active ledger reservations but op-material
-    # rows still show quantity_allocated=0, the reservation sync was skipped
-    # (e.g. orders created before fix #715, or a future code path that calls
-    # reserve_production_materials without the sync step).  Backfill now so
-    # the gate below reads truth rather than always-zero.
+    # Self-heal level 1: if the order has active ledger reservations but
+    # op-material rows still show quantity_allocated=0, the reservation sync
+    # was skipped (e.g. orders created before fix #715, or a future code path
+    # that calls reserve_production_materials without the sync step).
+    # Backfill now so the gate below reads truth rather than always-zero.
     _maybe_backfill_op_material_allocation(db, order)
 
     # Check material availability unless forced
     if not force:
+        # Self-heal level 2 (RESERVE-1): if rows still show a shortfall after
+        # the ledger backfill, reservation never ran or under-ran (e.g. pure
+        # routing-material products whose creation-time reservation walked an
+        # empty BOM).  reserve_production_materials is delta-safe, so this
+        # tops up only the missing quantities, then the gate re-checks.
+        _maybe_reserve_missing_materials(db, order, user_email)
+
         blocking_issues = []
         for op in order.operations:
             for mat in op.materials:
@@ -502,9 +566,12 @@ def release_production_order(
             ]
 
             if not_allocated and not short:
+                # Nearly unreachable after the level-2 self-heal above: it
+                # fires only when reservation itself errored for every
+                # shortfall component (e.g. UOMConversionError skip).
                 message = (
-                    "Materials not yet allocated — re-run material reservation "
-                    "for this order"
+                    "Material reservation failed during release — check "
+                    "component/UOM configuration"
                 )
             else:
                 parts = []

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -268,6 +268,12 @@ def setup_database():
             "ALTER TABLE purchase_orders "
             "ADD COLUMN IF NOT EXISTS landed_cost_allocated NUMERIC(18, 4) NOT NULL DEFAULT 0"
         ))
+        # SCHED-3+4: auto_dispatch company setting (column added to the model
+        # without a conftest patch entry — accumulated test DBs lack it)
+        conn.execute(text(
+            "ALTER TABLE company_settings "
+            "ADD COLUMN IF NOT EXISTS auto_dispatch BOOLEAN NOT NULL DEFAULT FALSE"
+        ))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -618,11 +618,17 @@ class TestReleaseProductionOrder:
             svc.release_production_order(db, order.id, "test@filaops.dev")
         assert exc_info.value.status_code == 400
 
-    def test_release_with_no_reservation_blocked_not_allocated(
+    def test_release_blocked_not_allocated_when_reservation_errors(
         self, db, finished_good, raw_material
     ):
-        """Should block release with 'not yet allocated' message when no
-        inventory reservation exists (e.g. allocation step was never run)."""
+        """Should block release with 'reservation failed' message when the
+        RESERVE-1 level-2 self-heal cannot reserve (incompatible UOM).
+
+        Note: since RESERVE-1, a plain unreserved order with valid units
+        self-heals at release time (see TestRoutingAwareReservation in
+        test_routing_aware_reservation.py) — the not_allocated gate now only
+        fires when reservation itself errors, e.g. a UOM conversion failure.
+        """
         # Create order directly (bypassing service) so no BOM/reservation exists
         order = _make_production_order(db, finished_good, status="draft")
         op = ProductionOrderOperation(
@@ -637,12 +643,15 @@ class TestReleaseProductionOrder:
         )
         db.add(op)
         db.flush()
+        # Row unit EA is incompatible with the component's inventory unit G,
+        # so the self-heal's reservation attempt raises UOMConversionError
+        # and skips this component — leaving it not_allocated.
         mat = ProductionOrderOperationMaterial(
             production_order_operation_id=op.id,
             component_id=raw_material.id,
             quantity_required=Decimal("500"),
             quantity_allocated=Decimal("0"),
-            unit="G",
+            unit="EA",
             status="pending",
         )
         db.add(mat)
@@ -656,7 +665,7 @@ class TestReleaseProductionOrder:
         assert isinstance(detail, dict)
         assert "shortages" in detail
         assert any(s["reason"] == "not_allocated" for s in detail["shortages"])
-        assert "not yet allocated" in detail["message"].lower()
+        assert "reservation failed" in detail["message"].lower()
 
     def test_release_with_force_overrides_shortage(self, db, finished_good, raw_material):
         """Should release despite shortages when force=True."""
@@ -838,7 +847,14 @@ class TestReleaseProductionOrder:
     def test_release_insufficient_stock_error_message(
         self, db, finished_good, raw_material
     ):
-        """When stock is genuinely short, error should say 'Insufficient stock for ...'"""
+        """When a partial reservation exists and the RESERVE-1 top-up cannot
+        complete it (incompatible UOM), error should say 'Insufficient stock
+        for ...'.
+
+        Note: since RESERVE-1, a partial reservation with valid units is
+        topped up by the level-2 self-heal at release time — this gate case
+        now only fires when the top-up itself errors.
+        """
         from app.models.inventory import InventoryLocation, InventoryTransaction
 
         location = db.query(InventoryLocation).first()
@@ -857,12 +873,15 @@ class TestReleaseProductionOrder:
         db.add(op)
         db.flush()
 
+        # Row unit EA is incompatible with the component's inventory unit G,
+        # so the self-heal's top-up attempt raises UOMConversionError and
+        # skips this component — leaving the partial reservation in place.
         mat = ProductionOrderOperationMaterial(
             production_order_operation_id=op.id,
             component_id=raw_material.id,
             quantity_required=Decimal("500"),
             quantity_allocated=Decimal("0"),
-            unit="G",
+            unit="EA",
             status="pending",
         )
         db.add(mat)

--- a/backend/tests/services/test_routing_aware_reservation.py
+++ b/backend/tests/services/test_routing_aware_reservation.py
@@ -559,3 +559,78 @@ class TestZeroStockHard5:
         assert reservations[0]["is_shortage"] is True
         assert reservations[0]["quantity_reserved"] == 30.0
         assert reservations[0]["available_after"] < 0
+
+
+class TestMixedUomDistribution:
+    """Row unit != component inventory unit (CodeRabbit finding on #728).
+
+    Routing rows may carry KG while the component's inventory unit is G.
+    Requirements are reserved in the component unit (grams), but
+    quantity_allocated must be written back in the ROW's unit so the
+    release gate's allocated-vs-required comparison is unit-consistent.
+    """
+
+    def test_kg_routing_row_against_gram_inventory(
+        self, db, finished_good, raw_material
+    ):
+        # 0.05 KG per unit x 10 units = 0.5 KG required = 500 G
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {
+                "component_id": raw_material.id,
+                "quantity": Decimal("0.05"),
+                "unit": "KG",
+            },
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=10)
+
+        reservations = reserve_production_materials(
+            db, order, created_by="test@filaops.dev"
+        )
+
+        # Ledger reserves in the component unit: 500 G
+        assert len(reservations) == 1
+        assert reservations[0]["quantity_reserved"] == 500.0
+        assert reservations[0]["unit"] == "G"
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert sum(Decimal(str(t.quantity)) for t in txns) == Decimal("500")
+
+        # Row allocation is written in the ROW's unit (KG): fully covered
+        # means allocated == required exactly (0.5 KG), NOT 500.
+        rows = _op_material_rows(db, order)
+        assert len(rows) == 1
+        assert Decimal(str(rows[0].quantity_required)) == Decimal("0.5")
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("0.5")
+
+        # Inventory allocated in component unit
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("500")
+
+        # And the release gate (allocated >= required, row units) passes
+        released = po_svc.release_production_order(
+            db, order.id, user_email="test@filaops.dev"
+        )
+        assert released.status == "released"
+
+    def test_partial_coverage_mixed_uom_prorates_in_row_units(
+        self, db, finished_good, raw_material
+    ):
+        """Partial reservation must prorate the row allocation in row units."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {
+                "component_id": raw_material.id,
+                "quantity": Decimal("0.1"),
+                "unit": "KG",
+            },
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("0"))
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=5)
+        # 0.5 KG = 500 G required; pre-reserve only 200 G via a direct call
+        # with a hand-rolled ledger row, then sync via the delta-safe path.
+        from app.services.inventory_service import _sync_op_material_allocation
+        _sync_op_material_allocation(
+            db, order, raw_material.id, Decimal("200")
+        )
+        rows = _op_material_rows(db, order)
+        # 200 G of 500 G = 40% coverage -> 0.2 KG of 0.5 KG in row units
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("0.2")

--- a/backend/tests/services/test_routing_aware_reservation.py
+++ b/backend/tests/services/test_routing_aware_reservation.py
@@ -1,0 +1,561 @@
+"""
+Tests for RESERVE-1 — routing-aware material reservation + release-time
+self-heal.
+
+Covers:
+- Routing-only products (empty/no-production-line BOM): creation-time
+  reservation reserves from op-material rows, ledger txns exist,
+  allocated == required.
+- BOM-only products (no routing/op rows): legacy BOM walk regression.
+- Mixed-source products: op rows present -> routing-first totals only,
+  no double reservation.
+- Delta idempotency: re-running reserve_production_materials never
+  double-reserves; partial pre-reservations are topped up by the delta only.
+- Release-time level-2 self-heal: draft WO with op rows and zero
+  reservations releases successfully, creating the reservations.
+- HARD-5 zero-stock semantics: reservation proceeds flagged, release
+  proceeds (flag, not block).
+
+All fixtures are created locally per test (fresh products per test via the
+conftest factories) — no assertions on global table counts, since the local
+dev/CI databases accumulate data across runs.
+"""
+from decimal import Decimal
+
+from app.models import ProductionOrder
+from app.models.inventory import Inventory, InventoryTransaction
+from app.models.manufacturing import (
+    Routing,
+    RoutingOperation,
+    RoutingOperationMaterial,
+)
+from app.services import production_order_service as po_svc
+from app.services.inventory_service import (
+    _get_net_reserved_by_component,
+    get_or_create_default_location,
+    reserve_production_materials,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_routing_with_materials(db, product, materials, *, code_suffix=""):
+    """Create a routing with one operation carrying the given materials.
+
+    materials: list of dicts with keys:
+        component_id (required), quantity (required Decimal),
+        unit (default "G"), scrap_factor (optional), is_cost_only (optional)
+    """
+    routing = Routing(
+        product_id=product.id,
+        code=f"RT-{product.sku}{code_suffix}",
+        name=f"Routing for {product.name}",
+        is_active=True,
+    )
+    db.add(routing)
+    db.flush()
+
+    rop = RoutingOperation(
+        routing_id=routing.id,
+        work_center_id=1,
+        sequence=10,
+        operation_code="PRINT",
+        operation_name="Print",
+        setup_time_minutes=0,
+        run_time_minutes=Decimal("10"),
+    )
+    db.add(rop)
+    db.flush()
+
+    for m in materials:
+        rom = RoutingOperationMaterial(
+            routing_operation_id=rop.id,
+            component_id=m["component_id"],
+            quantity=m["quantity"],
+            unit=m.get("unit", "G"),
+            scrap_factor=m.get("scrap_factor"),
+            is_cost_only=m.get("is_cost_only", False),
+        )
+        db.add(rom)
+    db.flush()
+
+    return routing, rop
+
+
+def _make_draft_order_with_ops(db, product, routing, *, quantity=10):
+    """Insert a draft ProductionOrder directly (NO service reservation) and
+    materialize op-material rows from the routing — simulates a brownfield
+    draft WO created before RESERVE-1."""
+    code = po_svc.generate_production_order_code(db)
+    order = ProductionOrder(
+        code=code,
+        product_id=product.id,
+        routing_id=routing.id,
+        quantity_ordered=quantity,
+        quantity_completed=0,
+        quantity_scrapped=0,
+        source="manual",
+        status="draft",
+        priority=3,
+        created_by="test@filaops.dev",
+    )
+    db.add(order)
+    db.flush()
+    po_svc.copy_routing_to_operations(db, order, routing.id)
+    db.flush()
+    return order
+
+
+def _get_inventory(db, product_id):
+    location = get_or_create_default_location(db)
+    return db.query(Inventory).filter(
+        Inventory.product_id == product_id,
+        Inventory.location_id == location.id,
+    ).first()
+
+
+def _seed_inventory(db, product_id, on_hand, allocated=Decimal("0")):
+    location = get_or_create_default_location(db)
+    inv = Inventory(
+        product_id=product_id,
+        location_id=location.id,
+        on_hand_quantity=on_hand,
+        allocated_quantity=allocated,
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+def _reservation_txns(db, order_id, product_id):
+    """All reservation ledger rows for (order, component) — scoped, never global."""
+    return db.query(InventoryTransaction).filter(
+        InventoryTransaction.reference_type == "production_order",
+        InventoryTransaction.reference_id == order_id,
+        InventoryTransaction.product_id == product_id,
+        InventoryTransaction.transaction_type == "reservation",
+    ).all()
+
+
+def _op_material_rows(db, order):
+    db.expire(order, ["operations"])
+    return [mat for op in order.operations for mat in op.materials]
+
+
+# =============================================================================
+# 1. Routing-only product (the PO-2026-0032 / FG-002 case)
+# =============================================================================
+
+class TestRoutingOnlyReservation:
+    """Products whose materials live on the routing, with an empty BOM."""
+
+    def test_creation_reserves_from_op_rows_with_empty_bom(
+        self, db, finished_good, raw_material, make_bom
+    ):
+        """Active but EMPTY BOM + routing materials: creation-time reservation
+        must reserve from op-material rows (previously reserved nothing)."""
+        # Active BOM with zero lines — the FG-002 configuration
+        make_bom(finished_good.id, lines=[])
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.2"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=10,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        # Op rows fully allocated (0.2 g * 10 = 2 g)
+        rows = _op_material_rows(db, order)
+        assert len(rows) == 1
+        assert Decimal(str(rows[0].quantity_required)) == Decimal("2")
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("2")
+
+        # Ledger audit row exists with the routing-derived quantity
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert len(txns) == 1
+        assert Decimal(str(txns[0].quantity)) == Decimal("2")
+
+        # inventory.allocated_quantity reflects the reservation
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("2")
+
+    def test_creation_reserves_from_op_rows_with_no_bom(
+        self, db, finished_good, raw_material
+    ):
+        """No BOM at all + routing materials: reservation still happens."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.12"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=10,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        rows = _op_material_rows(db, order)
+        assert len(rows) == 1
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal(
+            str(rows[0].quantity_required)
+        )
+        net = _get_net_reserved_by_component(db, order.id)
+        assert net.get(raw_material.id) == Decimal(str(rows[0].quantity_required))
+
+    def test_cost_only_routing_materials_not_reserved(
+        self, db, finished_good, raw_material, make_product
+    ):
+        """Cost-only routing materials are excluded at copy time and must not
+        be reserved (no double-exclusion either — real materials reserve)."""
+        cost_only = make_product(unit="EA", name="Machine Time (cost only)")
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("5"), "unit": "G"},
+            {"component_id": cost_only.id, "quantity": Decimal("1"),
+             "unit": "EA", "is_cost_only": True},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=2,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        # Only the real material got an op row and a reservation
+        rows = _op_material_rows(db, order)
+        assert [r.component_id for r in rows] == [raw_material.id]
+        assert _reservation_txns(db, order.id, cost_only.id) == []
+        assert len(_reservation_txns(db, order.id, raw_material.id)) == 1
+
+
+# =============================================================================
+# 2. BOM-only product — legacy walk regression
+# =============================================================================
+
+class TestBomOnlyReservation:
+    """Products with a BOM but no routing materials keep the legacy path."""
+
+    def test_bom_walk_still_reserves(
+        self, db, finished_good, raw_material, make_bom
+    ):
+        make_bom(finished_good.id, lines=[
+            {"component_id": raw_material.id, "quantity": Decimal("100"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=5,
+            created_by="test@filaops.dev",
+        )
+
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert len(txns) == 1
+        assert Decimal(str(txns[0].quantity)) == Decimal("500")
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("500")
+
+    def test_no_bom_no_routing_reserves_nothing(self, db, finished_good):
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=5,
+            created_by="test@filaops.dev",
+        )
+        reservations = reserve_production_materials(db, order)
+        assert reservations == []
+
+
+# =============================================================================
+# 3. Mixed-source product — routing-first, no double reservation
+# =============================================================================
+
+class TestMixedSourceReservation:
+    """When op rows exist they REPLACE the BOM walk entirely (HARD-12
+    routing-first semantics) — the same component must not be reserved from
+    both sources."""
+
+    def test_op_rows_replace_bom_walk(
+        self, db, finished_good, raw_material, make_bom
+    ):
+        # BOM says 100 g/unit; routing says 80 g/unit — routing wins.
+        make_bom(finished_good.id, lines=[
+            {"component_id": raw_material.id, "quantity": Decimal("100"), "unit": "G"},
+        ])
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("80"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("10000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=2,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        # Routing-first: 80 * 2 = 160 g — NOT 200 (BOM), NOT 360 (both)
+        net = _get_net_reserved_by_component(db, order.id)
+        assert net.get(raw_material.id) == Decimal("160")
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("160")
+
+
+# =============================================================================
+# 4. Delta idempotency
+# =============================================================================
+
+class TestDeltaIdempotency:
+    """reserve_production_materials must be safely re-runnable."""
+
+    def test_second_run_is_noop(
+        self, db, finished_good, raw_material
+    ):
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.5"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=10,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        inv = _get_inventory(db, raw_material.id)
+        allocated_after_first = Decimal(str(inv.allocated_quantity))
+        assert allocated_after_first == Decimal("5")
+
+        # Second run: no new reservations, nothing changes
+        second = reserve_production_materials(db, order, created_by="test@filaops.dev")
+        assert second == []
+
+        db.refresh(inv)
+        assert Decimal(str(inv.allocated_quantity)) == allocated_after_first
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert len(txns) == 1  # still only the original ledger row
+
+        rows = _op_material_rows(db, order)
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("5")
+
+    def test_partial_prereservation_topped_up_by_delta_only(
+        self, db, finished_good, raw_material
+    ):
+        """Brownfield mixed case (PO-2026-0026 shape): some quantity was
+        reserved at creation, the rest never was — re-run must reserve only
+        the delta and mark it as a top-up."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.5"), "unit": "G"},
+        ])
+        inv = _seed_inventory(
+            db, raw_material.id, Decimal("1000"), allocated=Decimal("2")
+        )
+
+        # Draft order with op rows (requirement: 0.5 * 10 = 5 g), plus a
+        # pre-existing partial reservation of 2 g.
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=10)
+        location = get_or_create_default_location(db)
+        db.add(InventoryTransaction(
+            product_id=raw_material.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=Decimal("2"),
+            reference_type="production_order",
+            reference_id=order.id,
+            unit="G",
+            notes="Pre-existing partial reservation (brownfield)",
+        ))
+        db.flush()
+
+        reservations = reserve_production_materials(
+            db, order, created_by="test@filaops.dev"
+        )
+
+        assert len(reservations) == 1
+        assert reservations[0]["quantity_reserved"] == 3.0  # delta only
+        assert reservations[0]["already_reserved"] == 2.0
+        assert reservations[0]["is_topup"] is True
+
+        # Ledger net = 2 + 3 = 5; inventory allocated topped up to 5
+        net = _get_net_reserved_by_component(db, order.id)
+        assert net.get(raw_material.id) == Decimal("5")
+        db.refresh(inv)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("5")
+
+        # The top-up ledger row is marked as such
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        topups = [t for t in txns if "Top-up reservation" in (t.notes or "")]
+        assert len(topups) == 1
+        assert Decimal(str(topups[0].quantity)) == Decimal("3")
+
+        # Op rows fully allocated
+        rows = _op_material_rows(db, order)
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("5")
+
+
+# =============================================================================
+# 5. Release-time level-2 self-heal
+# =============================================================================
+
+class TestReleaseSelfHealLevel2:
+    """Draft WOs with op rows and ZERO reservations (reservation never ran)
+    must heal at release time — no migration, no user action."""
+
+    def test_release_heals_never_reserved_order(
+        self, db, finished_good, raw_material
+    ):
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.2"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("1000"))
+
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=10)
+
+        # Sanity: nothing reserved yet
+        assert _reservation_txns(db, order.id, raw_material.id) == []
+        rows = _op_material_rows(db, order)
+        assert all(
+            Decimal(str(r.quantity_allocated)) == Decimal("0") for r in rows
+        )
+
+        # Release WITHOUT force — self-heal reserves, gate passes
+        released = po_svc.release_production_order(
+            db, order.id, "test@filaops.dev", force=False
+        )
+        assert released.status == "released"
+
+        # Reservations were created at release time
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert len(txns) == 1
+        assert Decimal(str(txns[0].quantity)) == Decimal("2")
+
+        rows = _op_material_rows(db, order)
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("2")
+
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("2")
+
+    def test_release_heals_partially_reserved_order(
+        self, db, finished_good, raw_material
+    ):
+        """Mixed brownfield: partial ledger reservation, rows out of sync —
+        level 1 backfills, level 2 tops up the remainder, release proceeds."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("0.5"), "unit": "G"},
+        ])
+        inv = _seed_inventory(
+            db, raw_material.id, Decimal("1000"), allocated=Decimal("2")
+        )
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=10)
+
+        location = get_or_create_default_location(db)
+        db.add(InventoryTransaction(
+            product_id=raw_material.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=Decimal("2"),
+            reference_type="production_order",
+            reference_id=order.id,
+            unit="G",
+            notes="Pre-existing partial reservation (brownfield)",
+        ))
+        db.flush()
+
+        released = po_svc.release_production_order(
+            db, order.id, "test@filaops.dev", force=False
+        )
+        assert released.status == "released"
+
+        net = _get_net_reserved_by_component(db, order.id)
+        assert net.get(raw_material.id) == Decimal("5")
+        db.refresh(inv)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("5")
+        rows = _op_material_rows(db, order)
+        assert Decimal(str(rows[0].quantity_allocated)) == Decimal("5")
+
+
+# =============================================================================
+# 6. HARD-5: zero-stock components — flag, not block
+# =============================================================================
+
+class TestZeroStockHard5:
+    """Reservations may exceed on_hand (ahead-of-receipt) — flagged, never
+    blocked, and release proceeds."""
+
+    def test_zero_stock_reservation_flagged_and_release_proceeds(
+        self, db, finished_good, raw_material
+    ):
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("10"), "unit": "G"},
+        ])
+        # NO inventory seeded — component has zero stock
+
+        order = po_svc.create_production_order(
+            db,
+            product_id=finished_good.id,
+            quantity_ordered=3,
+            created_by="test@filaops.dev",
+            routing_id=routing.id,
+        )
+
+        # Reservation happened despite zero stock and is flagged as shortage
+        txns = _reservation_txns(db, order.id, raw_material.id)
+        assert len(txns) == 1
+        assert Decimal(str(txns[0].quantity)) == Decimal("30")
+        inv = _get_inventory(db, raw_material.id)
+        assert Decimal(str(inv.allocated_quantity)) == Decimal("30")
+        assert Decimal(str(inv.on_hand_quantity)) == Decimal("0")
+
+        # Release proceeds — HARD-5 is flag-not-block
+        released = po_svc.release_production_order(
+            db, order.id, "test@filaops.dev", force=False
+        )
+        assert released.status == "released"
+
+    def test_zero_stock_self_heal_at_release(self, db, finished_good, raw_material):
+        """Never-reserved draft + zero stock: self-heal reserves ahead of
+        receipt and release proceeds."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("10"), "unit": "G"},
+        ])
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=3)
+
+        released = po_svc.release_production_order(
+            db, order.id, "test@filaops.dev", force=False
+        )
+        assert released.status == "released"
+        net = _get_net_reserved_by_component(db, order.id)
+        assert net.get(raw_material.id) == Decimal("30")
+
+    def test_shortage_flag_in_reservation_result(
+        self, db, finished_good, raw_material
+    ):
+        """Direct call surface: is_shortage=True when reserving past on_hand."""
+        routing, _ = _make_routing_with_materials(db, finished_good, [
+            {"component_id": raw_material.id, "quantity": Decimal("10"), "unit": "G"},
+        ])
+        _seed_inventory(db, raw_material.id, Decimal("5"))
+        order = _make_draft_order_with_ops(db, finished_good, routing, quantity=3)
+
+        reservations = reserve_production_materials(
+            db, order, created_by="test@filaops.dev"
+        )
+        assert len(reservations) == 1
+        assert reservations[0]["is_shortage"] is True
+        assert reservations[0]["quantity_reserved"] == 30.0
+        assert reservations[0]["available_after"] < 0


### PR DESCRIPTION
## Root cause

`reserve_production_materials` walked only BOM lines with `consume_stage='production'` — but products define their materials on **routings**. The op-material rows (`ProductionOrderOperationMaterial`) were correctly materialized from the routing at order creation, yet the reservation step silently reserved nothing because the BOM was empty or had no production-stage lines.

Result: the release gate read `quantity_allocated=0 < quantity_required` on every row and blocked release with *"Materials not yet allocated — re-run material reservation for this order"* — an instruction pointing at a button that does not exist.

**Case study: PO-2026-0032** — product FG-002 with an active-but-empty BOM and all materials on the routing. Op-material rows existed with correct `quantity_required`, ledger had zero reservations, release permanently blocked. At time of diagnosis, **18/18 draft WOs in the dev DB sat at zero allocation** for this reason.

## Design

1. **Op rows as requirement source (routing-first truth)** — `_get_reservation_requirements` reads `ProductionOrderOperationMaterial` rows when present; they are the order-specific truth and exactly what the release gate checks (scrap already applied, cost-only rows already excluded at copy time). Legacy active-BOM walk remains as fallback for products with no routing materials. The two sources never mix, so mixed-source products cannot double-reserve.

2. **Delta idempotency** — per component, the net ledger reservation (`sum(reservation) - sum(reservation_release)` for `reference_type='production_order'`, floored at 0) is subtracted from the requirement; only the shortfall is reserved as a marked "top-up". Re-running on a fully reserved order is a no-op. The shared helper `_get_net_reserved_by_component` also backs the existing ledger→row backfill.

3. **Level-2 self-heal at release** — level 1 (`_maybe_backfill_op_material_allocation`, pre-existing) only repairs ledger↔row desync. New `_maybe_reserve_missing_materials` covers the case where the ledger itself has no/insufficient reservations: if rows are still under-allocated after level 1, the now delta-safe reservation runs and the gate re-checks. Brownfield draft WOs heal the moment an operator clicks Release — no migration, no user action. The "not allocated" gate message now honestly reports genuine reservation failures (e.g. UOM misconfiguration) instead of telling users to press a nonexistent button.

4. **HARD-5 unchanged** — reserving ahead of receipt remains flag-not-block: zero-stock components reserve with `is_shortage=True` and release proceeds.

No schema changes. No alembic migrations. Decimal-only arithmetic throughout.

## Tests

New `backend/tests/services/test_routing_aware_reservation.py` (12 tests):
- Routing-only products (empty BOM / no BOM — the PO-2026-0032 shape): creation-time reservation from op rows, ledger + inventory + row state all asserted
- Cost-only routing materials excluded
- BOM-only regression (legacy walk intact), no-BOM-no-routing reserves nothing
- Mixed-source: routing replaces BOM, no double reservation
- Delta idempotency: second run is a no-op; partial pre-reservation topped up by delta only
- Release-time self-heal: never-reserved and partially-reserved drafts release cleanly
- HARD-5: zero-stock reservation flagged, release proceeds; `is_shortage` surfaced

Updated release-gate tests in `test_production_order_service.py` for the new self-heal semantics (the not-allocated gate now only fires when reservation itself errors).

Results: `tests/services/test_routing_aware_reservation.py` + `tests/services/test_production_order_service.py` → **213 passed**. Adjacent guards: `test_inventory_extra.py` + `test_reservation_reconciliation.py` → **106 passed**; `test_inventory_service.py` + `test_inventory_ledger.py` + `test_requirement_explosion.py` + `test_production_order_accept_short.py` → **89 passed**. `ruff check app/` clean.

Also includes a conftest patch adding `company_settings.auto_dispatch` for accumulated test DBs (column existed on the model without a conftest entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced routing-aware material reservation system with automatic top-up capability during production order release
  * Added self-healing mechanism to detect and resolve material allocation shortfalls at release time
  * Enhanced reservation tracking with ledger-driven delta calculations

* **Bug Fixes**
  * Improved error guidance for release-time material validation issues

* **Tests**
  * Added comprehensive end-to-end tests for routing-aware reservation and release self-healing
  * Updated existing production order release tests to reflect new reservation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->