### PR TITLE
fix(quality): write off FG inventory + post GL when scrapping a completed order (#780)

### DIFF
--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -851,10 +851,9 @@ def record_scrap(
     # Update order scrap quantity
     order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_scrapped
 
-    # Create scrap record with cost capture (mirrors scrap_service pattern,
-    # matching the real ScrapRecord columns and NOT-NULL cost fields).
     from app.models.user import User
     scrap_user = db.query(User).filter(User.email == user_email).first()
+    user_id = scrap_user.id if scrap_user else None
     product = order.product
     unit_cost = (
         product.standard_cost
@@ -862,19 +861,38 @@ def record_scrap(
         else Decimal("0")
     )
     qty_dec = Decimal(str(quantity_scrapped))
-    scrap_record = ScrapRecord(
-        production_order_id=order_id,
-        production_operation_id=operation_id,
-        product_id=order.product_id,
-        quantity=qty_dec,
-        unit_cost=unit_cost,
-        total_cost=unit_cost * qty_dec,
-        scrap_reason_id=reason.id,
-        scrap_reason_code=reason_code,
-        notes=notes,
-        created_by_user_id=scrap_user.id if scrap_user else None,
-    )
-    db.add(scrap_record)
+
+    # Finished goods are received into inventory at completion, so scrapping a
+    # completed order must write the units off the FG ledger (decrementing
+    # on_hand) and post the GL entry DR Scrap Expense (5020) / CR FG Inventory
+    # (1220). For orders not yet completed the FG is not in inventory, so we
+    # only record the scrap event + its cost.
+    if order.status == "complete":
+        from app.services.transaction_service import TransactionService
+        _, _, scrap_record = TransactionService(db).scrap_finished_goods(
+            production_order_id=order_id,
+            product_id=order.product_id,
+            quantity=qty_dec,
+            unit_cost=unit_cost,
+            reason_code=reason_code,
+            reason_id=reason.id,
+            notes=notes,
+            user_id=user_id,
+        )
+    else:
+        scrap_record = ScrapRecord(
+            production_order_id=order_id,
+            production_operation_id=operation_id,
+            product_id=order.product_id,
+            quantity=qty_dec,
+            unit_cost=unit_cost,
+            total_cost=unit_cost * qty_dec,
+            scrap_reason_id=reason.id,
+            scrap_reason_code=reason_code,
+            notes=notes,
+            created_by_user_id=user_id,
+        )
+        db.add(scrap_record)
     db.flush()
 
     result = {

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -485,6 +485,22 @@ class TransactionService:
         """
         total_cost = quantity * unit_cost
 
+        # Policy gate: refuse to drive on_hand negative.  inventory_ledger.post
+        # is mechanism-only; stock-sufficiency checks live in callers.
+        # Acquiring FOR UPDATE here serializes with the identical lock in
+        # _post_inventory so there is no TOCTOU window.
+        from app.services.inventory_service import get_or_create_default_location
+        resolved_location_id = get_or_create_default_location(self.db).id
+        inv_row = inventory_ledger.get_or_create_inventory_row(
+            self.db, product_id, resolved_location_id
+        )
+        current_on_hand = Decimal(str(inv_row.on_hand_quantity or 0))
+        if quantity > current_on_hand:
+            raise ValueError(
+                f"Cannot scrap {quantity} units of product {product_id}: "
+                f"only {current_on_hand} on hand"
+            )
+
         inv_txn = self._post_inventory(
             product_id=product_id,
             transaction_type="scrap",
@@ -493,6 +509,7 @@ class TransactionService:
             reference_type="production_order",
             reference_id=production_order_id,
             notes=f"Scrap (finished goods): {reason_code}",
+            location_id=resolved_location_id,
         )
         self.db.flush()  # Get inv_txn.id for the scrap record
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -459,6 +459,74 @@ class TransactionService:
 
         return inv_txn, je, scrap
 
+    def scrap_finished_goods(
+        self,
+        production_order_id: int,
+        product_id: int,
+        quantity: Decimal,
+        unit_cost: Decimal,
+        reason_code: str,
+        reason_id: int = None,
+        notes: str = None,
+        user_id: int = None,
+    ) -> Tuple[InventoryTransaction, Optional[GLJournalEntry], ScrapRecord]:
+        """
+        Scrap finished goods that were already received into inventory.
+
+        Unlike scrap_materials (WIP-side audit row, on_hand already gone), the
+        units here are physically on hand, so the movement goes through the
+        canonical ledger (HARD-4a) and decrements on_hand.
+
+        Inventory: SCRAP (negative qty); on_hand decremented.
+        Accounting: DR Scrap Expense (5020), CR FG Inventory (1220).
+
+        Returns:
+            Tuple of (inventory transaction, journal entry, scrap record)
+        """
+        total_cost = quantity * unit_cost
+
+        inv_txn = self._post_inventory(
+            product_id=product_id,
+            transaction_type="scrap",
+            quantity_delta=-quantity,  # Negative = removal from stock
+            unit_cost=unit_cost,
+            reference_type="production_order",
+            reference_id=production_order_id,
+            notes=f"Scrap (finished goods): {reason_code}",
+        )
+        self.db.flush()  # Get inv_txn.id for the scrap record
+
+        je = None
+        if total_cost > 0:
+            je = self._create_journal_entry(
+                description=f"Scrap finished goods at PO#{production_order_id}: {reason_code}",
+                lines=[
+                    ("5020", total_cost, "DR"),  # Scrap Expense
+                    ("1220", total_cost, "CR"),  # Finished Goods Inventory
+                ],
+                source_type="production_order",
+                source_id=production_order_id,
+                user_id=user_id,
+            )
+            inv_txn.journal_entry_id = je.id
+
+        scrap = ScrapRecord(
+            production_order_id=production_order_id,
+            product_id=product_id,
+            quantity=quantity,
+            unit_cost=unit_cost,
+            total_cost=total_cost,
+            scrap_reason_id=reason_id,
+            scrap_reason_code=reason_code,
+            notes=notes,
+            inventory_transaction_id=inv_txn.id,
+            journal_entry_id=je.id if je else None,
+            created_by_user_id=user_id,
+        )
+        self.db.add(scrap)
+
+        return inv_txn, je, scrap
+
     # === SHIPPING TRANSACTIONS ===
 
     def ship_order(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -483,6 +483,19 @@ class TransactionService:
         Returns:
             Tuple of (inventory transaction, journal entry, scrap record)
         """
+        # Boundary validation: a non-positive quantity would bypass the
+        # on-hand guard (a zero/negative delta can't make stock go negative)
+        # and a negative unit_cost would post a backwards GL entry. Reject
+        # both at the service boundary.
+        if quantity <= 0:
+            raise ValueError(
+                f"Scrap quantity must be positive, got {quantity}"
+            )
+        if unit_cost < 0:
+            raise ValueError(
+                f"Scrap unit_cost must be non-negative, got {unit_cost}"
+            )
+
         total_cost = quantity * unit_cost
 
         # Policy gate: refuse to drive on_hand negative.  inventory_ledger.post

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2394,6 +2394,28 @@ class TestRecordScrap:
         assert rec.unit_cost is not None
         assert rec.total_cost == rec.unit_cost * 3
 
+    def test_record_scrap_completed_order_writes_off_inventory(self, db, finished_good):
+        """Scrapping a COMPLETED order routes through the FG ledger write-off,
+        so the ScrapRecord is linked to an inventory transaction (on-hand
+        decrement) rather than being a cost-only row."""
+        from app.models.production_order import ScrapRecord as _ScrapRecord
+        _make_scrap_reason(db, code="fg-scrap", name="FG Scrap")
+        order = _make_production_order(db, finished_good, status="complete", quantity=10)
+        result = svc.record_scrap(
+            db, order.id,
+            quantity_scrapped=2,
+            reason_code="fg-scrap",
+            user_email="test@filaops.dev",
+            create_remake=False,
+        )
+        rec = (
+            db.query(_ScrapRecord)
+            .filter(_ScrapRecord.id == result["scrap_record_id"])
+            .first()
+        )
+        assert rec is not None
+        assert rec.inventory_transaction_id is not None
+
     def test_record_scrap_invalid_reason_rejected(self, db, finished_good):
         """Should reject scrap with a nonexistent reason code."""
         order = _make_production_order(db, finished_good, status="in_progress")

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2399,8 +2399,20 @@ class TestRecordScrap:
         so the ScrapRecord is linked to an inventory transaction (on-hand
         decrement) rather than being a cost-only row."""
         from app.models.production_order import ScrapRecord as _ScrapRecord
+        from app.services.inventory_service import get_or_create_default_location
         _make_scrap_reason(db, code="fg-scrap", name="FG Scrap")
         order = _make_production_order(db, finished_good, status="complete", quantity=10)
+        # FG is received into inventory at completion; seed on-hand at the
+        # default location so the write-off has stock to decrement (matches the
+        # location scrap_finished_goods resolves).
+        location = get_or_create_default_location(db)
+        db.add(Inventory(
+            product_id=finished_good.id,
+            location_id=location.id,
+            on_hand_quantity=Decimal("10"),
+            allocated_quantity=Decimal("0"),
+        ))
+        db.flush()
         result = svc.record_scrap(
             db, order.id,
             quantity_scrapped=2,

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -484,6 +484,53 @@ class TestScrapMaterials:
             db.rollback()
 
 
+class TestScrapFinishedGoods:
+    """Test scrap_finished_goods method (units already on hand)."""
+
+    def test_decrements_onhand_and_posts_fg_gl(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product):
+        """Should decrement on_hand and post DR Scrap Expense / CR FG Inventory."""
+        ts = TransactionService(db)
+        try:
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("10"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            inv_txn, je, scrap = ts.scrap_finished_goods(
+                production_order_id=test_production_order.id,
+                product_id=test_finished_good.id,
+                quantity=Decimal("2"),
+                unit_cost=Decimal("10.00"),
+                reason_code="QC_FAIL",
+                notes="Failed final inspection",
+            )
+            db.flush()
+
+            # Inventory: SCRAP removal through the canonical ledger (on_hand 10 -> 8)
+            assert inv_txn.transaction_type == "scrap"
+            assert inv_txn.quantity == Decimal("-2")
+            db.refresh(inv)
+            assert inv.on_hand_quantity == Decimal("8")
+
+            # Accounting: balanced DR Scrap Expense (5020) / CR FG Inventory (1220)
+            assert je is not None and je.is_balanced
+            dr_line = next(l for l in je.lines if l.debit_amount > 0)
+            cr_line = next(l for l in je.lines if l.credit_amount > 0)
+            assert dr_line.account.account_code == "5020"
+            assert cr_line.account.account_code == "1220"
+
+            # ScrapRecord links both the inventory txn and the journal entry
+            assert scrap.total_cost == Decimal("20.00")
+            assert scrap.inventory_transaction_id == inv_txn.id
+            assert scrap.journal_entry_id == je.id
+        finally:
+            db.rollback()
+
+
 # ============================================================================
 # Ship Order Tests
 # ============================================================================

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -554,6 +554,36 @@ class TestScrapFinishedGoods:
         finally:
             db.rollback()
 
+    def test_rejects_non_positive_quantity(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product):
+        """Should raise ValueError for zero/negative scrap quantity (boundary guard)."""
+        ts = TransactionService(db)
+        try:
+            with pytest.raises(ValueError, match="quantity must be positive"):
+                ts.scrap_finished_goods(
+                    production_order_id=test_production_order.id,
+                    product_id=test_finished_good.id,
+                    quantity=Decimal("0"),
+                    unit_cost=Decimal("10.00"),
+                    reason_code="QC_FAIL",
+                )
+        finally:
+            db.rollback()
+
+    def test_rejects_negative_unit_cost(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product):
+        """Should raise ValueError for negative unit_cost (would post a backwards GL entry)."""
+        ts = TransactionService(db)
+        try:
+            with pytest.raises(ValueError, match="unit_cost must be non-negative"):
+                ts.scrap_finished_goods(
+                    production_order_id=test_production_order.id,
+                    product_id=test_finished_good.id,
+                    quantity=Decimal("1"),
+                    unit_cost=Decimal("-5.00"),
+                    reason_code="QC_FAIL",
+                )
+        finally:
+            db.rollback()
+
 
 # ============================================================================
 # Ship Order Tests

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -554,15 +554,16 @@ class TestScrapFinishedGoods:
         finally:
             db.rollback()
 
-    def test_rejects_non_positive_quantity(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product):
-        """Should raise ValueError for zero/negative scrap quantity (boundary guard)."""
+    @pytest.mark.parametrize("bad_qty", [Decimal("0"), Decimal("-1")])
+    def test_rejects_non_positive_quantity(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product, bad_qty):
+        """Should raise ValueError for zero AND negative scrap quantity (boundary guard)."""
         ts = TransactionService(db)
         try:
             with pytest.raises(ValueError, match="quantity must be positive"):
                 ts.scrap_finished_goods(
                     production_order_id=test_production_order.id,
                     product_id=test_finished_good.id,
-                    quantity=Decimal("0"),
+                    quantity=bad_qty,
                     unit_cost=Decimal("10.00"),
                     reason_code="QC_FAIL",
                 )

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -530,6 +530,30 @@ class TestScrapFinishedGoods:
         finally:
             db.rollback()
 
+    def test_raises_when_quantity_exceeds_onhand(self, db: Session, test_production_order: ProductionOrder, test_finished_good: Product):
+        """Should raise ValueError when scrap qty would drive on_hand negative."""
+        ts = TransactionService(db)
+        try:
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("1"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            with pytest.raises(ValueError, match="only 1"):
+                ts.scrap_finished_goods(
+                    production_order_id=test_production_order.id,
+                    product_id=test_finished_good.id,
+                    quantity=Decimal("5"),
+                    unit_cost=Decimal("10.00"),
+                    reason_code="QC_FAIL",
+                )
+        finally:
+            db.rollback()
+
 
 # ============================================================================
 # Ship Order Tests


### PR DESCRIPTION
Advances #780 (part of the Quality epic #787): order-level scrap now writes off **finished-goods inventory and posts the GL entry**, instead of silently recording a cost-only row.

## Problem
After #791, `record_scrap` created a `ScrapRecord` with cost capture, but it never decremented on-hand inventory or posted to the ledger. So scrapping finished goods (e.g. after a failed QC) left FG stock overstated and nothing hit the GL — a silent inventory + accounting drift.

## Fix
- **New `TransactionService.scrap_finished_goods(...)`** — removes the units through the **canonical inventory ledger** (`_post_inventory`, the HARD-4a on-hand path, so `on_hand` is actually decremented) and posts a balanced journal entry: **DR Scrap Expense (5020) / CR Finished Goods Inventory (1220)**. Returns `(inventory_txn, journal_entry, scrap_record)` with the record linked to both.
  - This is intentionally distinct from the existing `scrap_materials`, which is a **WIP-side audit row** (no on-hand change, credits WIP `1210`) — correct for material/WIP scrap, wrong for finished goods that are physically on hand.
- **`record_scrap` routing** — a **completed** order's scrap (FG already received at completion) goes through `scrap_finished_goods`; a **not-yet-completed** order keeps the cost-only `ScrapRecord` (its FG isn't in inventory to remove).

## Tests
- `TestScrapFinishedGoods` — asserts on-hand decrements (10 → 8), a balanced **DR 5020 / CR 1220** journal entry, and the `ScrapRecord` links both the inventory txn and the journal entry.
- `record_scrap` completed-order test — asserts the completed path produces a `ScrapRecord` linked to an inventory transaction (vs the cost-only path).
- **262** transaction / production / quality tests pass; no regressions.

## Still open under #780 (separate, follow-up)
Finished goods are still **received into inventory at completion, before QC**, with no automatic reversal if QC then fails. This PR makes the *explicit scrap* path correct (so a failed unit can be properly written off); gating/reversing the FG **receipt** around QC is a completion-flow change left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced scrap recording for **completed** production orders to create an inventory write-off and associate the scrap record with it.
  * Finished-goods scrapping now can generate a balanced GL journal entry (when applicable) and link it to the write-off.

* **Bug Fixes**
  * Prevents scrapping beyond available on-hand quantity.
  * Adds validation for positive scrap quantity and non-negative unit cost.

* **Tests**
  * Added coverage for completed-order scrap write-off, GL journal creation/linking, and validation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->