### PR TITLE
docs: fix mkdocs --strict deploy blocker (CHANGELOG link) + index cross-link anchors

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -86,9 +86,9 @@ configuration.
 | Guide | What you will learn |
 |---|---|
 | [Managing Your Product Catalog](product-catalog.md) | Create finished goods, components, materials, and supplies; set reorder points; duplicate items; use the Variant Matrix to bulk-create color or material variants from a template |
-| [Bills of Materials](product-catalog.md#bill-of-materials) | Build multi-level BOMs, view the cost rollup, copy a BOM to another product, and launch a production order directly from a BOM |
+| [Bills of Materials](product-catalog.md#bills-of-materials-boms) | Build multi-level BOMs, view the cost rollup, copy a BOM to another product, and launch a production order directly from a BOM |
 | [Work Centers & Routings](production.md#work-centers) | Define work centers, assign printer resources, and create routings with per-operation materials |
-| [Material Spools](inventory.md#spools) | Track filament spools by weight, link to inventory items, and record consumption per print *(admin only)* |
+| [Material Spools](inventory.md#material-spools) | Track filament spools by weight, link to inventory items, and record consumption per print *(admin only)* |
 
 ---
 
@@ -96,7 +96,7 @@ configuration.
 
 | Guide | What you will learn |
 |---|---|
-| [Buy List & Material Shortages](purchasing.md#buy-list) | The Buy List in Purchasing consolidates demand across all open orders and shows what to buy, how much, and by when — with a one-click "Create PO" shortcut |
+| [Buy List & Material Shortages](purchasing.md#the-buy-list-tab) | The Buy List in Purchasing consolidates demand across all open orders and shows what to buy, how much, and by when — with a one-click "Create PO" shortcut |
 | [Invoices & Payments](accounting.md) | Generate invoices from sales orders, record customer payments, and track outstanding balances *(admin only)* |
 | [Accounting](accounting.md) | Sales journal, COGS & materials report, and tax center *(admin only)* |
 
@@ -107,7 +107,7 @@ configuration.
 | Guide | What you will learn |
 |---|---|
 | [Quality Dashboard](production.md#quality) | First-pass yield, pending inspections, scrap rate, and the inspection queue |
-| [Material Traceability](inventory.md#traceability) | Trace a filament spool from receipt through every production order it contributed to |
+| [Material Traceability](inventory.md#spool-usage-and-traceability) | Trace a filament spool from receipt through every production order it contributed to |
 
 ---
 
@@ -312,4 +312,4 @@ Key fields available in Settings:
 
 ---
 
-*FilaOps Core | open-source (BSL) | [changelog](../CHANGELOG.md)*
+*FilaOps Core | open-source (BSL) | [changelog](https://github.com/BLB3DPrinting/filaops/blob/main/CHANGELOG.md)*


### PR DESCRIPTION
## Why

The **Deploy Documentation** workflow (`.github/workflows/docs.yml`, `workflow_dispatch`) builds with `mkdocs build --strict`, which aborts on warnings. After #766 merged, the docs site can't publish because the strict build fails:

```
WARNING - user-guide/index.md contains a link '../CHANGELOG.md',
          but the target 'CHANGELOG.md' is not found among documentation files
Aborted with 1 warnings in strict mode!
```

PR CI never caught this — it doesn't run `--strict`.

## What

- **Deploy blocker:** repoint the index footer `changelog` link from `../CHANGELOG.md` (outside the docs tree) to the CHANGELOG on GitHub. External link → not validated by mkdocs → warning gone.
- **Cross-link anchors:** corrected 4 index links to their real heading slugs so they jump to the right section:
  - `product-catalog.md#bill-of-materials` → `#bills-of-materials-boms`
  - `inventory.md#spools` → `#material-spools`
  - `inventory.md#traceability` → `#spool-usage-and-traceability`
  - `purchasing.md#buy-list` → `#the-buy-list-tab`

## Result

`mkdocs build --strict` now passes (built clean, no abort). After this merges, the "Deploy Documentation" workflow can be run to publish the refreshed v4.1.0 docs.

## Known follow-up (not in this PR)

Two **INFO-level** (non-blocking) anchors remain: `production.md#quality` and `system-settings.md#import-orders`. The Quality Dashboard and Import Orders features don't yet have dedicated doc sections, so these are a content-completeness follow-up rather than an anchor tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation links throughout the user guide for Product Catalog & Manufacturing Setup, Planning & Finance, and Quality sections to ensure proper navigation between related content.
  * Changed the changelog link to direct users to the GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->