### PR TITLE
fix(orders): source-aware order-id mapping + null header price (#786)

### DIFF
--- a/backend/app/services/order_import_service.py
+++ b/backend/app/services/order_import_service.py
@@ -116,9 +116,16 @@ def find_or_create_customer(
 # ============================================================================
 
 ORDER_ID_COLS = ["order id", "Order ID", "order_id", "Order_ID", "Order Number", "order_number", "Order #", "Order#"]
+# Shopify's order export uses the bare "Name" column for the order number (e.g.
+# "#1001"). It is added to the order-id candidates ONLY when source == shopify,
+# because other platforms use "Name" for the customer — see import_orders_from_csv.
+SHOPIFY_ORDER_ID_COLS = ["Name", "name"]
 ORDER_DATE_COLS = ["order date", "Order Date", "order_date", "Date", "date", "Order Date/Time"]
 CUSTOMER_EMAIL_COLS = ["customer email", "Customer Email", "customer_email", "Email", "email", "Buyer Email", "buyer_email"]
-CUSTOMER_NAME_COLS = ["customer name", "Customer Name", "customer_name", "Name", "name", "Buyer Name", "buyer_name", "Shipping Name", "shipping name"]
+# Bare "Name"/"name" intentionally excluded: Shopify uses it for the order
+# number, so consuming it as the customer name corrupted order-id grouping and
+# source_order_id dedup (#786). Specific name headers are kept.
+CUSTOMER_NAME_COLS = ["customer name", "Customer Name", "customer_name", "Buyer Name", "buyer_name", "Shipping Name", "shipping name"]
 PRODUCT_SKU_COLS = ["product sku", "Product SKU", "product_sku", "SKU", "sku", "Variant SKU", "variant_sku", "Item SKU", "item_sku"]
 QUANTITY_COLS = ["quantity", "Quantity", "Qty", "qty", "QTY"]
 UNIT_PRICE_COLS = ["unit price", "Unit Price", "unit_price", "Price", "price", "Item Price", "item_price"]
@@ -181,6 +188,12 @@ def import_orders_from_csv(
     skipped = 0
     errors: List[dict] = []
 
+    # The source selection now affects column mapping (not just the stored
+    # label): Shopify exports the order number in the "Name" column.
+    order_id_cols = list(ORDER_ID_COLS)
+    if (source or "").strip().lower() == "shopify":
+        order_id_cols = order_id_cols + SHOPIFY_ORDER_ID_COLS
+
     # Group rows by Order ID for multi-line orders
     orders_dict: Dict[str, Dict[str, Any]] = {}
 
@@ -193,7 +206,7 @@ def import_orders_from_csv(
             # per-run grouping/display key when the CSV has no order id. Synthetic
             # keys must NOT be persisted as source_order_id — different files
             # would collide on IMPORT-2 etc. under the partial unique index.
-            external_order_id = _find_col(row, ORDER_ID_COLS) or None
+            external_order_id = _find_col(row, order_id_cols) or None
             order_id = external_order_id or f"IMPORT-{row_num}"
             customer_email = _find_col(row, CUSTOMER_EMAIL_COLS).lower()
             if not customer_email or "@" not in customer_email:
@@ -377,7 +390,9 @@ def import_orders_from_csv(
                 quantity=total_quantity,
                 material_type="PLA",
                 finish="standard",
-                unit_price=total_price / total_quantity if total_quantity > 0 else Decimal("0.00"),
+                # NULL for line_item orders — the per-line prices live on the
+                # SalesOrderLines; a blended header average was misleading.
+                unit_price=None,
                 total_price=total_price,
                 tax_amount=tax_amount,
                 shipping_cost=shipping_cost,

--- a/backend/tests/services/test_order_import_service.py
+++ b/backend/tests/services/test_order_import_service.py
@@ -151,3 +151,51 @@ class TestImportOrdersCorrectness:
         assert (
             db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).count() == 1
         )
+
+    def test_header_unit_price_null_for_imported_order(self, db, make_product):
+        """Imported (line_item) orders store NULL header unit_price, not a blend."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        src_id = _uniq("SRC")
+        res = import_orders_from_csv(
+            db, self._csv(src_id=src_id, sku=sku, qty="3", price="7.50"), current_user_id=1
+        )
+        assert res["created"] == 1, res
+        so = db.query(SalesOrder).filter(SalesOrder.source_order_id == src_id).first()
+        assert so is not None
+        assert so.unit_price is None
+
+    def test_shopify_source_maps_name_to_order_id(self, db, make_product):
+        """With source=shopify, the 'Name' column is the order id (source_order_id)."""
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        name_val = f"#{_uniq('SHOP')}"
+        csv_text = (
+            "Name,Email,SKU,Quantity,Unit Price\n"
+            f"{name_val},{_uniq('buyer')}@example.com,{sku},1,10.00\n"
+        )
+        res = import_orders_from_csv(db, csv_text, source="shopify", current_user_id=1)
+        assert res["created"] == 1, res
+        so = db.query(SalesOrder).filter(SalesOrder.source_order_id == name_val).first()
+        assert so is not None
+        assert so.source_order_id == name_val
+
+    def test_non_shopify_name_not_used_as_order_id(self, db, make_product):
+        """Without source=shopify, a 'Name' column is NOT consumed as the order
+        id (so it can't corrupt grouping/dedup); source_order_id stays NULL."""
+        from app.models.user import User
+        sku = _uniq("IMP")
+        make_product(sku=sku, name="Imported Widget")
+        name_val = f"#{_uniq('NOTSHOP')}"
+        email = f"{_uniq('buyer')}@example.com"
+        csv_text = (
+            "Name,Email,SKU,Quantity,Unit Price\n"
+            f"{name_val},{email},{sku},1,10.00\n"
+        )
+        res = import_orders_from_csv(db, csv_text, source="manual", current_user_id=1)
+        assert res["created"] == 1, res
+        # No order persisted under the Name value as source id.
+        assert db.query(SalesOrder).filter(SalesOrder.source_order_id == name_val).first() is None
+        cust = db.query(User).filter(User.email.ilike(email)).first()
+        so = db.query(SalesOrder).filter(SalesOrder.user_id == cust.id).first()
+        assert so is not None and so.source_order_id is None


### PR DESCRIPTION
Part of #787. Adequacy fixes for the CSV order importer (`/admin/orders/import`) from audit `wy6lada13`. Scoped to the **clear correctness + honesty** items; the larger feature (preview) and the genuinely ambiguous/policy items are deferred with notes below.

## Fixes

1. **Source dropdown is no longer cosmetic** (issue: "never changes column mapping despite the helper text"). With `source=shopify`, the bare `Name` column — Shopify's order number — is now mapped to the order id / `source_order_id`. The platform selection genuinely changes mapping for the case that matters most, so the existing "better column mapping" helper text is now accurate (kept, not removed).
2. **`Name` collision fixed.** Bare `Name`/`name` removed from `CUSTOMER_NAME_COLS`. Shopify uses `Name` for the order number, so consuming it as the customer name made the order id fall back to `IMPORT-{row}`, breaking multi-line grouping **and** `source_order_id` dedup. Specific headers (`Customer Name`, `Buyer Name`, `Shipping Name`, …) are retained.
3. **Blended header `unit_price` → NULL** for imported orders. The importer always creates `line_item` orders, and the model documents the header `unit_price` as NULL for those (per-line prices live on the `SalesOrderLine`s). Replaced the blended `total/qty` average with `None`.

## Tests

`shopify Name → source_order_id`; `non-shopify Name NOT used as order id` (stays NULL, can't corrupt grouping/dedup); `header unit_price NULL`.

## Deferred (separate follow-ups — several are product/policy calls)

- **Preview/dry-run** before commit — a real feature; the importer commits per-order, so a clean dry-run needs a refactor of the commit/rollback isolation. Worth its own PR.
- **Multi-line shipping/tax** taken from the first row — the fix depends on whether a given marketplace repeats order-level shipping/tax on every line (summing would double-count) or puts it once; needs a per-source decision.
- **Bad/missing email → placeholder customer** vs. a row error — a data-quality policy choice (current behavior keeps lossy imports working).
- **Summary-tile reconciliation** (line-level drops count as neither created nor skipped) — couples with the email-policy decision and a small frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV order import so external order IDs are detected correctly based on the order source, including Shopify-specific imports.
  * Prevented customer names from being mistaken for order IDs in non-Shopify imports.
  * Stopped imported line-item orders from using a blended header unit price, keeping pricing at the line-item level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->