### PR TITLE
fix(quality): make the Quality module functional (crashes, queue, metrics, QC UI)

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -588,10 +588,12 @@ async def get_qc_statuses(
     return {
         "statuses": [s.value for s in QCStatus],
         "descriptions": {
+            QCStatus.NOT_REQUIRED.value: "No inspection required",
             QCStatus.PENDING.value: "Awaiting inspection",
+            QCStatus.IN_PROGRESS.value: "Inspection in progress",
             QCStatus.PASSED.value: "Passed quality check",
             QCStatus.FAILED.value: "Failed quality check",
-            QCStatus.CONDITIONAL.value: "Passed with conditions",
+            QCStatus.WAIVED.value: "Failed but accepted (waived)",
         }
     }
 
@@ -1262,27 +1264,28 @@ async def record_qc_inspection(
     current_user: User = Depends(get_current_user),
 ) -> QCInspectionResponse:
     """Record QC inspection results."""
-    result = production_order_service.record_qc_inspection(
+    production_order_service.record_qc_inspection(
         db,
         order_id,
-        inspector=request.inspector or current_user.email,
-        qc_status=request.qc_status.value,
-        quantity_passed=request.quantity_passed,
-        quantity_failed=request.quantity_failed or 0,
-        failure_reason=request.failure_reason,
+        inspector=current_user.email,
+        qc_status=request.result.value,
         notes=request.notes,
     )
 
     db.commit()
 
+    order = production_order_service.get_production_order(db, order_id)
+
     return QCInspectionResponse(
-        order_id=result["order_id"],
-        order_code=result["order_code"],
-        qc_status=result["qc_status"],
-        quantity_passed=result["quantity_passed"],
-        quantity_failed=result["quantity_failed"],
-        inspector=result["inspector"],
-        inspected_at=result["inspected_at"],
+        production_order_id=order.id,
+        production_order_code=order.code,
+        qc_status=order.qc_status,
+        qc_notes=order.qc_notes,
+        qc_inspected_by=order.qc_inspected_by,
+        qc_inspected_at=order.qc_inspected_at,
+        sales_order_updated=False,
+        sales_order_status=None,
+        message=f"QC {order.qc_status} recorded for {order.code}",
     )
 
 
@@ -1332,11 +1335,11 @@ async def record_scrap(
     result = production_order_service.record_scrap(
         db,
         order_id,
-        quantity_scrapped=request.quantity,
-        reason_code=request.reason_code,
-        operation_id=request.operation_id,
+        quantity_scrapped=request.quantity_scrapped,
+        reason_code=request.scrap_reason_code,
+        operation_id=None,
         notes=request.notes,
-        create_remake=request.create_remake or False,
+        create_remake=request.create_replacement,
         user_email=current_user.email,
     )
 
@@ -1348,7 +1351,7 @@ async def record_scrap(
         order_id=order.id,
         order_code=order.code,
         quantity_scrapped=order.quantity_scrapped or 0,
-        scrap_reason=request.reason_code,
+        scrap_reason=request.scrap_reason_code,
         remake_order_id=result["remake_order"]["id"] if result["remake_order"] else None,
         remake_order_code=result["remake_order"]["code"] if result["remake_order"] else None,
     )

--- a/backend/app/schemas/quality.py
+++ b/backend/app/schemas/quality.py
@@ -44,7 +44,8 @@ class QualityMetricsResponse(BaseModel):
     )
     pending_inspections: int
     scrap_rate: Optional[float] = Field(
-        None, description="Scrapped qty as percentage of total completed"
+        None,
+        description="Scrapped qty as a percentage of total handled (good + scrapped)",
     )
     total_scrapped_cost: float = 0
 

--- a/backend/app/services/operation_status.py
+++ b/backend/app/services/operation_status.py
@@ -186,6 +186,10 @@ def update_po_status(db: Session, po: ProductionOrder, created_by: Optional[str]
             po.actual_end = datetime.now(timezone.utc)
             po.completed_at = datetime.now(timezone.utc)
 
+            # Route the finished order into the QC inspection queue
+            if po.qc_status in (None, 'not_required'):
+                po.qc_status = 'pending'
+
             # === AUTO-COMPLETE: Add finished goods to inventory ===
             # This triggers when all operations complete, not just when
             # the explicit /complete endpoint is called

--- a/backend/app/services/production_order_execution_service.py
+++ b/backend/app/services/production_order_execution_service.py
@@ -135,6 +135,10 @@ def complete_production_order(
         order.completed_at = datetime.now(timezone.utc)
         order.actual_end = datetime.now(timezone.utc)
 
+        # Route the finished order into the QC inspection queue
+        if order.qc_status in (None, "not_required"):
+            order.qc_status = "pending"
+
         # Complete all operations
         for op in order.operations:
             if op.status != "complete":
@@ -289,6 +293,10 @@ def accept_short_production_order(
     order.status = "complete"
     order.completed_at = datetime.now(timezone.utc)
     order.actual_end = datetime.now(timezone.utc)
+
+    # Route the finished order into the QC inspection queue
+    if order.qc_status in (None, "not_required"):
+        order.qc_status = "pending"
 
     # Complete any remaining operations
     for op in order.operations:

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -621,8 +621,8 @@ def record_qc_inspection(
     order_id: int,
     inspector: str,
     qc_status: str,
-    quantity_passed: int,
-    quantity_failed: int = 0,
+    quantity_passed: Optional[int] = None,
+    quantity_failed: Optional[int] = None,
     failure_reason: Optional[str] = None,
     notes: Optional[str] = None,
 ) -> dict:
@@ -642,6 +642,16 @@ def record_qc_inspection(
         Dict with inspection results
     """
     order = get_production_order(db, order_id)
+
+    # Derive whole-order pass/fail quantities when the caller does not supply
+    # them (e.g. the /qc endpoint, where QC is a binary pass/fail on the order).
+    if quantity_passed is None or quantity_failed is None:
+        order_qty = int(order.quantity_completed or order.quantity_ordered or 0)
+        if qc_status == "failed":
+            quantity_passed, quantity_failed = 0, order_qty
+        else:
+            quantity_passed, quantity_failed = order_qty, 0
+    quantity_failed = quantity_failed or 0
 
     inspected_at = datetime.now(timezone.utc)
 
@@ -670,9 +680,12 @@ def record_qc_inspection(
     order.qc_inspected_at = inspected_at
     order.qc_notes = notes
 
-    # Update order based on QC result
-    if qc_status == "failed" and quantity_failed > 0:
-        order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_failed
+    # Update order based on QC result. A failed inspection holds the order so
+    # it cannot be closed/fulfilled until it is dispositioned.
+    if qc_status == "failed":
+        order.status = "qc_hold"
+        if quantity_failed > 0:
+            order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_failed
 
     db.flush()
 
@@ -830,14 +843,28 @@ def record_scrap(
     # Update order scrap quantity
     order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_scrapped
 
-    # Create scrap record
+    # Create scrap record with cost capture (mirrors scrap_service pattern,
+    # matching the real ScrapRecord columns and NOT-NULL cost fields).
+    from app.models.user import User
+    scrap_user = db.query(User).filter(User.email == user_email).first()
+    product = order.product
+    unit_cost = (
+        product.standard_cost
+        if product is not None and product.standard_cost is not None
+        else Decimal("0")
+    )
+    qty_dec = Decimal(str(quantity_scrapped))
     scrap_record = ScrapRecord(
         production_order_id=order_id,
-        operation_id=operation_id,
-        quantity=quantity_scrapped,
-        reason_code=reason_code,
+        production_operation_id=operation_id,
+        product_id=order.product_id,
+        quantity=qty_dec,
+        unit_cost=unit_cost,
+        total_cost=unit_cost * qty_dec,
+        scrap_reason_id=reason.id,
+        scrap_reason_code=reason_code,
         notes=notes,
-        recorded_by=user_email,
+        created_by_user_id=scrap_user.id if scrap_user else None,
     )
     db.add(scrap_record)
     db.flush()

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -645,12 +645,19 @@ def record_qc_inspection(
 
     # Derive whole-order pass/fail quantities when the caller does not supply
     # them (e.g. the /qc endpoint, where QC is a binary pass/fail on the order).
+    # Only the missing side is derived, so a caller that supplies one keeps it.
     if quantity_passed is None or quantity_failed is None:
         order_qty = int(order.quantity_completed or order.quantity_ordered or 0)
         if qc_status == "failed":
-            quantity_passed, quantity_failed = 0, order_qty
+            if quantity_passed is None:
+                quantity_passed = 0
+            if quantity_failed is None:
+                quantity_failed = order_qty
         else:
-            quantity_passed, quantity_failed = order_qty, 0
+            if quantity_passed is None:
+                quantity_passed = order_qty
+            if quantity_failed is None:
+                quantity_failed = 0
     quantity_failed = quantity_failed or 0
 
     inspected_at = datetime.now(timezone.utc)

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -681,11 +681,12 @@ def record_qc_inspection(
     order.qc_notes = notes
 
     # Update order based on QC result. A failed inspection holds the order so
-    # it cannot be closed/fulfilled until it is dispositioned.
+    # it cannot be closed/fulfilled until it is dispositioned. The scrap count
+    # is recorded separately via record_scrap (the QC modal prompts the user to
+    # scrap + optionally remake); incrementing quantity_scrapped here as well
+    # would double-count the failed units.
     if qc_status == "failed":
         order.status = "qc_hold"
-        if quantity_failed > 0:
-            order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_failed
 
     db.flush()
 

--- a/backend/app/services/quality_service.py
+++ b/backend/app/services/quality_service.py
@@ -69,7 +69,7 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
     - failed: Orders that failed QC
     - first_pass_yield: passed / (passed + failed) as a percentage
     - pending_inspections: Current queue depth
-    - scrap_rate: scrapped qty / total completed qty as a percentage
+    - scrap_rate: scrapped qty / (completed + scrapped) qty as a percentage
     - total_scrapped_cost: Sum of scrap costs in the period
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
@@ -94,9 +94,12 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
     waived = counts.get("waived", 0)
     total_inspections = passed + failed + waived
 
+    # First-pass yield = passed / (passed + failed). Waived parts are excluded
+    # from the yield (they neither cleanly passed nor failed inspection).
+    fpy_denom = passed + failed
     first_pass_yield = (
-        round((passed / total_inspections) * 100, 1)
-        if total_inspections > 0
+        round((passed / fpy_denom) * 100, 1)
+        if fpy_denom > 0
         else None
     )
 
@@ -123,9 +126,11 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
     completed_qty = float(qty_agg.completed) if qty_agg else 0
     scrapped_qty = float(qty_agg.scrapped) if qty_agg else 0
 
+    # Scrap rate = scrapped / (good + scrapped) so it stays bounded 0-100%.
+    scrap_denom = completed_qty + scrapped_qty
     scrap_rate = (
-        round((scrapped_qty / completed_qty) * 100, 1)
-        if completed_qty > 0
+        round((scrapped_qty / scrap_denom) * 100, 1)
+        if scrap_denom > 0
         else None
     )
 

--- a/backend/app/services/quality_service.py
+++ b/backend/app/services/quality_service.py
@@ -110,7 +110,7 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
         .scalar()
     ) or 0
 
-    # Scrap rate: total scrapped qty / total completed qty (period)
+    # Aggregate good (completed) and scrapped quantities over the period.
     qty_agg = (
         db.query(
             func.coalesce(func.sum(ProductionOrder.quantity_completed), 0).label("completed"),

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2648,9 +2648,12 @@ class TestRecordQCInspection:
         assert reloaded.qc_notes == "All checks passed"
         assert reloaded.qc_inspected_at is not None
 
-    def test_record_failed_inspection_updates_scrap(self, db, finished_good):
-        """Should update scrap quantity on failed inspection."""
+    def test_record_failed_inspection_holds_order_without_autoscrap(self, db, finished_good):
+        """A failed inspection holds the order for disposition but does NOT
+        auto-increment quantity_scrapped — scrap is recorded separately via
+        record_scrap, so counting it here too would double-count."""
         order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        original_scrapped = int(order.quantity_scrapped or 0)
         svc.record_qc_inspection(
             db, order.id,
             inspector="Inspector Smith",
@@ -2659,9 +2662,9 @@ class TestRecordQCInspection:
             quantity_failed=3,
             failure_reason="Surface defects",
         )
-        # Service persists order-level QC fields and failed scrap quantity.
-        assert int(order.quantity_scrapped) == 3
         assert order.qc_status == "failed"
+        assert order.status == "qc_hold"
+        assert int(order.quantity_scrapped or 0) == original_scrapped
         assert order.qc_inspected_by == "Inspector Smith"
         assert order.qc_inspected_at is not None
 

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2360,11 +2360,39 @@ class TestRecordScrap:
     order.  It imports reserve_production_materials from inventory_service
     for the remake path; we mock that to avoid deep dependency chains.
 
-    NOTE: The service code's ScrapRecord construction uses field names
-    that do not match the model columns and omits required NOT-NULL columns.
-    We mock ScrapRecord to test the service logic without hitting the
-    schema mismatch.
+    The ScrapRecord construction now matches the model columns and populates
+    the NOT-NULL cost fields; test_record_scrap_creates_real_scrap_record
+    exercises the real persistence path. The remaining tests still mock
+    ScrapRecord to isolate the surrounding control flow.
     """
+
+    def test_record_scrap_creates_real_scrap_record(self, db, finished_good):
+        """Real path (no mock): persists a ScrapRecord with the correct
+        columns and NOT-NULL cost fields."""
+        from app.models.production_order import ScrapRecord as _ScrapRecord
+        reason = _make_scrap_reason(db, code="real-scrap", name="Real Scrap")
+        order = _make_production_order(
+            db, finished_good, status="in_progress", quantity=10
+        )
+        result = svc.record_scrap(
+            db, order.id,
+            quantity_scrapped=3,
+            reason_code="real-scrap",
+            user_email="test@filaops.dev",
+            create_remake=False,
+        )
+        rec = (
+            db.query(_ScrapRecord)
+            .filter(_ScrapRecord.id == result["scrap_record_id"])
+            .first()
+        )
+        assert rec is not None
+        assert rec.product_id == finished_good.id
+        assert int(rec.quantity) == 3
+        assert rec.scrap_reason_code == "real-scrap"
+        assert rec.scrap_reason_id == reason.id
+        assert rec.unit_cost is not None
+        assert rec.total_cost == rec.unit_cost * 3
 
     def test_record_scrap_invalid_reason_rejected(self, db, finished_good):
         """Should reject scrap with a nonexistent reason code."""

--- a/frontend/src/pages/admin/quality/QualityDashboard.jsx
+++ b/frontend/src/pages/admin/quality/QualityDashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
 import { useApi } from "../../../hooks/useApi";
 import StatCard from "../../../components/StatCard";
+import QCInspectionModal from "../../../components/QCInspectionModal";
 
 /**
  * QualityDashboard — Overview of quality management metrics.
@@ -20,6 +20,7 @@ export default function QualityDashboard() {
   const [scrapSummary, setScrapSummary] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [qcOrder, setQcOrder] = useState(null);
 
   useEffect(() => {
     fetchAll();
@@ -188,10 +189,11 @@ export default function QualityDashboard() {
           ) : (
             <div className="divide-y divide-[var(--border-subtle)]">
               {queue.items.map((item) => (
-                <Link
+                <button
                   key={item.id}
-                  to={`/admin/production/${item.id}`}
-                  className="flex items-center justify-between px-4 py-3 hover:bg-[var(--bg-secondary)] transition-colors"
+                  type="button"
+                  onClick={() => setQcOrder(item)}
+                  className="w-full text-left flex items-center justify-between px-4 py-3 hover:bg-[var(--bg-secondary)] transition-colors"
                 >
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-medium text-[var(--text-primary)] truncate">
@@ -207,7 +209,7 @@ export default function QualityDashboard() {
                     </span>
                     {qcBadge(item.qc_status)}
                   </div>
-                </Link>
+                </button>
               ))}
             </div>
           )}
@@ -300,6 +302,17 @@ export default function QualityDashboard() {
             </table>
           </div>
         </div>
+      )}
+
+      {qcOrder && (
+        <QCInspectionModal
+          productionOrder={qcOrder}
+          onClose={() => setQcOrder(null)}
+          onComplete={() => {
+            setQcOrder(null);
+            fetchAll();
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
+++ b/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { ToastProvider } from "../../../../components/Toast";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Reset the shared apiClient singleton between tests so each test
@@ -118,7 +119,9 @@ async function renderDashboard(fetchOverrides) {
   const { default: QualityDashboard } = await import("../QualityDashboard");
   return render(
     <MemoryRouter>
-      <QualityDashboard />
+      <ToastProvider>
+        <QualityDashboard />
+      </ToastProvider>
     </MemoryRouter>,
   );
 }
@@ -179,6 +182,9 @@ describe("QualityDashboard", () => {
     // Queue rows are no longer navigation links; clicking one opens the QC
     // inspection modal in place (the queue -> inspect -> resolve loop).
     expect(screen.getByText("PO-001").closest("a")).toBeNull();
+
+    fireEvent.click(screen.getByText("PO-001").closest("button"));
+    expect(await screen.findByText("Inspection Result *")).toBeInTheDocument();
   });
 
   it('renders "2 pending" in queue header', async () => {

--- a/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
+++ b/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { ToastProvider } from "../../../../components/Toast";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Reset the shared apiClient singleton between tests so each test
@@ -115,8 +114,12 @@ function mockFetch(overrides = {}) {
 
 async function renderDashboard(fetchOverrides) {
   mockFetch(fetchOverrides);
-  // Dynamic import after fetch mock is set, so the shared apiClient picks it up
+  // Dynamic import after fetch mock is set, so the shared apiClient picks it up.
+  // ToastProvider is imported dynamically too so it shares the same post-reset
+  // Toast module instance (and thus context) as the modal's useToast — a static
+  // import would resolve to a different ToastContext after vi.resetModules().
   const { default: QualityDashboard } = await import("../QualityDashboard");
+  const { ToastProvider } = await import("../../../../components/Toast");
   return render(
     <MemoryRouter>
       <ToastProvider>

--- a/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
+++ b/frontend/src/pages/admin/quality/__tests__/QualityDashboard.test.jsx
@@ -171,13 +171,14 @@ describe("QualityDashboard", () => {
     expect(screen.getByText("200/200")).toBeInTheDocument();
   });
 
-  it("renders inspection queue items as links to production order", async () => {
+  it("renders inspection queue items as buttons that open the QC modal", async () => {
     await renderDashboard();
     await waitFor(() => {
-      expect(screen.getByText("PO-001")).toBeInTheDocument();
+      expect(screen.getByText("PO-001").closest("button")).toBeInTheDocument();
     });
-    const link = screen.getByText("PO-001").closest("a");
-    expect(link).toHaveAttribute("href", "/admin/production/1");
+    // Queue rows are no longer navigation links; clicking one opens the QC
+    // inspection modal in place (the queue -> inspect -> resolve loop).
+    expect(screen.getByText("PO-001").closest("a")).toBeNull();
   });
 
   it('renders "2 pending" in queue header', async () => {


### PR DESCRIPTION
Makes the Quality module **functional end-to-end** — the audit (#787) found it non-functional (every QC submit, scrap, and qc-statuses call 500'd; the queue never populated; the QC modal was unreachable). After this, you can complete a production order, see it appear in the QC queue, click it, and pass/fail it — with correct dashboard metrics.

## Fixes the 3 crashes (#779)
- **`POST /{id}/qc`** read request fields (`qc_status`, `inspector`, `quantity_passed`, …) that aren't on `QCInspectionRequest` (only `result` + `notes`), and built a response with the wrong keys. Aligned the endpoint to the real schema: it derives whole-order pass/fail quantities in the service and returns a valid `QCInspectionResponse`.
- **`GET /qc-statuses`** referenced `QCStatus.CONDITIONAL`, which isn't in the enum → `AttributeError`. Replaced with the real members.
- **`POST /{id}/scrap`** read non-existent request fields, and `record_scrap` built `ScrapRecord` with wrong kwargs (`operation_id`, `reason_code`, `recorded_by`) while omitting NOT-NULL `product_id`/`unit_cost`/`total_cost`. Endpoint now reads the real `OperationScrapRequest` fields; the service constructs a correct, cost-bearing `ScrapRecord` (mirrors `scrap_service`).

## Populates the queue + gates (#780, partial)
- All three completion paths (explicit complete, accept-short, operation-driven auto-complete) now set `qc_status='pending'` when it's still `not_required`, so finished orders flow into the QC queue. **This is a behavioral change: completed orders now require a QC disposition before `can_close` is satisfied.**
- A **failed** inspection moves the order to `qc_hold`.

## Fixes the dashboard math (#782)
- `scrap_rate` = `scrapped / (completed + scrapped)` — bounded 0-100% (was `scrapped/completed`, which could exceed 100%).
- `first_pass_yield` = `passed / (passed + failed)` — waived excluded, matching its docstring.

## Wires the UI (#781)
- Quality Dashboard inspection-queue rows now open `QCInspectionModal` directly (resolving the queue→inspect→resolve loop) and refresh on completion, instead of linking to a detail page with no QC action.

## Tests
- Backend: **490+ green** — 232 production-order/quality, 261 completion/sync, plus a new **no-mock** scrap test that persists a real `ScrapRecord` and asserts the cost columns (the prior tests mocked the constructor to work around the bug). Frontend JSX validated; CI runs the full `vite build`.

## Deliberately deferred (tracked under #787)
- **Scrap trigger in `AdminProduction`** — those QC/Scrap modals are still mounted-but-unopened; the scrap *endpoint* is fixed and tested, but the order-queue button wiring is a follow-up (the Quality Dashboard QC loop is the primary path).
- **FG-received-before-QC accounting** (#780 deep) — completion still receives finished goods into inventory before inspection with no reversal on fail; full inventory/GL write-off on QC-scrap is a larger change.
- **Inspection-record table** (#783) and **Waive / defect taxonomy / photo / per-printer / trend** (#784) — the structural rebuild and capability gaps.

Closes #779, #782; advances #780, #781 (part of #787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed production orders (including short completions) now automatically move into the QC inspection queue.
  * Admin quality dashboard now opens a QC inspection modal from the inspection queue and refreshes metrics after completion.
* **Bug Fixes**
  * QC statuses endpoint description set updated (adds NOT_REQUIRED and WAIVED; removes CONDITIONAL).
  * QC inspection recording now saves inspection details consistently, routes failures to QC hold, and avoids auto-counting failed units as scrap.
  * Scrap recording now captures cost details and uses the correct scrap reason mapping.
  * Quality metrics updated: first pass yield and scrap rate calculations (including clarified scrap rate denominator).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->