### PR TITLE
fix: root route defaults to login screen

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -131,8 +131,10 @@ export default function App() {
               <UpgradeModal />
               <BrowserRouter>
                 <Routes>
-                  {/* Redirect root to admin */}
-                  <Route path="/" element={<Navigate to="/admin" replace />} />
+                  {/* Root defaults to the login screen (owner decision
+                      2026-06-12): opening the app always starts at sign-in;
+                      authenticated deep links to /admin/* are unaffected. */}
+                  <Route path="/" element={<Navigate to="/admin/login" replace />} />
 
                   {/* First-run setup — /setup redirects to /onboarding (Setup.jsx removed in PR-3) */}
                   <Route path="/setup" element={<Navigate to="/onboarding" replace />} />


### PR DESCRIPTION
Owner request: on startup the app always defaulted to Command Center; it now defaults to the login screen.

One-line route change: `/` → `/admin/login` (was `/admin`). Authenticated deep links to `/admin/*` are unaffected — the AdminLayout guard and post-login navigation are unchanged, so signing in still lands on Command Center.

Tests: full frontend suite 430 passed; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app launch behavior to redirect users to the sign-in page instead of the admin page. Deep links to other admin sections remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->