### PR TITLE
fix(orders): correctness bugs in CSV order import (#785)

### DIFF
--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -3,7 +3,7 @@ Sales Order Model
 
 Represents customer orders converted from approved quotes
 """
-from sqlalchemy import Column, Integer, String, Numeric, DateTime, ForeignKey, Text, Boolean, CheckConstraint, JSON
+from sqlalchemy import Column, Integer, String, Numeric, DateTime, ForeignKey, Text, Boolean, CheckConstraint, JSON, Index, text
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
@@ -13,6 +13,18 @@ from app.db.base import Base
 class SalesOrder(Base):
     """Sales Order - Customer order created from accepted quote"""
     __tablename__ = "sales_orders"
+    __table_args__ = (
+        # Partial UNIQUE index (#785): a marketplace order id can only map to one
+        # sales order, so concurrent imports of the same file can't create
+        # duplicates (the old plain index allowed check-then-act races). NULLs
+        # are excluded so portal/manual orders without a source id are unaffected.
+        Index(
+            "uq_sales_orders_source_order_id",
+            "source_order_id",
+            unique=True,
+            postgresql_where=text("source_order_id IS NOT NULL"),
+        ),
+    )
 
     # Primary Key
     id = Column(Integer, primary_key=True, index=True)
@@ -34,7 +46,7 @@ class SalesOrder(Base):
     source = Column(String(50), nullable=False, default='portal', index=True)
     # 'portal' | 'squarespace' | 'woocommerce' | 'manual'
 
-    source_order_id = Column(String(255), nullable=True, index=True)
+    source_order_id = Column(String(255), nullable=True)  # unique partial index in __table_args__
     # External order ID from marketplace (e.g., Squarespace order number)
 
     # Product Information (copied from quote)

--- a/backend/app/services/order_import_service.py
+++ b/backend/app/services/order_import_service.py
@@ -67,19 +67,12 @@ def find_or_create_customer(
         first_name = name_parts[0] if name_parts else ""
         last_name = name_parts[1] if len(name_parts) > 1 else ""
 
-    year = datetime.now(timezone.utc).year
-    last_customer = db.query(User).filter(
-        User.customer_number.like(f"CUST-{year}-%")
-    ).order_by(User.customer_number.desc()).first()
-
-    if last_customer:
-        try:
-            last_num = int(last_customer.customer_number.split("-")[2])
-            customer_number = f"CUST-{year}-{last_num + 1:06d}"
-        except (ValueError, IndexError):
-            customer_number = f"CUST-{year}-000001"
-    else:
-        customer_number = f"CUST-{year}-000001"
+    # Use the canonical, regex-filtered generator. The old LIKE-based query
+    # mis-detected the max (CUST-001 sorts above CUST-099 lexically) and minted
+    # a CUST-YYYY-NNNNNN format inconsistent with the rest of the app; the
+    # canonical generator filters ^CUST-\d+$ and emits CUST-NNN.
+    from app.services.customer_service import generate_customer_number
+    customer_number = generate_customer_number(db)
 
     now = datetime.now(timezone.utc)
     customer = User(
@@ -192,16 +185,21 @@ def import_orders_from_csv(
                 errors.append({"row": row_num, "error": "Product SKU missing - line item skipped", "order_id": order_id})
                 continue
 
-            # Parse quantity
+            # Parse quantity. A missing column defaults to 1, but a value that
+            # IS present and unparseable, non-positive, or fractional is a row
+            # error — not silently coerced to 1 or truncated (e.g. 2.7 -> 2).
             quantity = 1
             qty_str = _find_col(row, QUANTITY_COLS)
             if qty_str:
                 try:
-                    quantity = int(float(qty_str.replace(",", "")))
-                    if quantity <= 0:
-                        quantity = 1
+                    qty_val = float(qty_str.replace(",", ""))
                 except (ValueError, TypeError):
-                    pass
+                    errors.append({"row": row_num, "error": f"Invalid quantity '{qty_str}' - line item skipped", "order_id": order_id})
+                    continue
+                if qty_val <= 0 or qty_val != int(qty_val):
+                    errors.append({"row": row_num, "error": f"Quantity must be a positive whole number, got '{qty_str}' - line item skipped", "order_id": order_id})
+                    continue
+                quantity = int(qty_val)
 
             unit_price = None
             up_str = _find_col(row, UNIT_PRICE_COLS)
@@ -315,20 +313,12 @@ def import_orders_from_csv(
                 skipped += 1
                 continue
 
-            # Generate order number
-            year = datetime.now(timezone.utc).year
-            last_order = db.query(SalesOrder).filter(
-                SalesOrder.order_number.like(f"SO-{year}-%")
-            ).order_by(SalesOrder.order_number.desc()).first()
-
-            if last_order:
-                try:
-                    last_num = int(last_order.order_number.split("-")[2])
-                    order_number = f"SO-{year}-{last_num + 1:06d}"
-                except (ValueError, IndexError):
-                    order_number = f"SO-{year}-000001"
-            else:
-                order_number = f"SO-{year}-000001"
+            # Use the canonical row-locked generator (FOR UPDATE + consistent
+            # :03d format) instead of an ad-hoc :06d LIKE-max query that
+            # mis-sorts (SO-2026-001 > SO-2026-000999 lexically) and races
+            # concurrent imports.
+            from app.services.sales_order_service import generate_order_number
+            order_number = generate_order_number(db)
 
             shipping_cost = order_data["shipping_cost"]
             tax_amount = order_data["tax_amount"]

--- a/backend/app/services/order_import_service.py
+++ b/backend/app/services/order_import_service.py
@@ -216,6 +216,12 @@ def import_orders_from_csv(
                 except (InvalidOperation, ValueError, TypeError):
                     errors.append({"row": row_num, "error": f"Invalid quantity '{qty_str}' - line item skipped", "order_id": order_id})
                     continue
+                # Decimal accepts NaN/Infinity; reject them before the
+                # comparisons (NaN <= 0 signals InvalidOperation, int(Infinity)
+                # overflows) so they take the clean invalid-quantity path.
+                if not qty_val.is_finite():
+                    errors.append({"row": row_num, "error": f"Invalid quantity '{qty_str}' - line item skipped", "order_id": order_id})
+                    continue
                 if qty_val <= 0 or qty_val != qty_val.to_integral_value():
                     errors.append({"row": row_num, "error": f"Quantity must be a positive whole number, got '{qty_str}' - line item skipped", "order_id": order_id})
                     continue

--- a/backend/app/services/order_import_service.py
+++ b/backend/app/services/order_import_service.py
@@ -141,6 +141,15 @@ def _find_col(row: dict, candidates: list) -> str:
     return ""
 
 
+def _col_present(row: dict, candidates: list) -> bool:
+    """True if any candidate column key exists in the row, even if blank.
+
+    Lets callers distinguish "column absent" (use a default) from
+    "column present but value blank" (a data error).
+    """
+    return any(col in row for col in candidates)
+
+
 # ============================================================================
 # MAIN IMPORT FUNCTION
 # ============================================================================
@@ -180,7 +189,12 @@ def import_orders_from_csv(
         order_id = ""
 
         try:
-            order_id = _find_col(row, ORDER_ID_COLS) or f"IMPORT-{row_num}"
+            # The real external id (persisted as source_order_id) vs a synthetic
+            # per-run grouping/display key when the CSV has no order id. Synthetic
+            # keys must NOT be persisted as source_order_id — different files
+            # would collide on IMPORT-2 etc. under the partial unique index.
+            external_order_id = _find_col(row, ORDER_ID_COLS) or None
+            order_id = external_order_id or f"IMPORT-{row_num}"
             customer_email = _find_col(row, CUSTOMER_EMAIL_COLS).lower()
             if not customer_email or "@" not in customer_email:
                 customer_email = f"import-{order_id.lower().replace(' ', '-')}@placeholder.local"
@@ -190,21 +204,25 @@ def import_orders_from_csv(
                 errors.append({"row": row_num, "error": "Product SKU missing - line item skipped", "order_id": order_id})
                 continue
 
-            # Parse quantity. A missing column defaults to 1, but a value that
-            # IS present and unparseable, non-positive, or fractional is a row
-            # error — not silently coerced to 1 or truncated (e.g. 2.7 -> 2).
+            # Parse quantity. A missing column defaults to 1, but a present
+            # value that is blank, unparseable, non-positive, or fractional is a
+            # row error — not silently coerced to 1 or truncated (e.g. 2.7 -> 2).
+            # Decimal (not float) so precision can't mask a fractional value.
             quantity = 1
             qty_str = _find_col(row, QUANTITY_COLS)
             if qty_str:
                 try:
-                    qty_val = float(qty_str.replace(",", ""))
-                except (ValueError, TypeError):
+                    qty_val = Decimal(qty_str.replace(",", ""))
+                except (InvalidOperation, ValueError, TypeError):
                     errors.append({"row": row_num, "error": f"Invalid quantity '{qty_str}' - line item skipped", "order_id": order_id})
                     continue
-                if qty_val <= 0 or qty_val != int(qty_val):
+                if qty_val <= 0 or qty_val != qty_val.to_integral_value():
                     errors.append({"row": row_num, "error": f"Quantity must be a positive whole number, got '{qty_str}' - line item skipped", "order_id": order_id})
                     continue
                 quantity = int(qty_val)
+            elif _col_present(row, QUANTITY_COLS):
+                errors.append({"row": row_num, "error": "Quantity is blank - line item skipped", "order_id": order_id})
+                continue
 
             unit_price = None
             up_str = _find_col(row, UNIT_PRICE_COLS)
@@ -239,6 +257,7 @@ def import_orders_from_csv(
 
             if order_id not in orders_dict:
                 orders_dict[order_id] = {
+                    "external_order_id": external_order_id,
                     "customer_email": customer_email,
                     "customer_name": customer_name,
                     "shipping_address": shipping_address,
@@ -311,12 +330,18 @@ def import_orders_from_csv(
                 skipped += 1
                 continue
 
-            # Check duplicate
-            existing = db.query(SalesOrder).filter(SalesOrder.source_order_id == order_id).first()
-            if existing:
-                errors.append({"order_id": order_id, "error": f"Order already exists: {existing.order_number}"})
-                skipped += 1
-                continue
+            # Dedup only on a real external order id. Synthetic IMPORT-N keys are
+            # per-run and must not match across files, and they persist as NULL
+            # (exempt from the partial unique index).
+            external_order_id = order_data["external_order_id"]
+            if external_order_id:
+                existing = db.query(SalesOrder).filter(
+                    SalesOrder.source_order_id == external_order_id
+                ).first()
+                if existing:
+                    errors.append({"order_id": order_id, "error": f"Order already exists: {existing.order_number}"})
+                    skipped += 1
+                    continue
 
             # Use the canonical row-locked generator (FOR UPDATE + consistent
             # :03d format) instead of an ad-hoc :06d LIKE-max query that
@@ -341,7 +366,7 @@ def import_orders_from_csv(
                 order_number=order_number,
                 order_type="line_item",
                 source=source,
-                source_order_id=order_id,
+                source_order_id=external_order_id,
                 product_name=line_products[0]["product"].name if line_products else "Imported Order",
                 quantity=total_quantity,
                 material_type="PLA",

--- a/backend/app/services/order_import_service.py
+++ b/backend/app/services/order_import_service.py
@@ -60,6 +60,11 @@ def find_or_create_customer(
     if customer:
         return customer
 
+    # Normalize so the address .get() calls below are safe even when no
+    # shipping_address was supplied (the signature defaults it to None, and a
+    # couple of the country fields below dereference it unguarded).
+    shipping_address = shipping_address or {}
+
     first_name = ""
     last_name = ""
     if name:

--- a/backend/migrations/versions/094_unique_source_order_id.py
+++ b/backend/migrations/versions/094_unique_source_order_id.py
@@ -1,0 +1,49 @@
+"""partial unique index on sales_orders.source_order_id
+
+Revision ID: 094
+Revises: 093
+Create Date: 2026-06-24
+
+#785: the order CSV importer dedups on source_order_id with a check-then-act
+query, so two concurrent imports of the same marketplace file could both pass
+the check and create duplicate sales orders — the column had only a plain
+(non-unique) index. Replace it with a partial UNIQUE index (excluding NULLs, so
+portal/manual orders without a source id are unaffected) to make the dedup
+race-safe at the database.
+
+NOTE: if a database already contains duplicate non-null source_order_id values
+(from the previous racy path), this index creation will fail — resolve those
+duplicates before upgrading.
+
+Depends on 093 (qc_inspections); merge that first.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "094"
+down_revision = "093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the old plain index (auto-named by the column's index=True) if present,
+    # then create the partial unique index in its place.
+    op.execute("DROP INDEX IF EXISTS ix_sales_orders_source_order_id")
+    op.create_index(
+        "uq_sales_orders_source_order_id",
+        "sales_orders",
+        ["source_order_id"],
+        unique=True,
+        postgresql_where=sa.text("source_order_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_sales_orders_source_order_id", table_name="sales_orders")
+    op.create_index(
+        "ix_sales_orders_source_order_id",
+        "sales_orders",
+        ["source_order_id"],
+    )

--- a/backend/tests/services/test_order_import_service.py
+++ b/backend/tests/services/test_order_import_service.py
@@ -106,6 +106,21 @@ class TestImportOrdersCorrectness:
         res2, _ = _import_no_order_id()
         assert res2["created"] == 1, res2
 
+    def test_rejects_non_finite_quantity(self, db, make_product):
+        """NaN/Infinity are valid Decimal literals but invalid quantities -> row error."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        for bad in ("NaN", "Infinity", "-Infinity"):
+            src_id = _uniq("SRC")
+            csv_text = (
+                "Order ID,Email,SKU,Quantity,Unit Price\n"
+                f"{src_id},{_uniq('buyer')}@example.com,{sku},{bad},10.00\n"
+            )
+            res = import_orders_from_csv(db, csv_text, current_user_id=1)
+            assert res["created"] == 0, (bad, res)
+            assert db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).first() is None, bad
+            assert any("quantity" in (e.get("error", "").lower()) for e in res["errors"]), (bad, res["errors"])
+
     def test_blank_quantity_is_row_error(self, db, make_product):
         """A present-but-blank Quantity cell is a row error, not a default of 1."""
         sku = _uniq("IMP")

--- a/backend/tests/services/test_order_import_service.py
+++ b/backend/tests/services/test_order_import_service.py
@@ -1,0 +1,99 @@
+"""Tests for order_import_service correctness fixes (#785).
+
+Covers: canonical customer-number format, canonical :03d SO numbers,
+quantity validation as row errors, and source_order_id dedup.
+
+The importer commits per order, so assertions look up the specific row by its
+unique source_order_id and check formats (not exact sequence values), which is
+robust to the shared test DB accumulating data across runs.
+"""
+import re
+import uuid
+
+import pytest
+
+from app.models.sales_order import SalesOrder
+from app.services.order_import_service import (
+    find_or_create_customer,
+    import_orders_from_csv,
+)
+
+
+def _uniq(prefix):
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+class TestFindOrCreateCustomer:
+    def test_uses_canonical_customer_number_format(self, db):
+        """New import customers get the canonical CUST-NNN number (regex
+        generator), not the old two-hyphen CUST-YYYY-NNNNNN format."""
+        email = f"{_uniq('importcust')}@example.com"
+        cust = find_or_create_customer(db, email, name="Jane Doe")
+        db.flush()
+        assert cust is not None
+        assert re.match(r"^CUST-\d+$", cust.customer_number or ""), cust.customer_number
+
+
+class TestImportOrdersCorrectness:
+    def _csv(self, *, src_id, sku, qty="2", price="10.00", email=None):
+        email = email or f"{_uniq('buyer')}@example.com"
+        return (
+            "Order ID,Email,SKU,Quantity,Unit Price\n"
+            f"{src_id},{email},{sku},{qty},{price}\n"
+        )
+
+    def test_generates_canonical_so_number(self, db, make_product):
+        """Imported orders get a canonical :03d SO number, not the :06d format."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        res = import_orders_from_csv(
+            db, self._csv(src_id=src_id, sku=sku), current_user_id=1
+        )
+        assert res["created"] == 1, res
+        so = db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).first()
+        assert so is not None
+        # SO-YYYY-NNN — exactly three digits in the sequence segment (the old
+        # bug zero-padded to six: SO-YYYY-000001).
+        assert re.match(r"^SO-\d{4}-\d{3}$", so.order_number), so.order_number
+
+    def test_rejects_fractional_quantity(self, db, make_product):
+        """A fractional quantity is a row error, not silently truncated."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        res = import_orders_from_csv(
+            db, self._csv(src_id=src_id, sku=sku, qty="2.5"), current_user_id=1
+        )
+        assert res["created"] == 0, res
+        assert db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).first() is None
+        assert any("quantity" in (e.get("error", "").lower()) for e in res["errors"]), res["errors"]
+
+    def test_rejects_nonpositive_quantity(self, db, make_product):
+        """A zero/negative quantity is a row error, not coerced to 1."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        res = import_orders_from_csv(
+            db, self._csv(src_id=src_id, sku=sku, qty="0"), current_user_id=1
+        )
+        assert res["created"] == 0, res
+        assert any("quantity" in (e.get("error", "").lower()) for e in res["errors"]), res["errors"]
+
+    def test_dedupes_source_order_id(self, db, make_product):
+        """Re-importing the same source_order_id is skipped, not duplicated."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        csv_text = self._csv(src_id=src_id, sku=sku)
+
+        first = import_orders_from_csv(db, csv_text, current_user_id=1)
+        assert first["created"] == 1, first
+
+        second = import_orders_from_csv(db, csv_text, current_user_id=1)
+        assert second["created"] == 0, second
+        assert second["skipped"] >= 1
+        # Exactly one order persisted for this source id.
+        assert (
+            db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).count() == 1
+        )

--- a/backend/tests/services/test_order_import_service.py
+++ b/backend/tests/services/test_order_import_service.py
@@ -10,8 +10,6 @@ robust to the shared test DB accumulating data across runs.
 import re
 import uuid
 
-import pytest
-
 from app.models.sales_order import SalesOrder
 from app.services.order_import_service import (
     find_or_create_customer,
@@ -77,6 +75,47 @@ class TestImportOrdersCorrectness:
         res = import_orders_from_csv(
             db, self._csv(src_id=src_id, sku=sku, qty="0"), current_user_id=1
         )
+        assert res["created"] == 0, res
+        assert any("quantity" in (e.get("error", "").lower()) for e in res["errors"]), res["errors"]
+
+    def test_missing_order_id_persists_null_source(self, db, make_product):
+        """No Order ID column -> source_order_id is NULL (not a synthetic
+        IMPORT-N value), and two such files don't collide on the unique index."""
+        from app.models.user import User
+
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+
+        def _import_no_order_id():
+            email = f"{_uniq('buyer')}@example.com"
+            csv_text = (
+                "Email,SKU,Quantity,Unit Price\n"
+                f"{email},{sku},1,10.00\n"
+            )
+            res = import_orders_from_csv(db, csv_text, current_user_id=1)
+            return res, email
+
+        res1, email1 = _import_no_order_id()
+        assert res1["created"] == 1, res1
+        cust1 = db.query(User).filter(User.email.ilike(email1)).first()
+        so1 = db.query(SalesOrder).filter(SalesOrder.user_id == cust1.id).first()
+        assert so1 is not None
+        assert so1.source_order_id is None
+
+        # A second order-id-less file must not collide (both persist NULL).
+        res2, _ = _import_no_order_id()
+        assert res2["created"] == 1, res2
+
+    def test_blank_quantity_is_row_error(self, db, make_product):
+        """A present-but-blank Quantity cell is a row error, not a default of 1."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        csv_text = (
+            "Order ID,Email,SKU,Quantity,Unit Price\n"
+            f"{src_id},{_uniq('buyer')}@example.com,{sku},,10.00\n"
+        )
+        res = import_orders_from_csv(db, csv_text, current_user_id=1)
         assert res["created"] == 0, res
         assert any("quantity" in (e.get("error", "").lower()) for e in res["errors"]), res["errors"]
 


### PR DESCRIPTION
Closes #785 (part of #787). Fixes the data-integrity bugs in the CSV order importer (`/admin/orders/import`) found by audit `wy6lada13`.

## Fixes

1. **SO-number race + format corruption.** The importer minted numbers with its own `:06d` `LIKE`-max query (no `FOR UPDATE`), which mis-sorts (`SO-2026-001` > `SO-2026-000999` lexically) and races concurrent imports. Now calls the canonical row-locked `sales_order_service.generate_order_number` (`:03d`, `FOR UPDATE`) — the same path every other caller uses.
2. **Customer-number `LIKE`-not-regex.** Replaced the ad-hoc `CUST-YYYY-NNNNNN` `LIKE` generator (same lexical max-detection bug) with the canonical `customer_service.generate_customer_number`, which filters `^CUST-\d+$` and emits `CUST-NNN`.
3. **No unique `source_order_id`.** The dedup is check-then-act, so concurrent imports of the same file could both pass and insert duplicates. Replaced the plain index with a **partial UNIQUE index** (`WHERE source_order_id IS NOT NULL`, so portal/manual orders without a source id are unaffected) — model `__table_args__` + migration `094`.
4. **Silent quantity coercion.** `int(float(qty))` truncated decimals (`2.7 → 2`) and coerced non-positive/unparseable to `1`. A present-but-bad quantity is now a **row error**; a missing column still defaults to `1`.

## Tests

`test_order_import_service.py`: canonical `CUST-NNN` and `SO-YYYY-NNN` formats, fractional + non-positive quantity rejected (order not created), and `source_order_id` dedup (re-import skipped, exactly one row persists).

## ⚠️ Merge order

Migration `094` chains off `093` (the `qc_inspections` table from #800). **Merge #800 first.** If these land out of order, `094`'s `down_revision` needs flipping to `092` plus a merge migration.

## Out of scope (noted)

- Pre-existing mixed-width SO/customer rows from the old path are a data-cleanup concern; the canonical generators just stop *adding* `:06d`/`CUST-YYYY` values. If a DB already holds duplicate non-null `source_order_id`s, the unique index creation will fail until they're resolved (noted in the migration).
- #786 (source dropdown, preview, first-row shipping/tax, placeholder customers) is the separate adequacy issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported customers now use the canonical `CUST-<digits>` format, and imported sales orders use the canonical `SO-<4 digits>-<3 digits>` format.
* **Bug Fixes**
  * CSV imports now reject invalid quantities (blank, non-numeric, fractional, non-positive, or non-finite) as row errors, so affected lines aren’t imported.
  * Deduplication is improved: re-imports with the same source order ID avoid creating duplicates, including when the Order ID column is missing.
* **Chores**
  * Enforced database-level uniqueness for non-null source order IDs to make deduplication more reliable.
* **Tests**
  * Added/expanded coverage for numbering, quantity validation, missing Order ID handling, and duplicate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->