### PR TITLE
fix(quality): write off FG on QC-held scrap (#780) + reachable Scrap button (#781)

### DIFF
--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -865,9 +865,13 @@ def record_scrap(
     # Finished goods are received into inventory at completion, so scrapping a
     # completed order must write the units off the FG ledger (decrementing
     # on_hand) and post the GL entry DR Scrap Expense (5020) / CR FG Inventory
-    # (1220). For orders not yet completed the FG is not in inventory, so we
-    # only record the scrap event + its cost.
-    if order.status == "complete":
+    # (1220). A failed QC moves the order to "qc_hold", but the FG was already
+    # received at completion and is still physically on hand — so that case
+    # must write off too, otherwise a held order scrapped after a QC failure
+    # leaves the received FG on the books forever. For orders not yet completed
+    # (in_progress/released/short) the FG is not in inventory, so we only record
+    # the scrap event + its cost.
+    if order.status in ("complete", "qc_hold"):
         from app.services.transaction_service import TransactionService
         _, _, scrap_record = TransactionService(db).scrap_finished_goods(
             production_order_id=order_id,

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2428,6 +2428,39 @@ class TestRecordScrap:
         assert rec is not None
         assert rec.inventory_transaction_id is not None
 
+    def test_record_scrap_qc_hold_order_writes_off_inventory(self, db, finished_good):
+        """A QC failure moves a completed order to qc_hold, but the FG was
+        received at completion and is still on hand. Scrapping the held order
+        must therefore route through the FG ledger write-off (linked inventory
+        transaction), not the cost-only path — otherwise the received FG would
+        never leave the books."""
+        from app.models.production_order import ScrapRecord as _ScrapRecord
+        from app.services.inventory_service import get_or_create_default_location
+        _make_scrap_reason(db, code="qc-hold-scrap", name="QC Hold Scrap")
+        order = _make_production_order(db, finished_good, status="qc_hold", quantity=10)
+        location = get_or_create_default_location(db)
+        db.add(Inventory(
+            product_id=finished_good.id,
+            location_id=location.id,
+            on_hand_quantity=Decimal("10"),
+            allocated_quantity=Decimal("0"),
+        ))
+        db.flush()
+        result = svc.record_scrap(
+            db, order.id,
+            quantity_scrapped=2,
+            reason_code="qc-hold-scrap",
+            user_email="test@filaops.dev",
+            create_remake=False,
+        )
+        rec = (
+            db.query(_ScrapRecord)
+            .filter(_ScrapRecord.id == result["scrap_record_id"])
+            .first()
+        )
+        assert rec is not None
+        assert rec.inventory_transaction_id is not None
+
     def test_record_scrap_invalid_reason_rejected(self, db, finished_good):
         """Should reject scrap with a nonexistent reason code."""
         order = _make_production_order(db, finished_good, status="in_progress")

--- a/frontend/src/components/production/ProductionQueueList.jsx
+++ b/frontend/src/components/production/ProductionQueueList.jsx
@@ -102,8 +102,12 @@ function calculateTotalTime(operations) {
  * SCHED-3: When order.status === 'released', shows a light "Dispatch" affordance
  * button at the end of the row.  Clicking it calls onDispatch(order, firstPendingOp)
  * so the parent can open the OperationSchedulerModal prefilled.
+ *
+ * #781: orders that have produced something to scrap (in progress, completed, or
+ * held for QC) show a "Scrap" affordance that calls onScrap(order) so the parent
+ * can open the ScrapOrderModal — previously the modal was mounted but unreachable.
  */
-function ProductionQueueRow({ order, operations, onRowClick, onDispatch }) {
+function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap }) {
   const totalMinutes = calculateTotalTime(operations);
 
   // Gather all materials from all operations
@@ -114,6 +118,11 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch }) {
 
   // SCHED-3: first pending op for dispatch affordance
   const firstPendingOp = operations?.find(op => op.status === 'pending') ?? null;
+
+  // #781: scrap is meaningful once production has yielded units — WIP in
+  // progress, finished goods received at completion, or goods held after a QC
+  // failure.  draft/released have nothing made yet; scrapped/cancelled are done.
+  const canScrap = ['in_progress', 'complete', 'qc_hold', 'short'].includes(order.status);
 
   return (
     <tr
@@ -181,7 +190,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch }) {
         )}
       </td>
 
-      {/* SCHED-3: Light dispatch affordance on released orders */}
+      {/* SCHED-3: dispatch affordance on released orders; #781: scrap affordance once units exist */}
       <td className="px-4 py-3 text-right">
         {order.status === 'released' && firstPendingOp && onDispatch ? (
           <button
@@ -194,6 +203,18 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch }) {
             title="Open scheduler for this order's next pending operation"
           >
             Dispatch →
+          </button>
+        ) : canScrap && onScrap ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onScrap(order);
+            }}
+            className="text-xs text-red-400 hover:text-red-300 border border-red-500/30 hover:border-red-400/50 rounded px-2 py-1 transition-colors"
+            title="Record scrap for this order"
+          >
+            Scrap
           </button>
         ) : null}
       </td>
@@ -212,6 +233,7 @@ export default function ProductionQueueList({
   onFiltersChange,
   onCreateOrder,
   onDispatch,
+  onScrap,
 }) {
   const [operationsMap, setOperationsMap] = useState({});
   const [loadingOps, setLoadingOps] = useState(false);
@@ -425,6 +447,7 @@ export default function ProductionQueueList({
                   operations={operationsMap[order.id] || []}
                   onRowClick={onOrderClick}
                   onDispatch={onDispatch}
+                  onScrap={onScrap}
                 />
               ))
             )}

--- a/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
+++ b/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import ProductionQueueList from "../ProductionQueueList";
+
+// ProductionQueueList fetches work centers (once) and per-order operations
+// (per order) on mount. Stub both with empty payloads so the rows render
+// without network. The Scrap-button wiring under test does not depend on
+// operations data.
+beforeEach(() => {
+  global.fetch = vi.fn().mockImplementation(async (url) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+    let data = {};
+    if (urlStr.includes("/work-centers")) data = { items: [] };
+    else if (urlStr.includes("/operations")) data = { operations: [] };
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => data,
+      text: async () => JSON.stringify(data),
+    };
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const baseFilters = { status: "all", search: "", workCenter: "all" };
+
+function makeOrder(overrides) {
+  return {
+    id: 1,
+    code: "PO-001",
+    product_name: "Widget A",
+    quantity_ordered: 10,
+    quantity_completed: 10,
+    quantity_scrapped: 0,
+    status: "complete",
+    ...overrides,
+  };
+}
+
+function renderList(orders, onScrap) {
+  return render(
+    <ProductionQueueList
+      orders={orders}
+      onOrderClick={() => {}}
+      loading={false}
+      filters={baseFilters}
+      onFiltersChange={() => {}}
+      onCreateOrder={() => {}}
+      onScrap={onScrap}
+    />,
+  );
+}
+
+describe("ProductionQueueList — Scrap affordance (#781)", () => {
+  it("renders a Scrap button for a completed order and calls onScrap with it when clicked", async () => {
+    const onScrap = vi.fn();
+    const order = makeOrder({ status: "complete" });
+    renderList([order], onScrap);
+
+    const scrapBtn = await screen.findByRole("button", { name: /scrap/i });
+    expect(scrapBtn).toBeInTheDocument();
+
+    fireEvent.click(scrapBtn);
+    expect(onScrap).toHaveBeenCalledTimes(1);
+    expect(onScrap).toHaveBeenCalledWith(order);
+  });
+
+  it("renders a Scrap button for a QC-held order", async () => {
+    const onScrap = vi.fn();
+    renderList([makeOrder({ id: 2, code: "PO-002", status: "qc_hold" })], onScrap);
+
+    expect(
+      await screen.findByRole("button", { name: /scrap/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render a Scrap button for a draft order (nothing produced yet)", async () => {
+    const onScrap = vi.fn();
+    renderList([makeOrder({ id: 3, code: "PO-003", status: "draft" })], onScrap);
+
+    // Let the mount effects settle so we are asserting on the final render.
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /scrap/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
+++ b/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
@@ -70,14 +70,19 @@ describe("ProductionQueueList — Scrap affordance (#781)", () => {
     expect(onScrap).toHaveBeenCalledWith(order);
   });
 
-  it("renders a Scrap button for a QC-held order", async () => {
-    const onScrap = vi.fn();
-    renderList([makeOrder({ id: 2, code: "PO-002", status: "qc_hold" })], onScrap);
+  // `complete` is exercised by the click test above; cover the remaining
+  // scrappable statuses so the canScrap gate can't silently narrow.
+  it.each(["in_progress", "qc_hold", "short"])(
+    "renders a Scrap button for a %s order",
+    async (status) => {
+      const onScrap = vi.fn();
+      renderList([makeOrder({ id: 2, code: "PO-002", status })], onScrap);
 
-    expect(
-      await screen.findByRole("button", { name: /scrap/i }),
-    ).toBeInTheDocument();
-  });
+      expect(
+        await screen.findByRole("button", { name: /scrap/i }),
+      ).toBeInTheDocument();
+    },
+  );
 
   it("does NOT render a Scrap button for a draft order (nothing produced yet)", async () => {
     const onScrap = vi.fn();

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -577,6 +577,10 @@ export default function AdminProduction() {
             productionOrder: { id: order.id, code: order.code },
           });
         }}
+        onScrap={(order) => {
+          setSelectedOrderForScrap(order);
+          setShowScrapModal(true);
+        }}
       />
         </>
       )}


### PR DESCRIPTION
Two related Quality fixes from audit `wy6lada13`, both part of #787.

---

## 1. Write off FG when scrapping a QC-held order (#780)

The completion flow auto-receives FG into inventory (sets `completed_at`, `qc_status='pending'`, syncs the SO). A failed QC then moves the order to `qc_hold`. But `record_scrap` routed the FG write-off on `order.status == "complete"`:

```python
if order.status == "complete":           # qc_hold misses this
    TransactionService(db).scrap_finished_goods(...)   # decrement on_hand + GL
else:
    ScrapRecord(...)                     # cost-only, no inventory/GL movement
```

So the realistic flow — order auto-completes -> **FG received** -> QC fails -> `qc_hold` -> user scraps — took the **else** branch. FG received at completion was never decremented from `on_hand` and no GL entry posted: QC-failed goods sat on the books forever ("received before QC with no reversal on fail").

**Fix:** extend the write-off branch to `status in ("complete", "qc_hold")`. `qc_hold` is only reached *after* auto-completion (FG already received), so the units are on hand and must be written off — DR 5020 / CR 1220 — like a passed-then-scrapped order (#794). Orders that never completed (`in_progress`/`released`/`short`) still record cost only.

Test: `test_record_scrap_qc_hold_order_writes_off_inventory`.

## 2. Reachable Scrap button on the production queue (#781)

`ScrapOrderModal` was mounted in `AdminProduction` but nothing opened it — the only `setSelectedOrderForScrap` calls were the `onClose` null-resets, so order-level scrap was unreachable.

**Fix:** add a "Scrap" affordance to each `ProductionQueueList` row (mirroring the existing "Dispatch" affordance), shown for orders with produced units (`in_progress`, `complete`, `qc_hold`, `short`). It calls a new `onScrap(order)` that `AdminProduction` wires to open the existing modal (which posts to the fixed `/production-orders/{id}/scrap`).

Test: `ProductionQueueList.test.jsx` — asserts the button renders for completed/qc_hold orders, calls `onScrap` on click, and is absent for draft orders.

## Scope note

This addresses the **reversal-on-fail** half of #780. Full *receipt-gating* (deferring FG receipt + SO sync until QC passes) is a larger workflow-policy change and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected finished-goods handling for quality control (QC) holds when recording scrap, ensuring inventory write-offs occur when QC fails.
* **New Features**
  * Added a **Scrap** action to the Production Queue for eligible orders (including **in progress**, **completed**, **QC hold**, and **short**) when enabled from the page.
* **Tests**
  * Added backend coverage for QC-hold scrap inventory write-offs and frontend tests for Scrap button rendering and callback behavior.
* **Documentation**
  * Updated notes to reflect the adjusted QC-hold scrap/write-off behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->