### PR TITLE
docs: fix broken anchor link in troubleshooting guide

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -75,7 +75,7 @@ The `email-validator` library rejects `.local` domains (RFC 6762 reserved). If y
 
 ### Forgot password but SMTP is not configured
 
-When SMTP is not set up, the password reset flow auto-approves and displays the reset link directly on the Forgot Password page. No email is needed. See the [First-Run Setup Guide](../FIRST-RUN-SETUP.md#without-smtp-configured-development-mode) for details.
+When SMTP is not set up, the password reset flow auto-approves and displays the reset link directly on the Forgot Password page. No email is needed. See the [First-Run Setup Guide](../FIRST-RUN-SETUP.md#without-smtp-configured) for details.
 
 ### Locked out of admin account on a dev database
 


### PR DESCRIPTION
## What

Fix a broken anchor link in the user-guide troubleshooting page that kept `mkdocs build --strict` from producing a fully clean build.

The **"Forgot password but SMTP is not configured"** entry linked to:

```
../FIRST-RUN-SETUP.md#without-smtp-configured-development-mode
```

but the heading in `FIRST-RUN-SETUP.md` is **"Without SMTP Configured"**, whose generated anchor is `#without-smtp-configured`. The stale `-development-mode` suffix made the cross-reference resolve to nothing.

## Why it matters

The docs ship via `mkdocs build --strict` (.github/workflows/docs.yml). MkDocs reports this mismatch as a link diagnostic, so the build is never fully clean. The link also silently dropped readers at the top of the page instead of the intended section.

## Fix

One-line change in docs/user-guide/troubleshooting.md: drop the `-development-mode` suffix so the anchor matches the real heading.

## Verification

`mkdocs build --strict` run locally before and after:

- **Before:** MkDocs emits `... contains a link '../FIRST-RUN-SETUP.md#without-smtp-configured-development-mode', but the doc 'FIRST-RUN-SETUP.md' does not contain an anchor ...`
- **After:** exit `0`, no anchor/link diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the troubleshooting guide to link to the correct section for password reset issues when SMTP is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->