### PR TITLE
feat(intake): slicing-state UX for raw .3mf upload (quoter convergence)

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -76,6 +76,7 @@ export default function AdminIntakeStudio() {
   // Step 1 — Upload
   const [dragActive, setDragActive] = useState(false);
   const [uploadBusy, setUploadBusy] = useState(false);
+  const [busyMode, setBusyMode] = useState("parsing");
 
   // Step 2 — Review
   const [parseResult, setParseResult] = useState(null);
@@ -155,10 +156,11 @@ export default function AdminIntakeStudio() {
           </svg>
           <h3 className="text-lg font-semibold text-white mb-2">PRO Feature</h3>
           <p className="text-gray-400 mb-4">
-            Intake Studio lets you drop a sliced .gcode.3mf file, automatically
-            match filament spools from your inventory, configure print work
-            centers and finishing operations, and instantly create a sellable SKU
-            with a fully costed routing — all in one guided workflow.
+            Intake Studio lets you drop a 3D model (.3mf, sliced on the server)
+            or a pre-sliced .gcode.3mf, automatically match filament spools from
+            your inventory, configure print work centers and finishing operations,
+            and instantly create a sellable SKU with a fully costed routing — all
+            in one guided workflow.
           </p>
           <a
             href="/pricing"
@@ -207,6 +209,8 @@ export default function AdminIntakeStudio() {
       return;
     }
     sourceFileRef.current = f;
+    const isRaw = name.endsWith(".3mf") && !name.endsWith(".gcode.3mf");
+    setBusyMode(isRaw ? "slicing" : "parsing");
     setUploadBusy(true);
     try {
       const formData = new FormData();
@@ -455,6 +459,7 @@ export default function AdminIntakeStudio() {
     setStep(1);
     setDragActive(false);
     setUploadBusy(false);
+    setBusyMode("parsing");
     setParseResult(null);
     setProductName("");
     setMatchResults(null);
@@ -553,7 +558,16 @@ export default function AdminIntakeStudio() {
           {uploadBusy ? (
             <div className="flex flex-col items-center justify-center py-16 gap-4">
               <Spinner />
-              <p className="text-gray-400">Parsing file…</p>
+              {busyMode === "slicing" ? (
+                <>
+                  <p className="text-gray-400">Slicing your model…</p>
+                  <p className="text-gray-600 text-sm">
+                    This can take a minute or two — Bambu Studio is slicing on the server.
+                  </p>
+                </>
+              ) : (
+                <p className="text-gray-400">Parsing file…</p>
+              )}
             </div>
           ) : (
             <div
@@ -581,7 +595,7 @@ export default function AdminIntakeStudio() {
                 />
               </svg>
               <p className="text-lg font-medium text-white mb-2">
-                Drag and drop your .gcode.3mf file here
+                Drag and drop a .3mf or .gcode.3mf file here
               </p>
               <p className="text-gray-400 text-sm mb-4">or</p>
               <label className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-medium cursor-pointer transition-colors">
@@ -594,7 +608,7 @@ export default function AdminIntakeStudio() {
                 />
               </label>
               <p className="text-gray-600 text-xs mt-4">
-                Accepts .3mf and .gcode.3mf (Bambu Studio / Orca Slicer)
+                Raw .3mf is sliced on upload (takes a minute or two); pre-sliced .gcode.3mf is instant
               </p>
             </div>
           )}


### PR DESCRIPTION
Pairs with ecosystem #170 (raw Bambu `.3mf` → real Bambu-CLI slice in `/parse`). The Intake wizard already accepted `.3mf`, but the copy + busy state assumed a *pre-sliced* file. A raw `.3mf` now triggers a ~1–2 min server-side slice, so this makes the UX honest:

- **Busy state** now branches on the file: a raw `.3mf` shows **"Slicing your model…"** + a secondary "This can take a minute or two — Bambu Studio is slicing on the server"; a pre-sliced `.gcode.3mf` keeps the instant **"Parsing file…"**. (`busyMode` state set in `handleFile` from the filename; reset in `handleReset`.)
- **Copy**: dropzone heading → "Drag and drop a .3mf or .gcode.3mf file here"; sub-note → "Raw .3mf is sliced on upload (takes a minute or two); pre-sliced .gcode.3mf is instant"; PRO-gate intro reworded to cover both inputs.

FE-only, no logic/flow change beyond the busy label, no new deps. `eslint AdminIntakeStudio.jsx` → 0 errors/0 warnings.

Next on the convergence: **A.4c** — profile-driven slicing so STL/OBJ/STEP/non-Bambu 3MF also slice (feed Bambu a captured shop profile), which adds an operator profile picker here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Upload status messages now clarify whether your model is being sliced or your file is being parsed
* Updated upload instructions explicitly list supported file types and explain processing differences between raw and pre-sliced files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->