### PR TITLE
feat(ux): response normalizer kills the .map crash class (#808 Foundation F1)

### DIFF
--- a/frontend/src/components/production/ProductionQueueList.jsx
+++ b/frontend/src/components/production/ProductionQueueList.jsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 import { API_URL } from '../../config/api';
 import { formatDuration } from '../../utils/formatting';
 import { PRODUCTION_ORDER_BADGE_CONFIGS } from '../../lib/statusColors.js';
+import { normalizeList } from '../../lib/normalizeList';
 import ElapsedTimer from './ElapsedTimer';
 import EmptyState from '../EmptyState';
 
@@ -248,7 +249,7 @@ export default function ProductionQueueList({
         });
         if (res.ok) {
           const data = await res.json();
-          setWorkCenters(data.items || data || []);
+          setWorkCenters(normalizeList(data, ["work_centers", "workCenters"]).items);
         }
       } catch { // err unused
         // Non-critical

--- a/frontend/src/lib/normalizeList.js
+++ b/frontend/src/lib/normalizeList.js
@@ -1,0 +1,60 @@
+/**
+ * Response normalizer (UX Foundation, epic #808).
+ *
+ * FilaOps list endpoints are inconsistent: some return a bare array, most return
+ * a `{ items, pagination }` envelope (see apiTypes.js ListResponse), and a few
+ * use a domain-keyed envelope (`{ work_centers: [] }`, `{ products: [] }`, ...).
+ * Consumers hand-rolled `data.items || data || []` and `Array.isArray(data) ? ...`
+ * unwraps that diverge per call site and CRASH on a non-list body (an error
+ * payload, a 422 `{ detail: [...] }`, a stray object) with the classic
+ * `x.map is not a function`.
+ *
+ * `normalizeList` is the single, defensive coercion: it ALWAYS returns
+ * `{ items: Array, pagination: Object|null }`, never throws, and yields an empty
+ * list for anything that is not a recognizable collection.
+ */
+
+// Envelope keys we accept out of the box, in priority order. `items` is the
+// canonical Sprint 1-2 shape; the rest are the domain-keyed envelopes still in
+// the wild. Callers can pass extra keys for a bespoke shape.
+const DEFAULT_KEYS = [
+  "items",
+  "results",
+  "data",
+  "work_centers",
+  "workCenters",
+  "routings",
+  "products",
+  "operations",
+  "customers",
+  "transactions",
+  "spools",
+];
+
+/**
+ * Coerce any list-ish API payload into `{ items, pagination }`.
+ *
+ * @template T
+ * @param {unknown} data - The parsed response body (array, envelope, or junk).
+ * @param {string[]} [keys] - Extra envelope keys to check (tried before the defaults).
+ * @returns {{ items: T[], pagination: (import('./apiTypes').PaginationMeta|null) }}
+ */
+export function normalizeList(data, keys = []) {
+  if (Array.isArray(data)) {
+    return { items: data, pagination: null };
+  }
+
+  if (data && typeof data === "object") {
+    for (const key of [...keys, ...DEFAULT_KEYS]) {
+      if (Array.isArray(data[key])) {
+        return { items: data[key], pagination: data.pagination ?? null };
+      }
+    }
+  }
+
+  // null / undefined / "error string" / { error, message } / { detail: [...] }
+  // (FastAPI 422) / any non-collection object → render empty, never crash.
+  return { items: [], pagination: null };
+}
+
+export default normalizeList;

--- a/frontend/src/lib/normalizeList.test.js
+++ b/frontend/src/lib/normalizeList.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { normalizeList } from "./normalizeList";
+
+describe("normalizeList", () => {
+  it("passes a bare array through with null pagination", () => {
+    expect(normalizeList([1, 2, 3])).toEqual({ items: [1, 2, 3], pagination: null });
+  });
+
+  it("unwraps the canonical {items, pagination} envelope", () => {
+    const page = { total: 1, offset: 0, limit: 50, returned: 1 };
+    expect(normalizeList({ items: [{ id: 1 }], pagination: page })).toEqual({
+      items: [{ id: 1 }],
+      pagination: page,
+    });
+  });
+
+  it("unwraps domain-keyed envelopes", () => {
+    expect(normalizeList({ work_centers: [{ id: 1 }] }).items).toEqual([{ id: 1 }]);
+    expect(normalizeList({ products: [{ id: 2 }] }).items).toEqual([{ id: 2 }]);
+    expect(normalizeList({ spools: [{ id: 3 }] }).items).toEqual([{ id: 3 }]);
+  });
+
+  it("honors an explicit key before the defaults", () => {
+    expect(normalizeList({ rows: [{ id: 9 }] }, ["rows"]).items).toEqual([{ id: 9 }]);
+  });
+
+  it("prefers items over a domain key when both are present", () => {
+    expect(normalizeList({ items: [1], products: [2] }).items).toEqual([1]);
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty object", {}],
+    ["error string", "Internal Server Error"],
+    ["StandardApiError body", { error: "NOT_FOUND", message: "nope", timestamp: "t" }],
+    ["FastAPI 422 body", { detail: [{ loc: ["q"], msg: "bad" }] }],
+    ["a number", 42],
+    ["a non-array items value", { items: "oops" }],
+  ])("returns an empty list (never throws) for %s", (_label, payload) => {
+    const result = normalizeList(payload);
+    expect(result).toEqual({ items: [], pagination: null });
+    // The whole point: the result is always .map-able.
+    expect(() => result.items.map((x) => x)).not.toThrow();
+  });
+});

--- a/frontend/src/pages/admin/AdminManufacturing.jsx
+++ b/frontend/src/pages/admin/AdminManufacturing.jsx
@@ -6,6 +6,7 @@ import WorkCenterCard from "../../components/manufacturing/WorkCenterCard";
 import WorkCenterModal from "../../components/manufacturing/WorkCenterModal";
 import ResourceModal from "../../components/manufacturing/ResourceModal";
 import PrinterSetupModal from "../../components/manufacturing/PrinterSetupModal";
+import { normalizeList } from "../../lib/normalizeList";
 
 export default function AdminManufacturing() {
   const api = useApi();
@@ -39,7 +40,7 @@ export default function AdminManufacturing() {
     setLoading(true);
     try {
       const data = await api.get(`/api/v1/work-centers/?active_only=false`);
-      setWorkCenters(data);
+      setWorkCenters(normalizeList(data, ["work_centers", "workCenters"]).items);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -51,7 +52,7 @@ export default function AdminManufacturing() {
     setLoading(true);
     try {
       const data = await api.get(`/api/v1/routings/`);
-      setRoutings(data);
+      setRoutings(normalizeList(data, ["routings"]).items);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -62,8 +63,7 @@ export default function AdminManufacturing() {
   const fetchProducts = async () => {
     try {
       const data = await api.get(`/api/v1/products?limit=500`);
-      // Handle both array and {items: [...]} responses
-      setProducts(Array.isArray(data) ? data : (data.items || data.products || []));
+      setProducts(normalizeList(data, ["products"]).items);
     } catch {
       // Products fetch failure is non-critical - product selector will just be empty
       setProducts([]);

--- a/frontend/src/pages/admin/AdminOrders.jsx
+++ b/frontend/src/pages/admin/AdminOrders.jsx
@@ -6,6 +6,7 @@ import { useToast } from "../../components/Toast";
 import EmptyState from "../../components/EmptyState";
 import { SalesOrderCard } from "../../components/orders";
 import OrderFilters from "../../components/orders/OrderFilters";
+import { normalizeList } from "../../lib/normalizeList";
 
 export default function AdminOrders() {
   const navigate = useNavigate();
@@ -64,7 +65,7 @@ export default function AdminOrders() {
       if (sortOrder) params.set("sort_order", sortOrder);
 
       const data = await api.get(`/api/v1/sales-orders/?${params}`);
-      setOrders(data.items || data);
+      setOrders(normalizeList(data).items);
     } catch (err) {
       setError(err.message);
     } finally {

--- a/frontend/src/pages/admin/AdminPurchasing.jsx
+++ b/frontend/src/pages/admin/AdminPurchasing.jsx
@@ -12,6 +12,7 @@ import PurchaseOrdersTab from "../../components/purchasing/PurchaseOrdersTab";
 import VendorsTab from "../../components/purchasing/VendorsTab";
 import LowStockTab from "../../components/purchasing/LowStockTab";
 import BuyListTab from "../../components/purchasing/BuyListTab";
+import { normalizeList } from "../../lib/normalizeList";
 
 export default function AdminPurchasing() {
   const api = useApi();
@@ -260,8 +261,7 @@ export default function AdminPurchasing() {
       params.set("limit", "100");
 
       const data = await api.get(`/api/v1/purchase-orders?${params}`);
-      // Handle both array and {items: [...]} responses, and error objects
-      setOrders(Array.isArray(data) ? data : (data.items || []));
+      setOrders(normalizeList(data).items);
     } catch (err) {
       setError(err.message);
       setOrders([]);
@@ -274,8 +274,7 @@ export default function AdminPurchasing() {
     if (showLoading) setLoading(true);
     try {
       const data = await api.get(`/api/v1/vendors?active_only=false`);
-      // Handle both array and {items: [...]} responses, and error objects
-      setVendors(Array.isArray(data) ? data : (data.items || []));
+      setVendors(normalizeList(data, ["vendors"]).items);
     } catch (err) {
       if (showLoading) setError(err.message);
       setVendors([]);
@@ -287,7 +286,7 @@ export default function AdminPurchasing() {
   const fetchProducts = async () => {
     try {
       const data = await api.get(`/api/v1/items?limit=2000`);
-      setProducts(data.items || []);
+      setProducts(normalizeList(data, ["products"]).items);
     } catch (err) {
       // Products fetch failure is non-critical - product selector will just be empty
       console.error("[AdminPurchasing] Error fetching products:", err);
@@ -298,7 +297,7 @@ export default function AdminPurchasing() {
     setLowStockLoading(true);
     try {
       const data = await api.get(`/api/v1/items/low-stock`);
-      setLowStockItems(data.items || []);
+      setLowStockItems(normalizeList(data).items);
       setLowStockSummary(data.summary || null);
     } catch {
       setError("Failed to load low stock items. Please refresh the page.");

--- a/frontend/src/pages/admin/AdminSpools.jsx
+++ b/frontend/src/pages/admin/AdminSpools.jsx
@@ -3,6 +3,7 @@ import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../components/Toast";
 import EmptyState from "../../components/EmptyState";
 import { SPOOL_COLORS as statusColors } from "../../lib/statusColors.js";
+import { normalizeList } from "../../lib/normalizeList";
 
 export default function AdminSpools() {
   const toast = useToast();
@@ -34,7 +35,7 @@ export default function AdminSpools() {
       if (filters.search) params.set("search", filters.search);
 
       const data = await api.get(`/api/v1/spools?${params}`);
-      setSpools(data.items || data || []);
+      setSpools(normalizeList(data, ["spools"]).items);
     } catch (err) {
       setError(err.message);
       toast.error(err.message);
@@ -46,7 +47,7 @@ export default function AdminSpools() {
   const fetchProducts = async () => {
     try {
       const data = await api.get("/api/v1/products?type=material&limit=200");
-      setProducts(data.items || data || []);
+      setProducts(normalizeList(data, ["products"]).items);
     } catch (err) {
       console.error("Failed to fetch products:", err);
     }
@@ -55,7 +56,7 @@ export default function AdminSpools() {
   const fetchLocations = async () => {
     try {
       const data = await api.get("/api/v1/admin/locations/");
-      setLocations(data.items || data || []);
+      setLocations(normalizeList(data, ["locations"]).items);
     } catch (err) {
       console.error("Failed to fetch locations:", err);
     }


### PR DESCRIPTION
**Foundation F1 of the print-farm-OS UX program (epic #808)** — the first spine PR.

## Problem
FilaOps list endpoints are inconsistent — bare array, `{items, pagination}` (the Sprint 1-2 standard), and domain-keyed envelopes (`{work_centers: []}`, `{products: []}`). Every consumer hand-rolled a *different* unwrap (`data.items || data || []`, `Array.isArray(data) ? data : data.items`, or — worst — `setWorkCenters(data)` with no unwrap). On a non-list body (an error payload, a FastAPI 422 `{detail: [...]}`, a stray object) they crash with `x.map is not a function` — the named `workCenters.map` failure.

## Fix
`frontend/src/lib/normalizeList.js` — one defensive coercion that **always** returns `{items, pagination}`, never throws, and yields an empty list for any non-collection payload. Reuses the existing `apiTypes.js` `ListResponse` vocabulary; does **not** auto-wrap `apiClient` (object GETs must pass through), so consumers migrate explicitly.

## Migrated (verified, highest-risk first)
- **`AdminManufacturing.fetchWorkCenters` / `fetchRoutings`** — `setWorkCenters(data)` / `setRoutings(data)` with *no unwrap at all*. This is the literal `workCenters.map` crash source.
- **`AdminOrders`** — `data.items || data` (no array fallback → sets a non-array object).
- `AdminSpools` (3 triple-fallbacks), `AdminPurchasing` (4), `ProductionQueueList` work-centers (1).

12 sites across 5 files. **Behavior-preserving on valid payloads** — the only difference is a bad body now renders empty instead of crashing.

## Tests
`normalizeList.test.js` (vitest): array passthrough, canonical + domain-keyed envelopes, explicit-key override, `items`-priority, and the empty-list path for null/undefined/`{}`/error-string/StandardApiError/422/non-array-`items` — asserting the result is always `.map`-able.

## Scope
The remaining ~14 list consumers are a mechanical follow-up (F1b); this PR takes the floor + commercial-list pages we build the first slices on. Next Foundation PRs: status descriptor + `StatusBadge` (F2), next-action contract (F3), Command Center shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
