### PR TITLE
feat(intake): persist server-sliced .gcode.3mf as the SKU slice file

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -503,11 +503,18 @@ export default function AdminIntakeStudio() {
         } catch {
           setSliceFileSaved(false);
         }
-      } else if (createdId && !isServerSliced && src && !isBareMesh(src.name.toLowerCase())) {
+      } else if (
+        createdId &&
+        !isServerSliced &&
+        src &&
+        src.name.toLowerCase().endsWith(".gcode.3mf")
+      ) {
         // Pre-sliced .gcode.3mf upload: the uploaded file IS the printable
-        // slice file — persist it directly (unchanged path). Server-sliced
-        // inputs whose worker produced no .gcode.3mf are intentionally skipped
-        // here rather than saving the raw (non-printable) source.
+        // slice file — persist it directly (unchanged path). Requiring the
+        // .gcode.3mf extension here (not just "not a bare mesh") guarantees we
+        // never persist a raw .3mf source even under FE/backend version skew
+        // where the parse contract lacks the artifact ids. Server-sliced inputs
+        // whose worker produced no .gcode.3mf are intentionally skipped.
         try {
           const fd = new FormData();
           fd.append("file", src);

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -473,14 +473,41 @@ export default function AdminIntakeStudio() {
         persist_color_map: true,
       };
       const data = await api.post("/api/v1/pro/intake/sku", body);
-      // Upload the slice file non-fatally — SKU is already created.
-      // Skip bare meshes: sourceFileRef holds the raw .stl/.obj, not the
-      // server-generated gcode, so persisting it would save the wrong artifact.
-      // Persisting the real slice output needs a /parse→slice-file backend
-      // contract that doesn't exist yet (future).
+      // Persist the printable slice file non-fatally — the SKU is already created.
       const createdId = data.product?.id;
+      // SERVER-SLICED inputs (a raw .3mf, or a bare .stl/.obj) carry the worker
+      // artifact ids in the parse contract: gcode_3mf_artifact_id is the
+      // exported printable .gcode.3mf, gcode_artifact_id is the raw per-plate
+      // G-code (its presence flags "this was sliced server-side"). For those,
+      // the source upload is NOT the slice file, so we fetch + persist the
+      // worker's .gcode.3mf by id instead. A pre-sliced .gcode.3mf upload has
+      // neither id (it's parsed, not sliced) and IS the slice file itself.
+      const sliceArtifactId = parseResult?.gcode_3mf_artifact_id;
+      const isServerSliced = Boolean(parseResult?.gcode_artifact_id);
       const src = sourceFileRef.current;
-      if (createdId && src && !isBareMesh(src.name.toLowerCase())) {
+      if (createdId && sliceArtifactId) {
+        try {
+          const res = await fetch(
+            `${API_URL}/api/v1/pro/intake/products/${createdId}/slice-file-from-artifact`,
+            {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                gcode_artifact_id: sliceArtifactId,
+                filename: `${productName || data.product?.sku || "model"}.gcode.3mf`,
+              }),
+            }
+          );
+          setSliceFileSaved(res.ok);
+        } catch {
+          setSliceFileSaved(false);
+        }
+      } else if (createdId && !isServerSliced && src && !isBareMesh(src.name.toLowerCase())) {
+        // Pre-sliced .gcode.3mf upload: the uploaded file IS the printable
+        // slice file — persist it directly (unchanged path). Server-sliced
+        // inputs whose worker produced no .gcode.3mf are intentionally skipped
+        // here rather than saving the raw (non-printable) source.
         try {
           const fd = new FormData();
           fd.append("file", src);


### PR DESCRIPTION
## Why

Intake Studio now server-slices bare `.stl`/`.obj` (A.4c) and raw Bambu `.3mf` inputs on the slicer-worker, but `runCreateSku` never persisted the **printable** output for them: it **skipped** the slice-file step for bare meshes and **posted the raw source upload** for raw `.3mf` — neither of which is the printable slice file. (Pre-sliced `.gcode.3mf` uploads were and remain correct.)

## What

For **server-sliced** inputs, `runCreateSku` now persists the worker's exported `.gcode.3mf` via the new backend endpoint `POST /api/v1/pro/intake/products/{id}/slice-file-from-artifact`, keyed by `gcode_3mf_artifact_id` from the `/parse` contract:

- `gcode_3mf_artifact_id` present → fetch + persist the worker's printable `.gcode.3mf` (non-fatal).
- pre-sliced `.gcode.3mf` upload (no artifact ids in the contract) → persist the uploaded source file via `POST /slice-file` — **unchanged**.
- server-sliced but no `.gcode.3mf` produced (e.g. worker not yet upgraded) → **skip** rather than save the raw, non-printable source.

Single file touched: `frontend/src/pages/admin/AdminIntakeStudio.jsx`. eslint clean.

## Depends on

Backend half: **filaops-ecosystem PR #173** (worker `--export-3mf` opt-in, `gcode_3mf_artifact_id` in the parse contract, and the `slice-file-from-artifact` endpoint). This FE degrades gracefully until that ships (no `gcode_3mf_artifact_id` → server-sliced inputs simply persist no slice file, as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the SKU creation workflow to reliably persist slice files for both server-processed and pre-sliced uploads, using metadata to choose the correct persistence path.
  * File persistence errors are now non-blocking, so the SKU creation and wizard flow complete even if saving the slice file fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->