### PR TITLE
feat: maintenance windows — first-class scheduler blocks (SCHED-7)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -33,6 +33,7 @@ from app.api.v1.endpoints import (
     traceability,
     quality,
     maintenance,
+    maintenance_windows,
     command_center,
     security,
     invoices,
@@ -245,6 +246,9 @@ router.include_router(
     prefix="/maintenance",
     tags=["maintenance"]
 )
+
+# Maintenance Windows (SCHED-7 — planned downtime the scheduler respects)
+router.include_router(maintenance_windows.router)
 
 # Command Center (dashboard)
 router.include_router(

--- a/backend/app/api/v1/endpoints/dispatch.py
+++ b/backend/app/api/v1/endpoints/dispatch.py
@@ -17,7 +17,8 @@ from app.api.v1.deps import get_current_staff_user, get_db
 from app.models.user import User
 from app.schemas.dispatch import AssignRequest, AssignResponse, DispatchSuggestionsResponse
 from app.services.dispatch_service import dispatch_operation, get_dispatch_suggestions
-from app.services.resource_scheduling import SequenceError
+from app.services.maintenance_window_service import sync_printer_maintenance_status
+from app.services.resource_scheduling import MaintenanceWindowConflictError, SequenceError
 
 router = APIRouter(
     prefix="/dispatch",
@@ -48,8 +49,13 @@ async def get_suggestions(
     - ``maintenance_warning``: non-null when maintenance is due before the job
       would finish (the operator decides whether to proceed)
 
-    ZERO writes — safe to poll frequently.
+    Near-zero writes: the suggestion computation itself never writes, but
+    this endpoint first runs the SCHED-7 lazy status sync (windows whose
+    start/end has passed flip printer status between idle and maintenance —
+    see maintenance_window_service docstring for the seam rationale).
     """
+    if sync_printer_maintenance_status(db):
+        db.commit()
     return get_dispatch_suggestions(db, printer_id=printer_id)
 
 
@@ -86,6 +92,9 @@ async def assign_operation(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except SequenceError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except MaintenanceWindowConflictError as exc:
+        # SCHED-7: proposed slot overlaps a blocking maintenance window
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/backend/app/api/v1/endpoints/maintenance_windows.py
+++ b/backend/app/api/v1/endpoints/maintenance_windows.py
@@ -1,0 +1,146 @@
+"""
+Maintenance Window Endpoints (SCHED-7)
+
+CRUD-lite for planned maintenance time blocks:
+  POST   /api/v1/maintenance-windows               — schedule a window
+  GET    /api/v1/maintenance-windows               — list (by machine / range)
+  POST   /api/v1/maintenance-windows/{id}/cancel   — cancel a window
+  POST   /api/v1/maintenance-windows/{id}/complete — complete (writes MaintenanceLog)
+
+Auth-gated with get_current_user, matching the sibling maintenance.py file.
+"""
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.v1.deps import get_current_user
+from app.db.session import get_db
+from app.logging_config import get_logger
+from app.models.user import User
+from app.schemas.maintenance_window import (
+    MaintenanceWindowCompleteRequest,
+    MaintenanceWindowCreate,
+    MaintenanceWindowListResponse,
+    MaintenanceWindowResponse,
+)
+from app.services import maintenance_window_service
+
+router = APIRouter(
+    prefix="/maintenance-windows",
+    tags=["maintenance"],
+)
+logger = get_logger(__name__)
+
+
+@router.post("", response_model=MaintenanceWindowResponse, status_code=201)
+async def create_maintenance_window(
+    data: MaintenanceWindowCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Schedule a maintenance window on a printer or machine resource."""
+    try:
+        window = maintenance_window_service.create_window(
+            db,
+            printer_id=data.printer_id,
+            resource_id=data.resource_id,
+            starts_at=data.starts_at,
+            ends_at=data.ends_at,
+            reason=data.reason,
+            created_by=current_user.email,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(window)
+    logger.info(
+        f"Scheduled maintenance window {window.id} "
+        f"({'printer ' + str(window.printer_id) if window.printer_id else 'resource ' + str(window.resource_id)}) "
+        f"{window.starts_at} – {window.ends_at}"
+    )
+    return window
+
+
+@router.get("", response_model=MaintenanceWindowListResponse)
+async def list_maintenance_windows(
+    printer_id: Optional[int] = Query(None, description="Filter by printer"),
+    resource_id: Optional[int] = Query(None, description="Filter by machine resource"),
+    start: Optional[datetime] = Query(None, description="Only windows ending after this time"),
+    end: Optional[datetime] = Query(None, description="Only windows starting before this time"),
+    include_finished: bool = Query(
+        False, description="Include completed and cancelled windows"
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List maintenance windows by machine and/or time range."""
+    windows = maintenance_window_service.list_windows(
+        db,
+        printer_id=printer_id,
+        resource_id=resource_id,
+        start=start,
+        end=end,
+        include_finished=include_finished,
+    )
+    return MaintenanceWindowListResponse(items=windows, total=len(windows))
+
+
+@router.post("/{window_id}/cancel", response_model=MaintenanceWindowResponse)
+async def cancel_maintenance_window(
+    window_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Cancel a scheduled or in-progress maintenance window."""
+    try:
+        window = maintenance_window_service.cancel_window(db, window_id)
+    except ValueError as exc:
+        status = 404 if "not found" in str(exc) else 400
+        raise HTTPException(status_code=status, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(window)
+    logger.info(f"Cancelled maintenance window {window_id}")
+    return window
+
+
+@router.post("/{window_id}/complete", response_model=MaintenanceWindowResponse)
+async def complete_maintenance_window(
+    window_id: int,
+    data: MaintenanceWindowCompleteRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Complete a maintenance window.
+
+    For printer windows this writes a MaintenanceLog entry (downtime from
+    the window span, operator-supplied next_due_at) and links it via
+    maintenance_log_id, closing the loop with the /maintenance/due
+    endpoints. Resource windows just close (maintenance_logs requires a
+    printer).
+    """
+    try:
+        window = maintenance_window_service.complete_window(
+            db,
+            window_id,
+            maintenance_type=data.maintenance_type.value,
+            performed_by=data.performed_by or current_user.email,
+            next_due_at=data.next_due_at,
+            cost=data.cost,
+            notes=data.notes,
+        )
+    except ValueError as exc:
+        status = 404 if "not found" in str(exc) else 400
+        raise HTTPException(status_code=status, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(window)
+    logger.info(
+        f"Completed maintenance window {window_id} "
+        f"(log {window.maintenance_log_id})"
+    )
+    return window

--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -38,6 +38,7 @@ from app.services.resource_scheduling import (
     schedule_operation as schedule_operation_service,
     find_next_available_slot,
     get_earliest_start_after_predecessors,
+    MaintenanceWindowConflictError,
     SequenceError,
 )
 from app.services.operation_generation import (
@@ -576,6 +577,30 @@ def schedule_operation_endpoint(
                 next_start + timedelta(minutes=duration_minutes)
                 if next_start is not None else None
             ),
+        )
+    except MaintenanceWindowConflictError as e:
+        # SCHED-7: the slot overlaps a blocking maintenance window. The
+        # suggested slot is window-aware (find_next_available_slot skips
+        # windows), so "Use this slot" lands after the maintenance block.
+        earliest = get_earliest_start_after_predecessors(
+            db=db,
+            operation=op,
+            after=request.scheduled_start,
+        )
+        next_start = find_next_available_slot(
+            db=db,
+            resource_id=request.resource_id,
+            duration_minutes=duration_minutes,
+            after=earliest,
+            is_printer=request.is_printer,
+        )
+        return ScheduleOperationResponse(
+            success=False,
+            message=str(e),
+            conflicts=[],
+            conflict_type="maintenance",
+            next_available_start=next_start,
+            next_available_end=next_start + timedelta(minutes=duration_minutes),
         )
 
     if not success:

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -79,6 +79,7 @@ from app.services import production_order_service
 from app.services.resource_scheduling import (
     find_conflicts,
     find_next_available_slot,
+    find_window_conflicts,
     check_predecessor_scheduling,
     check_successor_scheduling,
     get_earliest_start_after_predecessors,
@@ -1026,6 +1027,38 @@ async def reschedule_operation(
             message=f"Scheduling conflict with {len(resource_conflicts)} existing operation(s)",
             conflicts=conflict_details,
             conflict_type="resource",
+            next_available_start=next_start,
+            next_available_end=next_start + timedelta(minutes=duration_minutes),
+        )
+
+    # --- Maintenance-window check (SCHED-7) ---
+    window_conflicts = find_window_conflicts(
+        db=db,
+        resource_id=new_resource_id,
+        start_time=new_start,
+        end_time=new_end,
+        is_printer=is_printer,
+    )
+    if window_conflicts:
+        w = window_conflicts[0]
+        # find_next_available_slot is window-aware, so the suggested slot
+        # already skips past the maintenance block.
+        next_start = find_next_available_slot(
+            db=db,
+            resource_id=new_resource_id,
+            duration_minutes=duration_minutes,
+            after=get_earliest_start_after_predecessors(db=db, operation=op, after=new_start),
+            is_printer=is_printer,
+        )
+        return RescheduleResponse(
+            success=False,
+            message=(
+                f"Overlaps maintenance window "
+                f"{w.starts_at:%Y-%m-%d %H:%M}–{w.ends_at:%H:%M} UTC"
+                + (f" ({w.reason})" if w.reason else "")
+            ),
+            conflicts=[],
+            conflict_type="maintenance",
             next_available_start=next_start,
             next_available_end=next_start + timedelta(minutes=duration_minutes),
         )

--- a/backend/app/api/v1/endpoints/resources.py
+++ b/backend/app/api/v1/endpoints/resources.py
@@ -16,11 +16,13 @@ from app.schemas.resource_scheduling import (
     ResourceScheduleResponse,
     ConflictCheckResponse,
     ConflictInfo,
+    MaintenanceWindowInfo,
     ScheduledOperationInfo,
 )
 from app.services.resource_scheduling import (
     get_resource_schedule,
     find_conflicts,
+    find_window_conflicts,
 )
 
 router = APIRouter()
@@ -106,8 +108,14 @@ def check_conflicts(
 
     conflicts = find_conflicts(db, resource_id, start, end, exclude_operation_id)
 
+    # SCHED-7: blocking maintenance windows count as conflicts too
+    window_conflicts = find_window_conflicts(db, resource_id, start, end)
+
     return ConflictCheckResponse(
-        has_conflicts=len(conflicts) > 0,
+        has_conflicts=len(conflicts) > 0 or len(window_conflicts) > 0,
+        maintenance_windows=[
+            MaintenanceWindowInfo.model_validate(w) for w in window_conflicts
+        ],
         conflicts=[
             ConflictInfo(
                 operation_id=op.id,

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -54,7 +54,7 @@ async def get_scheduler_board(
     """
     from sqlalchemy.orm import joinedload
 
-    from app.models.maintenance import MaintenanceWindow
+    from app.models.maintenance import WINDOW_BLOCKING_STATUSES, MaintenanceWindow
     from app.models.printer import Printer
     from app.models.production_order import ProductionOrderOperation
     from app.services.maintenance_window_service import (
@@ -159,12 +159,14 @@ async def get_scheduler_board(
         ops_by_lane.setdefault(key, []).append(op)
 
     # --- Maintenance windows in window (single query, SCHED-7) -------------
-    # Non-cancelled windows render as blocks; status lets the UI distinguish
-    # upcoming/active from already-completed history.
+    # Only blocking windows (scheduled / in_progress) render as blocks —
+    # the same statuses the engine treats as busy time. A window completed
+    # early must release its lane immediately, not ghost-block until its
+    # scheduled ends_at; completed windows are history (MaintenanceLog).
     windows = (
         db.query(MaintenanceWindow)
         .filter(
-            MaintenanceWindow.status != "cancelled",
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
             MaintenanceWindow.starts_at < end_date,
             MaintenanceWindow.ends_at > start_date,
         )

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -54,9 +54,19 @@ async def get_scheduler_board(
     """
     from sqlalchemy.orm import joinedload
 
+    from app.models.maintenance import MaintenanceWindow
     from app.models.printer import Printer
     from app.models.production_order import ProductionOrderOperation
+    from app.services.maintenance_window_service import (
+        sync_printer_maintenance_status,
+    )
     from app.services.resource_scheduling import TERMINAL_STATUSES
+
+    # SCHED-7 lazy seam: the board is one of the two surfaces that display
+    # printer status, so it advances window state / flips printer status
+    # before painting (see maintenance_window_service docstring).
+    if sync_printer_maintenance_status(db):
+        db.commit()
 
     # Scheduled_* columns are timezone-naive UTC, but values still in the
     # session identity map (or from other DBs) may carry tzinfo. Normalize
@@ -148,6 +158,37 @@ async def get_scheduler_board(
             key = f"resource-{op.resource_id}"
         ops_by_lane.setdefault(key, []).append(op)
 
+    # --- Maintenance windows in window (single query, SCHED-7) -------------
+    # Non-cancelled windows render as blocks; status lets the UI distinguish
+    # upcoming/active from already-completed history.
+    windows = (
+        db.query(MaintenanceWindow)
+        .filter(
+            MaintenanceWindow.status != "cancelled",
+            MaintenanceWindow.starts_at < end_date,
+            MaintenanceWindow.ends_at > start_date,
+        )
+        .order_by(MaintenanceWindow.starts_at)
+        .all()
+    )
+
+    windows_by_lane: dict[str, list] = {}
+    for w in windows:
+        if w.printer_id is not None:
+            key = f"printer-{w.printer_id}"
+        else:
+            key = f"resource-{w.resource_id}"
+        windows_by_lane.setdefault(key, []).append(w)
+
+    def _window_block(w) -> dict:
+        return {
+            "id": w.id,
+            "starts_at": _naive_utc(w.starts_at).isoformat(),
+            "ends_at": _naive_utc(w.ends_at).isoformat(),
+            "reason": w.reason,
+            "status": w.status,
+        }
+
     def _lane(kind: str, obj, work_center_code: Optional[str]) -> dict:
         key = f"{kind}-{obj.id}"
         lane_ops = ops_by_lane.get(key, [])
@@ -168,6 +209,7 @@ async def get_scheduler_board(
             "work_center_code": work_center_code,
             "utilization_percent": round(min(utilization, 100.0), 1),
             "operations": [_op_block(op) for op in lane_ops],
+            "windows": [_window_block(w) for w in windows_by_lane.get(key, [])],
         }
 
     lanes = [
@@ -624,9 +666,14 @@ async def get_resource_conflicts(
     Check for scheduling conflicts on a resource/printer in a time range.
 
     Used by the frontend's live conflict checker to warn before submitting.
-    Returns list of conflicting operations with their PO codes and times.
+    Returns list of conflicting operations with their PO codes and times,
+    plus maintenance-window conflicts (SCHED-7) discriminated by
+    ``type: "maintenance"`` (operations carry ``type: "operation"``).
     """
-    from app.services.resource_scheduling import find_conflicts
+    from app.services.resource_scheduling import (
+        find_conflicts,
+        find_window_conflicts,
+    )
 
     # Parse ISO timestamps (handle trailing Z for UTC)
     try:
@@ -650,12 +697,34 @@ async def get_resource_conflicts(
     for op in conflicting_ops:
         po = op.production_order
         conflicts.append({
+            "type": "operation",
             "operation_id": op.id,
             "operation_code": op.operation_code,
             "production_order_code": po.code if po else None,
             "po_code": po.code if po else None,
             "scheduled_start": op.scheduled_start.isoformat() if op.scheduled_start else None,
             "scheduled_end": op.scheduled_end.isoformat() if op.scheduled_end else None,
+        })
+
+    # Maintenance windows — shaped so the existing ConflictAlert renders
+    # them without changes ("Maintenance window - <reason> (start – end)").
+    conflicting_windows = find_window_conflicts(
+        db=db,
+        resource_id=resource_id,
+        start_time=start_time,
+        end_time=end_time,
+        is_printer=is_printer,
+    )
+    for w in conflicting_windows:
+        conflicts.append({
+            "type": "maintenance",
+            "window_id": w.id,
+            "operation_id": None,
+            "operation_code": w.reason or "Scheduled downtime",
+            "production_order_code": "Maintenance window",
+            "po_code": "Maintenance window",
+            "scheduled_start": w.starts_at.isoformat(),
+            "scheduled_end": w.ends_at.isoformat(),
         })
 
     return {"conflicts": conflicts}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,7 +29,7 @@ from app.models.order_event import OrderEvent
 from app.models.purchasing_event import PurchasingEvent
 from app.models.shipping_event import ShippingEvent
 from app.models.material_spool import MaterialSpool, ProductionOrderSpool
-from app.models.maintenance import MaintenanceLog
+from app.models.maintenance import MaintenanceLog, MaintenanceWindow
 from app.models.customer import Customer
 
 # Accounting (GL)
@@ -129,6 +129,7 @@ __all__ = [
     "ProductionOrderSpool",
     # Maintenance
     "MaintenanceLog",
+    "MaintenanceWindow",
     # CRM (Core)
     "Customer",
     # Accounting (GL)

--- a/backend/app/models/maintenance.py
+++ b/backend/app/models/maintenance.py
@@ -105,6 +105,10 @@ class MaintenanceWindow(Base):
             "ends_at > starts_at",
             name="ck_maintenance_windows_valid_range",
         ),
+        CheckConstraint(
+            "status IN ('scheduled', 'in_progress', 'completed', 'cancelled')",
+            name="ck_maintenance_windows_status",
+        ),
         Index("ix_maintenance_windows_printer_starts", "printer_id", "starts_at"),
         Index("ix_maintenance_windows_resource_starts", "resource_id", "starts_at"),
     )
@@ -125,8 +129,14 @@ class MaintenanceWindow(Base):
 
     reason = Column(String(255), nullable=True)
 
-    # scheduled | in_progress | completed | cancelled
+    # scheduled | in_progress | completed | cancelled (DB CHECK enforced)
     status = Column(String(20), nullable=False, default="scheduled", index=True)
+
+    # Printer status recorded when this window flipped the printer to
+    # 'maintenance' (always 'idle' or 'available' — the only flippable
+    # statuses). Restored verbatim when the last blocking window closes.
+    # NULL for resource windows and windows that never flipped a printer.
+    prior_printer_status = Column(String(50), nullable=True)
 
     # Set when the window is completed (printer windows only — MaintenanceLog
     # requires a printer_id)

--- a/backend/app/models/maintenance.py
+++ b/backend/app/models/maintenance.py
@@ -1,11 +1,24 @@
 """
-Maintenance Log Model
+Maintenance Models
 
-Tracks maintenance activities on printers for preventive maintenance scheduling.
-Freemium feature: Basic maintenance logging and scheduling.
+MaintenanceLog  — tracks maintenance activities on printers for preventive
+                  maintenance scheduling (freemium feature).
+MaintenanceWindow — SCHED-7: a planned maintenance time block on a printer
+                  or machine resource that the scheduling engine treats as
+                  busy time. Completing a window writes a MaintenanceLog.
 """
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, Text, DateTime, Numeric, ForeignKey
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from app.db.base import Base
@@ -59,3 +72,93 @@ class MaintenanceLog(Base):
 
     def __repr__(self):
         return f"<MaintenanceLog {self.id}: {self.maintenance_type} on Printer {self.printer_id}>"
+
+
+# Window statuses that block scheduling (treated as busy time by the engine).
+# 'completed' windows release the machine early; 'cancelled' never block.
+WINDOW_BLOCKING_STATUSES = ("scheduled", "in_progress")
+
+WINDOW_STATUSES = ("scheduled", "in_progress", "completed", "cancelled")
+
+
+class MaintenanceWindow(Base):
+    """
+    Planned maintenance time block (SCHED-7).
+
+    Exactly one of printer_id / resource_id is set (DB CHECK enforced) —
+    Printer and Resource are distinct models with no FK between them, the
+    same duality the scheduling engine handles via its ``is_printer`` flag.
+
+    Times are naive UTC (matching every other DateTime in the schema).
+
+    Lifecycle: scheduled → in_progress (window becomes active) →
+    completed (operator confirms work done; writes a MaintenanceLog for
+    printer windows) or cancelled (any time before completion).
+    """
+    __tablename__ = "maintenance_windows"
+    __table_args__ = (
+        CheckConstraint(
+            "(printer_id IS NOT NULL) != (resource_id IS NOT NULL)",
+            name="ck_maintenance_windows_one_machine",
+        ),
+        CheckConstraint(
+            "ends_at > starts_at",
+            name="ck_maintenance_windows_valid_range",
+        ),
+        Index("ix_maintenance_windows_printer_starts", "printer_id", "starts_at"),
+        Index("ix_maintenance_windows_resource_starts", "resource_id", "starts_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # Exactly one of these is set (CHECK constraint above)
+    printer_id = Column(
+        Integer, ForeignKey("printers.id", ondelete="CASCADE"), nullable=True
+    )
+    resource_id = Column(
+        Integer, ForeignKey("resources.id", ondelete="CASCADE"), nullable=True
+    )
+
+    # Window bounds — naive UTC
+    starts_at = Column(DateTime, nullable=False)
+    ends_at = Column(DateTime, nullable=False)
+
+    reason = Column(String(255), nullable=True)
+
+    # scheduled | in_progress | completed | cancelled
+    status = Column(String(20), nullable=False, default="scheduled", index=True)
+
+    # Set when the window is completed (printer windows only — MaintenanceLog
+    # requires a printer_id)
+    maintenance_log_id = Column(
+        Integer, ForeignKey("maintenance_logs.id", ondelete="SET NULL"), nullable=True
+    )
+
+    created_by = Column(String(100), nullable=True)
+
+    created_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    # Relationships (one-directional — no back_populates so Printer/Resource
+    # models stay untouched)
+    printer = relationship("Printer", foreign_keys=[printer_id])
+    resource = relationship("Resource", foreign_keys=[resource_id])
+    maintenance_log = relationship("MaintenanceLog", foreign_keys=[maintenance_log_id])
+
+    def __repr__(self):
+        machine = (
+            f"Printer {self.printer_id}"
+            if self.printer_id is not None
+            else f"Resource {self.resource_id}"
+        )
+        return (
+            f"<MaintenanceWindow {self.id}: {machine} "
+            f"{self.starts_at}–{self.ends_at} [{self.status}]>"
+        )

--- a/backend/app/schemas/maintenance_window.py
+++ b/backend/app/schemas/maintenance_window.py
@@ -1,0 +1,59 @@
+"""
+Maintenance Window Pydantic Schemas (SCHED-7)
+
+Planned maintenance time blocks on printers / machine resources.
+"""
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.schemas.maintenance import MaintenanceType
+
+
+class MaintenanceWindowCreate(BaseModel):
+    """Create a planned maintenance window.
+
+    Exactly one of printer_id / resource_id must be set (service-validated
+    in addition to the DB CHECK constraint).
+    """
+    printer_id: Optional[int] = Field(None, description="Target printer (XOR with resource_id)")
+    resource_id: Optional[int] = Field(None, description="Target machine resource (XOR with printer_id)")
+    starts_at: datetime = Field(..., description="Window start (UTC)")
+    ends_at: datetime = Field(..., description="Window end (UTC; must be after starts_at)")
+    reason: Optional[str] = Field(None, max_length=255, description="Why the machine is down")
+
+
+class MaintenanceWindowCompleteRequest(BaseModel):
+    """Complete a window — writes the MaintenanceLog entry (printer windows)."""
+    maintenance_type: MaintenanceType = Field(
+        MaintenanceType.ROUTINE, description="Type recorded on the MaintenanceLog"
+    )
+    performed_by: Optional[str] = Field(None, max_length=100)
+    next_due_at: Optional[datetime] = Field(
+        None, description="When the next maintenance is due (recorded on the log)"
+    )
+    cost: Optional[Decimal] = Field(None, ge=0)
+    notes: Optional[str] = None
+
+
+class MaintenanceWindowResponse(BaseModel):
+    id: int
+    printer_id: Optional[int]
+    resource_id: Optional[int]
+    starts_at: datetime
+    ends_at: datetime
+    reason: Optional[str]
+    status: str
+    maintenance_log_id: Optional[int]
+    created_by: Optional[str]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MaintenanceWindowListResponse(BaseModel):
+    items: List[MaintenanceWindowResponse]
+    total: int

--- a/backend/app/schemas/resource_scheduling.py
+++ b/backend/app/schemas/resource_scheduling.py
@@ -50,10 +50,25 @@ class ResourceScheduleResponse(BaseModel):
     operations: List[ScheduledOperationInfo]
 
 
+class MaintenanceWindowInfo(BaseModel):
+    """Information about a conflicting maintenance window (SCHED-7)."""
+    id: int
+    starts_at: datetime
+    ends_at: datetime
+    reason: Optional[str] = None
+    status: str
+
+    class Config:
+        from_attributes = True
+
+
 class ConflictCheckResponse(BaseModel):
     """Response from conflict check."""
     has_conflicts: bool
     conflicts: List[ConflictInfo]
+    # Maintenance windows overlapping the range (SCHED-7) — additive field,
+    # also counted in has_conflicts.
+    maintenance_windows: List[MaintenanceWindowInfo] = Field(default_factory=list)
 
 
 class ScheduleOperationResponse(BaseModel):
@@ -66,8 +81,9 @@ class ScheduleOperationResponse(BaseModel):
     next_available_end: Optional[datetime] = None
     # Predecessor-specific fields
     # conflict_type is "resource" when blocked by another op on the same
-    # resource, "predecessor" when blocked purely by sequence constraints.
-    conflict_type: Optional[Literal["predecessor", "resource"]] = None
+    # resource, "predecessor" when blocked purely by sequence constraints,
+    # "maintenance" when blocked by a maintenance window (SCHED-7).
+    conflict_type: Optional[Literal["predecessor", "resource", "maintenance"]] = None
     # earliest_valid_start is the latest predecessor scheduled_end — the
     # absolute floor for this operation regardless of resource availability.
     # Present only for predecessor conflicts (conflict_type == "predecessor").
@@ -135,7 +151,9 @@ class RescheduleResponse(BaseModel):
     # Conflict fields — same shape as ScheduleOperationResponse so the modal
     # can reuse its existing conflict/suggestion affordances.
     conflicts: List[ConflictInfo] = Field(default_factory=list)
-    conflict_type: Optional[Literal["predecessor", "resource", "successor"]] = None
+    conflict_type: Optional[
+        Literal["predecessor", "resource", "successor", "maintenance"]
+    ] = None
     earliest_valid_start: Optional[datetime] = None
     next_available_start: Optional[datetime] = None
     next_available_end: Optional[datetime] = None

--- a/backend/app/services/dispatch_service.py
+++ b/backend/app/services/dispatch_service.py
@@ -21,13 +21,19 @@ This is intentional: assigning ≠ starting.  The PO status is left
 untouched here; it transitions to ``in_progress`` when the first
 operation actually starts.
 
-Maintenance warning heuristic
+Maintenance awareness (SCHED-7)
 -------------------------------
-We compare ``printer.maintenance_logs[-1].next_due_at`` (latest log by
-performed_at) against ``now + estimated_duration``.  If due before job
-end → add ``maintenance_warning``.  This is a heuristic (not a hard
-block); the operator decides.  SCHED-7 will replace this with real
-maintenance-window rows.
+Real maintenance windows come first:
+
+- A printer inside an ACTIVE blocking window is excluded from
+  suggestions entirely (same treatment as status="maintenance").
+- A job whose estimated duration would overlap an UPCOMING window gets
+  a ``maintenance_warning`` naming the window start — warn, never
+  silently skip; the operator decides.
+
+When no windows exist for the printer, the original heuristic stays as
+fallback: compare the latest ``MaintenanceLog.next_due_at`` against
+``now + estimated_duration``.
 
 Default duration
 ----------------
@@ -55,8 +61,13 @@ from app.schemas.dispatch import (
     PrinterDispatchResult,
     PrinterInfo,
 )
+from app.services.maintenance_window_service import (
+    get_active_window,
+    get_next_window_overlapping,
+)
 from app.services.resource_compatibility_service import is_machine_compatible
 from app.services.resource_scheduling import (
+    MaintenanceWindowConflictError as MaintenanceWindowConflictError,  # re-exported
     SequenceError as SequenceError,  # re-exported for callers (endpoint catches it)
     check_predecessor_scheduling,
     schedule_operation,
@@ -142,8 +153,40 @@ def _get_maintenance_warning(
     duration_minutes: int,
 ) -> Optional[str]:
     """
-    Return a maintenance warning string if the printer's latest next_due_at
-    falls before now + duration, else None.
+    Return a maintenance warning string when the job would collide with
+    maintenance, else None.
+
+    Order of authority (SCHED-7):
+    1. Real maintenance windows — if a blocking window overlaps
+       [now, now + duration], warn naming the window start.
+    2. Heuristic fallback — latest MaintenanceLog.next_due_at before
+       now + duration (kept for installs with no windows scheduled).
+    """
+    now = _now_utc()
+    job_end_aware = now + timedelta(minutes=duration_minutes)
+
+    window = get_next_window_overlapping(
+        db, printer_id=printer.id, start=now, end=job_end_aware
+    )
+    if window is not None:
+        label = window.reason or "maintenance"
+        return (
+            f"Maintenance window ({label}) starts "
+            f"{window.starts_at:%Y-%m-%d %H:%M} UTC — "
+            f"before this job would finish"
+        )
+
+    return _get_next_due_warning(db, printer, duration_minutes)
+
+
+def _get_next_due_warning(
+    db: Session,
+    printer: Printer,
+    duration_minutes: int,
+) -> Optional[str]:
+    """
+    Heuristic fallback: warn if the printer's latest next_due_at falls
+    before now + duration, else None.
     """
     latest_log: Optional[MaintenanceLog] = (
         db.query(MaintenanceLog)
@@ -344,6 +387,12 @@ def get_dispatch_suggestions(
     results: List[PrinterDispatchResult] = []
 
     for printer in printers:
+        # SCHED-7: a printer inside an active maintenance window is not
+        # dispatchable, regardless of its status field (the lazy status
+        # sync may not have run yet).
+        if get_active_window(db, printer_id=printer.id) is not None:
+            continue
+
         candidates = _rank_candidates(db, printer)
 
         printer_info = PrinterInfo(
@@ -413,6 +462,8 @@ def dispatch_operation(
             is not eligible (maintenance status), if the operation is not in
             a dispatchable status, or if material-machine compatibility fails.
         SequenceError: If predecessor operations would be violated.
+        MaintenanceWindowConflictError: If the proposed slot overlaps a
+            blocking maintenance window (SCHED-7).
         RuntimeError: If schedule_operation reports a conflict.
     """
     op: Optional[ProductionOrderOperation] = db.get(
@@ -440,6 +491,16 @@ def dispatch_operation(
     if printer.status in SKIP_STATUSES:
         raise ValueError(
             f"Printer {printer.code} has status '{printer.status}' "
+            f"and cannot accept new assignments"
+        )
+
+    # SCHED-7: active maintenance window blocks assignment even if the
+    # printer's status field hasn't been flipped yet.
+    active_window = get_active_window(db, printer_id=printer.id)
+    if active_window is not None:
+        raise ValueError(
+            f"Printer {printer.code} is in a maintenance window until "
+            f"{active_window.ends_at:%Y-%m-%d %H:%M} UTC "
             f"and cannot accept new assignments"
         )
 

--- a/backend/app/services/maintenance_window_service.py
+++ b/backend/app/services/maintenance_window_service.py
@@ -22,12 +22,13 @@ the scheduler board). It:
 
 - advances ``scheduled`` windows whose start has passed to ``in_progress``
   and flips the printer to 'maintenance' (only from 'idle'/'available' —
-  never overwrites offline/printing/error);
+  never overwrites offline/printing/error), recording the prior status on
+  the window (``prior_printer_status``);
 - when an ``in_progress`` window's end has passed, flips the printer back
-  to 'idle' (only from 'maintenance', and only when no other blocking
-  window is active). The window itself stays ``in_progress`` until the
-  operator explicitly completes or cancels it — elapsed time is not proof
-  the work was done.
+  to its recorded prior status ('idle' if none was recorded; only from
+  'maintenance', and only when no other blocking window is active). The
+  window itself stays ``in_progress`` until the operator explicitly
+  completes or cancels it — elapsed time is not proof the work was done.
 
 Resource (non-printer) windows block scheduling but do not auto-flip
 Resource.status — resources have no live status poll to fight with, and
@@ -90,10 +91,31 @@ def create_window(
     if (printer_id is None) == (resource_id is None):
         raise ValueError("Exactly one of printer_id or resource_id must be set")
 
-    if printer_id is not None and db.get(Printer, printer_id) is None:
-        raise ValueError(f"Printer {printer_id} not found")
-    if resource_id is not None and db.get(Resource, resource_id) is None:
-        raise ValueError(f"Resource {resource_id} not found")
+    # Race: the overlap check below is read-then-insert — two concurrent
+    # creates for the same machine could both see "no overlap" and both
+    # insert, persisting overlapping windows. Serialize per machine by
+    # taking a row lock (SELECT ... FOR UPDATE) on the target Printer /
+    # Resource BEFORE the overlap check, so the second transaction waits
+    # for the first to commit and then sees its window. Same pattern as
+    # the HARD-8 PO row lock in purchase_order_service.receive path.
+    if printer_id is not None:
+        machine = (
+            db.query(Printer)
+            .filter(Printer.id == printer_id)
+            .with_for_update()
+            .first()
+        )
+        if machine is None:
+            raise ValueError(f"Printer {printer_id} not found")
+    else:
+        machine = (
+            db.query(Resource)
+            .filter(Resource.id == resource_id)
+            .with_for_update()
+            .first()
+        )
+        if machine is None:
+            raise ValueError(f"Resource {resource_id} not found")
 
     starts_at = _naive_utc(starts_at)
     ends_at = _naive_utc(ends_at)
@@ -164,7 +186,8 @@ def cancel_window(db: Session, window_id: int) -> MaintenanceWindow:
     Cancel a scheduled or in-progress window.
 
     If the window was active and had flipped its printer to 'maintenance',
-    the printer is flipped back to 'idle' (only from 'maintenance').
+    the printer is restored to its recorded prior status (only from
+    'maintenance'; 'idle' if no prior status was recorded).
     """
     window = db.get(MaintenanceWindow, window_id)
     if window is None:
@@ -179,7 +202,7 @@ def cancel_window(db: Session, window_id: int) -> MaintenanceWindow:
     db.flush()
 
     if was_in_progress and window.printer_id is not None:
-        _restore_printer_status(db, window.printer_id)
+        _restore_printer_status(db, window)
     return window
 
 
@@ -239,7 +262,7 @@ def complete_window(
     db.flush()
 
     if was_in_progress and window.printer_id is not None:
-        _restore_printer_status(db, window.printer_id)
+        _restore_printer_status(db, window)
     return window
 
 
@@ -289,15 +312,19 @@ def get_next_window_overlapping(
     )
 
 
-def _restore_printer_status(db: Session, printer_id: int) -> None:
-    """Flip the printer back to 'idle' — only from 'maintenance', and only
-    when no other blocking window is currently active."""
-    printer = db.get(Printer, printer_id)
+def _restore_printer_status(db: Session, window: MaintenanceWindow) -> None:
+    """Flip the printer back to the status recorded when the window flipped
+    it ('idle' if somehow unrecorded) — only from 'maintenance', and only
+    when no other blocking window is currently active (never clobbers
+    offline/printing/error)."""
+    if window.printer_id is None:
+        return
+    printer = db.get(Printer, window.printer_id)
     if printer is None or printer.status != "maintenance":
         return
-    if get_active_window(db, printer_id=printer_id) is not None:
+    if get_active_window(db, printer_id=window.printer_id) is not None:
         return
-    printer.status = "idle"
+    printer.status = window.prior_printer_status or "idle"
     db.flush()
 
 
@@ -330,6 +357,13 @@ def sync_printer_maintenance_status(db: Session) -> bool:
         if window.printer_id is not None:
             printer = db.get(Printer, window.printer_id)
             if printer is not None and printer.status in _FLIPPABLE_STATUSES:
+                # Record what we are overwriting so flip-out can restore it
+                # exactly ('available' must come back as 'available', not
+                # 'idle'). Keep the first recording — a telemetry revert
+                # mid-window (e.g. MQTT wrote 'idle') must not clobber the
+                # originally observed status.
+                if window.prior_printer_status is None:
+                    window.prior_printer_status = printer.status
                 printer.status = "maintenance"
                 changed = True
 
@@ -350,7 +384,7 @@ def sync_printer_maintenance_status(db: Session) -> bool:
             continue
         if get_active_window(db, printer_id=window.printer_id, at=now) is not None:
             continue
-        printer.status = "idle"
+        printer.status = window.prior_printer_status or "idle"
         changed = True
 
     if changed:

--- a/backend/app/services/maintenance_window_service.py
+++ b/backend/app/services/maintenance_window_service.py
@@ -1,0 +1,358 @@
+"""
+Maintenance Window Service (SCHED-7).
+
+Planned maintenance as a first-class time block the scheduler respects.
+
+Standalone functions, ``db: Session`` first param (ARCHITECT-003 pattern).
+Callers own commit/rollback; this module only flushes.
+
+Time conventions
+----------------
+All window bounds are stored as naive UTC (matching every DateTime in the
+schema). Public functions accept aware or naive datetimes and normalize
+via ``_naive_utc`` before comparing or persisting.
+
+Status auto-flip (lazy sync)
+----------------------------
+There is no reliable background poll seam for printer status: the MQTT
+monitor only covers connected Bambu printers and overwrites status from
+gcode telemetry. So ``sync_printer_maintenance_status(db)`` is called
+lazily from the two surfaces that display status (dispatch suggestions and
+the scheduler board). It:
+
+- advances ``scheduled`` windows whose start has passed to ``in_progress``
+  and flips the printer to 'maintenance' (only from 'idle'/'available' —
+  never overwrites offline/printing/error);
+- when an ``in_progress`` window's end has passed, flips the printer back
+  to 'idle' (only from 'maintenance', and only when no other blocking
+  window is active). The window itself stays ``in_progress`` until the
+  operator explicitly completes or cancels it — elapsed time is not proof
+  the work was done.
+
+Resource (non-printer) windows block scheduling but do not auto-flip
+Resource.status — resources have no live status poll to fight with, and
+the Gantt renders the window block either way.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.maintenance import (
+    WINDOW_BLOCKING_STATUSES,
+    MaintenanceLog,
+    MaintenanceWindow,
+)
+from app.models.manufacturing import Resource
+from app.models.printer import Printer
+
+#: Printer statuses we may overwrite when a window opens/closes.
+_FLIPPABLE_STATUSES = ("idle", "available")
+
+
+def _naive_utc(dt: datetime) -> datetime:
+    """Normalize aware or naive datetime to naive UTC."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _now_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _machine_filter(printer_id: Optional[int], resource_id: Optional[int]):
+    """Column filter for the window's target machine."""
+    if printer_id is not None:
+        return MaintenanceWindow.printer_id == printer_id
+    return MaintenanceWindow.resource_id == resource_id
+
+
+def create_window(
+    db: Session,
+    *,
+    printer_id: Optional[int] = None,
+    resource_id: Optional[int] = None,
+    starts_at: datetime,
+    ends_at: datetime,
+    reason: Optional[str] = None,
+    created_by: Optional[str] = None,
+) -> MaintenanceWindow:
+    """
+    Create a planned maintenance window.
+
+    Raises:
+        ValueError: machine selector invalid, machine missing, bad range,
+            or overlap with an existing blocking window on the same machine.
+    """
+    if (printer_id is None) == (resource_id is None):
+        raise ValueError("Exactly one of printer_id or resource_id must be set")
+
+    if printer_id is not None and db.get(Printer, printer_id) is None:
+        raise ValueError(f"Printer {printer_id} not found")
+    if resource_id is not None and db.get(Resource, resource_id) is None:
+        raise ValueError(f"Resource {resource_id} not found")
+
+    starts_at = _naive_utc(starts_at)
+    ends_at = _naive_utc(ends_at)
+    if ends_at <= starts_at:
+        raise ValueError("ends_at must be after starts_at")
+
+    overlap = (
+        db.query(MaintenanceWindow)
+        .filter(
+            _machine_filter(printer_id, resource_id),
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.starts_at < ends_at,
+            MaintenanceWindow.ends_at > starts_at,
+        )
+        .first()
+    )
+    if overlap is not None:
+        raise ValueError(
+            f"Overlaps existing maintenance window #{overlap.id} "
+            f"({overlap.starts_at:%Y-%m-%d %H:%M}–{overlap.ends_at:%H:%M} UTC)"
+        )
+
+    window = MaintenanceWindow(
+        printer_id=printer_id,
+        resource_id=resource_id,
+        starts_at=starts_at,
+        ends_at=ends_at,
+        reason=reason,
+        status="scheduled",
+        created_by=created_by,
+    )
+    db.add(window)
+    db.flush()
+    return window
+
+
+def list_windows(
+    db: Session,
+    *,
+    printer_id: Optional[int] = None,
+    resource_id: Optional[int] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    include_finished: bool = False,
+) -> List[MaintenanceWindow]:
+    """
+    List maintenance windows, optionally by machine and/or time range.
+
+    By default only blocking (scheduled / in_progress) windows are
+    returned; ``include_finished=True`` adds completed and cancelled.
+    """
+    query = db.query(MaintenanceWindow)
+    if printer_id is not None:
+        query = query.filter(MaintenanceWindow.printer_id == printer_id)
+    if resource_id is not None:
+        query = query.filter(MaintenanceWindow.resource_id == resource_id)
+    if not include_finished:
+        query = query.filter(MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES))
+    if start is not None:
+        query = query.filter(MaintenanceWindow.ends_at > _naive_utc(start))
+    if end is not None:
+        query = query.filter(MaintenanceWindow.starts_at < _naive_utc(end))
+    return query.order_by(MaintenanceWindow.starts_at).all()
+
+
+def cancel_window(db: Session, window_id: int) -> MaintenanceWindow:
+    """
+    Cancel a scheduled or in-progress window.
+
+    If the window was active and had flipped its printer to 'maintenance',
+    the printer is flipped back to 'idle' (only from 'maintenance').
+    """
+    window = db.get(MaintenanceWindow, window_id)
+    if window is None:
+        raise ValueError(f"Maintenance window {window_id} not found")
+    if window.status not in WINDOW_BLOCKING_STATUSES:
+        raise ValueError(
+            f"Window {window_id} is '{window.status}' and cannot be cancelled"
+        )
+
+    was_in_progress = window.status == "in_progress"
+    window.status = "cancelled"
+    db.flush()
+
+    if was_in_progress and window.printer_id is not None:
+        _restore_printer_status(db, window.printer_id)
+    return window
+
+
+def complete_window(
+    db: Session,
+    window_id: int,
+    *,
+    maintenance_type: str = "routine",
+    performed_by: Optional[str] = None,
+    next_due_at: Optional[datetime] = None,
+    cost=None,
+    notes: Optional[str] = None,
+) -> MaintenanceWindow:
+    """
+    Complete a window: writes a MaintenanceLog entry (printer windows only —
+    maintenance_logs.printer_id is NOT NULL so resource windows just close),
+    links it via maintenance_log_id, and restores the printer status.
+
+    next_due_at follows the existing convention (operator-supplied on the
+    log; the /maintenance/due endpoint reads the latest log's next_due_at).
+    Downtime is recorded as the elapsed window time (clipped to now for
+    early completion).
+    """
+    window = db.get(MaintenanceWindow, window_id)
+    if window is None:
+        raise ValueError(f"Maintenance window {window_id} not found")
+    if window.status not in WINDOW_BLOCKING_STATUSES:
+        raise ValueError(
+            f"Window {window_id} is '{window.status}' and cannot be completed"
+        )
+
+    now = _now_naive()
+    was_in_progress = window.status == "in_progress" or window.starts_at <= now
+
+    if window.printer_id is not None:
+        actual_end = min(now, window.ends_at)
+        downtime_minutes = max(
+            0, int((actual_end - window.starts_at).total_seconds() // 60)
+        )
+        log = MaintenanceLog(
+            printer_id=window.printer_id,
+            maintenance_type=maintenance_type,
+            description=window.reason,
+            performed_by=performed_by,
+            performed_at=now,
+            next_due_at=_naive_utc(next_due_at) if next_due_at is not None else None,
+            cost=cost,
+            downtime_minutes=downtime_minutes,
+            notes=notes,
+            created_at=now,
+        )
+        db.add(log)
+        db.flush()
+        window.maintenance_log_id = log.id
+
+    window.status = "completed"
+    db.flush()
+
+    if was_in_progress and window.printer_id is not None:
+        _restore_printer_status(db, window.printer_id)
+    return window
+
+
+def get_active_window(
+    db: Session,
+    *,
+    printer_id: Optional[int] = None,
+    resource_id: Optional[int] = None,
+    at: Optional[datetime] = None,
+) -> Optional[MaintenanceWindow]:
+    """Return the blocking window covering instant ``at`` (default now), if any."""
+    moment = _naive_utc(at) if at is not None else _now_naive()
+    return (
+        db.query(MaintenanceWindow)
+        .filter(
+            _machine_filter(printer_id, resource_id),
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.starts_at <= moment,
+            MaintenanceWindow.ends_at > moment,
+        )
+        .order_by(MaintenanceWindow.starts_at)
+        .first()
+    )
+
+
+def get_next_window_overlapping(
+    db: Session,
+    *,
+    printer_id: int,
+    start: datetime,
+    end: datetime,
+) -> Optional[MaintenanceWindow]:
+    """
+    Earliest blocking window on the printer overlapping [start, end).
+    Used by dispatch to warn when a job would collide with an upcoming window.
+    """
+    return (
+        db.query(MaintenanceWindow)
+        .filter(
+            MaintenanceWindow.printer_id == printer_id,
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.starts_at < _naive_utc(end),
+            MaintenanceWindow.ends_at > _naive_utc(start),
+        )
+        .order_by(MaintenanceWindow.starts_at)
+        .first()
+    )
+
+
+def _restore_printer_status(db: Session, printer_id: int) -> None:
+    """Flip the printer back to 'idle' — only from 'maintenance', and only
+    when no other blocking window is currently active."""
+    printer = db.get(Printer, printer_id)
+    if printer is None or printer.status != "maintenance":
+        return
+    if get_active_window(db, printer_id=printer_id) is not None:
+        return
+    printer.status = "idle"
+    db.flush()
+
+
+def sync_printer_maintenance_status(db: Session) -> bool:
+    """
+    Lazy status sync — see module docstring for the seam rationale.
+
+    Returns True when anything changed (caller decides whether to commit).
+    """
+    now = _now_naive()
+    changed = False
+
+    # 1) Activate: scheduled windows whose start has passed → in_progress;
+    #    flip idle/available printers to 'maintenance'. Also re-flip printers
+    #    whose window is already in_progress but whose status got reverted
+    #    (e.g. MQTT telemetry wrote 'idle' mid-window after a reconnect).
+    active_windows = (
+        db.query(MaintenanceWindow)
+        .filter(
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.starts_at <= now,
+            MaintenanceWindow.ends_at > now,
+        )
+        .all()
+    )
+    for window in active_windows:
+        if window.status == "scheduled":
+            window.status = "in_progress"
+            changed = True
+        if window.printer_id is not None:
+            printer = db.get(Printer, window.printer_id)
+            if printer is not None and printer.status in _FLIPPABLE_STATUSES:
+                printer.status = "maintenance"
+                changed = True
+
+    # 2) Expire: in_progress windows whose end has passed → restore the
+    #    printer (window status is left for explicit complete/cancel).
+    expired_windows = (
+        db.query(MaintenanceWindow)
+        .filter(
+            MaintenanceWindow.status == "in_progress",
+            MaintenanceWindow.ends_at <= now,
+            MaintenanceWindow.printer_id.isnot(None),
+        )
+        .all()
+    )
+    for window in expired_windows:
+        printer = db.get(Printer, window.printer_id)
+        if printer is None or printer.status != "maintenance":
+            continue
+        if get_active_window(db, printer_id=window.printer_id, at=now) is not None:
+            continue
+        printer.status = "idle"
+        changed = True
+
+    if changed:
+        db.flush()
+    return changed

--- a/backend/app/services/resource_scheduling.py
+++ b/backend/app/services/resource_scheduling.py
@@ -3,11 +3,19 @@ Resource scheduling service with conflict detection.
 
 Handles scheduling operations on resources and detecting time conflicts.
 Enforces operation sequencing and material/printer compatibility.
+
+SCHED-7: maintenance windows are busy time. ``find_window_conflicts`` is a
+PARALLEL check to ``find_conflicts`` (which keeps returning only
+ProductionOrderOperation rows — its return type is a public contract used
+by several endpoints). ``schedule_operation`` consults both and raises
+``MaintenanceWindowConflictError`` for window overlaps;
+``find_next_available_slot`` skips over windows when hunting for gaps.
 """
 from datetime import datetime, timezone
 from typing import Optional, List, Tuple
 from sqlalchemy.orm import Session
 
+from app.models.maintenance import WINDOW_BLOCKING_STATUSES, MaintenanceWindow
 from app.models.production_order import ProductionOrderOperation
 from app.models.manufacturing import RoutingOperation
 
@@ -105,6 +113,55 @@ def find_conflicts(
     return query.all()
 
 
+def find_window_conflicts(
+    db: Session,
+    resource_id: int,
+    start_time: datetime,
+    end_time: datetime,
+    is_printer: bool = False,
+) -> List[MaintenanceWindow]:
+    """
+    Find maintenance windows that conflict with a proposed time range (SCHED-7).
+
+    Parallel to ``find_conflicts`` (which only returns operations — its
+    return type is a public contract). A window conflicts when it targets
+    the same machine, is blocking (scheduled / in_progress), and overlaps:
+    (window.starts_at < end_time) AND (window.ends_at > start_time).
+
+    Args:
+        db: Database session
+        resource_id: Resource or printer ID to check
+        start_time: Proposed start
+        end_time: Proposed end
+        is_printer: True if checking a printer (uses printer_id column)
+
+    Returns:
+        List of conflicting MaintenanceWindow rows
+    """
+    if is_printer:
+        id_filter = MaintenanceWindow.printer_id == resource_id
+    else:
+        id_filter = MaintenanceWindow.resource_id == resource_id
+
+    # Window columns are naive UTC; normalize aware inputs before comparing.
+    def _naive(dt: datetime) -> datetime:
+        if dt.tzinfo is not None:
+            return dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+
+    return (
+        db.query(MaintenanceWindow)
+        .filter(
+            id_filter,
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.starts_at < _naive(end_time),
+            MaintenanceWindow.ends_at > _naive(start_time),
+        )
+        .order_by(MaintenanceWindow.starts_at)
+        .all()
+    )
+
+
 def find_running_operations(
     db: Session,
     resource_id: int,
@@ -172,7 +229,8 @@ def find_next_available_slot(
     """
     Find the next available time slot on a resource or printer.
 
-    Looks at scheduled operations and finds the first gap of sufficient duration.
+    Busy time = scheduled operations PLUS blocking maintenance windows
+    (SCHED-7). Returns the start of the first gap of sufficient duration.
 
     Args:
         db: Database session
@@ -184,28 +242,16 @@ def find_next_available_slot(
     Returns:
         datetime: Start time of next available slot
     """
-    from datetime import timedelta
-
     if after is None:
         after = datetime.now(timezone.utc)
 
     # Choose the correct column based on resource type
     if is_printer:
         id_filter = ProductionOrderOperation.printer_id == resource_id
+        window_filter = MaintenanceWindow.printer_id == resource_id
     else:
         id_filter = ProductionOrderOperation.resource_id == resource_id
-
-    # Get all scheduled ops on this resource starting from 'after'
-    scheduled_ops = db.query(ProductionOrderOperation).filter(
-        id_filter,
-        ProductionOrderOperation.status.notin_(TERMINAL_STATUSES),
-        ProductionOrderOperation.scheduled_end.isnot(None),
-        ProductionOrderOperation.scheduled_end > after
-    ).order_by(ProductionOrderOperation.scheduled_start).all()
-
-    if not scheduled_ops:
-        # No scheduled ops - can start immediately
-        return after
+        window_filter = MaintenanceWindow.resource_id == resource_id
 
     # DB columns are TIMESTAMP WITHOUT TIME ZONE, so values come back naive.
     # Treat them as UTC to allow arithmetic with tz-aware `after`.
@@ -214,31 +260,51 @@ def find_next_available_slot(
             return dt.replace(tzinfo=timezone.utc)
         return dt
 
-    # Check if there's a gap before the first scheduled op
-    first_op = scheduled_ops[0]
-    if first_op.scheduled_start:
-        gap_before_first = (_as_utc(first_op.scheduled_start) - after).total_seconds() / 60
-        if gap_before_first >= duration_minutes:
-            return after
+    # Naive variant of `after` for SQL comparisons against naive columns
+    after_naive = (
+        after.astimezone(timezone.utc).replace(tzinfo=None)
+        if after.tzinfo is not None
+        else after
+    )
 
-    # Look for gaps between scheduled operations
-    for i in range(len(scheduled_ops) - 1):
-        current_op = scheduled_ops[i]
-        next_op = scheduled_ops[i + 1]
+    # Get all scheduled ops on this resource still relevant after 'after'
+    scheduled_ops = db.query(ProductionOrderOperation).filter(
+        id_filter,
+        ProductionOrderOperation.status.notin_(TERMINAL_STATUSES),
+        ProductionOrderOperation.scheduled_end.isnot(None),
+        ProductionOrderOperation.scheduled_end > after_naive
+    ).order_by(ProductionOrderOperation.scheduled_start).all()
 
-        if current_op.scheduled_end and next_op.scheduled_start:
-            gap_start = _as_utc(current_op.scheduled_end)
-            gap_duration = (_as_utc(next_op.scheduled_start) - gap_start).total_seconds() / 60
-            if gap_duration >= duration_minutes:
-                return max(gap_start, after)
+    # Blocking maintenance windows still relevant after 'after'
+    windows = (
+        db.query(MaintenanceWindow)
+        .filter(
+            window_filter,
+            MaintenanceWindow.status.in_(WINDOW_BLOCKING_STATUSES),
+            MaintenanceWindow.ends_at > after_naive,
+        )
+        .all()
+    )
 
-    # No gap found - schedule after the last operation
-    last_op = scheduled_ops[-1]
-    if last_op.scheduled_end:
-        return max(_as_utc(last_op.scheduled_end), after)
+    # Merge ops + windows into one sorted busy-interval sweep
+    intervals = []
+    for op in scheduled_ops:
+        if op.scheduled_start and op.scheduled_end:
+            intervals.append((_as_utc(op.scheduled_start), _as_utc(op.scheduled_end)))
+    for w in windows:
+        intervals.append((_as_utc(w.starts_at), _as_utc(w.ends_at)))
+    intervals.sort(key=lambda pair: pair[0])
 
-    # Fallback: start 1 hour from now
-    return after + timedelta(hours=1)
+    cursor = after
+    for busy_start, busy_end in intervals:
+        if busy_start > cursor:
+            gap_minutes = (busy_start - cursor).total_seconds() / 60
+            if gap_minutes >= duration_minutes:
+                return cursor
+        if busy_end > cursor:
+            cursor = busy_end
+
+    return cursor
 
 
 def check_predecessor_scheduling(
@@ -399,7 +465,8 @@ def schedule_operation(
 
     Validates:
     1. No time conflicts with other operations on the same resource
-    2. Predecessor operations are scheduled/complete first
+    2. No overlap with blocking maintenance windows (SCHED-7)
+    3. Predecessor operations are scheduled/complete first
 
     Args:
         db: Database session
@@ -413,6 +480,11 @@ def schedule_operation(
         Tuple of (success, conflicts_or_errors)
         - If success=True, operation was scheduled
         - If success=False, conflicts contains blocking operations
+
+    Raises:
+        MaintenanceWindowConflictError: range overlaps a blocking
+            maintenance window (carries ``.windows``)
+        SequenceError: predecessor sequencing violated
     """
     # Check for conflicts using the appropriate column
     conflicts = find_conflicts(
@@ -426,6 +498,19 @@ def schedule_operation(
 
     if conflicts:
         return False, conflicts
+
+    # Maintenance windows are busy time (SCHED-7). Raised as a typed error
+    # rather than mixed into the conflicts list, which only carries
+    # ProductionOrderOperation rows by contract.
+    window_conflicts = find_window_conflicts(
+        db=db,
+        resource_id=resource_id,
+        start_time=scheduled_start,
+        end_time=scheduled_end,
+        is_printer=is_printer,
+    )
+    if window_conflicts:
+        raise MaintenanceWindowConflictError(window_conflicts)
 
     # Check predecessor sequencing
     seq_error = check_predecessor_scheduling(db, operation, scheduled_start)
@@ -452,3 +537,20 @@ def schedule_operation(
 class SequenceError(Exception):
     """Raised when operation scheduling violates sequence constraints."""
     pass
+
+
+class MaintenanceWindowConflictError(Exception):
+    """Raised when a proposed schedule overlaps a blocking maintenance window.
+
+    ``windows`` carries the conflicting MaintenanceWindow rows so callers
+    can surface them with a ``type: "maintenance"`` discriminator.
+    """
+
+    def __init__(self, windows: List[MaintenanceWindow]):
+        self.windows = windows
+        first = windows[0]
+        super().__init__(
+            f"Overlaps maintenance window "
+            f"{first.starts_at:%Y-%m-%d %H:%M}–{first.ends_at:%H:%M} UTC"
+            + (f" ({first.reason})" if first.reason else "")
+        )

--- a/backend/migrations/versions/092_add_maintenance_windows.py
+++ b/backend/migrations/versions/092_add_maintenance_windows.py
@@ -56,6 +56,10 @@ def upgrade() -> None:
             sa.ForeignKey("maintenance_logs.id", ondelete="SET NULL"),
             nullable=True,
         ),
+        # Printer status recorded when the window flipped the printer to
+        # 'maintenance'; restored verbatim when the last blocking window
+        # closes. NULL for resource windows / windows that never flipped.
+        sa.Column("prior_printer_status", sa.String(50), nullable=True),
         sa.Column("created_by", sa.String(100), nullable=True),
         sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
@@ -66,6 +70,10 @@ def upgrade() -> None:
         sa.CheckConstraint(
             "ends_at > starts_at",
             name="ck_maintenance_windows_valid_range",
+        ),
+        sa.CheckConstraint(
+            "status IN ('scheduled', 'in_progress', 'completed', 'cancelled')",
+            name="ck_maintenance_windows_status",
         ),
     )
     op.create_index(

--- a/backend/migrations/versions/092_add_maintenance_windows.py
+++ b/backend/migrations/versions/092_add_maintenance_windows.py
@@ -1,0 +1,96 @@
+"""add maintenance_windows table
+
+Revision ID: 092
+Revises: 091
+Create Date: 2026-06-12
+
+SCHED-7: Planned maintenance becomes a first-class time block the
+scheduling engine respects. A window targets EXACTLY ONE machine —
+either a printer (dispatch path) or a machine resource (scheduler
+modal path) — enforced by a CHECK constraint, mirroring the engine's
+``is_printer`` duality.
+
+Lifecycle: scheduled → in_progress → completed | cancelled.
+Completion links the MaintenanceLog entry written for printer windows.
+
+Additive table — no existing data touched.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "092"
+down_revision = "091"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "maintenance_windows",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "printer_id",
+            sa.Integer,
+            sa.ForeignKey("printers.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "resource_id",
+            sa.Integer,
+            sa.ForeignKey("resources.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("starts_at", sa.DateTime, nullable=False),
+        sa.Column("ends_at", sa.DateTime, nullable=False),
+        sa.Column("reason", sa.String(255), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="scheduled",
+        ),
+        sa.Column(
+            "maintenance_log_id",
+            sa.Integer,
+            sa.ForeignKey("maintenance_logs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_by", sa.String(100), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "(printer_id IS NOT NULL) != (resource_id IS NOT NULL)",
+            name="ck_maintenance_windows_one_machine",
+        ),
+        sa.CheckConstraint(
+            "ends_at > starts_at",
+            name="ck_maintenance_windows_valid_range",
+        ),
+    )
+    op.create_index(
+        "ix_maintenance_windows_printer_starts",
+        "maintenance_windows",
+        ["printer_id", "starts_at"],
+    )
+    op.create_index(
+        "ix_maintenance_windows_resource_starts",
+        "maintenance_windows",
+        ["resource_id", "starts_at"],
+    )
+    op.create_index(
+        "ix_maintenance_windows_status",
+        "maintenance_windows",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_maintenance_windows_status", table_name="maintenance_windows")
+    op.drop_index(
+        "ix_maintenance_windows_resource_starts", table_name="maintenance_windows"
+    )
+    op.drop_index(
+        "ix_maintenance_windows_printer_starts", table_name="maintenance_windows"
+    )
+    op.drop_table("maintenance_windows")

--- a/backend/tests/api/v1/test_maintenance_windows_api.py
+++ b/backend/tests/api/v1/test_maintenance_windows_api.py
@@ -1,0 +1,270 @@
+"""
+API tests for SCHED-7 — /api/v1/maintenance-windows + scheduler board windows.
+
+Covers:
+- POST create (201), validation (400 on overlap / bad machine selector)
+- GET list with machine filter
+- POST /{id}/cancel and /{id}/complete (MaintenanceLog linked)
+- GET /scheduling/board includes per-lane windows
+- auth required (401 unauthenticated)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.models.printer import Printer
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _make_printer(db, *, status: str = "idle") -> Printer:
+    uid = _uid()
+    p = Printer(
+        code=f"PRT-{uid}",
+        name=f"Printer {uid}",
+        model="X1C",
+        brand="bambulab",
+        status=status,
+        active=True,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+class TestMaintenanceWindowEndpoints:
+    def test_create_and_list(self, client, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(days=1)
+        end = start + timedelta(hours=2)
+
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(start),
+                "ends_at": _iso(end),
+                "reason": "PM service",
+            },
+        )
+        assert res.status_code == 201, res.text
+        body = res.json()
+        assert body["printer_id"] == printer.id
+        assert body["resource_id"] is None
+        assert body["status"] == "scheduled"
+        assert body["reason"] == "PM service"
+        window_id = body["id"]
+
+        res = client.get(f"/api/v1/maintenance-windows?printer_id={printer.id}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["total"] == 1
+        assert data["items"][0]["id"] == window_id
+
+    def test_create_rejects_overlap(self, client, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(days=1)
+        end = start + timedelta(hours=2)
+        payload = {
+            "printer_id": printer.id,
+            "starts_at": _iso(start),
+            "ends_at": _iso(end),
+        }
+        assert client.post("/api/v1/maintenance-windows", json=payload).status_code == 201
+
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(start + timedelta(minutes=30)),
+                "ends_at": _iso(end + timedelta(hours=1)),
+            },
+        )
+        assert res.status_code == 400
+        assert "Overlaps" in res.json()["detail"]
+
+    def test_create_rejects_missing_machine(self, client):
+        start = _now() + timedelta(days=1)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "starts_at": _iso(start),
+                "ends_at": _iso(start + timedelta(hours=1)),
+            },
+        )
+        assert res.status_code == 400
+        assert "Exactly one" in res.json()["detail"]
+
+    def test_cancel_window(self, client, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(days=1)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(start),
+                "ends_at": _iso(start + timedelta(hours=1)),
+            },
+        )
+        window_id = res.json()["id"]
+
+        res = client.post(f"/api/v1/maintenance-windows/{window_id}/cancel")
+        assert res.status_code == 200
+        assert res.json()["status"] == "cancelled"
+
+        # Cancelling again → 400
+        res = client.post(f"/api/v1/maintenance-windows/{window_id}/cancel")
+        assert res.status_code == 400
+
+    def test_cancel_unknown_window_404(self, client):
+        res = client.post("/api/v1/maintenance-windows/99999999/cancel")
+        assert res.status_code == 404
+
+    def test_complete_window_links_log(self, client, db):
+        printer = _make_printer(db)
+        start = _now() - timedelta(hours=1)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(start),
+                "ends_at": _iso(start + timedelta(hours=2)),
+                "reason": "Lube rails",
+            },
+        )
+        window_id = res.json()["id"]
+        next_due = _now() + timedelta(days=60)
+
+        res = client.post(
+            f"/api/v1/maintenance-windows/{window_id}/complete",
+            json={
+                "maintenance_type": "routine",
+                "next_due_at": _iso(next_due),
+                "notes": "done",
+            },
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "completed"
+        assert body["maintenance_log_id"] is not None
+
+        # The linked log is reachable via the existing maintenance endpoint
+        res = client.get(f"/api/v1/maintenance/{body['maintenance_log_id']}")
+        assert res.status_code == 200
+        log = res.json()
+        assert log["printer_id"] == printer.id
+        assert log["description"] == "Lube rails"
+
+    def test_requires_auth(self, unauthed_client):
+        res = unauthed_client.get("/api/v1/maintenance-windows")
+        assert res.status_code in (401, 403)
+
+
+class TestSchedulerBoardWindows:
+    def test_board_includes_lane_windows(self, client, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        end = start + timedelta(hours=2)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(start),
+                "ends_at": _iso(end),
+                "reason": "Nozzle swap",
+            },
+        )
+        assert res.status_code == 201
+        window_id = res.json()["id"]
+
+        window_start = _now() - timedelta(hours=1)
+        window_end = _now() + timedelta(hours=24)
+        res = client.get(
+            "/api/v1/scheduling/board",
+            params={
+                "start_date": _iso(window_start),
+                "end_date": _iso(window_end),
+            },
+        )
+        assert res.status_code == 200, res.text
+        board = res.json()
+
+        lane = next(
+            (l for l in board["lanes"] if l["key"] == f"printer-{printer.id}"), None
+        )
+        assert lane is not None, "printer lane missing from board"
+        assert "windows" in lane
+        ids = [w["id"] for w in lane["windows"]]
+        assert window_id in ids
+        block = next(w for w in lane["windows"] if w["id"] == window_id)
+        assert block["reason"] == "Nozzle swap"
+        assert block["status"] == "scheduled"
+        assert set(block.keys()) == {"id", "starts_at", "ends_at", "reason", "status"}
+
+    def test_board_excludes_out_of_range_windows(self, client, db):
+        printer = _make_printer(db)
+        far = _now() + timedelta(days=30)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(far),
+                "ends_at": _iso(far + timedelta(hours=1)),
+            },
+        )
+        assert res.status_code == 201
+
+        res = client.get(
+            "/api/v1/scheduling/board",
+            params={
+                "start_date": _iso(_now()),
+                "end_date": _iso(_now() + timedelta(days=1)),
+            },
+        )
+        assert res.status_code == 200
+        lane = next(
+            (l for l in res.json()["lanes"] if l["key"] == f"printer-{printer.id}"),
+            None,
+        )
+        assert lane is not None
+        assert lane["windows"] == []
+
+    def test_board_sync_flips_printer_status(self, client, db):
+        """Lazy seam: hitting the board flips a printer inside an active window."""
+        printer = _make_printer(db, status="idle")
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(_now() - timedelta(minutes=10)),
+                "ends_at": _iso(_now() + timedelta(hours=1)),
+            },
+        )
+        assert res.status_code == 201
+
+        res = client.get(
+            "/api/v1/scheduling/board",
+            params={
+                "start_date": _iso(_now() - timedelta(hours=1)),
+                "end_date": _iso(_now() + timedelta(hours=12)),
+            },
+        )
+        assert res.status_code == 200
+        lane = next(
+            (l for l in res.json()["lanes"] if l["key"] == f"printer-{printer.id}"),
+            None,
+        )
+        assert lane is not None
+        assert lane["status"] == "maintenance"
+        assert lane["windows"][0]["status"] == "in_progress"

--- a/backend/tests/api/v1/test_maintenance_windows_api.py
+++ b/backend/tests/api/v1/test_maintenance_windows_api.py
@@ -201,7 +201,7 @@ class TestSchedulerBoardWindows:
         board = res.json()
 
         lane = next(
-            (l for l in board["lanes"] if l["key"] == f"printer-{printer.id}"), None
+            (x for x in board["lanes"] if x["key"] == f"printer-{printer.id}"), None
         )
         assert lane is not None, "printer lane missing from board"
         assert "windows" in lane
@@ -234,7 +234,62 @@ class TestSchedulerBoardWindows:
         )
         assert res.status_code == 200
         lane = next(
-            (l for l in res.json()["lanes"] if l["key"] == f"printer-{printer.id}"),
+            (x for x in res.json()["lanes"] if x["key"] == f"printer-{printer.id}"),
+            None,
+        )
+        assert lane is not None
+        assert lane["windows"] == []
+
+    def test_board_excludes_completed_and_cancelled_windows(self, client, db):
+        """CR #733: a window completed EARLY must release its lane
+        immediately — only blocking (scheduled/in_progress) windows render
+        on the board; completed/cancelled are history."""
+        printer = _make_printer(db)
+        # Active window, completed early (well before its scheduled ends_at)
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(_now() - timedelta(hours=1)),
+                "ends_at": _iso(_now() + timedelta(hours=6)),
+            },
+        )
+        assert res.status_code == 201
+        completed_id = res.json()["id"]
+        assert (
+            client.post(
+                f"/api/v1/maintenance-windows/{completed_id}/complete", json={}
+            ).status_code
+            == 200
+        )
+
+        # Future window, cancelled
+        res = client.post(
+            "/api/v1/maintenance-windows",
+            json={
+                "printer_id": printer.id,
+                "starts_at": _iso(_now() + timedelta(hours=8)),
+                "ends_at": _iso(_now() + timedelta(hours=9)),
+            },
+        )
+        cancelled_id = res.json()["id"]
+        assert (
+            client.post(
+                f"/api/v1/maintenance-windows/{cancelled_id}/cancel"
+            ).status_code
+            == 200
+        )
+
+        res = client.get(
+            "/api/v1/scheduling/board",
+            params={
+                "start_date": _iso(_now() - timedelta(hours=2)),
+                "end_date": _iso(_now() + timedelta(hours=12)),
+            },
+        )
+        assert res.status_code == 200
+        lane = next(
+            (x for x in res.json()["lanes"] if x["key"] == f"printer-{printer.id}"),
             None,
         )
         assert lane is not None
@@ -262,7 +317,7 @@ class TestSchedulerBoardWindows:
         )
         assert res.status_code == 200
         lane = next(
-            (l for l in res.json()["lanes"] if l["key"] == f"printer-{printer.id}"),
+            (x for x in res.json()["lanes"] if x["key"] == f"printer-{printer.id}"),
             None,
         )
         assert lane is not None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -274,6 +274,27 @@ def setup_database():
             "ALTER TABLE company_settings "
             "ADD COLUMN IF NOT EXISTS auto_dispatch BOOLEAN NOT NULL DEFAULT FALSE"
         ))
+        # Migration 092 (SCHED-7): prior-status restore + status CHECK on
+        # maintenance_windows (accumulated DBs created the table via
+        # create_all before these were added to the model)
+        conn.execute(text(
+            "ALTER TABLE maintenance_windows "
+            "ADD COLUMN IF NOT EXISTS prior_printer_status VARCHAR(50)"
+        ))
+        conn.execute(text("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'ck_maintenance_windows_status'
+                ) THEN
+                    ALTER TABLE maintenance_windows
+                    ADD CONSTRAINT ck_maintenance_windows_status
+                    CHECK (status IN ('scheduled', 'in_progress', 'completed', 'cancelled'));
+                END IF;
+            END
+            $$;
+        """))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/services/test_maintenance_window_service.py
+++ b/backend/tests/services/test_maintenance_window_service.py
@@ -1,0 +1,797 @@
+"""
+Tests for SCHED-7 — maintenance windows.
+
+Covers (per plan):
+- service CRUD: create validation (XOR machine, range, overlap rejection),
+  list filters, cancel, complete → MaintenanceLog written + linked
+- engine: find_window_conflicts; find_next_available_slot skips windows;
+  schedule_operation raises MaintenanceWindowConflictError
+- dispatch: printers in an active window are excluded; jobs overlapping an
+  upcoming window get maintenance_warning (window beats next_due_at
+  heuristic); assign blocked during an active window
+- status auto-flip: sync_printer_maintenance_status flips idle→maintenance
+  while active and maintenance→idle after the window ends; never touches
+  printing/offline printers
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.models.maintenance import MaintenanceLog, MaintenanceWindow
+from app.models.manufacturing import Resource
+from app.models.printer import Printer
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+from app.services.dispatch_service import (
+    dispatch_operation,
+    get_dispatch_suggestions,
+)
+from app.services.maintenance_window_service import (
+    cancel_window,
+    complete_window,
+    create_window,
+    get_active_window,
+    list_windows,
+    sync_printer_maintenance_status,
+)
+from app.services.resource_scheduling import (
+    MaintenanceWindowConflictError,
+    find_next_available_slot,
+    find_window_conflicts,
+    schedule_operation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / factories
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _now() -> datetime:
+    """Naive UTC now (matches DB column convention)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _make_printer(db, *, status: str = "idle", work_center_id=None) -> Printer:
+    uid = _uid()
+    p = Printer(
+        code=f"PRT-{uid}",
+        name=f"Printer {uid}",
+        model="X1C",
+        brand="bambulab",
+        status=status,
+        active=True,
+        work_center_id=work_center_id,
+    )
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_resource(db, work_center_id) -> Resource:
+    uid = _uid()
+    r = Resource(
+        work_center_id=work_center_id,
+        code=f"RES-{uid}",
+        name=f"Resource {uid}",
+        status="available",
+        is_active=True,
+    )
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _make_wo(db, product_id: int, *, status: str = "released") -> ProductionOrder:
+    uid = _uid()
+    wo = ProductionOrder(
+        code=f"WO-{uid}",
+        product_id=product_id,
+        quantity_ordered=Decimal("10"),
+        status=status,
+        priority=3,
+        source="manual",
+    )
+    db.add(wo)
+    db.flush()
+    return wo
+
+
+def _make_op(
+    db,
+    wo_id: int,
+    work_center_id: int,
+    *,
+    sequence: int = 10,
+    status: str = "pending",
+    planned_run_minutes: float = 60.0,
+) -> ProductionOrderOperation:
+    op = ProductionOrderOperation(
+        production_order_id=wo_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_code=f"OP-{_uid()}",
+        operation_name="Print",
+        planned_setup_minutes=Decimal("0"),
+        planned_run_minutes=Decimal(str(planned_run_minutes)),
+        status=status,
+    )
+    db.add(op)
+    db.flush()
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Service CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWindow:
+    def test_create_printer_window(self, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        end = start + timedelta(hours=1)
+
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=start,
+            ends_at=end,
+            reason="Nozzle swap",
+            created_by="tester@example.com",
+        )
+
+        assert w.id is not None
+        assert w.printer_id == printer.id
+        assert w.resource_id is None
+        assert w.status == "scheduled"
+        assert w.reason == "Nozzle swap"
+        assert w.created_by == "tester@example.com"
+
+    def test_create_resource_window(self, db, make_work_center):
+        wc = make_work_center(center_type="machine")
+        resource = _make_resource(db, wc.id)
+        start = _now() + timedelta(hours=2)
+
+        w = create_window(
+            db,
+            resource_id=resource.id,
+            starts_at=start,
+            ends_at=start + timedelta(hours=1),
+        )
+        assert w.resource_id == resource.id
+        assert w.printer_id is None
+
+    def test_requires_exactly_one_machine(self, db, make_work_center):
+        printer = _make_printer(db)
+        wc = make_work_center(center_type="machine")
+        resource = _make_resource(db, wc.id)
+        start = _now() + timedelta(hours=1)
+        end = start + timedelta(hours=1)
+
+        with pytest.raises(ValueError, match="Exactly one"):
+            create_window(db, starts_at=start, ends_at=end)
+
+        with pytest.raises(ValueError, match="Exactly one"):
+            create_window(
+                db,
+                printer_id=printer.id,
+                resource_id=resource.id,
+                starts_at=start,
+                ends_at=end,
+            )
+
+    def test_rejects_unknown_machine(self, db):
+        start = _now() + timedelta(hours=1)
+        with pytest.raises(ValueError, match="not found"):
+            create_window(
+                db, printer_id=99999999, starts_at=start, ends_at=start + timedelta(hours=1)
+            )
+
+    def test_rejects_inverted_range(self, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        with pytest.raises(ValueError, match="after starts_at"):
+            create_window(
+                db, printer_id=printer.id, starts_at=start, ends_at=start
+            )
+
+    def test_rejects_overlap_on_same_machine(self, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        end = start + timedelta(hours=2)
+        create_window(db, printer_id=printer.id, starts_at=start, ends_at=end)
+
+        # Overlapping the middle of the existing window
+        with pytest.raises(ValueError, match="Overlaps existing"):
+            create_window(
+                db,
+                printer_id=printer.id,
+                starts_at=start + timedelta(minutes=30),
+                ends_at=end + timedelta(hours=1),
+            )
+
+    def test_overlap_allowed_on_other_machine(self, db):
+        printer_a = _make_printer(db)
+        printer_b = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        end = start + timedelta(hours=2)
+        create_window(db, printer_id=printer_a.id, starts_at=start, ends_at=end)
+
+        w = create_window(db, printer_id=printer_b.id, starts_at=start, ends_at=end)
+        assert w.id is not None
+
+    def test_overlap_allowed_with_cancelled_window(self, db):
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        end = start + timedelta(hours=2)
+        w1 = create_window(db, printer_id=printer.id, starts_at=start, ends_at=end)
+        cancel_window(db, w1.id)
+
+        w2 = create_window(db, printer_id=printer.id, starts_at=start, ends_at=end)
+        assert w2.id != w1.id
+
+    def test_adjacent_windows_do_not_overlap(self, db):
+        """Back-to-back windows (end == next start) are allowed."""
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        mid = start + timedelta(hours=1)
+        create_window(db, printer_id=printer.id, starts_at=start, ends_at=mid)
+        w = create_window(
+            db, printer_id=printer.id, starts_at=mid, ends_at=mid + timedelta(hours=1)
+        )
+        assert w.id is not None
+
+
+class TestListWindows:
+    def test_list_by_machine_and_range(self, db):
+        printer_a = _make_printer(db)
+        printer_b = _make_printer(db)
+        base = _now() + timedelta(days=1)
+
+        w_a = create_window(
+            db, printer_id=printer_a.id, starts_at=base, ends_at=base + timedelta(hours=1)
+        )
+        create_window(
+            db,
+            printer_id=printer_b.id,
+            starts_at=base,
+            ends_at=base + timedelta(hours=1),
+        )
+
+        items = list_windows(db, printer_id=printer_a.id)
+        assert [w.id for w in items] == [w_a.id]
+
+        # Range filter excludes a window entirely outside the range
+        items = list_windows(
+            db,
+            printer_id=printer_a.id,
+            start=base + timedelta(hours=2),
+            end=base + timedelta(hours=3),
+        )
+        assert items == []
+
+    def test_finished_windows_hidden_by_default(self, db):
+        printer = _make_printer(db)
+        base = _now() + timedelta(days=1)
+        w = create_window(
+            db, printer_id=printer.id, starts_at=base, ends_at=base + timedelta(hours=1)
+        )
+        cancel_window(db, w.id)
+
+        assert list_windows(db, printer_id=printer.id) == []
+        finished = list_windows(db, printer_id=printer.id, include_finished=True)
+        assert [x.id for x in finished] == [w.id]
+
+
+class TestCancelComplete:
+    def test_cancel_scheduled_window(self, db):
+        printer = _make_printer(db)
+        base = _now() + timedelta(days=1)
+        w = create_window(
+            db, printer_id=printer.id, starts_at=base, ends_at=base + timedelta(hours=1)
+        )
+        cancelled = cancel_window(db, w.id)
+        assert cancelled.status == "cancelled"
+
+    def test_cancel_active_window_restores_printer(self, db):
+        printer = _make_printer(db, status="idle")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=10),
+            ends_at=_now() + timedelta(hours=1),
+        )
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        assert printer.status == "maintenance"
+        assert w.status == "in_progress"
+
+        cancel_window(db, w.id)
+        db.refresh(printer)
+        assert printer.status == "idle"
+
+    def test_complete_writes_and_links_maintenance_log(self, db):
+        printer = _make_printer(db, status="idle")
+        next_due = _now() + timedelta(days=30)
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=90),
+            ends_at=_now() + timedelta(minutes=30),
+            reason="Belt tensioning",
+        )
+        sync_printer_maintenance_status(db)
+
+        completed = complete_window(
+            db,
+            w.id,
+            maintenance_type="repair",
+            performed_by="tech@example.com",
+            next_due_at=next_due,
+            notes="replaced belt",
+        )
+
+        assert completed.status == "completed"
+        assert completed.maintenance_log_id is not None
+        log = db.get(MaintenanceLog, completed.maintenance_log_id)
+        assert log.printer_id == printer.id
+        assert log.maintenance_type == "repair"
+        assert log.description == "Belt tensioning"
+        assert log.performed_by == "tech@example.com"
+        assert log.next_due_at == next_due
+        # Elapsed downtime ≈ 90 minutes (early completion clips to now)
+        assert 85 <= log.downtime_minutes <= 95
+        assert log.notes == "replaced belt"
+
+        # Printer restored
+        db.refresh(printer)
+        assert printer.status == "idle"
+
+    def test_complete_resource_window_skips_log(self, db, make_work_center):
+        """maintenance_logs requires a printer; resource windows just close."""
+        wc = make_work_center(center_type="machine")
+        resource = _make_resource(db, wc.id)
+        w = create_window(
+            db,
+            resource_id=resource.id,
+            starts_at=_now() - timedelta(minutes=30),
+            ends_at=_now() + timedelta(minutes=30),
+        )
+        completed = complete_window(db, w.id)
+        assert completed.status == "completed"
+        assert completed.maintenance_log_id is None
+
+    def test_complete_twice_rejected(self, db):
+        printer = _make_printer(db)
+        base = _now() + timedelta(days=1)
+        w = create_window(
+            db, printer_id=printer.id, starts_at=base, ends_at=base + timedelta(hours=1)
+        )
+        complete_window(db, w.id)
+        with pytest.raises(ValueError, match="cannot be completed"):
+            complete_window(db, w.id)
+        with pytest.raises(ValueError, match="cannot be cancelled"):
+            cancel_window(db, w.id)
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+class TestEngineIntegration:
+    def test_find_window_conflicts_printer(self, db):
+        printer = _make_printer(db)
+        base = _now() + timedelta(hours=4)
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=base,
+            ends_at=base + timedelta(hours=2),
+        )
+
+        hits = find_window_conflicts(
+            db,
+            resource_id=printer.id,
+            start_time=base + timedelta(minutes=30),
+            end_time=base + timedelta(hours=3),
+            is_printer=True,
+        )
+        assert [x.id for x in hits] == [w.id]
+
+        # Non-overlapping range → no conflicts
+        assert (
+            find_window_conflicts(
+                db,
+                resource_id=printer.id,
+                start_time=base + timedelta(hours=2),
+                end_time=base + timedelta(hours=3),
+                is_printer=True,
+            )
+            == []
+        )
+
+        # Cancelled windows never block
+        cancel_window(db, w.id)
+        assert (
+            find_window_conflicts(
+                db,
+                resource_id=printer.id,
+                start_time=base,
+                end_time=base + timedelta(hours=1),
+                is_printer=True,
+            )
+            == []
+        )
+
+    def test_find_next_available_slot_skips_window(self, db, make_work_center):
+        wc = make_work_center(center_type="machine")
+        resource = _make_resource(db, wc.id)
+        after = datetime.now(timezone.utc) + timedelta(hours=1)
+
+        window_start = after + timedelta(minutes=30)
+        window_end = window_start + timedelta(hours=2)
+        create_window(
+            db,
+            resource_id=resource.id,
+            starts_at=window_start,
+            ends_at=window_end,
+        )
+
+        # 60-minute job can't fit in the 30-minute gap before the window —
+        # the suggested slot must land at the window's end.
+        slot = find_next_available_slot(
+            db, resource.id, duration_minutes=60, after=after
+        )
+        assert slot == window_end.replace(tzinfo=timezone.utc)
+
+        # A 20-minute job fits before the window
+        slot = find_next_available_slot(
+            db, resource.id, duration_minutes=20, after=after
+        )
+        assert slot == after
+
+    def test_find_next_available_slot_skips_window_printer(self, db):
+        printer = _make_printer(db)
+        after = datetime.now(timezone.utc) + timedelta(hours=1)
+        window_end = after + timedelta(hours=3)
+        create_window(
+            db, printer_id=printer.id, starts_at=after, ends_at=window_end
+        )
+
+        slot = find_next_available_slot(
+            db, printer.id, duration_minutes=60, after=after, is_printer=True
+        )
+        assert slot == window_end.replace(tzinfo=timezone.utc)
+
+    def test_schedule_operation_raises_on_window_overlap(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+
+        start = datetime.now(timezone.utc) + timedelta(hours=1)
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=start,
+            ends_at=start + timedelta(hours=2),
+        )
+
+        with pytest.raises(MaintenanceWindowConflictError) as exc_info:
+            schedule_operation(
+                db=db,
+                operation=op,
+                resource_id=printer.id,
+                scheduled_start=start + timedelta(minutes=15),
+                scheduled_end=start + timedelta(minutes=75),
+                is_printer=True,
+            )
+        assert len(exc_info.value.windows) == 1
+        # Operation untouched
+        assert op.scheduled_start is None
+        assert op.status == "pending"
+
+    def test_schedule_operation_ok_outside_window(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+
+        start = datetime.now(timezone.utc) + timedelta(hours=1)
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=start + timedelta(hours=5),
+            ends_at=start + timedelta(hours=6),
+        )
+
+        success, conflicts = schedule_operation(
+            db=db,
+            operation=op,
+            resource_id=printer.id,
+            scheduled_start=start,
+            scheduled_end=start + timedelta(hours=1),
+            is_printer=True,
+        )
+        assert success is True
+        assert conflicts == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchIntegration:
+    def test_printer_in_active_window_excluded(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id)
+
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=10),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        assert all(r.printer.id != printer.id for r in resp.results)
+
+    def test_upcoming_window_yields_warning(
+        self, db, make_product, make_work_center
+    ):
+        """A 60-min job overlapping a window starting in 30 min gets warned."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60.0)
+
+        window_start = _now() + timedelta(minutes=30)
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=window_start,
+            ends_at=window_start + timedelta(hours=1),
+            reason="filter swap",
+        )
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        assert len(resp.results) == 1
+        suggestion = resp.results[0].top_suggestion
+        assert suggestion is not None
+        assert suggestion.maintenance_warning is not None
+        assert "Maintenance window" in suggestion.maintenance_warning
+        assert "filter swap" in suggestion.maintenance_warning
+
+    def test_far_future_window_no_warning(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60.0)
+
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() + timedelta(days=7),
+            ends_at=_now() + timedelta(days=7, hours=2),
+        )
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        suggestion = resp.results[0].top_suggestion
+        assert suggestion is not None
+        assert suggestion.maintenance_warning is None
+
+    def test_window_warning_beats_next_due_heuristic(
+        self, db, make_product, make_work_center
+    ):
+        """When a real window overlaps, the warning names the window (not next_due)."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60.0)
+
+        # Heuristic would fire (next_due in 10 minutes)...
+        log = MaintenanceLog(
+            printer_id=printer.id,
+            maintenance_type="routine",
+            performed_at=_now() - timedelta(days=30),
+            next_due_at=_now() + timedelta(minutes=10),
+        )
+        db.add(log)
+        db.flush()
+
+        # ...but the real window takes precedence in the message.
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() + timedelta(minutes=30),
+            ends_at=_now() + timedelta(minutes=90),
+        )
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        warning = resp.results[0].top_suggestion.maintenance_warning
+        assert warning is not None
+        assert "Maintenance window" in warning
+
+    def test_heuristic_fallback_without_windows(
+        self, db, make_product, make_work_center
+    ):
+        """No windows → original next_due_at heuristic still warns."""
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        _make_op(db, wo.id, wc.id, planned_run_minutes=60.0)
+
+        log = MaintenanceLog(
+            printer_id=printer.id,
+            maintenance_type="routine",
+            performed_at=_now() - timedelta(days=30),
+            next_due_at=_now() + timedelta(minutes=10),
+        )
+        db.add(log)
+        db.flush()
+
+        resp = get_dispatch_suggestions(db, printer_id=printer.id)
+        warning = resp.results[0].top_suggestion.maintenance_warning
+        assert warning is not None
+        assert "Maintenance due" in warning
+
+    def test_assign_blocked_during_active_window(
+        self, db, make_product, make_work_center
+    ):
+        wc = make_work_center()
+        product = make_product()
+        printer = _make_printer(db, status="idle", work_center_id=wc.id)
+        wo = _make_wo(db, product.id)
+        op = _make_op(db, wo.id, wc.id)
+
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        with pytest.raises(ValueError, match="maintenance window"):
+            dispatch_operation(db, op.id, printer.id, user=None)
+
+
+# ---------------------------------------------------------------------------
+# Status auto-flip (lazy sync)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSync:
+    def test_active_window_flips_idle_printer(self, db):
+        printer = _make_printer(db, status="idle")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        changed = sync_printer_maintenance_status(db)
+        assert changed is True
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "maintenance"
+        assert w.status == "in_progress"
+
+        # Idempotent: second run is a no-op
+        assert sync_printer_maintenance_status(db) is False
+
+    def test_never_overwrites_printing_printer(self, db):
+        printer = _make_printer(db, status="printing")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "printing"  # untouched
+        assert w.status == "in_progress"  # window state still advances
+
+    def test_never_overwrites_offline_printer(self, db):
+        printer = _make_printer(db, status="offline")
+        create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        assert printer.status == "offline"
+
+    def test_expired_window_flips_back_to_idle(self, db):
+        printer = _make_printer(db, status="idle")
+        w = MaintenanceWindow(
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(hours=2),
+            ends_at=_now() - timedelta(minutes=5),
+            status="in_progress",
+        )
+        db.add(w)
+        printer.status = "maintenance"
+        db.flush()
+
+        changed = sync_printer_maintenance_status(db)
+        assert changed is True
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "idle"
+        # Window awaits explicit complete/cancel — elapsed ≠ done
+        assert w.status == "in_progress"
+
+    def test_no_flip_back_when_second_window_active(self, db):
+        printer = _make_printer(db, status="maintenance")
+        db.add(
+            MaintenanceWindow(
+                printer_id=printer.id,
+                starts_at=_now() - timedelta(hours=3),
+                ends_at=_now() - timedelta(hours=2),
+                status="in_progress",
+            )
+        )
+        db.add(
+            MaintenanceWindow(
+                printer_id=printer.id,
+                starts_at=_now() - timedelta(minutes=10),
+                ends_at=_now() + timedelta(hours=1),
+                status="in_progress",
+            )
+        )
+        db.flush()
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        assert printer.status == "maintenance"
+
+    def test_active_window_recorded_by_get_active_window(self, db):
+        printer = _make_printer(db)
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+        active = get_active_window(db, printer_id=printer.id)
+        assert active is not None and active.id == w.id
+
+        # Outside the window → None
+        assert (
+            get_active_window(
+                db, printer_id=printer.id, at=_now() + timedelta(hours=2)
+            )
+            is None
+        )

--- a/backend/tests/services/test_maintenance_window_service.py
+++ b/backend/tests/services/test_maintenance_window_service.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
 
 from app.models.maintenance import MaintenanceLog, MaintenanceWindow
 from app.models.manufacturing import Resource
@@ -247,6 +249,65 @@ class TestCreateWindow:
             db, printer_id=printer.id, starts_at=mid, ends_at=mid + timedelta(hours=1)
         )
         assert w.id is not None
+
+    def test_create_locks_machine_row_before_overlap_check(self, db):
+        """CR #733: the overlap check is read-then-insert, so concurrent
+        creates for the same machine could both pass it and insert
+        overlapping windows. create_window must serialize per machine by
+        SELECT ... FOR UPDATE on the target Printer/Resource row BEFORE
+        the overlap check (HARD-8 PO row-lock precedent)."""
+        printer = _make_printer(db)
+        captured: list[str] = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            captured.append(statement)
+
+        bind = db.get_bind()
+        event.listen(bind, "before_cursor_execute", _capture)
+        try:
+            start = _now() + timedelta(hours=2)
+            create_window(
+                db,
+                printer_id=printer.id,
+                starts_at=start,
+                ends_at=start + timedelta(hours=1),
+            )
+        finally:
+            event.remove(bind, "before_cursor_execute", _capture)
+
+        lock_selects = [
+            s for s in captured if "FOR UPDATE" in s and "printers" in s
+        ]
+        assert lock_selects, (
+            "create_window must take a FOR UPDATE row lock on the printer "
+            f"before the overlap check; statements seen: {captured}"
+        )
+        # And the lock must come before the overlap SELECT on windows
+        first_lock = next(
+            i for i, s in enumerate(captured) if "FOR UPDATE" in s
+        )
+        overlap_selects = [
+            i
+            for i, s in enumerate(captured)
+            if "maintenance_windows" in s and s.lstrip().upper().startswith("SELECT")
+        ]
+        assert overlap_selects and first_lock < overlap_selects[0]
+
+    def test_status_check_constraint_rejects_unknown_status(self, db):
+        """CR #733: status is DB-CHECK constrained, not a free-form string."""
+        printer = _make_printer(db)
+        start = _now() + timedelta(hours=2)
+        db.add(
+            MaintenanceWindow(
+                printer_id=printer.id,
+                starts_at=start,
+                ends_at=start + timedelta(hours=1),
+                status="paused",  # not in the allowed set
+            )
+        )
+        with pytest.raises(IntegrityError, match="ck_maintenance_windows_status"):
+            db.flush()
+        db.rollback()
 
 
 class TestListWindows:
@@ -776,6 +837,100 @@ class TestStatusSync:
         sync_printer_maintenance_status(db)
         db.refresh(printer)
         assert printer.status == "maintenance"
+
+    def test_restore_returns_available_printer_to_available(self, db):
+        """CR #733: flip-in records the prior status; complete restores it
+        verbatim — 'available' must NOT land on 'idle'."""
+        printer = _make_printer(db, status="available")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "maintenance"
+        assert w.prior_printer_status == "available"
+
+        complete_window(db, w.id)
+        db.refresh(printer)
+        assert printer.status == "available"
+
+    def test_restore_returns_idle_printer_to_idle(self, db):
+        """Symmetric case: idle → maintenance → idle (via cancel)."""
+        printer = _make_printer(db, status="idle")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=5),
+            ends_at=_now() + timedelta(hours=1),
+        )
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "maintenance"
+        assert w.prior_printer_status == "idle"
+
+        cancel_window(db, w.id)
+        db.refresh(printer)
+        assert printer.status == "idle"
+
+    def test_lazy_expiry_restores_prior_available(self, db):
+        """Lazy flip-out (window end passed, no explicit complete) also
+        restores the recorded prior status."""
+        printer = _make_printer(db, status="available")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=30),
+            ends_at=_now() + timedelta(minutes=5),
+        )
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        assert printer.status == "maintenance"
+
+        # Window end passes without operator action
+        w.ends_at = _now() - timedelta(minutes=1)
+        db.flush()
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "available"
+        # Window still awaits explicit complete/cancel
+        assert w.status == "in_progress"
+
+    def test_telemetry_revert_does_not_clobber_prior_status(self, db):
+        """If telemetry reverts the printer mid-window (e.g. MQTT wrote
+        'idle'), the re-flip keeps the originally recorded prior status."""
+        printer = _make_printer(db, status="available")
+        w = create_window(
+            db,
+            printer_id=printer.id,
+            starts_at=_now() - timedelta(minutes=10),
+            ends_at=_now() + timedelta(hours=1),
+        )
+        sync_printer_maintenance_status(db)
+        db.refresh(w)
+        assert w.prior_printer_status == "available"
+
+        # Telemetry revert mid-window
+        printer.status = "idle"
+        db.flush()
+
+        sync_printer_maintenance_status(db)
+        db.refresh(printer)
+        db.refresh(w)
+        assert printer.status == "maintenance"  # re-flipped
+        assert w.prior_printer_status == "available"  # first recording kept
+
+        complete_window(db, w.id)
+        db.refresh(printer)
+        assert printer.status == "available"
 
     def test_active_window_recorded_by_get_active_window(self, db):
         printer = _make_printer(db)

--- a/frontend/src/components/printers/MaintenanceModal.jsx
+++ b/frontend/src/components/printers/MaintenanceModal.jsx
@@ -1,12 +1,28 @@
 /**
- * MaintenanceModal - Form for logging printer maintenance activities.
+ * MaintenanceModal - Log past maintenance OR schedule a maintenance window.
  *
- * Extracted from AdminPrinters.jsx (ARCHITECT-002)
+ * Extracted from AdminPrinters.jsx (ARCHITECT-002).
+ *
+ * SCHED-7: adds a "Schedule Window" tab — planned downtime becomes a
+ * first-class block the scheduler treats as busy time. The tab also lists
+ * upcoming (blocking) windows with cancel / complete actions; completing a
+ * window writes the MaintenanceLog entry server-side.
+ *
+ * datetime-local convention: inputs are seeded ONLY via toLocalInputValue
+ * (local wall time) and submitted via new Date(localValue).toISOString().
+ *
+ * Props:
+ *   printers          — printer list for the selector
+ *   selectedPrinterId — preselected printer (optional)
+ *   initialMode       — "log" | "schedule" (default "log")
+ *   onClose           — () => void
+ *   onSave            — () => void (maintenance logged; parent closes + refreshes)
+ *   onWindowsChanged  — () => void (optional; a window was created/cancelled/completed)
  */
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { API_URL } from "../../config/api";
 import { useToast } from "../Toast";
-import { toLocalInputValue } from "../../utils/formatting";
+import { toLocalInputValue, parseDateTime } from "../../utils/formatting";
 import Modal from "../Modal";
 
 const maintenanceTypes = [
@@ -16,8 +32,31 @@ const maintenanceTypes = [
   { value: "cleaning", label: "Cleaning", description: "Nozzle, bed, or general cleaning" },
 ];
 
-export default function MaintenanceModal({ printers, selectedPrinterId, onClose, onSave }) {
+const inputClass =
+  "w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orange-500";
+const placeholderInputClass = `${inputClass} placeholder-gray-500`;
+
+function fmtWindowTime(value) {
+  const d = parseDateTime(value);
+  if (!d || Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function MaintenanceModal({
+  printers,
+  selectedPrinterId,
+  initialMode = "log",
+  onClose,
+  onSave,
+  onWindowsChanged,
+}) {
   const toast = useToast();
+  const [mode, setMode] = useState(initialMode); // log | schedule
   const [loading, setLoading] = useState(false);
   const [form, setForm] = useState({
     printer_id: selectedPrinterId || "",
@@ -31,6 +70,47 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
     parts_used: "",
     notes: "",
   });
+
+  // --- Schedule Window state (SCHED-7) ---
+  // Lazy initializer: seeds start = now, end = +1h, both as local wall
+  // time via toLocalInputValue (the datetime-local contract).
+  const [windowForm, setWindowForm] = useState(() => {
+    const seed = new Date();
+    return {
+      printer_id: selectedPrinterId || "",
+      starts_at: toLocalInputValue(seed),
+      ends_at: toLocalInputValue(new Date(seed.getTime() + 60 * 60 * 1000)),
+      reason: "",
+    };
+  });
+  const [windows, setWindows] = useState([]);
+  // Starts true (list fetch fires when the schedule tab opens) and is only
+  // flipped from async continuations — no synchronous setState in effects.
+  const [windowsLoading, setWindowsLoading] = useState(true);
+  // window id with an action (cancel/complete) in flight — disables its buttons
+  const [windowActionId, setWindowActionId] = useState(null);
+
+  const fetchWindows = useCallback(async () => {
+    try {
+      // Default listing = blocking windows only (scheduled / in_progress)
+      const res = await fetch(`${API_URL}/api/v1/maintenance-windows`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to load maintenance windows");
+      const data = await res.json();
+      setWindows(data.items || []);
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setWindowsLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (mode === "schedule") {
+      fetchWindows();
+    }
+  }, [mode, fetchWindows]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -78,19 +158,133 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
     }
   };
 
+  const handleScheduleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!windowForm.printer_id) {
+      toast.error("Please select a printer");
+      return;
+    }
+    if (!windowForm.starts_at || !windowForm.ends_at) {
+      toast.error("Start and end times are required");
+      return;
+    }
+    if (new Date(windowForm.ends_at) <= new Date(windowForm.starts_at)) {
+      toast.error("End time must be after start time");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload = {
+        printer_id: parseInt(windowForm.printer_id),
+        starts_at: new Date(windowForm.starts_at).toISOString(),
+        ends_at: new Date(windowForm.ends_at).toISOString(),
+        reason: windowForm.reason || null,
+      };
+
+      const res = await fetch(`${API_URL}/api/v1/maintenance-windows`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || "Failed to schedule maintenance window");
+      }
+
+      toast.success("Maintenance window scheduled");
+      await fetchWindows();
+      onWindowsChanged?.();
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleWindowAction = async (windowId, action) => {
+    setWindowActionId(windowId);
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/maintenance-windows/${windowId}/${action}`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          // complete: server defaults (routine type, current user, window-span
+          // downtime) — the detailed MaintenanceLog form stays on the Log tab.
+          body: JSON.stringify({}),
+        }
+      );
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || `Failed to ${action} window`);
+      }
+      toast.success(
+        action === "cancel" ? "Maintenance window cancelled" : "Maintenance window completed"
+      );
+      await fetchWindows();
+      onWindowsChanged?.();
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setWindowActionId(null);
+    }
+  };
+
+  const printerName = (printerId) => {
+    const p = printers.find((x) => x.id === printerId);
+    return p ? `${p.name} (${p.code})` : `Printer #${printerId}`;
+  };
+
   return (
     <Modal
       isOpen={true}
       onClose={onClose}
-      title="Log Maintenance"
+      title="Maintenance"
       className="w-full max-w-lg max-h-[90vh] overflow-y-auto"
       disableClose={loading}
     >
       <div className="p-6 border-b border-gray-700">
-        <h2 className="text-xl font-bold text-white">Log Maintenance</h2>
-        <p className="text-gray-400 text-sm mt-1">Track maintenance activities, costs, and downtime</p>
+        <h2 className="text-xl font-bold text-white">
+          {mode === "log" ? "Log Maintenance" : "Schedule Maintenance Window"}
+        </h2>
+        <p className="text-gray-400 text-sm mt-1">
+          {mode === "log"
+            ? "Track maintenance activities, costs, and downtime"
+            : "Block out planned downtime — the scheduler treats it as busy time"}
+        </p>
+        {/* Mode tabs */}
+        <div className="flex gap-1 mt-4 bg-gray-800 rounded-lg p-1 w-fit" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "log"}
+            onClick={() => setMode("log")}
+            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+              mode === "log" ? "bg-orange-600 text-white" : "text-gray-400 hover:text-white"
+            }`}
+          >
+            Log Maintenance
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === "schedule"}
+            onClick={() => setMode("schedule")}
+            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
+              mode === "schedule" ? "bg-orange-600 text-white" : "text-gray-400 hover:text-white"
+            }`}
+          >
+            Schedule Window
+          </button>
+        </div>
       </div>
 
+      {mode === "log" ? (
       <form onSubmit={handleSubmit} className="p-6 space-y-4">
           {/* Printer Selection */}
           <div>
@@ -99,7 +293,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               value={form.printer_id}
               onChange={(e) => setForm({ ...form, printer_id: e.target.value })}
               required
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={inputClass}
             >
               <option value="">Select printer...</option>
               {printers.map((p) => (
@@ -115,7 +309,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               value={form.maintenance_type}
               onChange={(e) => setForm({ ...form, maintenance_type: e.target.value })}
               required
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={inputClass}
             >
               {maintenanceTypes.map((t) => (
                 <option key={t.value} value={t.value}>{t.label}</option>
@@ -131,7 +325,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               value={form.description}
               onChange={(e) => setForm({ ...form, description: e.target.value })}
               placeholder="e.g., Replaced nozzle, cleaned bed"
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={placeholderInputClass}
             />
           </div>
 
@@ -143,7 +337,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               value={form.performed_by}
               onChange={(e) => setForm({ ...form, performed_by: e.target.value })}
               placeholder="Your name"
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={placeholderInputClass}
             />
           </div>
 
@@ -156,7 +350,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
                 value={form.performed_at}
                 onChange={(e) => setForm({ ...form, performed_at: e.target.value })}
                 required
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className={inputClass}
               />
             </div>
             <div>
@@ -165,7 +359,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
                 type="datetime-local"
                 value={form.next_due_at}
                 onChange={(e) => setForm({ ...form, next_due_at: e.target.value })}
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className={inputClass}
               />
             </div>
           </div>
@@ -181,7 +375,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
                 value={form.cost}
                 onChange={(e) => setForm({ ...form, cost: e.target.value })}
                 placeholder="0.00"
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className={placeholderInputClass}
               />
             </div>
             <div>
@@ -192,7 +386,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
                 value={form.downtime_minutes}
                 onChange={(e) => setForm({ ...form, downtime_minutes: e.target.value })}
                 placeholder="0"
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className={placeholderInputClass}
               />
             </div>
           </div>
@@ -205,7 +399,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               value={form.parts_used}
               onChange={(e) => setForm({ ...form, parts_used: e.target.value })}
               placeholder="e.g., Hardened nozzle 0.4mm, PTFE tube"
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={placeholderInputClass}
             />
             <p className="text-xs text-gray-500 mt-1">Comma-separated list of parts used</p>
           </div>
@@ -218,7 +412,7 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
               onChange={(e) => setForm({ ...form, notes: e.target.value })}
               placeholder="Additional notes..."
               rows={2}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+              className={placeholderInputClass}
             />
           </div>
 
@@ -240,6 +434,136 @@ export default function MaintenanceModal({ printers, selectedPrinterId, onClose,
             </button>
           </div>
       </form>
+      ) : (
+      <div className="p-6 space-y-6">
+        {/* Schedule Window form (SCHED-7) */}
+        <form onSubmit={handleScheduleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Printer *</label>
+            <select
+              value={windowForm.printer_id}
+              onChange={(e) => setWindowForm({ ...windowForm, printer_id: e.target.value })}
+              required
+              className={inputClass}
+            >
+              <option value="">Select printer...</option>
+              {printers.map((p) => (
+                <option key={p.id} value={p.id}>{p.name} ({p.code})</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">Starts *</label>
+              <input
+                type="datetime-local"
+                aria-label="Window start"
+                value={windowForm.starts_at}
+                onChange={(e) => setWindowForm({ ...windowForm, starts_at: e.target.value })}
+                required
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">Ends *</label>
+              <input
+                type="datetime-local"
+                aria-label="Window end"
+                value={windowForm.ends_at}
+                onChange={(e) => setWindowForm({ ...windowForm, ends_at: e.target.value })}
+                required
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Reason</label>
+            <input
+              type="text"
+              value={windowForm.reason}
+              onChange={(e) => setWindowForm({ ...windowForm, reason: e.target.value })}
+              placeholder="e.g., Hotend swap, belt tensioning"
+              maxLength={255}
+              className={placeholderInputClass}
+            />
+          </div>
+
+          <div className="flex gap-3 pt-4 border-t border-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 text-gray-400 hover:text-white border border-gray-700 rounded-lg transition-colors"
+            >
+              Close
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex-1 bg-orange-600 hover:bg-orange-500 disabled:bg-orange-600/50 text-white px-4 py-2 rounded-lg transition-colors"
+            >
+              {loading ? "Saving..." : "Schedule Window"}
+            </button>
+          </div>
+        </form>
+
+        {/* Upcoming windows list */}
+        <div>
+          <h3 className="text-sm font-semibold text-white mb-2">Upcoming Windows</h3>
+          {windowsLoading ? (
+            <p className="text-xs text-gray-500">Loading windows...</p>
+          ) : windows.length === 0 ? (
+            <p className="text-xs text-gray-500">No maintenance windows scheduled.</p>
+          ) : (
+            <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
+              {windows.map((w) => (
+                <div
+                  key={w.id}
+                  className="bg-gray-800 border border-gray-700 rounded-lg p-3 flex items-start justify-between gap-3"
+                  data-testid={`maintenance-window-${w.id}`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm text-white truncate">
+                      {w.printer_id != null
+                        ? printerName(w.printer_id)
+                        : `Resource #${w.resource_id}`}
+                    </div>
+                    <div className="text-xs text-gray-400">
+                      {fmtWindowTime(w.starts_at)} → {fmtWindowTime(w.ends_at)}
+                    </div>
+                    <div className="text-[11px] text-gray-500 truncate">
+                      {w.status === "in_progress" ? "In progress" : "Scheduled"}
+                      {w.reason && ` · ${w.reason}`}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => handleWindowAction(w.id, "complete")}
+                      disabled={windowActionId === w.id}
+                      title="Mark done — writes a maintenance log entry"
+                      className="px-2 py-1 text-xs rounded bg-green-600/80 hover:bg-green-600 disabled:opacity-50 text-white transition-colors"
+                    >
+                      Complete
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleWindowAction(w.id, "cancel")}
+                      disabled={windowActionId === w.id}
+                      title="Cancel this window"
+                      className="px-2 py-1 text-xs rounded border border-gray-600 text-gray-300 hover:text-white hover:border-gray-500 disabled:opacity-50 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      )}
     </Modal>
   );
 }

--- a/frontend/src/components/printers/MaintenanceModal.jsx
+++ b/frontend/src/components/printers/MaintenanceModal.jsx
@@ -11,6 +11,9 @@
  * datetime-local convention: inputs are seeded ONLY via toLocalInputValue
  * (local wall time) and submitted via new Date(localValue).toISOString().
  *
+ * All API calls go through useApi (shared client: silent token refresh,
+ * 401 bounce to login, app-wide error events) — never raw fetch.
+ *
  * Props:
  *   printers          — printer list for the selector
  *   selectedPrinterId — preselected printer (optional)
@@ -20,7 +23,7 @@
  *   onWindowsChanged  — () => void (optional; a window was created/cancelled/completed)
  */
 import { useState, useEffect, useCallback } from "react";
-import { API_URL } from "../../config/api";
+import { useApi } from "../../hooks/useApi";
 import { useToast } from "../Toast";
 import { toLocalInputValue, parseDateTime } from "../../utils/formatting";
 import Modal from "../Modal";
@@ -55,6 +58,7 @@ export default function MaintenanceModal({
   onSave,
   onWindowsChanged,
 }) {
+  const api = useApi();
   const toast = useToast();
   const [mode, setMode] = useState(initialMode); // log | schedule
   const [loading, setLoading] = useState(false);
@@ -93,18 +97,14 @@ export default function MaintenanceModal({
   const fetchWindows = useCallback(async () => {
     try {
       // Default listing = blocking windows only (scheduled / in_progress)
-      const res = await fetch(`${API_URL}/api/v1/maintenance-windows`, {
-        credentials: "include",
-      });
-      if (!res.ok) throw new Error("Failed to load maintenance windows");
-      const data = await res.json();
-      setWindows(data.items || []);
+      const data = await api.get("/api/v1/maintenance-windows");
+      setWindows(data?.items || []);
     } catch (err) {
-      toast.error(err.message);
+      toast.error(err.message || "Failed to load maintenance windows");
     } finally {
       setWindowsLoading(false);
     }
-  }, [toast]);
+  }, [api, toast]);
 
   useEffect(() => {
     if (mode === "schedule") {
@@ -135,24 +135,15 @@ export default function MaintenanceModal({
         notes: form.notes || null,
       };
 
-      const res = await fetch(`${API_URL}/api/v1/maintenance/printers/${form.printer_id}/maintenance`, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to log maintenance");
-      }
+      await api.post(
+        `/api/v1/maintenance/printers/${form.printer_id}/maintenance`,
+        payload
+      );
 
       toast.success("Maintenance logged successfully");
       onSave();
     } catch (err) {
-      toast.error(err.message);
+      toast.error(err.message || "Failed to log maintenance");
     } finally {
       setLoading(false);
     }
@@ -183,23 +174,13 @@ export default function MaintenanceModal({
         reason: windowForm.reason || null,
       };
 
-      const res = await fetch(`${API_URL}/api/v1/maintenance-windows`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || "Failed to schedule maintenance window");
-      }
+      await api.post("/api/v1/maintenance-windows", payload);
 
       toast.success("Maintenance window scheduled");
       await fetchWindows();
       onWindowsChanged?.();
     } catch (err) {
-      toast.error(err.message);
+      toast.error(err.message || "Failed to schedule maintenance window");
     } finally {
       setLoading(false);
     }
@@ -208,28 +189,16 @@ export default function MaintenanceModal({
   const handleWindowAction = async (windowId, action) => {
     setWindowActionId(windowId);
     try {
-      const res = await fetch(
-        `${API_URL}/api/v1/maintenance-windows/${windowId}/${action}`,
-        {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          // complete: server defaults (routine type, current user, window-span
-          // downtime) — the detailed MaintenanceLog form stays on the Log tab.
-          body: JSON.stringify({}),
-        }
-      );
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.detail || `Failed to ${action} window`);
-      }
+      // complete: server defaults (routine type, current user, window-span
+      // downtime) — the detailed MaintenanceLog form stays on the Log tab.
+      await api.post(`/api/v1/maintenance-windows/${windowId}/${action}`, {});
       toast.success(
         action === "cancel" ? "Maintenance window cancelled" : "Maintenance window completed"
       );
       await fetchWindows();
       onWindowsChanged?.();
     } catch (err) {
-      toast.error(err.message);
+      toast.error(err.message || `Failed to ${action} window`);
     } finally {
       setWindowActionId(null);
     }

--- a/frontend/src/components/printers/PrinterCard.jsx
+++ b/frontend/src/components/printers/PrinterCard.jsx
@@ -18,8 +18,12 @@
  *   testing              — boolean (is this printer currently being connection-tested)
  *   commandPending       — boolean (is a fleet command currently in-flight for this printer)
  *   maintenanceDueSoon   — boolean (optional, SCHED-4 — show maintenance due badge)
+ *   upcomingMaintenanceWindow — object|null (optional, SCHED-7 — next blocking
+ *                          maintenance window {starts_at, ends_at, reason, status};
+ *                          shows a "Maint Scheduled" / "In Maintenance" badge)
  */
 import { brandLabels } from "./constants";
+import { parseDateTime } from "../../utils/formatting";
 
 const STATUS_STYLES = {
   printing:
@@ -103,6 +107,7 @@ export default function PrinterCard({
   testing,
   commandPending,
   maintenanceDueSoon,
+  upcomingMaintenanceWindow,
 }) {
   const status = (printer.status || "offline").toLowerCase();
   const isActive = status === "printing" || status === "paused";
@@ -116,6 +121,30 @@ export default function PrinterCard({
   const hasProgress = Number.isFinite(progressRaw);
   const eta = fmtEta(printer.remaining_minutes ?? printer.mc_remaining_time);
   const ams = getActiveAmsSlot(printer.ams_slots);
+
+  // SCHED-7: upcoming/active maintenance window badge. Backend timestamps
+  // are naive UTC, so parseDateTime (which appends 'Z') renders them local.
+  const windowBadge = (() => {
+    if (!upcomingMaintenanceWindow) return null;
+    const w = upcomingMaintenanceWindow;
+    const fmt = (v) => {
+      const d = parseDateTime(v);
+      return d && !Number.isNaN(d.getTime())
+        ? d.toLocaleString(undefined, {
+            month: "numeric",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          })
+        : "?";
+    };
+    return {
+      label: w.status === "in_progress" ? "In Maintenance" : "Maint Scheduled",
+      title:
+        `Maintenance window ${fmt(w.starts_at)} → ${fmt(w.ends_at)}` +
+        (w.reason ? ` — ${w.reason}` : ""),
+    };
+  })();
 
   // Surface HMI errors from Bambu MQTT telemetry. print_error is an integer
   // (0 = none); hms_codes is an array of "ATTR_CODE" hex strings. hms_descriptions
@@ -232,6 +261,20 @@ export default function PrinterCard({
                   d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
               Maint Due
+            </span>
+          )}
+          {/* SCHED-7: upcoming/active maintenance window badge */}
+          {windowBadge && (
+            <span
+              className="flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-400 ring-1 ring-inset ring-amber-400/30"
+              data-testid="maintenance-window-badge"
+              title={windowBadge.title}
+            >
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              {windowBadge.label}
             </span>
           )}
         </div>

--- a/frontend/src/components/printers/__tests__/MaintenanceModal.test.jsx
+++ b/frontend/src/components/printers/__tests__/MaintenanceModal.test.jsx
@@ -4,6 +4,11 @@
  * Verifies the datetime-local seeding contract (toLocalInputValue local
  * wall time), the submit contract (new Date(local).toISOString()), and the
  * upcoming-window list's cancel/complete actions.
+ *
+ * API access goes through a mocked useApi (CR #733 — the component uses
+ * the shared client, never raw fetch). The mock returns a STABLE object:
+ * the real hook memoizes a module-level singleton, and an unstable mock
+ * would retrigger every effect keyed on `api`.
  */
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -13,6 +18,8 @@ const { mocks } = vi.hoisted(() => ({
   mocks: {
     toastError: vi.fn(),
     toastSuccess: vi.fn(),
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
   },
 }));
 
@@ -24,6 +31,19 @@ vi.mock("../../Toast", () => ({
     info: vi.fn(),
   }),
 }));
+
+// Stable object — created once at mock-definition time, same reference on
+// every useApi() call (mirrors the real hook's memoized singleton).
+vi.mock("../../../hooks/useApi", () => {
+  const api = {
+    get: mocks.apiGet,
+    post: mocks.apiPost,
+    put: vi.fn(),
+    patch: vi.fn(),
+    del: vi.fn(),
+  };
+  return { useApi: () => api };
+});
 
 vi.mock("../../Modal", () => ({
   default: ({ children }) => <div role="dialog">{children}</div>,
@@ -54,21 +74,15 @@ const WINDOWS = [
 // Frozen clock so the datetime-local seeds are deterministic.
 const FROZEN_NOW = new Date(2026, 5, 15, 10, 0, 0);
 
-const jsonRes = (body) => ({ ok: true, json: async () => body });
-
 /**
- * Find the last fetch call whose URL matches `re` (and, when given,
- * whose method matches); returns [url, opts]. The method filter matters
- * because a successful POST immediately triggers a list-refresh GET to
- * the same collection URL.
+ * Find the last api.post call whose path matches `re`; returns
+ * [path, payload]. The filter matters because a successful POST
+ * immediately triggers a list-refresh GET via api.get.
  */
-function lastFetchMatching(re, method) {
-  const calls = globalThis.fetch.mock.calls;
+function lastPostMatching(re) {
+  const calls = mocks.apiPost.mock.calls;
   for (let i = calls.length - 1; i >= 0; i--) {
-    const [url, opts] = calls[i];
-    if (re.test(String(url)) && (!method || opts?.method === method)) {
-      return calls[i];
-    }
+    if (re.test(String(calls[i][0]))) return calls[i];
   }
   return null;
 }
@@ -78,18 +92,20 @@ beforeEach(() => {
   vi.setSystemTime(FROZEN_NOW);
   mocks.toastError.mockReset();
   mocks.toastSuccess.mockReset();
-  globalThis.fetch = vi.fn(async (url, opts = {}) => {
-    const u = String(url);
-    if (/\/api\/v1\/maintenance-windows\/\d+\/(cancel|complete)$/.test(u)) {
-      return jsonRes({ ...WINDOWS[0], status: "cancelled" });
+  mocks.apiGet.mockReset();
+  mocks.apiPost.mockReset();
+  mocks.apiGet.mockImplementation(async () => ({
+    items: WINDOWS,
+    total: WINDOWS.length,
+  }));
+  mocks.apiPost.mockImplementation(async (path) => {
+    if (/\/api\/v1\/maintenance-windows\/\d+\/(cancel|complete)$/.test(path)) {
+      return { ...WINDOWS[0], status: "cancelled" };
     }
-    if (u.includes("/api/v1/maintenance-windows")) {
-      if (opts.method === "POST") {
-        return jsonRes({ id: 9, status: "scheduled" });
-      }
-      return jsonRes({ items: WINDOWS, total: WINDOWS.length });
+    if (path === "/api/v1/maintenance-windows") {
+      return { id: 9, status: "scheduled" };
     }
-    return jsonRes({});
+    return {};
   });
 });
 
@@ -106,7 +122,7 @@ describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
       screen.getByRole("heading", { name: "Log Maintenance" })
     ).toBeInTheDocument();
     // No window list fetched in log mode
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(mocks.apiGet).not.toHaveBeenCalled();
   });
 
   it("seeds the window start/end inputs with local wall time via toLocalInputValue", async () => {
@@ -161,15 +177,14 @@ describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
       );
     });
 
-    const [url, opts] = lastFetchMatching(/maintenance-windows$/, "POST") || [];
-    expect(url).toMatch(/\/api\/v1\/maintenance-windows$/);
-    expect(opts.method).toBe("POST");
-    const body = JSON.parse(opts.body);
-    expect(body.printer_id).toBe(1);
+    const [path, payload] =
+      lastPostMatching(/\/api\/v1\/maintenance-windows$/) || [];
+    expect(path).toBe("/api/v1/maintenance-windows");
+    expect(payload.printer_id).toBe(1);
     // The submit contract: new Date(localValue).toISOString()
-    expect(body.starts_at).toBe(new Date("2026-06-16T08:00").toISOString());
-    expect(body.ends_at).toBe(new Date("2026-06-16T12:30").toISOString());
-    expect(body.reason).toBe("Quarterly service");
+    expect(payload.starts_at).toBe(new Date("2026-06-16T08:00").toISOString());
+    expect(payload.ends_at).toBe(new Date("2026-06-16T12:30").toISOString());
+    expect(payload.reason).toBe("Quarterly service");
   });
 
   it("rejects an end time at or before the start time client-side", async () => {
@@ -194,9 +209,7 @@ describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
         "End time must be after start time"
       );
     });
-    expect(lastFetchMatching(/maintenance-windows$/)?.[1]?.method).not.toBe(
-      "POST"
-    );
+    expect(mocks.apiPost).not.toHaveBeenCalled();
   });
 
   it("lists upcoming windows with printer name, times, and reason", async () => {
@@ -233,9 +246,8 @@ describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
         "Maintenance window cancelled"
       );
     });
-    const [url, opts] = lastFetchMatching(/\/5\/cancel$/);
-    expect(url).toMatch(/\/api\/v1\/maintenance-windows\/5\/cancel$/);
-    expect(opts.method).toBe("POST");
+    const [path] = lastPostMatching(/\/5\/cancel$/);
+    expect(path).toBe("/api/v1/maintenance-windows/5/cancel");
     expect(onWindowsChanged).toHaveBeenCalled();
   });
 
@@ -258,24 +270,19 @@ describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
         "Maintenance window completed"
       );
     });
-    const [url, opts] = lastFetchMatching(/\/5\/complete$/);
-    expect(url).toMatch(/\/api\/v1\/maintenance-windows\/5\/complete$/);
-    expect(opts.method).toBe("POST");
+    const [path] = lastPostMatching(/\/5\/complete$/);
+    expect(path).toBe("/api/v1/maintenance-windows/5/complete");
     expect(onWindowsChanged).toHaveBeenCalled();
   });
 
   it("surfaces a backend overlap rejection as a toast error", async () => {
-    globalThis.fetch.mockImplementation(async (url, opts = {}) => {
-      const u = String(url);
-      if (u.includes("/api/v1/maintenance-windows") && opts.method === "POST") {
-        return {
-          ok: false,
-          json: async () => ({
-            detail: "Overlaps existing maintenance window #5",
-          }),
-        };
-      }
-      return jsonRes({ items: [], total: 0 });
+    // The shared client throws ApiError with message = response detail
+    mocks.apiGet.mockImplementation(async () => ({ items: [], total: 0 }));
+    mocks.apiPost.mockImplementation(async () => {
+      throw Object.assign(
+        new Error("Overlaps existing maintenance window #5"),
+        { name: "ApiError", status: 400 }
+      );
     });
 
     render(

--- a/frontend/src/components/printers/__tests__/MaintenanceModal.test.jsx
+++ b/frontend/src/components/printers/__tests__/MaintenanceModal.test.jsx
@@ -1,0 +1,300 @@
+/**
+ * MaintenanceModal — SCHED-7 "Schedule Window" tab tests.
+ *
+ * Verifies the datetime-local seeding contract (toLocalInputValue local
+ * wall time), the submit contract (new Date(local).toISOString()), and the
+ * upcoming-window list's cancel/complete actions.
+ */
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toLocalInputValue } from "../../../utils/formatting";
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+  },
+}));
+
+vi.mock("../../Toast", () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("../../Modal", () => ({
+  default: ({ children }) => <div role="dialog">{children}</div>,
+}));
+
+import MaintenanceModal from "../MaintenanceModal";
+
+const printers = [
+  { id: 1, name: "Bambu A1 Bay 1", code: "PRT-001" },
+  { id: 2, name: "Bambu P1S", code: "PRT-002" },
+];
+
+const WINDOWS = [
+  {
+    id: 5,
+    printer_id: 1,
+    resource_id: null,
+    starts_at: "2026-06-16T03:00:00",
+    ends_at: "2026-06-16T05:00:00",
+    reason: "Belt swap",
+    status: "scheduled",
+    maintenance_log_id: null,
+    created_by: "ops@blb3d.com",
+    created_at: "2026-06-15T00:00:00",
+  },
+];
+
+// Frozen clock so the datetime-local seeds are deterministic.
+const FROZEN_NOW = new Date(2026, 5, 15, 10, 0, 0);
+
+const jsonRes = (body) => ({ ok: true, json: async () => body });
+
+/**
+ * Find the last fetch call whose URL matches `re` (and, when given,
+ * whose method matches); returns [url, opts]. The method filter matters
+ * because a successful POST immediately triggers a list-refresh GET to
+ * the same collection URL.
+ */
+function lastFetchMatching(re, method) {
+  const calls = globalThis.fetch.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const [url, opts] = calls[i];
+    if (re.test(String(url)) && (!method || opts?.method === method)) {
+      return calls[i];
+    }
+  }
+  return null;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(FROZEN_NOW);
+  mocks.toastError.mockReset();
+  mocks.toastSuccess.mockReset();
+  globalThis.fetch = vi.fn(async (url, opts = {}) => {
+    const u = String(url);
+    if (/\/api\/v1\/maintenance-windows\/\d+\/(cancel|complete)$/.test(u)) {
+      return jsonRes({ ...WINDOWS[0], status: "cancelled" });
+    }
+    if (u.includes("/api/v1/maintenance-windows")) {
+      if (opts.method === "POST") {
+        return jsonRes({ id: 9, status: "scheduled" });
+      }
+      return jsonRes({ items: WINDOWS, total: WINDOWS.length });
+    }
+    return jsonRes({});
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("MaintenanceModal schedule-window tab (SCHED-7)", () => {
+  it("defaults to the Log Maintenance tab", () => {
+    render(
+      <MaintenanceModal printers={printers} onClose={vi.fn()} onSave={vi.fn()} />
+    );
+    expect(
+      screen.getByRole("heading", { name: "Log Maintenance" })
+    ).toBeInTheDocument();
+    // No window list fetched in log mode
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("seeds the window start/end inputs with local wall time via toLocalInputValue", async () => {
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    // Seeds MUST be the toLocalInputValue rendering of the frozen clock —
+    // local wall time, never toISOString().slice() (which shifts by the
+    // runner's UTC offset).
+    expect(screen.getByLabelText("Window start")).toHaveValue(
+      toLocalInputValue(FROZEN_NOW)
+    );
+    expect(screen.getByLabelText("Window end")).toHaveValue(
+      toLocalInputValue(new Date(FROZEN_NOW.getTime() + 60 * 60 * 1000))
+    );
+  });
+
+  it("submits the window as UTC ISO strings derived from the local inputs", async () => {
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText("Window start"), {
+      target: { value: "2026-06-16T08:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Window end"), {
+      target: { value: "2026-06-16T12:30" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Hotend swap/), {
+      target: { value: "Quarterly service" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Schedule Window" }));
+
+    await waitFor(() => {
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Maintenance window scheduled"
+      );
+    });
+
+    const [url, opts] = lastFetchMatching(/maintenance-windows$/, "POST") || [];
+    expect(url).toMatch(/\/api\/v1\/maintenance-windows$/);
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body);
+    expect(body.printer_id).toBe(1);
+    // The submit contract: new Date(localValue).toISOString()
+    expect(body.starts_at).toBe(new Date("2026-06-16T08:00").toISOString());
+    expect(body.ends_at).toBe(new Date("2026-06-16T12:30").toISOString());
+    expect(body.reason).toBe("Quarterly service");
+  });
+
+  it("rejects an end time at or before the start time client-side", async () => {
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText("Window end"), {
+      target: { value: toLocalInputValue(new Date(FROZEN_NOW.getTime() - 3600000)) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule Window" }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "End time must be after start time"
+      );
+    });
+    expect(lastFetchMatching(/maintenance-windows$/)?.[1]?.method).not.toBe(
+      "POST"
+    );
+  });
+
+  it("lists upcoming windows with printer name, times, and reason", async () => {
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+    const row = await screen.findByTestId("maintenance-window-5");
+    expect(row).toHaveTextContent("Bambu A1 Bay 1 (PRT-001)");
+    expect(row).toHaveTextContent("Belt swap");
+    expect(row).toHaveTextContent("Scheduled");
+  });
+
+  it("cancel posts to /{id}/cancel and notifies onWindowsChanged", async () => {
+    const onWindowsChanged = vi.fn();
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onWindowsChanged={onWindowsChanged}
+      />
+    );
+    const row = await screen.findByTestId("maintenance-window-5");
+    fireEvent.click(within(row).getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Maintenance window cancelled"
+      );
+    });
+    const [url, opts] = lastFetchMatching(/\/5\/cancel$/);
+    expect(url).toMatch(/\/api\/v1\/maintenance-windows\/5\/cancel$/);
+    expect(opts.method).toBe("POST");
+    expect(onWindowsChanged).toHaveBeenCalled();
+  });
+
+  it("complete posts to /{id}/complete (server writes the MaintenanceLog)", async () => {
+    const onWindowsChanged = vi.fn();
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+        onWindowsChanged={onWindowsChanged}
+      />
+    );
+    const row = await screen.findByTestId("maintenance-window-5");
+    fireEvent.click(within(row).getByRole("button", { name: "Complete" }));
+
+    await waitFor(() => {
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        "Maintenance window completed"
+      );
+    });
+    const [url, opts] = lastFetchMatching(/\/5\/complete$/);
+    expect(url).toMatch(/\/api\/v1\/maintenance-windows\/5\/complete$/);
+    expect(opts.method).toBe("POST");
+    expect(onWindowsChanged).toHaveBeenCalled();
+  });
+
+  it("surfaces a backend overlap rejection as a toast error", async () => {
+    globalThis.fetch.mockImplementation(async (url, opts = {}) => {
+      const u = String(url);
+      if (u.includes("/api/v1/maintenance-windows") && opts.method === "POST") {
+        return {
+          ok: false,
+          json: async () => ({
+            detail: "Overlaps existing maintenance window #5",
+          }),
+        };
+      }
+      return jsonRes({ items: [], total: 0 });
+    });
+
+    render(
+      <MaintenanceModal
+        printers={printers}
+        initialMode="schedule"
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule Window" }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Overlaps existing maintenance window #5"
+      );
+    });
+  });
+});

--- a/frontend/src/components/printers/__tests__/PrinterCard.test.jsx
+++ b/frontend/src/components/printers/__tests__/PrinterCard.test.jsx
@@ -1,0 +1,81 @@
+/**
+ * PrinterCard — SCHED-7 upcoming maintenance-window badge tests.
+ *
+ * The card is a pure component (no hooks), so no harness mocks are needed.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import PrinterCard from "../PrinterCard";
+
+const basePrinter = {
+  id: 1,
+  name: "Bambu A1 Bay 1",
+  code: "PRT-001",
+  brand: "bambulab",
+  model: "A1",
+  status: "idle",
+};
+
+describe("PrinterCard maintenance-window badge (SCHED-7)", () => {
+  it("renders no window badge when upcomingMaintenanceWindow is absent", () => {
+    render(<PrinterCard printer={basePrinter} />);
+    expect(
+      screen.queryByTestId("maintenance-window-badge")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows 'Maint Scheduled' for a scheduled window with times + reason in the tooltip", () => {
+    render(
+      <PrinterCard
+        printer={basePrinter}
+        upcomingMaintenanceWindow={{
+          id: 5,
+          starts_at: "2026-06-16T03:00:00",
+          ends_at: "2026-06-16T05:00:00",
+          reason: "Belt swap",
+          status: "scheduled",
+        }}
+      />
+    );
+    const badge = screen.getByTestId("maintenance-window-badge");
+    expect(badge).toHaveTextContent("Maint Scheduled");
+    expect(badge.title).toContain("Belt swap");
+    expect(badge.title).toMatch(/Maintenance window .+ → .+/);
+  });
+
+  it("shows 'In Maintenance' when the window is in progress", () => {
+    render(
+      <PrinterCard
+        printer={{ ...basePrinter, status: "maintenance" }}
+        upcomingMaintenanceWindow={{
+          id: 6,
+          starts_at: "2026-06-15T08:00:00",
+          ends_at: "2026-06-15T12:00:00",
+          reason: null,
+          status: "in_progress",
+        }}
+      />
+    );
+    expect(screen.getByTestId("maintenance-window-badge")).toHaveTextContent(
+      "In Maintenance"
+    );
+  });
+
+  it("window badge coexists with the SCHED-4 due-soon badge", () => {
+    render(
+      <PrinterCard
+        printer={basePrinter}
+        maintenanceDueSoon
+        upcomingMaintenanceWindow={{
+          id: 7,
+          starts_at: "2026-06-16T03:00:00",
+          ends_at: "2026-06-16T05:00:00",
+          reason: "Nozzle change",
+          status: "scheduled",
+        }}
+      />
+    );
+    expect(screen.getByTestId("maintenance-due-badge")).toBeInTheDocument();
+    expect(screen.getByTestId("maintenance-window-badge")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/production/SchedulerBoard.jsx
+++ b/frontend/src/components/production/SchedulerBoard.jsx
@@ -154,6 +154,44 @@ function OperationBlock({ op, windowStart, windowEnd, onClick }) {
   );
 }
 
+// SCHED-7: shared stripe pattern for maintenance blocks (amber diagonal).
+const MAINTENANCE_STRIPES =
+  "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.28) 0 6px, rgba(245, 158, 11, 0.08) 6px 12px)";
+
+function MaintenanceWindowBlock({ win, windowStart, windowEnd }) {
+  // Same naive-UTC convention as OperationBlock.
+  const start = parseDateTime(win.starts_at);
+  const end = parseDateTime(win.ends_at);
+  const left = pctOf(start, windowStart, windowEnd);
+  const right = pctOf(end, windowStart, windowEnd);
+  const width = Math.max(right - left, 0.6);
+
+  const fmt = (d) =>
+    d.toLocaleString(undefined, {
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+  return (
+    <div
+      data-testid={`gantt-window-${win.id}`}
+      title={`Maintenance — ${win.reason || "scheduled downtime"}\n${fmt(start)} → ${fmt(
+        end
+      )} · ${win.status.replace(/_/g, " ")}`}
+      className={`absolute top-0 bottom-0 rounded-sm border-x border-amber-500/50 ${
+        win.status === "completed" ? "opacity-40" : ""
+      }`}
+      style={{
+        left: `${left}%`,
+        width: `${width}%`,
+        backgroundImage: MAINTENANCE_STRIPES,
+      }}
+    />
+  );
+}
+
 export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 }) {
   const api = useApi();
   const [viewMode, setViewMode] = useState("day");
@@ -303,6 +341,13 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
           On hold
         </span>
         <span className="flex items-center gap-1.5">
+          <span
+            className="w-3 h-3 rounded-sm border border-amber-500/50"
+            style={{ backgroundImage: MAINTENANCE_STRIPES }}
+          />
+          Maintenance
+        </span>
+        <span className="flex items-center gap-1.5">
           <span className="w-0.5 h-3 bg-red-500" />
           Now
         </span>
@@ -413,6 +458,18 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                             data-testid="now-line"
                           />
                         )}
+                        {/* Maintenance window blocks (SCHED-7) — render
+                            BEFORE operation blocks so ops paint above and
+                            stay clickable; windows are non-operational
+                            background blocks (no click-through). */}
+                        {(lane.windows || []).map((win) => (
+                          <MaintenanceWindowBlock
+                            key={`win-${win.id}`}
+                            win={win}
+                            windowStart={start}
+                            windowEnd={end}
+                          />
+                        ))}
                         {/* Operation blocks */}
                         {lane.operations.map((op) => (
                           <OperationBlock

--- a/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
+++ b/frontend/src/components/production/__tests__/SchedulerBoard.test.jsx
@@ -41,6 +41,7 @@ const BOARD = {
       status: "available",
       work_center_code: "FDM-POOL",
       utilization_percent: 25.0,
+      windows: [],
       operations: [
         {
           id: 11,
@@ -69,6 +70,16 @@ const BOARD = {
       status: "maintenance",
       work_center_code: null,
       utilization_percent: 0,
+      // SCHED-7: blocking maintenance window 4h→10h on the day axis
+      windows: [
+        {
+          id: 7,
+          starts_at: at(4),
+          ends_at: at(10),
+          reason: "Hotend swap",
+          status: "in_progress",
+        },
+      ],
       operations: [],
     },
   ],
@@ -250,6 +261,41 @@ describe("SchedulerBoard", () => {
     await waitFor(() => {
       expect(mocks.get.mock.calls.length).toBeGreaterThan(callsBefore);
     });
+  });
+
+  it("renders maintenance window blocks as amber striped non-op blocks (SCHED-7)", async () => {
+    const onSchedule = vi.fn();
+    render(<SchedulerBoard onScheduleOperation={onSchedule} />);
+    const block = await screen.findByTestId("gantt-window-7");
+
+    // 4h→10h on a 24h axis = left 16.67%, width 25%
+    expect(parseFloat(block.style.left)).toBeCloseTo(16.67, 1);
+    expect(parseFloat(block.style.width)).toBeCloseTo(25, 1);
+
+    // Striped amber background, not a button — clicking never opens the
+    // scheduler modal (windows are non-operational blocks).
+    expect(block.style.backgroundImage).toContain("repeating-linear-gradient");
+    expect(block.tagName).not.toBe("BUTTON");
+    fireEvent.click(block);
+    expect(onSchedule).not.toHaveBeenCalled();
+
+    // Tooltip carries the reason
+    expect(block.title).toContain("Hotend swap");
+  });
+
+  it("includes a Maintenance legend entry (SCHED-7)", async () => {
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+    await screen.findByText("FDM-01");
+    expect(screen.getByText("Maintenance")).toBeInTheDocument();
+  });
+
+  it("tolerates lanes without a windows array (older payloads)", async () => {
+    mocks.get.mockResolvedValue({
+      ...BOARD,
+      lanes: [{ ...BOARD.lanes[0], windows: undefined }],
+    });
+    render(<SchedulerBoard onScheduleOperation={vi.fn()} />);
+    expect(await screen.findByText("FDM-01")).toBeInTheDocument();
   });
 
   it("shows the error banner when the fetch fails", async () => {

--- a/frontend/src/pages/admin/AdminPrinters.jsx
+++ b/frontend/src/pages/admin/AdminPrinters.jsx
@@ -43,6 +43,10 @@ export default function AdminPrinters() {
   const [maintenanceLogs, setMaintenanceLogs] = useState([]);
   const [maintenanceDue, setMaintenanceDue] = useState({ printers: [], total_overdue: 0, total_due_soon: 0 });
   const [maintenanceLoading, setMaintenanceLoading] = useState(false);
+  // SCHED-7: blocking maintenance windows (for PrinterCard badges)
+  const [maintenanceWindows, setMaintenanceWindows] = useState([]);
+  // Which tab the MaintenanceModal opens on: "log" | "schedule"
+  const [maintenanceModalMode, setMaintenanceModalMode] = useState("log");
 
   // Discovery state
   const [discovering, setDiscovering] = useState(false);
@@ -75,6 +79,7 @@ export default function AdminPrinters() {
     fetchBrandInfo();
     fetchActiveWork();
     fetchMaintenanceDue();
+    fetchMaintenanceWindows();
 
     // Poll for active work every 30 seconds
     const interval = setInterval(fetchActiveWork, 30000);
@@ -87,6 +92,7 @@ export default function AdminPrinters() {
     } else if (activeTab === "maintenance") {
       fetchMaintenanceLogs();
       fetchMaintenanceDue();
+      fetchMaintenanceWindows();
     }
   }, [activeTab, filters.brand, filters.status]);
 
@@ -207,6 +213,18 @@ export default function AdminPrinters() {
     try {
       const data = await api.get(`/api/v1/maintenance/due?days_ahead=14`);
       setMaintenanceDue(data);
+    } catch {
+      // Non-critical
+    }
+  };
+
+  // SCHED-7: blocking (scheduled / in_progress) maintenance windows —
+  // drives the "Maint Scheduled" badge on PrinterCard. Backend returns
+  // them sorted by starts_at, so find() yields the earliest per printer.
+  const fetchMaintenanceWindows = async () => {
+    try {
+      const data = await api.get(`/api/v1/maintenance-windows`);
+      setMaintenanceWindows(data.items || []);
     } catch {
       // Non-critical
     }
@@ -581,6 +599,11 @@ export default function AdminPrinters() {
                     maintenanceDueSoon={maintenanceDue.printers.some(
                       (p) => p.printer_id === printer.id
                     )}
+                    upcomingMaintenanceWindow={
+                      maintenanceWindows.find(
+                        (w) => w.printer_id === printer.id
+                      ) || null
+                    }
                   />
                 ))}
               </div>
@@ -949,21 +972,38 @@ export default function AdminPrinters() {
             </div>
           )}
 
-          {/* Log Maintenance Button */}
+          {/* Log Maintenance / Schedule Window Buttons */}
           <div className="flex justify-between items-center">
             <h2 className="text-lg font-medium text-white">Maintenance History</h2>
-            <button
-              onClick={() => {
-                setSelectedPrinter(null);
-                setShowMaintenanceModal(true);
-              }}
-              className="bg-orange-600 hover:bg-orange-500 text-white px-4 py-2 rounded-lg flex items-center gap-2"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              Log Maintenance
-            </button>
+            <div className="flex gap-2">
+              <button
+                onClick={() => {
+                  setSelectedPrinter(null);
+                  setMaintenanceModalMode("schedule");
+                  setShowMaintenanceModal(true);
+                }}
+                className="border border-orange-600/60 text-orange-400 hover:text-orange-300 hover:border-orange-500 px-4 py-2 rounded-lg flex items-center gap-2"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                Schedule Window
+              </button>
+              <button
+                onClick={() => {
+                  setSelectedPrinter(null);
+                  setMaintenanceModalMode("log");
+                  setShowMaintenanceModal(true);
+                }}
+                className="bg-orange-600 hover:bg-orange-500 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Log Maintenance
+              </button>
+            </div>
           </div>
 
           {/* Maintenance Logs Table */}
@@ -1058,6 +1098,7 @@ export default function AdminPrinters() {
         <MaintenanceModal
           printers={printers}
           selectedPrinterId={selectedPrinter?.id}
+          initialMode={maintenanceModalMode}
           onClose={() => {
             setShowMaintenanceModal(false);
             setSelectedPrinter(null);
@@ -1067,6 +1108,13 @@ export default function AdminPrinters() {
             setSelectedPrinter(null);
             fetchMaintenanceLogs();
             fetchMaintenanceDue();
+          }}
+          onWindowsChanged={() => {
+            // SCHED-7: keep card badges + due summary in sync as windows
+            // are scheduled / cancelled / completed (modal stays open).
+            fetchMaintenanceWindows();
+            fetchMaintenanceDue();
+            fetchMaintenanceLogs();
           }}
         />
       )}


### PR DESCRIPTION
## Summary

SCHED-7 per `docs/plans/2026-06-11-scheduling-dispatch-plan.md`: planned maintenance becomes a first-class time block that the scheduling engine, dispatcher, printer status, and UI all respect. Resumes and completes work from a prior agent session (backend inherited + verified; frontend added in this session).

## Model + migration

- `maintenance_windows` table (migration **092**, `down_revision='091'`, single head verified via `alembic heads`): `printer_id` XOR `resource_id` (DB CHECK, mirroring the engine's `is_printer` duality), naive-UTC `starts_at`/`ends_at` with `ends_at > starts_at` CHECK, `reason`, `status` (`scheduled → in_progress → completed | cancelled`), `maintenance_log_id` FK (SET NULL), composite indexes on (printer_id, starts_at) / (resource_id, starts_at) + status.
- Completing a window writes a `MaintenanceLog` (printer windows; downtime = elapsed window span clipped to now, operator-supplied `next_due_at` recorded on the log so `/maintenance/due` recalculates) and links it via `maintenance_log_id`. Resource windows just close (`maintenance_logs.printer_id` is NOT NULL).

## Engine design choice (as implemented)

`find_conflicts`' return type (list of `ProductionOrderOperation`) is a public contract used by several endpoints — it is **unchanged**. Windows are checked by a **parallel `find_window_conflicts`** consulted by all call sites:

- `schedule_operation` raises a typed `MaintenanceWindowConflictError` (carries `.windows`) instead of mixing windows into the operation-conflict list.
- Call sites surface it with a `type: "maintenance"` discriminator (`/scheduling/conflicts` items carry `type: "operation" | "maintenance"`; `ScheduleOperationResponse`/`RescheduleResponse` gained `conflict_type: "maintenance"`; `ConflictCheckResponse` gained an additive `maintenance_windows` list also counted in `has_conflicts`).
- `find_next_available_slot` merges scheduled ops + blocking windows into one sorted busy-interval sweep, so suggested slots already skip past maintenance blocks.

## Dispatch

- Printers inside an **active** blocking window are excluded from suggestions and `dispatch_operation` refuses assignment (independent of the status field, in case the lazy sync hasn't run).
- Jobs whose estimated duration overlaps an **upcoming** window get `maintenance_warning` naming the window start — warn only, never auto-dispatch/skip; the `next_due_at` heuristic is kept as fallback when no windows exist.

## Status-flip seam

There is no reliable background poll seam (the MQTT monitor only covers connected Bambu printers and overwrites status from telemetry), so `sync_printer_maintenance_status(db)` runs **lazily from the two surfaces that display printer status**: `GET /dispatch/suggestions` and `GET /scheduling/board`. It advances `scheduled → in_progress` and flips printers `idle/available → maintenance` when a window opens; when the window end passes it restores `maintenance → idle` (only if no other window is active). It **never clobbers offline/printing/error**. Window status stays `in_progress` past its end until the operator explicitly completes/cancels — elapsed time isn't proof the work was done. Documented in the service module docstring.

## UI surfaces

- **MaintenanceModal**: new "Schedule Window" tab — printer select, start/end `datetime-local` inputs seeded **only** via `toLocalInputValue` (local wall time) and submitted as `new Date(local).toISOString()`, reason; plus an upcoming-window list with Cancel / Complete actions (complete uses server defaults; the detailed log form stays on the Log tab).
- **PrinterCard**: "Maint Scheduled" / "In Maintenance" amber badge for the printer's next blocking window (tooltip carries local times + reason), coexists with the SCHED-4 due-soon badge.
- **SchedulerBoard**: lane `windows[]` (returned by the board endpoint **in the same single call**, one extra query server-side) render as amber **striped non-operational blocks** behind operation blocks — not clickable, tooltip with reason/times; completed windows dimmed; Maintenance legend entry added.
- **AdminPrinters**: fetches blocking windows for card badges, "Schedule Window" button on the Maintenance tab, keeps badges/logs/due summary in sync via `onWindowsChanged`.

## Tests

- Backend: **205 passed** across all touched suites (`test_maintenance_windows_api` 10, `test_maintenance_window_service` 33 — both new — plus `test_operation_status_scheduling`, `test_production_orders`, `test_reschedule_unschedule`, `test_auto_dispatch`, `test_dispatch_service`, `test_resource_scheduling`). `ruff check app/` clean. `alembic heads` = single head `092`.
- Frontend: **459 passed (51 files)** full `npm run test:unit` — 15 new (MaintenanceModal 8, PrinterCard 4, SchedulerBoard +3). `npm run build` green.

## Notes

- One `react-hooks/set-state-in-effect` lint finding on the modal's fetch-on-tab-open effect matches SchedulerBoard's existing fetch-on-mount pattern (repo has 209 pre-existing findings; CI lint is non-blocking).
- Migration is additive only; do not stamp — apply normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance window scheduling for printers and resources (create/list/cancel/complete)
  * Scheduler and dispatch respect maintenance windows (block suggestions, show warnings)
  * Auto-status updates flip printers to/from maintenance during active windows
  * UI: schedule/view/complete/cancel windows from Maintenance modal and Admin printers
  * Visuals: maintenance badges on printer cards and striped blocks on scheduler board
<!-- end of auto-generated comment: release notes by coderabbit.ai -->