### PR TITLE
chore: complete org rename (Blb3D -> BLB3DPrinting) across repo URLs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,8 +12,8 @@ REMOTE_URL="$2"
 # Only block pushes to the public repo (upstream).
 # Pushes to origin (private repo) are allowed to contain PRO code.
 case "$REMOTE_URL" in
-    *Blb3D/filaops.git*|*Blb3D/filaops\ *)
-        ;; # public repo — check for PRO code
+    *BLB3DPrinting/filaops.git*|*BLB3DPrinting/filaops\ *|*Blb3D/filaops.git*|*Blb3D/filaops\ *)
+        ;; # public repo (new org or old redirect) — check for PRO code
     *)
         exit 0 ;; # private repo — allow everything
 esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,15 +381,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Invoice Parser (PRO)
 - License management (PRO)
 
-[Unreleased]: https://github.com/Blb3D/filaops/compare/v3.7.1...HEAD
-[3.7.1]: https://github.com/Blb3D/filaops/compare/v3.7.0...v3.7.1
-[3.7.0]: https://github.com/Blb3D/filaops/compare/v3.6.0...v3.7.0
-[3.6.0]: https://github.com/Blb3D/filaops/compare/v3.5.0...v3.6.0
-[3.5.0]: https://github.com/Blb3D/filaops/compare/v3.4.0...v3.5.0
-[3.4.0]: https://github.com/Blb3D/filaops/compare/v3.3.0...v3.4.0
-[3.3.0]: https://github.com/Blb3D/filaops/compare/v3.2.0...v3.3.0
-[3.2.0]: https://github.com/Blb3D/filaops/compare/v3.1.1...v3.2.0
-[3.1.1]: https://github.com/Blb3D/filaops/compare/v3.1.0...v3.1.1
-[3.1.0]: https://github.com/Blb3D/filaops/compare/v3.0.1...v3.1.0
-[3.0.1]: https://github.com/Blb3D/filaops/compare/v3.0.0...v3.0.1
-[3.0.0]: https://github.com/Blb3D/filaops/releases/tag/v3.0.0
+[Unreleased]: https://github.com/BLB3DPrinting/filaops/compare/v3.7.1...HEAD
+[3.7.1]: https://github.com/BLB3DPrinting/filaops/compare/v3.7.0...v3.7.1
+[3.7.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.6.0...v3.7.0
+[3.6.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.5.0...v3.6.0
+[3.5.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.4.0...v3.5.0
+[3.4.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.3.0...v3.4.0
+[3.3.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.2.0...v3.3.0
+[3.2.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.1.1...v3.2.0
+[3.1.1]: https://github.com/BLB3DPrinting/filaops/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/BLB3DPrinting/filaops/compare/v3.0.1...v3.1.0
+[3.0.1]: https://github.com/BLB3DPrinting/filaops/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/BLB3DPrinting/filaops/releases/tag/v3.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ pytest tests/endpoints/        # Endpoint tests only
 
 ## Reporting Issues
 
-Use [GitHub Issues](https://github.com/Blb3D/filaops/issues) with:
+Use [GitHub Issues](https://github.com/BLB3DPrinting/filaops/issues) with:
 
 - Clear title describing the problem
 - Steps to reproduce

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # FilaOps
 
-[![CI](https://github.com/Blb3DPrinting/filaops/actions/workflows/filaops-ci.yml/badge.svg)](https://github.com/Blb3DPrinting/filaops/actions/workflows/filaops-ci.yml)
-[![CodeQL](https://github.com/Blb3DPrinting/filaops/actions/workflows/codeql.yml/badge.svg)](https://github.com/Blb3DPrinting/filaops/actions/workflows/codeql.yml)
+[![CI](https://github.com/BLB3DPrinting/filaops/actions/workflows/filaops-ci.yml/badge.svg)](https://github.com/BLB3DPrinting/filaops/actions/workflows/filaops-ci.yml)
+[![CodeQL](https://github.com/BLB3DPrinting/filaops/actions/workflows/codeql.yml/badge.svg)](https://github.com/BLB3DPrinting/filaops/actions/workflows/codeql.yml)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
-[![Latest Release](https://img.shields.io/github/v/release/Blb3DPrinting/filaops)](https://github.com/Blb3D/filaops/releases/latest)
+[![Latest Release](https://img.shields.io/github/v/release/BLB3DPrinting/filaops)](https://github.com/BLB3DPrinting/filaops/releases/latest)
 
 Open-source ERP for 3D print farms. Manage inventory, production, sales, purchasing, MRP, and accounting in one system built specifically for additive manufacturing.
 
-**[Documentation](https://blb3d.github.io/filaops/)** | **[Release Notes](https://github.com/Blb3D/filaops/releases/latest)**
+**[Documentation](https://blb3dprinting.github.io/filaops/)** | **[Release Notes](https://github.com/BLB3DPrinting/filaops/releases/latest)**
 
 ## Quick Start (Docker)
 
 ```bash
-git clone https://github.com/Blb3D/filaops.git
+git clone https://github.com/BLB3DPrinting/filaops.git
 cd filaops
 cp backend/.env.example .env
 # Generate secrets (required — production startup refuses to boot without these):
@@ -195,7 +195,7 @@ cd frontend && npm test
 
 ## Documentation
 
-- **[Full Documentation](https://blb3d.github.io/filaops/)** — Deployment, configuration, and API reference
+- **[Full Documentation](https://blb3dprinting.github.io/filaops/)** — Deployment, configuration, and API reference
 - [User Guide](docs/user-guide/index.md) — Module-by-module usage
 - [Contributing](CONTRIBUTING.md) — Development setup and PR guidelines
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 The **only** official source for FilaOps is:
 
-**[github.com/Blb3D/filaops](https://github.com/Blb3D/filaops)**
+**[github.com/BLB3DPrinting/filaops](https://github.com/BLB3DPrinting/filaops)**
 
-Malicious forks and repackaged copies of FilaOps exist. We will **never** ask you to download zip files from `raw.githubusercontent.com` links. If you encounter this, it is malware. Always verify releases at: [github.com/Blb3D/filaops/releases](https://github.com/Blb3D/filaops/releases)
+Malicious forks and repackaged copies of FilaOps exist. We will **never** ask you to download zip files from `raw.githubusercontent.com` links. If you encounter this, it is malware. Always verify releases at: [github.com/BLB3DPrinting/filaops/releases](https://github.com/BLB3DPrinting/filaops/releases)
 
 ---
 
@@ -32,7 +32,7 @@ If you discover a security vulnerability in FilaOps, we appreciate your help in 
 
 1. **GitHub Private Vulnerability Reporting (Preferred)**
    Use GitHub's built-in private reporting at:
-   [github.com/Blb3D/filaops/security/advisories/new](https://github.com/Blb3D/filaops/security/advisories/new)
+   [github.com/BLB3DPrinting/filaops/security/advisories/new](https://github.com/BLB3DPrinting/filaops/security/advisories/new)
 
 2. **Email**
    Send details to: **security@blb3dprinting.com**

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -693,7 +693,7 @@ async def request_password_reset(
                 "SECURITY WARNING: Password reset auto-approved in production because "
                 "SMTP is not configured. This bypasses admin approval. Configure SMTP "
                 "to enable secure password resets. "
-                "See: https://blb3d.github.io/filaops/EMAIL_CONFIGURATION/",
+                "See: https://blb3dprinting.github.io/filaops/EMAIL_CONFIGURATION/",
                 extra={"user_id": user.id, "email": user.email}
             )
         reset_request.status = 'approved'  # type: ignore[assignment]

--- a/backend/migrations/versions/061_fix_product_customer_fk.py
+++ b/backend/migrations/versions/061_fix_product_customer_fk.py
@@ -3,7 +3,7 @@
 The customer_id column on products is meant for B2B customer restriction,
 so it should reference the customers table (not users).
 
-Issue: https://github.com/Blb3D/filaops/issues/310
+Issue: https://github.com/BLB3DPrinting/filaops/issues/310
 """
 from alembic import op
 

--- a/docs/BACKUP-AND-RECOVERY.md
+++ b/docs/BACKUP-AND-RECOVERY.md
@@ -326,7 +326,7 @@ Complete restore from scratch when the entire server is lost.
 # 1. Install Docker and Docker Compose on the new server
 
 # 2. Clone the repository (or copy docker-compose.yml and .env)
-git clone https://github.com/Blb3D/filaops.git
+git clone https://github.com/BLB3DPrinting/filaops.git
 cd filaops
 
 # 3. Copy your .env file with DB credentials

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,7 +43,7 @@ docker compose version
 ## 2. Quick Start
 
 ```bash
-git clone https://github.com/Blb3D/filaops.git
+git clone https://github.com/BLB3DPrinting/filaops.git
 cd filaops
 
 # Create environment file from the template

--- a/docs/FIRST-RUN-SETUP.md
+++ b/docs/FIRST-RUN-SETUP.md
@@ -65,7 +65,7 @@ When `SMTP_USER` and `SMTP_PASSWORD` are not set in `.env`:
 
 No email is sent. The Forgot Password page displays the reset link directly with a "Reset My Password" button.
 
-> **Production warning:** If SMTP is not configured in production, auto-approval still works but a **SECURITY WARNING** is logged on every password reset. This bypasses admin approval, meaning anyone who knows a valid email address can reset that account's password without inbox verification. **Configure SMTP for production deployments** — see [Email Setup](https://blb3d.github.io/filaops/EMAIL_CONFIGURATION/).
+> **Production warning:** If SMTP is not configured in production, auto-approval still works but a **SECURITY WARNING** is logged on every password reset. This bypasses admin approval, meaning anyone who knows a valid email address can reset that account's password without inbox verification. **Configure SMTP for production deployments** — see [Email Setup](https://blb3dprinting.github.io/filaops/EMAIL_CONFIGURATION/).
 
 ### Anti-Enumeration (Security Note)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,7 +160,7 @@ Manage inventory, production, MRP, sales, purchasing, and accounting — built s
   <a href="user-guide/installation/" class="btn-primary">
     :material-rocket-launch: Get Started
   </a>
-  <a href="https://github.com/Blb3D/filaops" target="_blank" class="btn-secondary">
+  <a href="https://github.com/BLB3DPrinting/filaops" target="_blank" class="btn-secondary">
     :fontawesome-brands-github: View on GitHub
   </a>
 </div>
@@ -249,7 +249,7 @@ API endpoints, database schema, UI components, and conventions for contributors.
 === "Docker (recommended)"
 
     ```bash
-    git clone https://github.com/Blb3D/filaops.git
+    git clone https://github.com/BLB3DPrinting/filaops.git
     cd filaops
     cp backend/.env.example .env
     docker compose up -d
@@ -276,6 +276,6 @@ API endpoints, database schema, UI components, and conventions for contributors.
 
 <div style="text-align: center; padding: 2rem 0;" markdown>
 
-**Built by [BLB3D Labs](https://blb3dprinting.com)** · [GitHub](https://github.com/Blb3D/filaops) · [BSL 1.1 License](https://github.com/Blb3D/filaops/blob/main/LICENSE)
+**Built by [BLB3D Labs](https://blb3dprinting.com)** · [GitHub](https://github.com/BLB3DPrinting/filaops) · [BSL 1.1 License](https://github.com/BLB3DPrinting/filaops/blob/main/LICENSE)
 
 </div>

--- a/docs/operations/external-ci-statuses.md
+++ b/docs/operations/external-ci-statuses.md
@@ -25,14 +25,14 @@ against a Core PR with:
 
 ```powershell
 .\scripts\ci\run-external-ci.ps1 `
-  -Repository Blb3D/filaops `
+  -Repository BLB3DPrinting/filaops `
   -PrNumber <pr-number> `
   -Profile core
 ```
 
 ```bash
 scripts/ci/run-external-ci.sh \
-  --repository Blb3D/filaops \
+  --repository BLB3DPrinting/filaops \
   --pr-number <pr-number> \
   --profile core
 ```

--- a/frontend/src/components/ProFeaturesAnnouncement.jsx
+++ b/frontend/src/components/ProFeaturesAnnouncement.jsx
@@ -164,7 +164,7 @@ export default function ProFeaturesAnnouncement() {
               Want to be notified when Pro launches?
             </p>
             <a
-              href="https://github.com/Blb3D/filaops/discussions"
+              href="https://github.com/BLB3DPrinting/filaops/discussions"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block px-6 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500 transition-all font-medium"

--- a/frontend/src/components/UpdateNotification.jsx
+++ b/frontend/src/components/UpdateNotification.jsx
@@ -19,7 +19,7 @@ const UpdateNotification = () => {
       setShowModal(true);
     } catch (err) {
       console.error("Failed to load instructions:", err);
-      window.open("https://github.com/Blb3D/filaops/blob/main/UPGRADE.md", "_blank");
+      window.open("https://github.com/BLB3DPrinting/filaops/blob/main/UPGRADE.md", "_blank");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/useVersionCheck.js
+++ b/frontend/src/hooks/useVersionCheck.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { getVersionInfo, isVersionLessThan, formatVersion } from "../utils/version";
 
-const GITHUB_API_URL = "https://api.github.com/repos/Blb3D/filaops/releases/latest";
+const GITHUB_API_URL = "https://api.github.com/repos/BLB3DPrinting/filaops/releases/latest";
 const SESSION_STORAGE_KEY = "filaops_version_check";
 const SESSION_STORAGE_TIMESTAMP = "filaops_version_check_timestamp";
 const CHECK_INTERVAL_MS = 1000 * 60 * 60; // 1 hour

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -1019,7 +1019,7 @@ const AdminSettings = () => {
                   </button>
                   {latestVersion && updateAvailable && (
                     <a
-                      href={`https://github.com/Blb3D/filaops/releases/tag/v${formatVersion(
+                      href={`https://github.com/BLB3DPrinting/filaops/releases/tag/v${formatVersion(
                         latestVersion
                       )}`}
                       target="_blank"


### PR DESCRIPTION
## What

Completes the migration from the old personal account to the organization across the whole repo, normalizing to canonical casing.

- `github.com/Blb3D/filaops` -> `github.com/BLB3DPrinting/filaops`
- mixed-case `Blb3DPrinting` -> canonical `BLB3DPrinting`
- `blb3d.github.io` -> `blb3dprinting.github.io` (lowercase, matches mkdocs `site_url`)

## Why

#765 fixed only the two README doc-site links and introduced a mixed-case Pages host (`blb3dPrinting.github.io`, capital P). This supersedes it: it corrects the casing and sweeps every remaining reference, so nothing points at the old account or the old Pages host — which will **not** redirect once Pages serves from the org.

## Scope (16 files)

- README badges, release link, docs link, clone URL
- backend password-reset SECURITY-WARNING log + `docs/FIRST-RUN-SETUP.md` email-setup link
- CHANGELOG compare/release links, CONTRIBUTING issues link, SECURITY (repo / releases / advisories)
- frontend in-app links: ProFeaturesAnnouncement (Discussions), UpdateNotification (UPGRADE), AdminSettings (release tag), and `useVersionCheck` (the `api.github.com` release endpoint)
- docs: DEPLOYMENT, BACKUP-AND-RECOVERY, index, external-ci-statuses, and one migration comment

## pre-push guard fix

`.githooks/pre-push` only matched the **old** remote URL when deciding whether a push targets the public core repo. After the org move it would match neither pattern, so the `case` falls through to allow-everything — silently disabling the PRO-code push guard. Added the `BLB3DPrinting` patterns while keeping the old ones for redirect safety.

## Left untouched (intentional)

- `filaops-ecosystem` (separate private repo; its new location is not confirmed here)
- the PRO repo name in the guard message
- the `blb3dprinting.com` marketing domain

Supersedes #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references and documentation links across the application to reflect the correct GitHub organization.
  * Corrected GitHub URLs for issue reporting, release notes, upgrade instructions, and documentation access to ensure users are directed to the proper resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->