### PR TITLE
fix(quality): PO is_ready_for_qc/can_close test 'complete' not 'completed' (#808 PR-0)

### DIFF
--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -182,13 +182,16 @@ class ProductionOrder(Base):
     @property
     def is_ready_for_qc(self):
         """True if WO is ready for quality inspection"""
-        return self.status == 'completed' and self.qc_status == 'pending'
-    
+        # Runtime PO status is 'complete' (operation_status/execution_service +
+        # the COMPLETE enum); the old 'completed' literal made this permanently
+        # False, so the cockpit "QC-due" lane could never populate.
+        return self.status == 'complete' and self.qc_status == 'pending'
+
     @property
     def can_close(self):
         """True if WO can be closed (all checks passed)"""
         return (
-            self.status == 'completed' and
+            self.status == 'complete' and
             self.qc_status in ['passed', 'not_required', 'waived'] and
             self.quantity_completed >= self.quantity_ordered
         )

--- a/backend/tests/services/test_model_properties.py
+++ b/backend/tests/services/test_model_properties.py
@@ -137,7 +137,7 @@ class TestProductionOrderProperties:
     def test_is_ready_for_qc_true(self, db, make_product, make_production_order):
         product = make_product()
         po = make_production_order(
-            product_id=product.id, status="completed", qc_status="pending",
+            product_id=product.id, status="complete", qc_status="pending",
         )
         assert po.is_ready_for_qc is True
 
@@ -151,7 +151,7 @@ class TestProductionOrderProperties:
     def test_is_ready_for_qc_false_wrong_qc_status(self, db, make_product, make_production_order):
         product = make_product()
         po = make_production_order(
-            product_id=product.id, status="completed", qc_status="passed",
+            product_id=product.id, status="complete", qc_status="passed",
         )
         assert po.is_ready_for_qc is False
 
@@ -159,7 +159,7 @@ class TestProductionOrderProperties:
         product = make_product()
         po = make_production_order(
             product_id=product.id,
-            status="completed",
+            status="complete",
             qc_status="passed",
             quantity=5,
             quantity_completed=Decimal("5"),
@@ -170,7 +170,7 @@ class TestProductionOrderProperties:
         product = make_product()
         po = make_production_order(
             product_id=product.id,
-            status="completed",
+            status="complete",
             qc_status="not_required",
             quantity=5,
             quantity_completed=Decimal("5"),
@@ -181,7 +181,7 @@ class TestProductionOrderProperties:
         product = make_product()
         po = make_production_order(
             product_id=product.id,
-            status="completed",
+            status="complete",
             qc_status="waived",
             quantity=5,
             quantity_completed=Decimal("5"),
@@ -203,7 +203,7 @@ class TestProductionOrderProperties:
         product = make_product()
         po = make_production_order(
             product_id=product.id,
-            status="completed",
+            status="complete",
             qc_status="failed",
             quantity=5,
             quantity_completed=Decimal("5"),
@@ -214,7 +214,7 @@ class TestProductionOrderProperties:
         product = make_product()
         po = make_production_order(
             product_id=product.id,
-            status="completed",
+            status="complete",
             qc_status="passed",
             quantity=10,
             quantity_completed=Decimal("5"),


### PR DESCRIPTION
**PR-0 of the print-farm-OS UX program (epic #808).** The Foundation-blocking guard fix the adversarial review flagged.

## The bug
The runtime `ProductionOrder.status` is `'complete'` everywhere — `operation_status.py:160` (`derive_po_status` returns `'complete'`), `production_order_execution_service.py:134/293`, and the `COMPLETE = "complete"` enum. But two model guards compared against `'completed'`, a literal **no writer ever sets**:

```python
def is_ready_for_qc: return self.status == 'completed' and self.qc_status == 'pending'   # always False
def can_close:       return self.status == 'completed' and ...                            # always False
```

So both were **permanently `False`**. The UX program's Command Center "QC-due" and "ready-to-close" next-action lanes read these guards, so they have to be correct before the Foundation can light those lanes.

## Why this is safe
`grep` confirms **nothing in `app/` or `frontend/src` consumes these two properties** — only `test_model_properties.py` asserted them, and it did so by setting the phantom `status='completed'` to coax a `True`. So this flips **zero current behavior**; it makes the guards correct. The tests now use the real runtime status `'complete'`, exercising the guards against a state the system actually produces — the `True` cases would have failed before this fix.

## Scope
Deliberately just these two guards. The broader `'complete'`/`'completed'` inconsistency across the suite (~60 test usages of the phantom PO status) is the Foundation **status-descriptor** reconciliation (F1 in #808), not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production order QC and closure checks to recognize the correct completed status value, ensuring orders move through the QC-due flow properly.
  * Improved closure eligibility behavior so completed orders are evaluated correctly alongside QC status and quantity requirements.
* **Tests**
  * Updated automated coverage to reflect the corrected production order status value in QC and closing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->