### PR TITLE
fix(license): tolerate missing activated_at in license cache reader

### DIFF
--- a/backend/app/core/license_cache.py
+++ b/backend/app/core/license_cache.py
@@ -110,7 +110,7 @@ class LicenseCache:
         the upgraded shape must call ``save_license_cache`` on the
         returned object.
         """
-        activated_at = data["activated_at"]
+        activated_at = data.get("activated_at") or EPOCH_ZERO_ISO
         # For legacy files, anchor the upgrade window at "now" rather
         # than at activated_at (see class docstring).
         upgrade_anchor_iso = utc_now_iso()


### PR DESCRIPTION
LicenseCache.from_dict() read `activated_at` with a hard data["activated_at"] lookup while every other field uses .get() with a default. PRO's heartbeat rewrites license.json every ~6h without `activated_at`, so the KeyError is caught and the license is treated as absent — a valid Professional install displays as Community even while the PRO heartbeat reports active.

Default to EPOCH_ZERO_ISO, matching last_server_timestamp and from_dict's docstring intent. Verified against a copy of production data: the cache now loads and reports tier=professional.

## Summary
<!-- What does this PR do? 1-3 bullet points. -->

## Related Issues
<!-- Closes #XX, Fixes #XX -->

## Changes
<!-- List key file changes -->

## Testing
- [ ] Manual browser validation (eyes and mouse)
- [ ] API endpoint tested
- [ ] Fresh database tested

## Checklist
- [ ] No secrets or business data committed
- [ ] No PRO code in core changes
- [ ] Tested on Windows (if backend/seed changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issue when loading legacy licenses with missing or malformed activation date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->