### PR TITLE
feat(quality): append-only qc_inspections table + audit-trail history (#783)

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -44,6 +44,8 @@ from app.schemas.production_order import (
     ScrapReasonsResponse,
     QCInspectionRequest,
     QCInspectionResponse,
+    QCInspectionRecord,
+    QCInspectionHistoryResponse,
     OperationMaterialResponse,
     SwapMaterialVariantRequest,
     OperationScrapRequest,
@@ -1286,6 +1288,24 @@ async def record_qc_inspection(
         sales_order_updated=False,
         sales_order_status=None,
         message=f"QC {order.qc_status} recorded for {order.code}",
+    )
+
+
+@router.get("/{order_id}/qc-inspections", response_model=QCInspectionHistoryResponse)
+async def get_qc_inspections(
+    order_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> QCInspectionHistoryResponse:
+    """Return the append-only QC inspection history for an order (#783).
+
+    Oldest-first, so the first entry is the first-pass inspection.
+    """
+    inspections = production_order_service.get_qc_inspections(db, order_id)
+    return QCInspectionHistoryResponse(
+        production_order_id=order_id,
+        total=len(inspections),
+        inspections=[QCInspectionRecord.model_validate(i) for i in inspections],
     )
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,7 @@
 """Database models - FilaOps Open Source Core"""
 from app.models.item_category import ItemCategory
 from app.models.product import Product
-from app.models.production_order import ProductionOrder, ProductionOrderOperation, ProductionOrderOperationMaterial, ScrapRecord
+from app.models.production_order import ProductionOrder, ProductionOrderOperation, ProductionOrderOperationMaterial, ScrapRecord, QCInspection
 from app.models.print_job import PrintJob
 from app.models.inventory import Inventory, InventoryTransaction, InventoryLocation
 from app.models.sales_order import SalesOrder, SalesOrderLine
@@ -103,6 +103,7 @@ __all__ = [
     "RoutingOperationMaterial",
     "ProductionOrderOperationMaterial",
     "ScrapRecord",
+    "QCInspection",
     # MRP
     "MRPRun",
     "PlannedOrder",

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -488,14 +488,21 @@ class QCInspection(Base):
 
     id = Column(Integer, primary_key=True, index=True)
 
-    # What was inspected
+    # What was inspected. ondelete mirrors migration 093 so create_all
+    # (tests/self-host) and Alembic (deploy) produce identical FK semantics.
     production_order_id = Column(
-        Integer, ForeignKey("production_orders.id"), nullable=False, index=True
+        Integer,
+        ForeignKey("production_orders.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     # Optional link to the QC operation (and through it the printer/resource);
     # nullable because order-level QC need not map to a specific operation.
     production_operation_id = Column(
-        Integer, ForeignKey("production_order_operations.id"), nullable=True, index=True
+        Integer,
+        ForeignKey("production_order_operations.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
 
     # Result of THIS inspection. CHECK-constrained at the DB (see migration 093)
@@ -507,7 +514,9 @@ class QCInspection(Base):
 
     # Inspector: resolved user FK when known (cf. ScrapRecord.created_by_user_id),
     # plus the verbatim name for display / when no user record matches.
-    inspector_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    inspector_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     inspector_name = Column(String(100), nullable=True)
 
     failure_reason = Column(Text, nullable=True)

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -7,7 +7,7 @@ Integrates with:
 - Routings (process steps to follow)
 - Work Centers & Resources (where/how work happens)
 """
-from sqlalchemy import Column, Integer, String, Numeric, DateTime, Date, ForeignKey, Text
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, Date, ForeignKey, Text, CheckConstraint
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
@@ -463,3 +463,67 @@ class ScrapRecord(Base):
 
     def __repr__(self):
         return f"<ScrapRecord {self.id}: {self.quantity} x product {self.product_id} @ ${self.total_cost}>"
+
+
+class QCInspection(Base):
+    """Append-only record of a single QC inspection of a production order.
+
+    The four ``ProductionOrder.qc_*`` scalar columns are last-write-wins and
+    cannot represent re-inspections, an audit trail, or true first-pass yield.
+    This table fixes that (#783): every inspection — including re-inspections —
+    appends a new row, so history and FPY (first row per order) are derivable.
+    ``ProductionOrder.qc_*`` remains as a denormalized latest-result cache.
+
+    Append-only by convention: rows are inserted, never updated or deleted.
+    """
+    __tablename__ = "qc_inspections"
+    __table_args__ = (
+        # Mirror migration 093 so create_all (tests/self-host) enforces the
+        # same domain the migration does on a real deployment.
+        CheckConstraint(
+            "result IN ('passed', 'failed', 'waived', 'conditional')",
+            name="ck_qc_inspections_result",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # What was inspected
+    production_order_id = Column(
+        Integer, ForeignKey("production_orders.id"), nullable=False, index=True
+    )
+    # Optional link to the QC operation (and through it the printer/resource);
+    # nullable because order-level QC need not map to a specific operation.
+    production_operation_id = Column(
+        Integer, ForeignKey("production_order_operations.id"), nullable=True, index=True
+    )
+
+    # Result of THIS inspection. CHECK-constrained at the DB (see migration 093)
+    # so values cannot drift out of the domain the way the unconstrained
+    # ProductionOrder.qc_status VARCHAR can.
+    result = Column(String(20), nullable=False)  # passed | failed | waived | conditional
+    quantity_passed = Column(Integer, nullable=True)
+    quantity_failed = Column(Integer, nullable=True)
+
+    # Inspector: resolved user FK when known (cf. ScrapRecord.created_by_user_id),
+    # plus the verbatim name for display / when no user record matches.
+    inspector_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    inspector_name = Column(String(100), nullable=True)
+
+    failure_reason = Column(Text, nullable=True)
+    notes = Column(Text, nullable=True)
+
+    inspected_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    created_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    # Relationships
+    production_order = relationship("ProductionOrder", backref="qc_inspections")
+    production_operation = relationship("ProductionOrderOperation")
+    inspector = relationship("User", foreign_keys=[inspector_user_id])
+
+    def __repr__(self):
+        return f"<QCInspection {self.id}: PO {self.production_order_id} -> {self.result}>"

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -596,6 +596,31 @@ class QCInspectionResponse(BaseModel):
     message: str
 
 
+class QCInspectionRecord(BaseModel):
+    """One append-only QC inspection row (#783) — an entry in the audit trail."""
+    id: int
+    production_order_id: int
+    production_operation_id: Optional[int] = None
+    result: str
+    quantity_passed: Optional[int] = None
+    quantity_failed: Optional[int] = None
+    inspector_user_id: Optional[int] = None
+    inspector_name: Optional[str] = None
+    failure_reason: Optional[str] = None
+    notes: Optional[str] = None
+    inspected_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class QCInspectionHistoryResponse(BaseModel):
+    """Full QC inspection history for a production order, oldest-first."""
+    production_order_id: int
+    total: int
+    inspections: List[QCInspectionRecord]
+
+
 # ============================================================================
 # Spool Consumption Schemas
 # ============================================================================

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -643,6 +643,25 @@ def record_qc_inspection(
     """
     order = get_production_order(db, order_id)
 
+    # Guard before ANY side effect (QC op completion, qc_* cache, history row).
+    # record_qc_inspection records an inspection *result*; a transient
+    # pending/in_progress/not_required is not a result and must not stamp the
+    # order as inspected or complete the QC operation.
+    _QC_RESULTS = ("passed", "failed", "waived", "conditional")
+    if qc_status not in _QC_RESULTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"qc_status must be an inspection result {_QC_RESULTS}, got '{qc_status}'",
+        )
+    # Reject negative quantities before they are written to the immutable
+    # history row, where they would permanently skew audit / FPY figures.
+    for _name, _val in (("quantity_passed", quantity_passed), ("quantity_failed", quantity_failed)):
+        if _val is not None and _val < 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{_name} cannot be negative (got {_val})",
+            )
+
     # Derive whole-order pass/fail quantities when the caller does not supply
     # them (e.g. the /qc endpoint, where QC is a binary pass/fail on the order).
     # Only the missing side is derived, so a caller that supplies one keeps it.
@@ -697,34 +716,30 @@ def record_qc_inspection(
 
     # #783: append an immutable inspection record so re-inspections keep a
     # history and true first-pass yield is derivable. The order.qc_* fields
-    # above remain the denormalized latest-result cache. Only real inspection
-    # outcomes are recorded (a transient pending/in_progress is not an
-    # inspection and must not pollute the audit trail / FPY).
-    inspection_id = None
-    if qc_status in ("passed", "failed", "waived", "conditional"):
-        from app.models.user import User
-        inspector_user = (
-            db.query(User).filter(User.email == inspector).first()
-            if inspector
-            else None
-        )
-        inspection = QCInspection(
-            production_order_id=order_id,
-            production_operation_id=qc_op.id if qc_op else None,
-            result=qc_status,
-            quantity_passed=quantity_passed,
-            quantity_failed=quantity_failed,
-            inspector_user_id=inspector_user.id if inspector_user else None,
-            inspector_name=inspector,
-            failure_reason=failure_reason,
-            notes=notes,
-            inspected_at=inspected_at,
-        )
-        db.add(inspection)
+    # above remain the denormalized latest-result cache. qc_status is already
+    # validated to be a real inspection result above, so this is unconditional.
+    from app.models.user import User
+    inspector_user = (
+        db.query(User).filter(User.email == inspector).first()
+        if inspector
+        else None
+    )
+    inspection = QCInspection(
+        production_order_id=order_id,
+        production_operation_id=qc_op.id if qc_op else None,
+        result=qc_status,
+        quantity_passed=quantity_passed,
+        quantity_failed=quantity_failed,
+        inspector_user_id=inspector_user.id if inspector_user else None,
+        inspector_name=inspector,
+        failure_reason=failure_reason,
+        notes=notes,
+        inspected_at=inspected_at,
+    )
+    db.add(inspection)
 
     db.flush()
-    if qc_status in ("passed", "failed", "waived", "conditional"):
-        inspection_id = inspection.id
+    inspection_id = inspection.id
 
     inspection_result = {
         "order_id": order_id,

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -23,7 +23,7 @@ from app.models import (
 from app.models.bom import BOMLine
 from app.models.inventory import Inventory
 from app.models.manufacturing import Routing, RoutingOperation, Resource
-from app.models.production_order import ProductionOrderOperationMaterial, ScrapRecord
+from app.models.production_order import ProductionOrderOperationMaterial, ScrapRecord, QCInspection
 from app.models.work_center import WorkCenter
 from app.models.material_spool import MaterialSpool, ProductionOrderSpool
 from app.services.supply_netting import get_projected_available
@@ -695,7 +695,36 @@ def record_qc_inspection(
     if qc_status == "failed":
         order.status = "qc_hold"
 
+    # #783: append an immutable inspection record so re-inspections keep a
+    # history and true first-pass yield is derivable. The order.qc_* fields
+    # above remain the denormalized latest-result cache. Only real inspection
+    # outcomes are recorded (a transient pending/in_progress is not an
+    # inspection and must not pollute the audit trail / FPY).
+    inspection_id = None
+    if qc_status in ("passed", "failed", "waived", "conditional"):
+        from app.models.user import User
+        inspector_user = (
+            db.query(User).filter(User.email == inspector).first()
+            if inspector
+            else None
+        )
+        inspection = QCInspection(
+            production_order_id=order_id,
+            production_operation_id=qc_op.id if qc_op else None,
+            result=qc_status,
+            quantity_passed=quantity_passed,
+            quantity_failed=quantity_failed,
+            inspector_user_id=inspector_user.id if inspector_user else None,
+            inspector_name=inspector,
+            failure_reason=failure_reason,
+            notes=notes,
+            inspected_at=inspected_at,
+        )
+        db.add(inspection)
+
     db.flush()
+    if qc_status in ("passed", "failed", "waived", "conditional"):
+        inspection_id = inspection.id
 
     inspection_result = {
         "order_id": order_id,
@@ -707,11 +736,28 @@ def record_qc_inspection(
         "failure_reason": failure_reason,
         "notes": notes,
         "inspected_at": inspected_at.isoformat(),
+        "inspection_id": inspection_id,
     }
 
     logger.info(f"QC inspection recorded for {order.code}: {qc_status}")
 
     return inspection_result
+
+
+def get_qc_inspections(db: Session, order_id: int) -> list[QCInspection]:
+    """Return the append-only QC inspection history for an order (#783).
+
+    Ordered oldest-first so the first row is the first-pass inspection (the
+    basis for true first-pass yield) and the list reads as an audit trail.
+    Raises 404 if the order does not exist.
+    """
+    get_production_order(db, order_id)  # 404s if missing
+    return (
+        db.query(QCInspection)
+        .filter(QCInspection.production_order_id == order_id)
+        .order_by(QCInspection.inspected_at.asc(), QCInspection.id.asc())
+        .all()
+    )
 
 
 # =============================================================================

--- a/backend/migrations/versions/093_add_qc_inspections.py
+++ b/backend/migrations/versions/093_add_qc_inspections.py
@@ -1,0 +1,84 @@
+"""add qc_inspections table
+
+Revision ID: 093
+Revises: 092
+Create Date: 2026-06-23
+
+#783: QC state lived only in four last-write-wins ``ProductionOrder.qc_*``
+columns — no re-inspection history, no audit trail, and true first-pass yield
+was impossible. This append-only table records every inspection (PO FK,
+optional operation FK, inspector user FK + denormalized name, result, qty
+passed/failed, reason, notes, timestamp). ``ProductionOrder.qc_*`` stays as a
+denormalized latest-result cache.
+
+The ``result`` column is CHECK-constrained so values cannot drift the way the
+unconstrained ``ProductionOrder.qc_status`` VARCHAR can.
+
+Additive table — no existing data touched.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "093"
+down_revision = "092"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "qc_inspections",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "production_order_id",
+            sa.Integer,
+            sa.ForeignKey("production_orders.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "production_operation_id",
+            sa.Integer,
+            sa.ForeignKey("production_order_operations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("result", sa.String(20), nullable=False),
+        sa.Column("quantity_passed", sa.Integer, nullable=True),
+        sa.Column("quantity_failed", sa.Integer, nullable=True),
+        sa.Column(
+            "inspector_user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("inspector_name", sa.String(100), nullable=True),
+        sa.Column("failure_reason", sa.Text, nullable=True),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column("inspected_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "result IN ('passed', 'failed', 'waived', 'conditional')",
+            name="ck_qc_inspections_result",
+        ),
+    )
+    op.create_index(
+        "ix_qc_inspections_production_order_id",
+        "qc_inspections",
+        ["production_order_id"],
+    )
+    # History reads order by (order, time); index supports the audit-trail query.
+    op.create_index(
+        "ix_qc_inspections_order_inspected_at",
+        "qc_inspections",
+        ["production_order_id", "inspected_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_qc_inspections_order_inspected_at", table_name="qc_inspections"
+    )
+    op.drop_index(
+        "ix_qc_inspections_production_order_id", table_name="qc_inspections"
+    )
+    op.drop_table("qc_inspections")

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2846,6 +2846,95 @@ class TestRecordQCInspection:
         assert exc_info.value.status_code == 404
 
 
+class TestQCInspectionRecords:
+    """#783: append-only qc_inspections history behind the qc_* cache."""
+
+    def test_record_inspection_appends_immutable_record(self, db, finished_good):
+        """A recorded inspection appends one qc_inspections row mirroring the result."""
+        from app.models.production_order import QCInspection
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        result = svc.record_qc_inspection(
+            db, order.id,
+            inspector="inspector@filaops.dev",
+            qc_status="passed",
+            quantity_passed=10,
+            quantity_failed=0,
+            notes="ok",
+        )
+        rows = (
+            db.query(QCInspection)
+            .filter(QCInspection.production_order_id == order.id)
+            .all()
+        )
+        assert len(rows) == 1
+        rec = rows[0]
+        assert rec.result == "passed"
+        assert rec.quantity_passed == 10
+        assert rec.quantity_failed == 0
+        assert rec.inspector_name == "inspector@filaops.dev"
+        assert rec.inspected_at is not None
+        assert result["inspection_id"] == rec.id
+
+    def test_reinspection_appends_to_history_oldest_first(self, db, finished_good):
+        """Re-inspecting appends a second row; history reads oldest-first."""
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        svc.record_qc_inspection(
+            db, order.id, inspector="qc1@filaops.dev",
+            qc_status="failed", quantity_passed=8, quantity_failed=2,
+            failure_reason="warp",
+        )
+        svc.record_qc_inspection(
+            db, order.id, inspector="qc2@filaops.dev",
+            qc_status="passed", quantity_passed=10, quantity_failed=0,
+        )
+        history = svc.get_qc_inspections(db, order.id)
+        assert [h.result for h in history] == ["failed", "passed"]
+        # First-pass (first row) is the failed inspection — the basis for FPY.
+        assert history[0].failure_reason == "warp"
+
+    def test_inspector_resolved_to_user_fk_when_email_matches(self, db, finished_good):
+        """When the inspector string matches a user email, link the user FK."""
+        from app.models.user import User
+        from app.models.production_order import QCInspection
+        user = User(email="real.inspector@filaops.dev", password_hash="x")
+        db.add(user)
+        db.flush()
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=4)
+        svc.record_qc_inspection(
+            db, order.id, inspector="real.inspector@filaops.dev",
+            qc_status="passed", quantity_passed=4,
+        )
+        rec = (
+            db.query(QCInspection)
+            .filter(QCInspection.production_order_id == order.id)
+            .one()
+        )
+        assert rec.inspector_user_id == user.id
+        assert rec.inspector_name == "real.inspector@filaops.dev"
+
+    def test_inspector_user_none_when_no_match(self, db, finished_good):
+        """A free-text inspector with no matching user leaves the FK null."""
+        from app.models.production_order import QCInspection
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=4)
+        svc.record_qc_inspection(
+            db, order.id, inspector="Walk-in Inspector",
+            qc_status="passed", quantity_passed=4,
+        )
+        rec = (
+            db.query(QCInspection)
+            .filter(QCInspection.production_order_id == order.id)
+            .one()
+        )
+        assert rec.inspector_user_id is None
+        assert rec.inspector_name == "Walk-in Inspector"
+
+    def test_get_qc_inspections_404_for_missing_order(self, db):
+        """History lookup 404s for a nonexistent order."""
+        with pytest.raises(HTTPException) as exc_info:
+            svc.get_qc_inspections(db, 999999)
+        assert exc_info.value.status_code == 404
+
+
 # =============================================================================
 # Work Center Queues
 # =============================================================================

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2934,6 +2934,36 @@ class TestQCInspectionRecords:
             svc.get_qc_inspections(db, 999999)
         assert exc_info.value.status_code == 404
 
+    def test_rejects_non_terminal_status_without_side_effects(self, db, finished_good):
+        """A transient (non-result) qc_status is rejected before any mutation:
+        no qc_* cache write, no QC-op completion, no history row."""
+        from app.models.production_order import QCInspection
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=5)
+        before = order.qc_status
+        with pytest.raises(HTTPException) as exc_info:
+            svc.record_qc_inspection(
+                db, order.id, inspector="qc@filaops.dev",
+                qc_status="in_progress", quantity_passed=5,
+            )
+        assert exc_info.value.status_code == 400
+        assert order.qc_status == before  # cache untouched
+        assert (
+            db.query(QCInspection)
+            .filter(QCInspection.production_order_id == order.id)
+            .count()
+            == 0
+        )
+
+    def test_rejects_negative_quantity(self, db, finished_good):
+        """Negative QC quantities are rejected before persisting history."""
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=5)
+        with pytest.raises(HTTPException) as exc_info:
+            svc.record_qc_inspection(
+                db, order.id, inspector="qc@filaops.dev",
+                qc_status="failed", quantity_passed=3, quantity_failed=-2,
+            )
+        assert exc_info.value.status_code == 400
+
 
 # =============================================================================
 # Work Center Queues

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2934,16 +2934,18 @@ class TestQCInspectionRecords:
             svc.get_qc_inspections(db, 999999)
         assert exc_info.value.status_code == 404
 
-    def test_rejects_non_terminal_status_without_side_effects(self, db, finished_good):
+    @pytest.mark.parametrize("transient", ["pending", "in_progress", "not_required"])
+    def test_rejects_non_terminal_status_without_side_effects(self, db, finished_good, transient):
         """A transient (non-result) qc_status is rejected before any mutation:
-        no qc_* cache write, no QC-op completion, no history row."""
+        no qc_* cache write, no QC-op completion, no history row. Covers every
+        non-terminal value so the append-only contract can't regress."""
         from app.models.production_order import QCInspection
         order = _make_production_order(db, finished_good, status="in_progress", quantity=5)
         before = order.qc_status
         with pytest.raises(HTTPException) as exc_info:
             svc.record_qc_inspection(
                 db, order.id, inspector="qc@filaops.dev",
-                qc_status="in_progress", quantity_passed=5,
+                qc_status=transient, quantity_passed=5,
             )
         assert exc_info.value.status_code == 400
         assert order.qc_status == before  # cache untouched


### PR DESCRIPTION
Closes the core of #783 (part of #787). Audit `wy6lada13` found QC state was structurally too thin: all QC lived in four last-write-wins `ProductionOrder.qc_*` columns that `record_qc_inspection` overwrote every call — no re-inspection history, no audit trail, and true first-pass yield impossible.

## What

An append-only `qc_inspections` table that records every inspection; `ProductionOrder.qc_*` stays as the denormalized latest-result cache.

- **Model `QCInspection`** — PO FK, optional operation FK, inspector **user FK** (cf. `ScrapRecord.created_by_user_id`) + denormalized `inspector_name`, `result`, `quantity_passed/failed`, `failure_reason`, `notes`, `inspected_at`. `result` is **CHECK-constrained** (`passed/failed/waived/conditional`) at the DB so values can't drift the way the unconstrained `qc_status` VARCHAR can. The CHECK is in both the model `__table_args__` and the migration, so `create_all` (tests/self-host) and Alembic (deploy) enforce the same domain.
- **Migration `093`** — additive table; `down_revision = "092"` (the current single head). No existing data touched.
- **`record_qc_inspection`** now appends a row for real outcomes (`passed/failed/waived/conditional`; a transient `pending/in_progress` is not an inspection and is skipped), resolves the inspector email to a user FK, and returns `inspection_id`.
- **History API** — `get_qc_inspections(order)` + `GET /production-orders/{id}/qc-inspections`, oldest-first so the first row is the first-pass inspection (the FPY basis).

## Tests

`TestQCInspectionRecords`: row appended on record; re-inspection builds oldest-first history; inspector→user FK resolution (and null when no match); 404 on missing order. (Backend tests build the schema via `create_all`, so the new table + CHECK are exercised in CI.)

## Scope / follow-ups (not bundled)

Deliberately scoped to the data model + recording + audit trail. Left for follow-ups (noted on #787): compute FPY from the first inspection row in `quality_service`; DB-constrain `ProductionOrder.qc_status` itself; cascade results to `SerialNumber.qc_passed` / `MaterialLot.inspection_status`. These edge into #784 and a larger metrics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added append-only QC inspection history tracking for production orders, capturing each inspection result, optional passed/failed quantities, inspector details, timestamps, and failure notes.
  * Added an API endpoint to retrieve a production order’s QC inspection history in chronological order.
* **Tests**
  * Added coverage for recording inspections, ordering across multiple inspections, inspector identity resolution, and validation/404 error behavior.
* **Chores**
  * Added a database migration introducing the QC inspections audit table, constraints, and indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->