### PR TITLE
feat(intake): + Add material per op in the wizard

### DIFF
--- a/frontend/src/components/OperationMaterialModal.jsx
+++ b/frontend/src/components/OperationMaterialModal.jsx
@@ -12,7 +12,7 @@ export default function OperationMaterialModal({
   isOpen,
   onClose,
   operationId,
-  operation = null,          // Operation context (for title/label)
+  operation: _operation = null, // Operation context (for title/label)
   defaultTypeFilter = 'all', // Smart default computed by parent from operation name
   material = null,           // If provided, editing existing material
   onSave,
@@ -42,6 +42,7 @@ export default function OperationMaterialModal({
   useEffect(() => {
     if (!isOpen) return;
     if (material) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setFormData({
         component_id: material.component_id || '',
         quantity: material.quantity || 1,
@@ -130,6 +131,15 @@ export default function OperationMaterialModal({
         is_variable: formData.is_variable,
         notes: formData.notes || null,
       };
+
+      // Wizard/local mode: no operationId yet — return the material to the parent
+      // instead of POSTing. Include the picked product's sku/name for display.
+      if (!operationId) {
+        const sp = products.find((p) => p.id === parseInt(formData.component_id));
+        onSave?.({ ...payload, component_sku: sp?.sku, component_name: sp?.name });
+        onClose();
+        return;
+      }
 
       let res;
       if (isEditing) {

--- a/frontend/src/components/OperationMaterialModal.jsx
+++ b/frontend/src/components/OperationMaterialModal.jsx
@@ -116,7 +116,6 @@ export default function OperationMaterialModal({
       return;
     }
 
-    setLoading(true);
     setError(null);
 
     try {
@@ -141,6 +140,8 @@ export default function OperationMaterialModal({
         return;
       }
 
+      // Network path only — wizard mode returns above without touching loading
+      setLoading(true);
       let res;
       if (isEditing) {
         // Update existing material

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -4,6 +4,7 @@ import { useToast } from "../../components/Toast";
 import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import { API_URL } from "../../config/api";
 import SearchableSelect from "../../components/SearchableSelect";
+import OperationMaterialModal from "../../components/OperationMaterialModal";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,6 +80,7 @@ export default function AdminIntakeStudio() {
   const [contextBusy, setContextBusy] = useState(false);
   const [printWorkCenterId, setPrintWorkCenterId] = useState("");
   const [finishingOps, setFinishingOps] = useState([]);
+  const [matModalOpIdx, setMatModalOpIdx] = useState(null);
   const [actualPrice, setActualPrice] = useState("");
 
   // Step 4 — new UX state
@@ -314,6 +316,13 @@ export default function AdminIntakeStudio() {
             operation_name: o.operation_name,
             run_time_minutes: Number(o.run_time_minutes) || 0,
             setup_time_minutes: Number(o.setup_time_minutes) || 0,
+            materials: (o.materials || []).map((m) => ({
+              component_product_id: m.component_id,
+              quantity: Number(m.quantity) || 0,
+              unit: m.unit || "EA",
+              quantity_per: m.quantity_per || "unit",
+              scrap_factor: Number(m.scrap_factor) || 0,
+            })),
           })),
         packaging: [],
         persist_color_map: true,
@@ -367,6 +376,13 @@ export default function AdminIntakeStudio() {
             operation_name: o.operation_name,
             run_time_minutes: Number(o.run_time_minutes) || 0,
             setup_time_minutes: Number(o.setup_time_minutes) || 0,
+            materials: (o.materials || []).map((m) => ({
+              component_product_id: m.component_id,
+              quantity: Number(m.quantity) || 0,
+              unit: m.unit || "EA",
+              quantity_per: m.quantity_per || "unit",
+              scrap_factor: Number(m.scrap_factor) || 0,
+            })),
           })),
         packaging: [],
       };
@@ -442,6 +458,7 @@ export default function AdminIntakeStudio() {
         operation_name: "",
         run_time_minutes: "",
         setup_time_minutes: "",
+        materials: [],
       },
     ];
     setFinishingOps(next);
@@ -950,104 +967,164 @@ export default function AdminIntakeStudio() {
                     {finishingOps.map((op, idx) => (
                       <div
                         key={idx}
-                        className="bg-gray-800/50 rounded-lg p-4 grid grid-cols-1 md:grid-cols-4 gap-3 items-end"
+                        className="bg-gray-800/50 rounded-lg p-4 space-y-3"
                       >
-                        <div>
-                          <label className="block text-xs text-gray-400 mb-1">
-                            Work center
-                          </label>
-                          <SearchableSelect
-                            options={(context.work_centers || [])
-                              .filter((wc) => wc.is_active)
-                              .map((wc) => ({
-                                id: wc.id,
-                                name: `${wc.name} (${wc.code})`,
-                                sku: wc.code,
-                              }))}
-                            value={op.work_center_id ? String(op.work_center_id) : ""}
-                            onChange={(val) =>
-                              updateFinishingOp(idx, "work_center_id", val)
-                            }
-                            placeholder="Work center…"
-                            displayKey="name"
-                            valueKey="id"
-                            formatOption={(opt) => opt.name}
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs text-gray-400 mb-1">
-                            Operation name
-                          </label>
-                          <input
-                            type="text"
-                            value={op.operation_name}
-                            onChange={(e) =>
-                              updateFinishingOp(
-                                idx,
-                                "operation_name",
-                                e.target.value
-                              )
-                            }
-                            placeholder="e.g. Support removal"
-                            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs text-gray-400 mb-1">
-                            Run time (min)
-                          </label>
-                          <input
-                            type="number"
-                            min="0"
-                            value={op.run_time_minutes}
-                            onChange={(e) =>
-                              updateFinishingOp(
-                                idx,
-                                "run_time_minutes",
-                                e.target.value
-                              )
-                            }
-                            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
-                          />
-                        </div>
-                        <div className="flex gap-2 items-end">
-                          <div className="flex-1">
+                        {/* Op fields row */}
+                        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+                          <div>
                             <label className="block text-xs text-gray-400 mb-1">
-                              Setup (min)
+                              Work center
+                            </label>
+                            <SearchableSelect
+                              options={(context.work_centers || [])
+                                .filter((wc) => wc.is_active)
+                                .map((wc) => ({
+                                  id: wc.id,
+                                  name: `${wc.name} (${wc.code})`,
+                                  sku: wc.code,
+                                }))}
+                              value={op.work_center_id ? String(op.work_center_id) : ""}
+                              onChange={(val) =>
+                                updateFinishingOp(idx, "work_center_id", val)
+                              }
+                              placeholder="Work center…"
+                              displayKey="name"
+                              valueKey="id"
+                              formatOption={(opt) => opt.name}
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-400 mb-1">
+                              Operation name
+                            </label>
+                            <input
+                              type="text"
+                              value={op.operation_name}
+                              onChange={(e) =>
+                                updateFinishingOp(
+                                  idx,
+                                  "operation_name",
+                                  e.target.value
+                                )
+                              }
+                              placeholder="e.g. Support removal"
+                              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-400 mb-1">
+                              Run time (min)
                             </label>
                             <input
                               type="number"
                               min="0"
-                              value={op.setup_time_minutes}
+                              value={op.run_time_minutes}
                               onChange={(e) =>
                                 updateFinishingOp(
                                   idx,
-                                  "setup_time_minutes",
+                                  "run_time_minutes",
                                   e.target.value
                                 )
                               }
                               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
                             />
                           </div>
-                          <button
-                            onClick={() => removeFinishingOp(idx)}
-                            className="text-gray-500 hover:text-red-400 p-2 transition-colors flex-shrink-0"
-                            title="Remove"
-                          >
-                            <svg
-                              className="w-4 h-4"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M6 18L18 6M6 6l12 12"
+                          <div className="flex gap-2 items-end">
+                            <div className="flex-1">
+                              <label className="block text-xs text-gray-400 mb-1">
+                                Setup (min)
+                              </label>
+                              <input
+                                type="number"
+                                min="0"
+                                value={op.setup_time_minutes}
+                                onChange={(e) =>
+                                  updateFinishingOp(
+                                    idx,
+                                    "setup_time_minutes",
+                                    e.target.value
+                                  )
+                                }
+                                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
                               />
-                            </svg>
-                          </button>
+                            </div>
+                            <button
+                              onClick={() => removeFinishingOp(idx)}
+                              className="text-gray-500 hover:text-red-400 p-2 transition-colors flex-shrink-0"
+                              title="Remove"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M6 18L18 6M6 6l12 12"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+
+                        {/* Materials sub-section */}
+                        <div className="border-t border-gray-700 pt-2">
+                          <div className="flex items-center justify-between mb-1">
+                            <span className="text-xs text-gray-500">
+                              Materials
+                            </span>
+                            <button
+                              onClick={() => setMatModalOpIdx(idx)}
+                              className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 transition-colors"
+                            >
+                              <svg
+                                className="w-3 h-3"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M12 4v16m8-8H4"
+                                />
+                              </svg>
+                              + Add material
+                            </button>
+                          </div>
+                          {(op.materials || []).length > 0 && (
+                            <div className="space-y-1">
+                              {(op.materials || []).map((m, mIdx) => (
+                                <div
+                                  key={mIdx}
+                                  className="flex items-center justify-between text-xs text-gray-300 bg-gray-800 rounded px-2 py-1"
+                                >
+                                  <span>
+                                    {m.component_sku} — {m.component_name} · {m.quantity} {m.unit}
+                                  </span>
+                                  <button
+                                    onClick={() => {
+                                      const next = finishingOps.map((o, i) =>
+                                        i === idx
+                                          ? { ...o, materials: o.materials.filter((_, mi) => mi !== mIdx) }
+                                          : o
+                                      );
+                                      setFinishingOps(next);
+                                      runPreview({ finishingOps: next });
+                                    }}
+                                    className="text-gray-500 hover:text-red-400 ml-2 transition-colors"
+                                    title="Remove material"
+                                  >
+                                    ×
+                                  </button>
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       </div>
                     ))}
@@ -1193,6 +1270,25 @@ export default function AdminIntakeStudio() {
           )}
         </div>
       )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Operation Material Modal (wizard / collect-into-state mode)        */}
+      {/* ------------------------------------------------------------------ */}
+      <OperationMaterialModal
+        isOpen={matModalOpIdx !== null}
+        operationId={null}
+        material={null}
+        defaultTypeFilter="all"
+        onClose={() => setMatModalOpIdx(null)}
+        onSave={(mat) => {
+          const next = finishingOps.map((op, i) =>
+            i === matModalOpIdx ? { ...op, materials: [...(op.materials || []), mat] } : op
+          );
+          setFinishingOps(next);
+          setMatModalOpIdx(null);
+          runPreview({ finishingOps: next });
+        }}
+      />
 
       {/* ------------------------------------------------------------------ */}
       {/* STEP 5 — Result                                                     */}

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -421,6 +421,7 @@ export default function AdminIntakeStudio() {
     setContextBusy(false);
     setPrintWorkCenterId("");
     setFinishingOps([]);
+    setMatModalOpIdx(null);
     setActualPrice("");
     setSkuResult(null);
     setSkuBusy(false);


### PR DESCRIPTION
Frontend half of Intake Phase 2 — bring the routing editor's per-op material control into the intake wizard.

- `OperationMaterialModal` gains a **no-`operationId` "collect-into-state" mode**: when there's no operation id yet (the wizard's ops aren't created until `/sku`), it returns the picked material `{component_id, sku, name, quantity, unit, …}` to the parent instead of POSTing. The routing editor (always passes `operationId`) is unchanged.
- Each finishing-op row gets **`+ Add material`** → the modal → adds to that op's `materials` state, rendered as a removable list under the op. Component search reuses `GET /api/v1/items`.
- `runPreview` + `runCreateSku` include each op's `materials` in the `finishing_ops` payload (`component_product_id` mapped).

So the operator assembles Print (gcode filament, auto) + QC + Pack (box) with materials per op, during intake. **ESLint clean.** Pairs with filaops-ecosystem per-op-materials PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Materials section for each finishing operation in the intake workflow, including an “Add material” action.
  * Users can now add, view, and remove materials per finishing operation.
  * Finishing-operation materials are included in cost preview calculations for more accurate estimates.
* **Bug Fixes**
  * Improved the material entry flow in the modal for cases where the operation context isn’t provided, reducing unnecessary waiting during save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->