### PR TITLE
fix(intake): multi-plate picker follow-ups (review of #804)

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -143,6 +143,13 @@ function PreParsePanel({ preparse }) {
  */
 function PlatePicker({ plates, isRaw, selectedPlateIndex, onSelect }) {
   if (!Array.isArray(plates) || plates.length === 0) return null;
+  // Only plates with a usable plate_index are selectable; derive the header
+  // count from these so it always matches the number of rendered rows (a plate
+  // missing plate_index is dropped below — counting plates.length would show a
+  // header total one higher than the selectable rows).
+  const renderablePlates = plates.filter((p) => p.plate_index != null);
+  if (renderablePlates.length === 0) return null;
+  const plateCount = renderablePlates.length;
   return (
     <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 mb-5">
       <h2 className="text-base font-semibold text-white mb-1">
@@ -150,12 +157,11 @@ function PlatePicker({ plates, isRaw, selectedPlateIndex, onSelect }) {
       </h2>
       <p className="text-gray-500 text-sm mb-4">
         {isRaw
-          ? `This file has ${plates.length} plates. Pick the one to intake — it will be sliced on the server.`
-          : `This file has ${plates.length} plates. Pick the one to intake.`}
+          ? `This file has ${plateCount} plates. Pick the one to intake — it will be sliced on the server.`
+          : `This file has ${plateCount} plates. Pick the one to intake.`}
       </p>
       <div className="space-y-2">
-        {plates.map((p) => {
-          if (p.plate_index == null) return null;
+        {renderablePlates.map((p) => {
           const idx = p.plate_index;
           const selected = selectedPlateIndex != null && idx === selectedPlateIndex;
           const slots = Array.isArray(p.slots) ? p.slots : [];
@@ -1200,9 +1206,14 @@ export default function AdminIntakeStudio() {
       // Read the pre-parse slot count from the ref (not the state) so the raw
       // .3mf path — where preparseIntakeFile resolves after this closure was
       // created — compares against the just-computed value, not a stale null.
-      // For a multi-plate pick, compare against the CHOSEN plate's slot count
-      // (the pre-parse top-level slot_count describes the default plate, not the
-      // one selected), falling back to the top-level count when unavailable.
+      // For a multi-plate pick the baseline MUST be the CHOSEN plate's slot
+      // count, never the top-level slot_count: the top-level value describes the
+      // default plate (sliced .3mf) or the whole-project material count (raw
+      // .3mf), and neither is a valid baseline for the single plate being
+      // sliced. Raw plates carry no per-plate slots, so when there is no real
+      // chosen-plate count we leave preparseSlotCount null and skip the reconcile
+      // notice rather than comparing against the wrong whole-project fallback
+      // (which fired a spurious notice on normal multi-plate raw intake).
       let preparseSlotCount = preparseResultRef.current?.slot_count;
       if (plateIndex != null) {
         const chosenPlate = (preparseResultRef.current?.plates || []).find(
@@ -1211,7 +1222,8 @@ export default function AdminIntakeStudio() {
         const chosenSlotCount = Array.isArray(chosenPlate?.slots)
           ? chosenPlate.slots.length
           : null;
-        if (chosenSlotCount != null) preparseSlotCount = chosenSlotCount;
+        // Use the chosen plate's count when known; otherwise null → no notice.
+        preparseSlotCount = chosenSlotCount;
       }
       if (unifiedFlow && willSlice && preparseSlotCount != null) {
         const slicedCount = Array.isArray(data.slots)
@@ -1232,8 +1244,12 @@ export default function AdminIntakeStudio() {
         }
       }
       // Multi-plate: the parse succeeded — now it's safe to clear the held file
-      // and picker state. Clearing before uploadIntakeFile (as it was) left an
-      // enabled but no-op Continue after a parse failure or Step-2 Back.
+      // and picker state. Deferring the clear to here (rather than before
+      // uploadIntakeFile, as it was) keeps the picker intact on a PARSE FAILURE:
+      // a !res.ok / thrown error returns above, leaving pendingPlateFileRef +
+      // preparseResult + selectedPlateIndex live so the operator can retry from
+      // the still-rendered picker. (Step-2 Back is NOT preserved — it clears to
+      // the drop zone like the single-plate path, matching legacy behavior.)
       if (plateIndex != null) {
         pendingPlateFileRef.current = null;
         setPreparseResult(null);
@@ -1263,9 +1279,10 @@ export default function AdminIntakeStudio() {
   const continueWithSelectedPlate = () => {
     const pending = pendingPlateFileRef.current;
     if (!pending || selectedPlateIndex == null) return;
-    // Do NOT clear pendingPlateFileRef here — keep the held file available for
-    // retry (parse failure) or Step-2 Back. It is cleared in uploadIntakeFile's
-    // success path once the parse returns ok (plateIndex != null branch above).
+    // Do NOT clear pendingPlateFileRef here — keep the held file available so a
+    // parse failure leaves the picker intact for retry. It is cleared in
+    // uploadIntakeFile's success path once the parse returns ok (the
+    // plateIndex != null branch above).
     uploadIntakeFile(pending, null, null, selectedPlateIndex);
   };
 
@@ -2115,9 +2132,13 @@ export default function AdminIntakeStudio() {
               </div>
             </div>
           ) : isMultiPlatePending ? (
-            /* Multi-plate file: pick a single plate before parsing/slicing. */
+            /* Multi-plate file: pick a single plate before parsing/slicing.
+               No PreParsePanel here — its top-level slot_count/multi-material
+               badge/swatches describe only the DEFAULT plate (the contract's
+               top level is plate 1 when no plate_index was sent), so showing it
+               above the chooser would misrepresent the default plate's slots as
+               file-wide. The PlatePicker shows the correct per-plate detail. */
             <div className="space-y-5">
-              <PreParsePanel preparse={preparseResult} />
               <PlatePicker
                 plates={preparseResult?.plates || []}
                 isRaw={isRawPreparse}


### PR DESCRIPTION
## Summary

Follow-up to the merged multi-plate picker (**#804**, commit `391aa5a`), addressing the four Core-FE findings raised by the multi-plate adversarial review. All four are in `frontend/src/pages/admin/AdminIntakeStudio.jsx`. Each was re-verified against the current merged code before fixing; fixes are minimal and do not regress single-plate or gate-off (`unifiedFlow` off) behavior.

## Findings → fixes

### [MEDIUM] Raw .3mf reconcile-notice false positive
For a multi-plate **raw** `.3mf`, preparse plates carry no per-plate `slots`, so the chosen-plate slot count was `null` and the reconcile baseline **fell back to the top-level `slot_count`** — which for raw is the *whole-project* material count from `/analyze`, not the chosen plate's. After slicing only the selected plate, `data.slots.length` legitimately differs (e.g. plate 2 uses 1 of the project's 4 materials), so a spurious `"Slicing detected 1 material slot, but the pre-parse estimated 4…"` notice fired on perfectly normal multi-plate raw intake.

**Fix:** for a multi-plate pick the baseline is now strictly the chosen plate's slot count; when unavailable (raw pre-slice) `preparseSlotCount` stays `null` and the pre-existing `preparseSlotCount != null` guard skips the notice. The single-plate path (`plateIndex == null`) still uses the top-level `slot_count` unchanged.

### [LOW] PreParsePanel showed the default plate's slots as file-wide
In the multi-plate render branch, `PreParsePanel` rendered the **top-level** (default-plate) `slot_count` / multi-material badge / swatches above the picker, implying they characterized the whole file while the picker below let the operator choose a *different* plate.

**Fix:** removed `PreParsePanel` from the multi-plate branch. The `PlatePicker` already shows correct per-plate weight/time/swatches. (`PreParsePanel` is still used in the bare-mesh/single-plate branch.)

### [LOW] PlatePicker header count vs rendered rows could diverge
The header read `This file has ${plates.length} plates` but each row skipped `p.plate_index == null`, so a null-index entry would show a header total one higher than the selectable rows.

**Fix:** header count now derives from `renderablePlates = plates.filter(p => p.plate_index != null)`, the same list the rows are mapped from — header and rows can no longer disagree.

### [LOW] Comments overstated retry behavior
The cleanup and `continueWithSelectedPlate` comments claimed the held file/picker survives a Step-2 "Back". In reality the success path clears `preparseResult` before `setStep(2)`, so the Back button (no state restore) lands on the empty drop zone — only the **parse-failure** retry keeps the picker intact (and that works correctly).

**Fix:** corrected both comments to match actual behavior (minimal; picker-preserving Back was not implemented — it would require restoring state the success path deliberately clears, and the current behavior matches the legacy single-plate Back).

## Validation
- `npx eslint src/pages/admin/AdminIntakeStudio.jsx` → 0 errors
- `npm run build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plate selection so only valid, selectable plates are shown, and the “Choose a plate” count now matches what can actually be picked.
  * Fixed multi-plate upload behavior so slot counts and notices use the selected plate’s values, avoiding misleading comparisons.
  * Simplified the pending plate selection view to avoid showing unrelated default slot information when choosing a non-default plate.
  * Kept selected file/plate state intact if parsing fails, so users can retry without losing their selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->