### PR TITLE
chore: env-driven dev seed credentials; exclude walkthrough from CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Portal quote checkout flow now keeps auto-priced quotes `approved` until payment succeeds instead of marking them `accepted` when checkout starts or fails.
 - Portal multi-color print selections are snapshotted to `QuoteMaterial` rows so selected red/yellow/black slot colors do not collapse back to the default single color.
 
+### Security
+
+- Dev seed data and the walkthrough E2E suite no longer hardcode an admin password. Credentials are read from `SEED_ADMIN_PASSWORD` / `WALKTHROUGH_PASSWORD`; when unset, the seed script generates a random password and prints it once. The `walkthrough` Playwright project is also excluded from CI runs (#748).
+
 ## [4.0.0] - 2026-04-14
 
 ### Added

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,17 @@ ENVIRONMENT=development
 DEBUG=false
 
 # ===========================================
+# DEV SEED DATA (Optional — local dev only)
+# ===========================================
+# Credentials for the admin user created by `python -m scripts.seed_dev_data`.
+# Leave SEED_ADMIN_PASSWORD unset and the script generates a random password,
+# printed once on seed. Set it to pin a stable password for repeat logins or
+# E2E runs (the walkthrough suite reads WALKTHROUGH_EMAIL / WALKTHROUGH_PASSWORD).
+# Never use these for anything but a local dev database.
+# SEED_ADMIN_EMAIL=admin@filaops.dev
+# SEED_ADMIN_PASSWORD=
+
+# ===========================================
 # CORS (Required for frontend)
 # ===========================================
 # Comma-separated list of allowed origins

--- a/backend/scripts/seed_dev_data.py
+++ b/backend/scripts/seed_dev_data.py
@@ -26,7 +26,9 @@ Safety:
     - --reset prompts for confirmation before truncating
 """
 
+import os
 import sys
+import secrets
 import argparse
 from pathlib import Path
 from datetime import datetime, timezone, timedelta, date
@@ -38,6 +40,16 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from app.db.session import SessionLocal, engine
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dev admin credentials — resolved from env, never committed to source.
+# Set SEED_ADMIN_PASSWORD to pin a stable password (e.g. for repeat logins or
+# E2E runs); otherwise a random one is generated and printed once on seed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+ADMIN_EMAIL = os.environ.get("SEED_ADMIN_EMAIL", "admin@filaops.dev")
+ADMIN_PASSWORD = os.environ.get("SEED_ADMIN_PASSWORD") or secrets.token_urlsafe(12)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -255,8 +267,8 @@ def seed_admin_user(db: Session):
     from app.core.security import hash_password
 
     admin = User(
-        email="admin@filaops.dev",
-        password_hash=hash_password("FilaOps2026!"),
+        email=ADMIN_EMAIL,
+        password_hash=hash_password(ADMIN_PASSWORD),
         first_name="Admin",
         last_name="User",
         account_type="admin",
@@ -265,7 +277,7 @@ def seed_admin_user(db: Session):
     )
     db.add(admin)
     db.flush()
-    print("  Admin user: admin@filaops.dev / FilaOps2026!")
+    print(f"  Admin user: {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
     return admin
 
 
@@ -1504,7 +1516,7 @@ def main():
         db.commit()
 
         print("\n-- Summary -----------------------------------------------------")
-        print("  Login:  admin@filaops.dev / FilaOps2026!")
+        print(f"  Login:  {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
         print("  Data includes:")
         print("    -14 raw materials (filament with G/KG UOM)")
         print("    -11 components & packaging (EA)")

--- a/backend/scripts/seed_dev_data.py
+++ b/backend/scripts/seed_dev_data.py
@@ -46,10 +46,14 @@ from app.db.session import SessionLocal, engine
 # Dev admin credentials — resolved from env, never committed to source.
 # Set SEED_ADMIN_PASSWORD to pin a stable password (e.g. for repeat logins or
 # E2E runs); otherwise a random one is generated and printed once on seed.
+# A generated password is echoed exactly once (at admin creation); an
+# env-provided password is never echoed back (the caller already has it).
 # ─────────────────────────────────────────────────────────────────────────────
 
 ADMIN_EMAIL = os.environ.get("SEED_ADMIN_EMAIL", "admin@filaops.dev")
-ADMIN_PASSWORD = os.environ.get("SEED_ADMIN_PASSWORD") or secrets.token_urlsafe(12)
+_seed_admin_password = os.environ.get("SEED_ADMIN_PASSWORD")
+ADMIN_PASSWORD = _seed_admin_password or secrets.token_urlsafe(12)
+ADMIN_PASSWORD_WAS_GENERATED = not _seed_admin_password
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -277,7 +281,11 @@ def seed_admin_user(db: Session):
     )
     db.add(admin)
     db.flush()
-    print(f"  Admin user: {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
+    if ADMIN_PASSWORD_WAS_GENERATED:
+        # Echo the generated password exactly once so the dev can log in.
+        print(f"  Admin user: {ADMIN_EMAIL} / {ADMIN_PASSWORD}  (generated — save this)")
+    else:
+        print(f"  Admin user: {ADMIN_EMAIL}  (password from SEED_ADMIN_PASSWORD)")
     return admin
 
 
@@ -1516,7 +1524,9 @@ def main():
         db.commit()
 
         print("\n-- Summary -----------------------------------------------------")
-        print(f"  Login:  {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
+        # Don't re-print the secret here; it was echoed once at admin creation
+        # (when generated) or supplied by the caller via SEED_ADMIN_PASSWORD.
+        print(f"  Login:  {ADMIN_EMAIL}  (password shown above / SEED_ADMIN_PASSWORD)")
         print("  Data includes:")
         print("    -14 raw materials (filament with G/KG UOM)")
         print("    -11 components & packaging (EA)")

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -42,12 +42,19 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
-    // Walkthrough — self-contained auth, no setup dependency
-    {
-      name: 'walkthrough',
-      testMatch: /walkthrough-screenshots\.spec\.ts/,
-      use: { ...devices['Desktop Chrome'] },
-    },
+    // Walkthrough — self-contained auth, no setup dependency.
+    // Excluded from default CI runs: it depends on a locally-seeded dev
+    // environment. Opt in by running `npx playwright test --project=walkthrough`
+    // (or `npm run test:walkthrough`) outside CI.
+    ...(process.env.CI
+      ? []
+      : [
+          {
+            name: 'walkthrough',
+            testMatch: /walkthrough-screenshots\.spec\.ts/,
+            use: { ...devices['Desktop Chrome'] },
+          },
+        ]),
   ],
 
   // Docker containers should be running before tests

--- a/frontend/tests/e2e/pages/walkthrough-screenshots.spec.ts
+++ b/frontend/tests/e2e/pages/walkthrough-screenshots.spec.ts
@@ -22,8 +22,8 @@ import * as fs from 'fs';
 // Config
 // ---------------------------------------------------------------------------
 
-const DEV_EMAIL = 'admin@filaops.dev';
-const DEV_PASSWORD = 'FilaOps2026!';
+const DEV_EMAIL = process.env.WALKTHROUGH_EMAIL ?? 'admin@filaops.dev';
+const DEV_PASSWORD = process.env.WALKTHROUGH_PASSWORD ?? '';
 const SCREENSHOT_DIR = 'docs/screenshots/walkthrough';
 const API_BASE = 'http://localhost:8000';
 
@@ -130,6 +130,15 @@ test.describe.serial('Customer Walkthrough', () => {
       baseURL: process.env.BASE_URL || 'http://localhost:5173',
     });
     page = await context.newPage();
+
+    // Credentials must be supplied via env — no secrets committed to the repo.
+    if (!DEV_PASSWORD) {
+      throw new Error(
+        'WALKTHROUGH_PASSWORD env var is not set. Set WALKTHROUGH_EMAIL and ' +
+          'WALKTHROUGH_PASSWORD to your local dev seed credentials before running ' +
+          'the walkthrough suite.'
+      );
+    }
 
     // Login with dev seed credentials
     await page.goto('/admin/login');


### PR DESCRIPTION
## Summary
- Remove the hardcoded dev admin password (`FilaOps2026!`) that GitGuardian flags; resolve it from env with a random fallback that is printed once, only when generated.
- Make the walkthrough E2E suite read credentials from env, and exclude it from CI (it needs a locally-seeded dev DB).

## Related Issues
<!-- None — proactive security hygiene. -->

## Changes
- `backend/scripts/seed_dev_data.py` — admin creds resolved from `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD`; a random `secrets.token_urlsafe(12)` is used when unset and echoed **exactly once** at admin creation. An env-provided password is never echoed back.
- `frontend/tests/e2e/pages/walkthrough-screenshots.spec.ts` — credentials read from `WALKTHROUGH_EMAIL` / `WALKTHROUGH_PASSWORD`; throws a clear, actionable error if the password is unset.
- `frontend/playwright.config.ts` — spread-excludes the `walkthrough` project when `CI` is set, so `npx playwright test` no longer runs the locally-seeded suite in CI.
- `backend/.env.example` — documents the new optional `SEED_ADMIN_*` vars (local dev only).
- `CHANGELOG.md` — `[Unreleased] > Security` entry.

## Testing
- [ ] Manual browser validation (eyes and mouse) — N/A (no UI/runtime behavior change)
- [ ] API endpoint tested — N/A (no endpoint change)
- [ ] Fresh database tested — seed **not** run against a live DB in this change; `python -m py_compile` is clean and the credential/print logic was reviewed. CI `core-backend-tests` and `core-frontend-build` pass.

## Checklist
- [x] No secrets or business data committed — removes the only hardcoded credential; repo-wide `grep FilaOps2026` returns zero
- [x] No PRO code in core changes — `core-pro-guard` passes
- [x] Tested on Windows (if backend/seed changes) — `py_compile` verified on Windows (seed not executed against a DB)

> Note: these are **local-dev-only** credentials, never used in production — nothing to rotate.

## Follow-up (separate PR)
`frontend/tests/e2e/config.ts` and several flow specs still hardcode a different dev password (`TestPass123!`) — same class of finding, worth a focused cleanup.
