### PR TITLE
feat(intake): wizard UX — cost-before-price, parts-on-plate, editable SKU, back/edit

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
@@ -84,9 +84,16 @@ export default function AdminIntakeStudio() {
   // Step 4 — new UX state
   const [partsOnPlate, setPartsOnPlate] = useState(1);
   const [skuCode, setSkuCode] = useState("");
+  const [skuEdited, setSkuEdited] = useState(false);
   const [estimatedCost, setEstimatedCost] = useState(null);
   const [previewBusy, setPreviewBusy] = useState(false);
   const [priceEdited, setPriceEdited] = useState(false);
+
+  // Guards against stale /preview responses overwriting newer state, and a
+  // ref mirror of priceEdited so the async runPreview closure reads the live
+  // value rather than a stale capture. (No useEffect — Core eslint forbids it.)
+  const previewRequestIdRef = useRef(0);
+  const priceEditedRef = useRef(false);
 
   // Step 5 — Result
   const [skuResult, setSkuResult] = useState(null);
@@ -269,8 +276,8 @@ export default function AdminIntakeStudio() {
       if (mappedWcId) {
         setPrintWorkCenterId(mappedWcId);
       }
-      // Seed SKU code from product name if not already set
-      if (!skuCode && productName) {
+      // Seed SKU code from product name unless the operator has edited it
+      if (!skuEdited && productName) {
         setSkuCode(buildSuggestedSku(productName));
       }
       setStep(4);
@@ -300,12 +307,14 @@ export default function AdminIntakeStudio() {
         parts_on_plate: partsOnPlate,
         sku: skuCode || undefined,
         slots: buildSlotsPayload(),
-        finishing_ops: finishingOps.map((o) => ({
-          work_center_id: Number(o.work_center_id),
-          operation_name: o.operation_name,
-          run_time_minutes: Number(o.run_time_minutes) || 0,
-          setup_time_minutes: Number(o.setup_time_minutes) || 0,
-        })),
+        finishing_ops: finishingOps
+          .filter((o) => o.work_center_id)
+          .map((o) => ({
+            work_center_id: Number(o.work_center_id),
+            operation_name: o.operation_name,
+            run_time_minutes: Number(o.run_time_minutes) || 0,
+            setup_time_minutes: Number(o.setup_time_minutes) || 0,
+          })),
         packaging: [],
         persist_color_map: true,
       };
@@ -342,6 +351,8 @@ export default function AdminIntakeStudio() {
     const parts = overrides.partsOnPlate ?? partsOnPlate;
     const ops = overrides.finishingOps ?? finishingOps;
     if (!wcId || !parseResult) return;
+    // Token this request; a newer call invalidates anything in flight.
+    const requestId = ++previewRequestIdRef.current;
     setPreviewBusy(true);
     try {
       const body = {
@@ -349,23 +360,31 @@ export default function AdminIntakeStudio() {
         print_time_seconds: parseResult.print_time_seconds,
         parts_on_plate: parts,
         slots: buildSlotsPayload(),
-        finishing_ops: ops.map((o) => ({
-          work_center_id: Number(o.work_center_id),
-          operation_name: o.operation_name,
-          run_time_minutes: Number(o.run_time_minutes) || 0,
-          setup_time_minutes: Number(o.setup_time_minutes) || 0,
-        })),
+        finishing_ops: ops
+          .filter((o) => o.work_center_id)
+          .map((o) => ({
+            work_center_id: Number(o.work_center_id),
+            operation_name: o.operation_name,
+            run_time_minutes: Number(o.run_time_minutes) || 0,
+            setup_time_minutes: Number(o.setup_time_minutes) || 0,
+          })),
         packaging: [],
       };
       const data = await api.post("/api/v1/pro/intake/preview", body);
+      // A newer preview started while we awaited — drop this stale response.
+      if (requestId !== previewRequestIdRef.current) return;
       setEstimatedCost(data);
-      if (!priceEdited && data.suggested_price != null) {
+      if (!priceEditedRef.current && data.suggested_price != null) {
         setActualPrice(String(data.suggested_price));
       }
     } catch {
-      setEstimatedCost(null);
+      if (requestId === previewRequestIdRef.current) {
+        setEstimatedCost(null);
+      }
     } finally {
-      setPreviewBusy(false);
+      if (requestId === previewRequestIdRef.current) {
+        setPreviewBusy(false);
+      }
     }
   };
 
@@ -392,9 +411,13 @@ export default function AdminIntakeStudio() {
     // new UX state
     setPartsOnPlate(1);
     setSkuCode("");
+    setSkuEdited(false);
     setEstimatedCost(null);
     setPreviewBusy(false);
     setPriceEdited(false);
+    priceEditedRef.current = false;
+    // Invalidate any preview still in flight so its response is ignored.
+    previewRequestIdRef.current += 1;
   };
 
   // ---------------------------------------------------------------------------
@@ -873,7 +896,10 @@ export default function AdminIntakeStudio() {
                     <input
                       type="text"
                       value={skuCode}
-                      onChange={(e) => setSkuCode(e.target.value)}
+                      onChange={(e) => {
+                        setSkuCode(e.target.value);
+                        setSkuEdited(true);
+                      }}
                       placeholder="INTAKE-MY-PRODUCT"
                       className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
                     />
@@ -1090,6 +1116,7 @@ export default function AdminIntakeStudio() {
                                   String(estimatedCost.suggested_price)
                                 );
                                 setPriceEdited(false);
+                                priceEditedRef.current = false;
                               }}
                               className="text-xs text-blue-400 hover:text-blue-300 underline transition-colors"
                             >
@@ -1126,6 +1153,7 @@ export default function AdminIntakeStudio() {
                       onChange={(e) => {
                         setActualPrice(e.target.value);
                         setPriceEdited(true);
+                        priceEditedRef.current = true;
                       }}
                       placeholder="0.00"
                       className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -81,6 +81,13 @@ export default function AdminIntakeStudio() {
   const [finishingOps, setFinishingOps] = useState([]);
   const [actualPrice, setActualPrice] = useState("");
 
+  // Step 4 — new UX state
+  const [partsOnPlate, setPartsOnPlate] = useState(1);
+  const [skuCode, setSkuCode] = useState("");
+  const [estimatedCost, setEstimatedCost] = useState(null);
+  const [previewBusy, setPreviewBusy] = useState(false);
+  const [priceEdited, setPriceEdited] = useState(false);
+
   // Step 5 — Result
   const [skuResult, setSkuResult] = useState(null);
   const [skuBusy, setSkuBusy] = useState(false);
@@ -245,6 +252,9 @@ export default function AdminIntakeStudio() {
   // Step 3 → 4: GET /context
   // ---------------------------------------------------------------------------
 
+  const buildSuggestedSku = (name) =>
+    `INTAKE-${(name || "").toUpperCase().replace(/[^A-Z0-9]+/g, "-").replace(/^-+|-+$/g, "")}`;
+
   const runContext = async () => {
     setContextBusy(true);
     try {
@@ -253,10 +263,21 @@ export default function AdminIntakeStudio() {
       // Default print work center from printer map
       const mapped =
         data.printer_work_center_map?.[parseResult.printer_model];
-      if (mapped?.work_center_id) {
-        setPrintWorkCenterId(String(mapped.work_center_id));
+      const mappedWcId = mapped?.work_center_id
+        ? String(mapped.work_center_id)
+        : null;
+      if (mappedWcId) {
+        setPrintWorkCenterId(mappedWcId);
+      }
+      // Seed SKU code from product name if not already set
+      if (!skuCode && productName) {
+        setSkuCode(buildSuggestedSku(productName));
       }
       setStep(4);
+      // Kick off preview now that we have the work center (if available)
+      if (mappedWcId) {
+        runPreview({ printWorkCenterId: mappedWcId });
+      }
     } catch (err) {
       toast.error(err.message || "Failed to load context");
     } finally {
@@ -276,13 +297,9 @@ export default function AdminIntakeStudio() {
         actual_price: Number(actualPrice),
         print_work_center_id: Number(printWorkCenterId),
         print_time_seconds: parseResult.print_time_seconds,
-        slots: parseResult.slots.map((s) => ({
-          slot_id: s.slot_id,
-          filament_type: s.filament_type,
-          color_hex: s.color_hex,
-          used_g: s.used_g,
-          spool_product_id: matchChoices[s.slot_id]?.product_id,
-        })),
+        parts_on_plate: partsOnPlate,
+        sku: skuCode || undefined,
+        slots: buildSlotsPayload(),
         finishing_ops: finishingOps.map((o) => ({
           work_center_id: Number(o.work_center_id),
           operation_name: o.operation_name,
@@ -300,6 +317,55 @@ export default function AdminIntakeStudio() {
       toast.error(err.message || "SKU creation failed");
     } finally {
       setSkuBusy(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Shared slot-payload builder (used by /preview and /sku)
+  // ---------------------------------------------------------------------------
+
+  const buildSlotsPayload = () =>
+    (parseResult?.slots || []).map((s) => ({
+      slot_id: s.slot_id,
+      filament_type: s.filament_type,
+      color_hex: s.color_hex,
+      used_g: s.used_g,
+      spool_product_id: matchChoices[s.slot_id]?.product_id,
+    }));
+
+  // ---------------------------------------------------------------------------
+  // Step 4 — /preview (cost estimate before committing)
+  // ---------------------------------------------------------------------------
+
+  const runPreview = async (overrides = {}) => {
+    const wcId = overrides.printWorkCenterId ?? printWorkCenterId;
+    const parts = overrides.partsOnPlate ?? partsOnPlate;
+    const ops = overrides.finishingOps ?? finishingOps;
+    if (!wcId || !parseResult) return;
+    setPreviewBusy(true);
+    try {
+      const body = {
+        print_work_center_id: Number(wcId),
+        print_time_seconds: parseResult.print_time_seconds,
+        parts_on_plate: parts,
+        slots: buildSlotsPayload(),
+        finishing_ops: ops.map((o) => ({
+          work_center_id: Number(o.work_center_id),
+          operation_name: o.operation_name,
+          run_time_minutes: Number(o.run_time_minutes) || 0,
+          setup_time_minutes: Number(o.setup_time_minutes) || 0,
+        })),
+        packaging: [],
+      };
+      const data = await api.post("/api/v1/pro/intake/preview", body);
+      setEstimatedCost(data);
+      if (!priceEdited && data.suggested_price != null) {
+        setActualPrice(String(data.suggested_price));
+      }
+    } catch {
+      setEstimatedCost(null);
+    } finally {
+      setPreviewBusy(false);
     }
   };
 
@@ -323,6 +389,12 @@ export default function AdminIntakeStudio() {
     setActualPrice("");
     setSkuResult(null);
     setSkuBusy(false);
+    // new UX state
+    setPartsOnPlate(1);
+    setSkuCode("");
+    setEstimatedCost(null);
+    setPreviewBusy(false);
+    setPriceEdited(false);
   };
 
   // ---------------------------------------------------------------------------
@@ -340,25 +412,31 @@ export default function AdminIntakeStudio() {
   // ---------------------------------------------------------------------------
 
   const addFinishingOp = () => {
-    setFinishingOps((prev) => [
-      ...prev,
+    const next = [
+      ...finishingOps,
       {
         work_center_id: "",
         operation_name: "",
         run_time_minutes: "",
         setup_time_minutes: "",
       },
-    ]);
+    ];
+    setFinishingOps(next);
+    runPreview({ finishingOps: next });
   };
 
   const updateFinishingOp = (idx, field, value) => {
-    setFinishingOps((prev) =>
-      prev.map((op, i) => (i === idx ? { ...op, [field]: value } : op))
+    const next = finishingOps.map((op, i) =>
+      i === idx ? { ...op, [field]: value } : op
     );
+    setFinishingOps(next);
+    runPreview({ finishingOps: next });
   };
 
   const removeFinishingOp = (idx) => {
-    setFinishingOps((prev) => prev.filter((_, i) => i !== idx));
+    const next = finishingOps.filter((_, i) => i !== idx);
+    setFinishingOps(next);
+    runPreview({ finishingOps: next });
   };
 
   // ---------------------------------------------------------------------------
@@ -578,12 +656,20 @@ export default function AdminIntakeStudio() {
 
           {/* Buttons */}
           <div className="flex justify-between pt-2">
-            <button
-              onClick={handleReset}
-              className="border border-gray-700 text-gray-300 hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors"
-            >
-              Start over
-            </button>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setStep(1)}
+                className="border border-gray-700 text-gray-300 hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleReset}
+                className="border border-gray-700 text-gray-500 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+              >
+                Start over
+              </button>
+            </div>
             <button
               onClick={runMatch}
               disabled={matchBusy || !productName.trim()}
@@ -743,7 +829,10 @@ export default function AdminIntakeStudio() {
                           sku: wc.code,
                         }))}
                       value={printWorkCenterId}
-                      onChange={setPrintWorkCenterId}
+                      onChange={(v) => {
+                        setPrintWorkCenterId(v);
+                        runPreview({ printWorkCenterId: v });
+                      }}
                       placeholder="Select work center…"
                       displayKey="name"
                       valueKey="id"
@@ -757,6 +846,40 @@ export default function AdminIntakeStudio() {
                     <div className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white">
                       {secondsToHms(parseResult.print_time_seconds)}
                     </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm text-gray-400 mb-1">
+                      Parts on this plate
+                    </label>
+                    <input
+                      type="number"
+                      min="1"
+                      value={partsOnPlate}
+                      onChange={(e) => {
+                        const v = Math.max(1, parseInt(e.target.value, 10) || 1);
+                        setPartsOnPlate(v);
+                        runPreview({ partsOnPlate: v });
+                      }}
+                      className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+                    />
+                    <p className="text-gray-600 text-xs mt-1">
+                      Per-unit cost = plate &divide; parts.
+                    </p>
+                  </div>
+                  <div>
+                    <label className="block text-sm text-gray-400 mb-1">
+                      SKU code
+                    </label>
+                    <input
+                      type="text"
+                      value={skuCode}
+                      onChange={(e) => setSkuCode(e.target.value)}
+                      placeholder="INTAKE-MY-PRODUCT"
+                      className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+                    />
+                    <p className="text-gray-600 text-xs mt-1">
+                      Letters, numbers, hyphens — auto-uppercased on save.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -911,6 +1034,85 @@ export default function AdminIntakeStudio() {
                 <h2 className="text-base font-semibold text-white mb-3">
                   Pricing
                 </h2>
+
+                {/* Estimated cost panel — shown BEFORE the price input */}
+                <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 mb-4">
+                  {previewBusy && (
+                    <p className="text-gray-400 text-sm">Calculating…</p>
+                  )}
+                  {!previewBusy && estimatedCost == null && (
+                    <p className="text-gray-500 text-sm">
+                      Pick a work center to estimate cost.
+                    </p>
+                  )}
+                  {!previewBusy && estimatedCost != null && (
+                    <>
+                      <div className="flex items-baseline gap-3 mb-3">
+                        <span className="text-2xl font-bold text-white">
+                          ${Number(estimatedCost.per_unit_cost || 0).toFixed(2)}
+                        </span>
+                        <span className="text-gray-400 text-sm">
+                          estimated cost per unit
+                        </span>
+                      </div>
+                      <div className="flex gap-6 text-sm mb-3">
+                        <div>
+                          <span className="text-gray-400">Material</span>
+                          <span className="text-gray-200 ml-2">
+                            ${Number(estimatedCost.bom_cost || 0).toFixed(2)}
+                          </span>
+                        </div>
+                        <div>
+                          <span className="text-gray-400">Labor</span>
+                          <span className="text-gray-200 ml-2">
+                            ${Number(estimatedCost.routing_cost || 0).toFixed(2)}
+                          </span>
+                        </div>
+                      </div>
+                      {estimatedCost.suggested_price != null && (
+                        <div className="flex items-center gap-3 border-t border-gray-700 pt-3">
+                          <p className="text-blue-300 text-sm">
+                            Suggested price:{" "}
+                            <span className="font-semibold">
+                              ${Number(estimatedCost.suggested_price).toFixed(2)}
+                            </span>
+                            {estimatedCost.default_margin_percent != null && (
+                              <span className="text-gray-400 ml-1">
+                                ({estimatedCost.default_margin_percent}% margin)
+                              </span>
+                            )}
+                          </p>
+                          {priceEdited && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setActualPrice(
+                                  String(estimatedCost.suggested_price)
+                                );
+                                setPriceEdited(false);
+                              }}
+                              className="text-xs text-blue-400 hover:text-blue-300 underline transition-colors"
+                            >
+                              Use suggested
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+
+                <div className="flex justify-end mb-2">
+                  <button
+                    type="button"
+                    onClick={() => runPreview()}
+                    disabled={previewBusy || !printWorkCenterId}
+                    className="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Recalculate cost
+                  </button>
+                </div>
+
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
                   <div>
                     <label className="block text-sm text-gray-400 mb-1">
@@ -921,7 +1123,10 @@ export default function AdminIntakeStudio() {
                       min="0"
                       step="0.01"
                       value={actualPrice}
-                      onChange={(e) => setActualPrice(e.target.value)}
+                      onChange={(e) => {
+                        setActualPrice(e.target.value);
+                        setPriceEdited(true);
+                      }}
                       placeholder="0.00"
                       className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
                     />
@@ -1098,12 +1303,22 @@ export default function AdminIntakeStudio() {
             </p>
           )}
 
-          <button
-            onClick={handleReset}
-            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
-          >
-            Create another
-          </button>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={handleReset}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+            >
+              Create another
+            </button>
+            {skuResult.product?.id && (
+              <a
+                href={`/admin/products/${skuResult.product.id}`}
+                className="border border-gray-700 text-gray-300 hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors"
+              >
+                View / edit product
+              </a>
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Frontend half of the Intake Studio improvements (dogfooded on the 129 brownfield). Scoped to **`AdminIntakeStudio.jsx` only**. Pairs with filaops-ecosystem **#162** (the SKU cost/procurement fix) + **#163** (`parts_on_plate`, `POST /preview`, `suggested_price`) — merge those so the endpoints exist.

## What changed (the four asks)
1. **Cost before price** (the main flow complaint: *"you have to enter a selling price before you see the costing"*). Step 4 now shows an **Estimated cost** panel above the price input — per-unit cost, material/labor breakdown, and a suggested price — fed by `POST /preview` (which computes the exact `/sku` cost without creating anything). The price field pre-fills from the suggestion until the operator edits it ("Use suggested" restores it).
2. **Parts on this plate** — numeric input, sent as `parts_on_plate` to `/preview` + `/sku`, so a 12-up plate costs **per part** (fixes the "margins are off" report at its root).
3. **Editable SKU code** — seeded `INTAKE-<NAME>` (uppercased) on Step 4, operator-editable, sent as `sku` (server normalises to `[A-Z0-9-]`).
4. **Navigation** — real **Back** on Step 2 (no state wipe); **View / edit product** link on the Done screen.

## Implementation note
`/preview` is wired **event-driven** (no `useEffect`) — `runPreview()` fires from the work-center / parts / finishing-op handlers, on Step-4 entry, and a "Recalculate cost" button, each passing the just-changed value as an override to avoid stale-closure reads. This satisfies Core's strict `react-hooks` rules (`set-state-in-effect` + `rules-of-hooks`).

**ESLint: 0 errors, 0 warnings.** (Full frontend build is verified by CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an enhanced preview step that estimates cost before order submission.
  * Introduced parts-per-plate and operator SKU code inputs to drive preview and SKU setup.
* **Improvements**
  * Automatically recalculates cost when print work center or finishing operations change.
  * Selling price edits are preserved during preview updates.
  * Expanded reset behavior and added an explicit back button for step navigation.
  * Added a link to view/edit the created product after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->