### PR TITLE
fix: dead sessions bounce to login instead of 401-riddled admin shell

### DIFF
--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import Breadcrumbs from "./Breadcrumbs";
 import SecurityBadge from "./SecurityBadge";
 import useActivityTokenRefresh from "../hooks/useActivityTokenRefresh";
+import { useApi } from "../hooks/useApi";
 import {
   getCurrentVersion,
   getCurrentVersionSync,
@@ -626,6 +627,7 @@ const navGroups = [
 
 export default function AdminLayout() {
   const navigate = useNavigate();
+  const api = useApi();
   // Persist sidebar state in localStorage
   const [sidebarOpen, setSidebarOpen] = useState(() => {
     const saved = localStorage.getItem("sidebarOpen");
@@ -739,6 +741,20 @@ export default function AdminLayout() {
       navigate("/admin/login");
     }
   }, [navigate]);
+
+  // Validate the session against the server on entering the admin shell.
+  // The localStorage check above is only a fast hint — after a backend
+  // restart the cookie session can be dead while adminUser persists,
+  // which used to leave users on a 401-riddled page until they manually
+  // re-signed in. The shared apiClient attempts a silent token refresh
+  // on 401; if that fails, its onUnauthorized clears adminUser and
+  // redirects to login, so a dead session bounces cleanly instead of
+  // looking broken. Network-level failures (backend fully down) are
+  // swallowed — login couldn't succeed either, and the connection
+  // banner already communicates the outage.
+  useEffect(() => {
+    api.get("/api/v1/auth/me").catch(() => {});
+  }, [api]);
 
   useEffect(() => {
     const fetchVersion = async () => {

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -16,7 +16,11 @@ function getClient() {
     _sharedClient = createApiClient({
       baseUrl: API_URL,
       onUnauthorized: () => {
-        // Redirect to login on 401
+        // Session is genuinely dead (silent refresh already failed): clear
+        // the stale auth flag so AdminLayout's localStorage guard agrees,
+        // then go to login. Without the removeItem, a restarted backend
+        // left users on a half-rendered admin shell full of 401 errors.
+        localStorage.removeItem("adminUser");
         if (!window.location.pathname.includes("/login")) {
           window.location.href = "/admin/login";
         }


### PR DESCRIPTION
Owner report: stop/restart the backend while a browser holds an authenticated session → /admin renders the shell and every API call 401s with ugly errors until the user manually re-signs in. Looks broken to a new user.

Root cause: AdminLayout's guard only checks `localStorage.adminUser` (never server truth), raw-fetch calls bypass the apiClient's 401 handling, and `onUnauthorized` never cleared the stale flag.

Fix:
- AdminLayout mount: `GET /auth/me` through the shared apiClient — silent refresh first, genuine 401 → clean bounce to login
- `onUnauthorized` clears `adminUser` so the guard and reality agree
- Backend fully down (network error) deliberately does not bounce: login can't succeed either; the existing connection banner covers that case

Tests: full frontend suite 430 passed; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin session validation when entering the admin area
  * Enhanced authentication state cleanup to prevent stale credentials from persisting after session failures or backend refresh issues
  * Refined unauthorized access handling to ensure proper redirection to login when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->