### PR TITLE
fix: scheduler datetime-local inputs render local wall time (SCHED-TZ)

### DIFF
--- a/frontend/src/components/printers/MaintenanceModal.jsx
+++ b/frontend/src/components/printers/MaintenanceModal.jsx
@@ -6,6 +6,7 @@
 import { useState } from "react";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
+import { toLocalInputValue } from "../../utils/formatting";
 import Modal from "../Modal";
 
 const maintenanceTypes = [
@@ -23,7 +24,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
     maintenance_type: "routine",
     description: "",
     performed_by: "",
-    performed_at: new Date().toISOString().slice(0, 16),
+    performed_at: toLocalInputValue(new Date()),
     next_due_at: "",
     cost: "",
     downtime_minutes: "",

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -6,7 +6,7 @@
 import { useState, useEffect } from "react";
 import { API_URL } from "../../config/api";
 import { useResources, useResourceConflicts } from "../../hooks/useResources";
-import { formatDuration, formatTime } from "../../utils/formatting";
+import { formatDuration, formatTime, toLocalInputValue } from "../../utils/formatting";
 import Modal from "../Modal";
 
 /**
@@ -497,10 +497,10 @@ export default function OperationSchedulerModal({
       setResourceId(wizardSuggestion.resourceId);
     }
     if (wizardSuggestion.startTime) {
-      setStartTime(wizardSuggestion.startTime);
+      setStartTime(toLocalInputValue(wizardSuggestion.startTime));
     }
     if (wizardSuggestion.endTime) {
-      setEndTime(wizardSuggestion.endTime);
+      setEndTime(toLocalInputValue(wizardSuggestion.endTime));
     }
   }, [wizardMode, isOpen, wizardSuggestion, isEditMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -536,7 +536,7 @@ export default function OperationSchedulerModal({
     if (startTime && estimatedMinutes > 0) {
       const start = new Date(startTime);
       const end = new Date(start.getTime() + estimatedMinutes * 60000);
-      setEndTime(end.toISOString().slice(0, 16));
+      setEndTime(toLocalInputValue(end));
     }
   }, [startTime, estimatedMinutes]);
 
@@ -545,7 +545,7 @@ export default function OperationSchedulerModal({
     if (isOpen && !startTime) {
       const now = new Date();
       now.setMinutes(Math.ceil(now.getMinutes() / 15) * 15, 0, 0);
-      setStartTime(now.toISOString().slice(0, 16));
+      setStartTime(toLocalInputValue(now));
     }
   }, [isOpen, startTime]);
 
@@ -565,11 +565,12 @@ export default function OperationSchedulerModal({
   // chose this slot and we should show it rather than immediately replacing it.
   useEffect(() => {
     if (isOpen && isEditMode && currentOp?.scheduled_start) {
-      const start = new Date(currentOp.scheduled_start);
-      setStartTime(start.toISOString().slice(0, 16));
+      // scheduled_start/end are naive-UTC server strings — toLocalInputValue
+      // routes them through parseDateTime so they land at local wall time.
+      // (Plain `new Date(naiveString)` would mis-parse them as local.)
+      setStartTime(toLocalInputValue(currentOp.scheduled_start));
       if (currentOp.scheduled_end) {
-        const end = new Date(currentOp.scheduled_end);
-        setEndTime(end.toISOString().slice(0, 16));
+        setEndTime(toLocalInputValue(currentOp.scheduled_end));
       }
     }
   }, [isOpen, isEditMode, currentOp?.id]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -638,10 +639,8 @@ export default function OperationSchedulerModal({
         if (res.ok && !cancelled) {
           const data = await res.json();
           if (data.next_available && !cancelled) {
-            const start = new Date(data.next_available);
-            const end = new Date(data.suggested_end);
-            setStartTime(start.toISOString().slice(0, 16));
-            setEndTime(end.toISOString().slice(0, 16));
+            setStartTime(toLocalInputValue(data.next_available));
+            setEndTime(toLocalInputValue(data.suggested_end));
           }
         }
       } catch {
@@ -821,14 +820,13 @@ export default function OperationSchedulerModal({
     // Set fresh default start time
     const now = new Date();
     now.setMinutes(Math.ceil(now.getMinutes() / 15) * 15, 0, 0);
-    setStartTime(now.toISOString().slice(0, 16));
+    setStartTime(toLocalInputValue(now));
   };
 
   const handleUseSuggestedSlot = (suggestedStart, suggestedEnd) => {
-    const start = new Date(suggestedStart);
-    setStartTime(start.toISOString().slice(0, 16));
+    setStartTime(toLocalInputValue(suggestedStart));
     if (suggestedEnd) {
-      setEndTime(new Date(suggestedEnd).toISOString().slice(0, 16));
+      setEndTime(toLocalInputValue(suggestedEnd));
     }
     setServerConflicts([]);
     setPredecessorConflict(null);
@@ -1007,8 +1005,8 @@ export default function OperationSchedulerModal({
                     productionOrderId={productionOrder.id}
                     disabled={submitting}
                     onSlotPicked={(start, end) => {
-                      setStartTime(new Date(start).toISOString().slice(0, 16));
-                      setEndTime(new Date(end).toISOString().slice(0, 16));
+                      setStartTime(toLocalInputValue(start));
+                      setEndTime(toLocalInputValue(end));
                       setServerConflicts([]);
                       setPredecessorConflict(null);
                       setSuccessorConflicts([]);

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { API_URL } from "../../config/api";
-import { formatDuration, formatDate } from "../../utils/formatting";
+import { formatDuration, formatDate, toLocalInputValue } from "../../utils/formatting";
 import { PRODUCTION_ORDER_BADGE_CONFIGS } from "../../lib/statusColors.js";
 import Modal from "../Modal";
 import OperationCard from "./OperationCard";
@@ -388,7 +388,7 @@ export default function ProductionOrderModal({
     setSelectedWorkCenter(operation.work_center_id || null);
     const now = new Date();
     now.setHours(now.getHours() + 1);
-    setScheduledStart(now.toISOString().slice(0, 16));
+    setScheduledStart(toLocalInputValue(now));
     setScheduleModalOpen(true);
   };
 
@@ -491,8 +491,7 @@ export default function ProductionOrderModal({
   // Apply suggested time slot
   const applySuggestedSlot = () => {
     if (suggestedSlot) {
-      const suggested = new Date(suggestedSlot.start);
-      setScheduledStart(suggested.toISOString().slice(0, 16));
+      setScheduledStart(toLocalInputValue(suggestedSlot.start));
       setSuggestedSlot(null);
       setError(null);
     }

--- a/frontend/src/components/production/ReleaseScheduleWizard.jsx
+++ b/frontend/src/components/production/ReleaseScheduleWizard.jsx
@@ -115,10 +115,14 @@ async function fetchSuggestionForOp(op, earliestStart) {
       if (slotRes.ok) {
         const slotData = await slotRes.json();
         if (slotData.next_available) {
+          // Pass the server's UTC ISO strings through untouched — the modal
+          // converts them to local wall time (toLocalInputValue) exactly once
+          // when seeding the datetime-local inputs. Slicing toISOString()
+          // here would inject UTC into a local-by-definition input.
           return {
             resourceId: String(suggestedResourceId),
-            startTime: new Date(slotData.next_available).toISOString().slice(0, 16),
-            endTime: new Date(slotData.suggested_end).toISOString().slice(0, 16),
+            startTime: slotData.next_available,
+            endTime: slotData.suggested_end,
             maintenanceWarning,
           };
         }
@@ -136,10 +140,11 @@ async function fetchSuggestionForOp(op, earliestStart) {
         estimatedMinutes > 0
           ? new Date(base.getTime() + estimatedMinutes * 60000)
           : new Date(base.getTime() + 60 * 60000);
+      // Full UTC ISO strings (with 'Z') — the modal localizes them once.
       return {
         resourceId: String(suggestedResourceId),
-        startTime: base.toISOString().slice(0, 16),
-        endTime: end.toISOString().slice(0, 16),
+        startTime: base.toISOString(),
+        endTime: end.toISOString(),
         maintenanceWarning,
       };
     }

--- a/frontend/src/components/production/__tests__/OperationSchedulerModal.tz.test.jsx
+++ b/frontend/src/components/production/__tests__/OperationSchedulerModal.tz.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * Timezone tests for OperationSchedulerModal datetime-local seeding (SCHED-TZ).
+ *
+ * Regression for the UTC/local double-shift: the modal used to seed its
+ * datetime-local inputs with `Date.toISOString().slice(0, 16)` (UTC wall
+ * time) — at 2:42 PM Eastern the default start showed 6:45 PM (+4h) and the
+ * auto-calculated end showed start + duration + ANOTHER offset hop. Edit
+ * mode additionally mis-parsed naive-UTC server strings as local.
+ *
+ * The bug is invisible when tests run in UTC, so we pin a non-UTC timezone
+ * via process.env.TZ at the very top — before any import constructs a Date.
+ * CI (Linux) honors TZ; platforms that ignore it (some Windows local runs)
+ * skip the TZ-dependent assertions instead of silently passing.
+ *
+ * Mock setup mirrors OperationSchedulerModal.test.jsx.
+ */
+globalThis.process.env.TZ = "America/New_York";
+
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import OperationSchedulerModal from '../OperationSchedulerModal'
+import { toLocalInputValue } from '../../../utils/formatting'
+
+// Verify the TZ pin took effect (Jan 1 in America/New_York = EST = UTC-5).
+const TZ_PINNED = new Date(2026, 0, 1).getTimezoneOffset() === 300
+if (!TZ_PINNED) {
+  console.warn(
+    '[OperationSchedulerModal.tz.test] process.env.TZ pin ignored by this ' +
+      'platform — skipping TZ-dependent assertions (they run in CI on Linux).',
+  )
+}
+
+let _mockResources = []
+
+vi.mock('../../../hooks/useResources', () => ({
+  useResources: () => ({ resources: _mockResources, loading: false, error: null }),
+  useResourceConflicts: () => ({
+    conflicts: [],
+    checking: false,
+    error: null,
+    hasConflicts: false,
+  }),
+}))
+
+beforeEach(() => {
+  _mockResources = [
+    { id: 7, code: 'PRINTER-01', name: 'Bambu X1C', is_printer: true },
+  ]
+  // Silence fetch calls the component fires (compat check, next-available, etc.)
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// Naive-UTC strings exactly as the backend serializes them (no 'Z' suffix).
+const NAIVE_START = '2026-06-12T18:45:00'
+const NAIVE_END = '2026-06-12T20:25:00' // start + 100 min (10 setup + 90 run)
+
+const scheduledOp = {
+  id: 50,
+  sequence: 10,
+  operation_code: 'PRINT',
+  operation_name: 'FDM Print',
+  work_center_id: 1,
+  resource_id: null,
+  printer_id: 7,
+  planned_setup_minutes: '10.00',
+  planned_run_minutes: '90.00',
+  status: 'queued',
+  scheduled_start: NAIVE_START,
+  scheduled_end: NAIVE_END,
+}
+
+const productionOrder = { id: 1, code: 'PO-2026-000001' }
+
+function getDateTimeInputs(container) {
+  return Array.from(container.querySelectorAll('input[type="datetime-local"]'))
+}
+
+async function renderEditModal() {
+  let utils
+  await act(async () => {
+    utils = render(
+      <OperationSchedulerModal
+        isOpen={true}
+        onClose={vi.fn()}
+        operation={scheduledOp}
+        productionOrder={productionOrder}
+        onScheduled={vi.fn()}
+      />,
+    )
+  })
+  return utils
+}
+
+describe('OperationSchedulerModal — edit-mode prefill is local wall time (SCHED-TZ)', () => {
+  it('seeds the start input with toLocalInputValue of the naive-UTC scheduled_start', async () => {
+    const { container } = await renderEditModal()
+
+    // Sanity: it's edit mode
+    expect(screen.getAllByText('Edit Schedule').length).toBeGreaterThanOrEqual(1)
+
+    const [startInput] = getDateTimeInputs(container)
+    expect(startInput).toBeDefined()
+    expect(startInput.value).toBe(toLocalInputValue(NAIVE_START))
+  })
+
+  it('auto-calculated end is start + duration with no extra offset hop', async () => {
+    const { container } = await renderEditModal()
+
+    const [, endInput] = getDateTimeInputs(container)
+    expect(endInput).toBeDefined()
+    // Auto-calc: end = local-parse(startInput.value) + 100 min, serialized
+    // back as local wall time. Equals toLocalInputValue(NAIVE_END) because
+    // the fixture's scheduled_end is exactly start + 100 min.
+    expect(endInput.value).toBe(toLocalInputValue(NAIVE_END))
+  })
+
+  it.skipIf(!TZ_PINNED)(
+    'start input shows Eastern wall time, NOT the raw UTC slice (18:45 → 14:45 EDT)',
+    async () => {
+      const { container } = await renderEditModal()
+
+      const [startInput] = getDateTimeInputs(container)
+      expect(startInput.value).toBe('2026-06-12T14:45')
+      // Explicit regression guard against the old broken seeding
+      expect(startInput.value).not.toBe('2026-06-12T18:45')
+    },
+  )
+
+  it.skipIf(!TZ_PINNED)(
+    'end input shows start + 1h40m, not start + 1h40m + timezone offset',
+    async () => {
+      const { container } = await renderEditModal()
+
+      const [, endInput] = getDateTimeInputs(container)
+      expect(endInput.value).toBe('2026-06-12T16:25')
+    },
+  )
+})

--- a/frontend/src/utils/__tests__/toLocalInputValue.test.js
+++ b/frontend/src/utils/__tests__/toLocalInputValue.test.js
@@ -1,0 +1,108 @@
+/**
+ * Tests for toLocalInputValue (SCHED-TZ).
+ *
+ * The UTC/local double-shift bug is INVISIBLE when the test runner's
+ * timezone is UTC (local === UTC, so the broken toISOString().slice path
+ * produces the same string as the correct local path). We pin a non-UTC
+ * timezone via process.env.TZ at the very top of this file — before any
+ * import that could construct a Date — so the TZ-dependent assertions
+ * actually exercise the offset. CI (Linux) honors TZ; some Windows local
+ * runs ignore it, so TZ-dependent tests are skipped (not silently passed)
+ * when the pin did not take effect.
+ */
+globalThis.process.env.TZ = "America/New_York";
+
+import { describe, it, expect } from "vitest";
+import { toLocalInputValue, parseDateTime } from "../formatting";
+
+// Verify the TZ pin actually took effect on this runner.
+// Jan 1 in America/New_York is EST = UTC-5 → getTimezoneOffset() === 300.
+const TZ_PINNED = new Date(2026, 0, 1).getTimezoneOffset() === 300;
+if (!TZ_PINNED) {
+  console.warn(
+    "[toLocalInputValue.test] process.env.TZ pin ignored by this platform — " +
+      "skipping TZ-dependent assertions (they run in CI on Linux).",
+  );
+}
+
+describe("toLocalInputValue — timezone-independent", () => {
+  it("round-trips a local Date object to the same wall time in ANY timezone", () => {
+    // Date constructed from local wall-clock fields must come back verbatim.
+    expect(toLocalInputValue(new Date(2026, 5, 12, 14, 42))).toBe(
+      "2026-06-12T14:42",
+    );
+  });
+
+  it("zero-pads months, days, hours, and minutes", () => {
+    expect(toLocalInputValue(new Date(2026, 0, 5, 9, 5))).toBe(
+      "2026-01-05T09:05",
+    );
+  });
+
+  it("returns '' for null, undefined, and empty string", () => {
+    expect(toLocalInputValue(null)).toBe("");
+    expect(toLocalInputValue(undefined)).toBe("");
+    expect(toLocalInputValue("")).toBe("");
+  });
+
+  it("returns '' for an unparseable string", () => {
+    expect(toLocalInputValue("not-a-date")).toBe("");
+  });
+
+  it("naive-UTC string lands at the correct local time (computed via parseDateTime)", () => {
+    // TZ-agnostic: build the expected local wall time from the same
+    // parseDateTime the implementation uses, with independent formatting.
+    const naive = "2026-06-12T18:45:00";
+    const d = parseDateTime(naive);
+    const pad = (n) => String(n).padStart(2, "0");
+    const expected = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    expect(toLocalInputValue(naive)).toBe(expected);
+  });
+
+  it("submit round-trip preserves the UTC instant: new Date(value).toISOString() === original", () => {
+    // The submit path does `new Date(datetimeLocalValue).toISOString()`.
+    // Feeding it toLocalInputValue of a naive-UTC server string must yield
+    // the exact same UTC instant — in ANY timezone. This is the invariant
+    // the old toISOString().slice(0, 16) seeding violated.
+    const value = toLocalInputValue("2026-06-12T18:45:00"); // naive UTC
+    expect(new Date(value).toISOString()).toBe("2026-06-12T18:45:00.000Z");
+  });
+});
+
+describe("toLocalInputValue — TZ-dependent (America/New_York)", () => {
+  it.skipIf(!TZ_PINNED)(
+    "naive-UTC server string shifts to Eastern wall time (18:45 UTC → 14:45 EDT)",
+    () => {
+      expect(toLocalInputValue("2026-06-12T18:45:00")).toBe(
+        "2026-06-12T14:45",
+      );
+    },
+  );
+
+  it.skipIf(!TZ_PINNED)(
+    "'Z'-suffixed UTC string shifts to Eastern wall time",
+    () => {
+      expect(toLocalInputValue("2026-06-12T18:45:00Z")).toBe(
+        "2026-06-12T14:45",
+      );
+    },
+  );
+
+  it.skipIf(!TZ_PINNED)(
+    "winter (EST, UTC-5) instant shifts by 5 hours",
+    () => {
+      expect(toLocalInputValue("2026-01-15T18:45:00")).toBe(
+        "2026-01-15T13:45",
+      );
+    },
+  );
+
+  it.skipIf(!TZ_PINNED)(
+    "regression: result differs from the broken toISOString().slice(0, 16) seeding",
+    () => {
+      const d = parseDateTime("2026-06-12T18:45:00");
+      const broken = d.toISOString().slice(0, 16); // "2026-06-12T18:45" — UTC wall time
+      expect(toLocalInputValue("2026-06-12T18:45:00")).not.toBe(broken);
+    },
+  );
+});

--- a/frontend/src/utils/formatting.js
+++ b/frontend/src/utils/formatting.js
@@ -37,6 +37,25 @@ export function parseDateTime(datetime) {
 }
 
 /**
+ * Convert a datetime to the local wall-time string a `datetime-local` input
+ * expects ("YYYY-MM-DDTHH:mm").
+ *
+ * `datetime-local` inputs hold LOCAL wall time by definition — never feed
+ * them `Date.toISOString().slice(0, 16)`, which is UTC and renders shifted
+ * by the user's timezone offset. String inputs go through `parseDateTime`,
+ * so naive-UTC server strings (no 'Z' suffix) land at the correct local time.
+ *
+ * @param {string|Date} datetime - ISO datetime string (naive strings assumed UTC) or Date object
+ * @returns {string} Local wall-time value for datetime-local inputs (e.g., "2026-06-12T14:42"), or "" if unparseable
+ */
+export function toLocalInputValue(datetime) {
+  const d = parseDateTime(datetime);
+  if (!d || Number.isNaN(d.getTime())) return "";
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
  * Format datetime to time string
  * @param {string|Date} datetime - ISO datetime string or Date object
  * @returns {string} Formatted time (e.g., "2:30 PM")


### PR DESCRIPTION
## Symptom (owner-reported, with screenshot)

At 2:42 PM Eastern, opening the operation scheduler showed a default **start of 6:45 PM (+4h)**, and the auto-calculated end of a 1h40m operation landed **5h40m after the start** (duration + another 4h hop). Submitting saved times ~timezone-offset later than what the user saw on screen.

## Root cause

`datetime-local` inputs hold **local wall time by definition**, but every editable scheduling field was seeded with `Date.toISOString().slice(0, 16)` — a **UTC** string. Three variants of the same bug:

1. **Seeding** — default start / suggestions / auto-pick fed UTC strings into a local-by-definition input → display shifted +offset.
2. **End auto-calc compounding** — the calc parsed the already-shifted field value as local, added the duration, then sliced `toISOString()` again → end = start + duration + *another* offset hop.
3. **Edit-mode prefill naive parse** — `new Date(currentOp.scheduled_start)` on a **naive-UTC** server string parses as *local*, shifting the other way.

## Fix

New `toLocalInputValue(datetime)` in `frontend/src/utils/formatting.js`: accepts a Date or ISO string, routes strings through the existing `parseDateTime` (naive strings assumed UTC, per the storage model), and emits the local `"YYYY-MM-DDTHH:mm"` form `datetime-local` expects.

All editable `datetime-local` seeding sites converted (every `toISOString().slice(0, 16)` in `frontend/src`):

- **OperationSchedulerModal.jsx**: wizard-suggestion pre-fill, end auto-calc, default-now, edit-mode prefill (start + end, fixes the naive-parse variant), next-available auto-suggest, advance-to-next-op default, conflict "Use this time" slot, PRO auto-pick slot.
- **ReleaseScheduleWizard.jsx**: suggestion now passes **raw UTC ISO strings** (server values untouched / full `toISOString()` for the fallback); the modal localizes exactly once — no double conversion.
- **ProductionOrderModal.jsx**: schedule default (+1h) and suggested-slot apply.
- **MaintenanceModal.jsx**: `performed_at` default.

## Storage model unchanged

API still stores UTC. Submit paths are untouched and were already correct: `new Date(datetimeLocalValue).toISOString()` (local parse → UTC serialize). Read-only displays (`formatTime` / `formatDate` via `parseDateTime`, #721) are untouched.

## Test strategy

The bug is **invisible when tests run in UTC** (local === UTC), so both new test files pin `TZ=America/New_York` at the very top — before any import constructs a Date — and **assert the pin took effect** (`new Date(2026,0,1).getTimezoneOffset() === 300`). If a platform ignores `TZ`, the TZ-dependent tests are explicitly skipped with a console warning rather than silently passing. CI (Linux) honors `TZ`; the pin also took effect on the local Windows run.

- `src/utils/__tests__/toLocalInputValue.test.js` (10 tests): TZ-independent Date round-trip (`new Date(2026, 5, 12, 14, 42)` → `"2026-06-12T14:42"` in any TZ), padding, null/invalid → `""`, naive-UTC string vs `parseDateTime`-computed expectation, submit round-trip invariant (`new Date(value).toISOString()` returns the original UTC instant), plus TZ-pinned EDT/EST shift and an explicit regression check against the old `toISOString().slice` output.
- `src/components/production/__tests__/OperationSchedulerModal.tz.test.jsx` (4 tests): modal opened in edit mode for an op with naive-UTC `scheduled_start: "2026-06-12T18:45:00"`; asserts the start input equals `toLocalInputValue(...)` (not the raw slice), end = start + duration with no extra hop, and TZ-pinned absolute values (18:45 UTC → 14:45 EDT). Mock setup mirrors the existing `OperationSchedulerModal.test.jsx`.

## Verification

- `npm run test:unit`: **49 files / 444 tests passed** (430 pre-existing + 14 new)
- `npm run build`: passes
- ESLint on new test files: clean; pre-existing `react-hooks/set-state-in-effect` debt in the touched modals is unchanged (same count before/after) and logged via cortex_observe

🤖 Generated with [Claude Code](https://claude.com/claude-code)