### PR TITLE
fix(intake): clear staged mesh in new-file reset

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -243,6 +243,7 @@ export default function AdminIntakeStudio() {
   // Does NOT touch `step` — handleFile/staging manages navigation.
   const resetDerivedStateForNewFile = () => {
     // bare-mesh picker
+    setPendingMesh(null);
     setSliceMaterial("PLA Basic");
     setSlicePrinter("X1C");
     setSliceQuality("standard");


### PR DESCRIPTION
Follow-up to #796. `resetDerivedStateForNewFile()` (called at the top of `handleFile`) now also clears `pendingMesh`, so a newly selected file can't leave a stale slicing-options picker on screen — closes the edge case where staging a bare mesh then selecting a `.3mf` whose upload fails re-rendered the old picker. The bare-mesh branch re-stages immediately for a new bare mesh, so behavior is unchanged for the normal flow. One-line change; eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where 3D model staging selections would incorrectly persist when starting a new intake file, ensuring a clean state for each workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->