### PR TITLE
docs: AGENT_POLICY file-size limits (DEBT-1 regrowth prevention)

### DIFF
--- a/AGENT_POLICY.md
+++ b/AGENT_POLICY.md
@@ -100,6 +100,19 @@ Comply with hook and CI feedback instead of routing around it.
 - When renaming or changing a contract, search direct calls, type references,
   string literals, dynamic imports, re-exports, tests, and mocks.
 
+### File-Size Limits (DEBT-1, owner-approved 2026-06-12)
+
+- New functionality goes in NEW modules by default — "match the surrounding
+  file" governs style, not placement.
+- Files over 1,200 lines (backend Python) or 800 lines (frontend
+  components/pages) must NOT accept new responsibilities. Extract the area
+  you are touching into a focused module first, or split as part of the
+  change.
+- Mechanical splits are always SEPARATE PRs from behavior changes — never
+  mix moves with logic edits in one diff.
+- The decomposition backlog and split conventions live in
+  docs/plans/2026-06-12-god-file-decomposition.md.
+
 ## Core Vs PRO Architecture
 
 ```text


### PR DESCRIPTION
The Wave-1 policy rider from the DEBT-1 plan (docs/plans/2026-06-12-god-file-decomposition.md): new functionality defaults to new modules; files >1,200 lines (backend) / >800 (frontend components) stop accepting new responsibilities; mechanical splits never mix with behavior changes. Agents read AGENT_POLICY.md on every dispatch, so this is where the rule compounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)