### PR TITLE
feat(ux): per-axis status descriptor + StatusBadge primitive (#808 Foundation F2)

### DIFF
--- a/frontend/src/components/ui/StatusBadge.jsx
+++ b/frontend/src/components/ui/StatusBadge.jsx
@@ -1,0 +1,31 @@
+import Badge from "./Badge.jsx";
+import { getDescriptor } from "../../lib/statusDescriptors.js";
+
+/**
+ * Renders a status value as a Badge using the per-axis descriptor registry
+ * (UX Foundation, epic #808). The (model, field, value) triple resolves to a
+ * consistent label + tone everywhere, replacing per-screen status→color maps.
+ *
+ * @param {Object} props
+ * @param {string} props.model - e.g. 'production_order'
+ * @param {string} [props.field='status'] - the status axis (e.g. 'qc_status')
+ * @param {string|null|undefined} props.value
+ * @param {boolean} [props.dot]
+ * @param {'sm'|'md'} [props.size]
+ * @param {string} [props.className]
+ */
+export default function StatusBadge({
+  model,
+  field = "status",
+  value,
+  dot = false,
+  size,
+  className,
+}) {
+  const { label, tone } = getDescriptor(model, field, value);
+  return (
+    <Badge variant={tone} dot={dot} size={size} className={className}>
+      {label}
+    </Badge>
+  );
+}

--- a/frontend/src/components/ui/StatusBadge.test.jsx
+++ b/frontend/src/components/ui/StatusBadge.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import StatusBadge from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("renders the descriptor label", () => {
+    render(<StatusBadge model="production_order" field="status" value="complete" />);
+    expect(screen.getByText("Complete")).toBeInTheDocument();
+  });
+
+  it("applies the descriptor tone to the Badge (danger → red)", () => {
+    render(<StatusBadge model="sales_order" field="payment_status" value="overdue" />);
+    expect(screen.getByText("Overdue").className).toContain("text-red-400");
+  });
+
+  it("defaults field to 'status' and renders complete/completed identically", () => {
+    const { rerender } = render(<StatusBadge model="production_order" value="complete" />);
+    expect(screen.getByText("Complete").className).toContain("text-green-400");
+    rerender(<StatusBadge model="production_order" value="completed" />);
+    expect(screen.getByText("Complete").className).toContain("text-green-400");
+  });
+
+  it("falls back to a neutral badge for an unknown status (never blank/crash)", () => {
+    render(<StatusBadge model="production_order" field="status" value="warp_drive" />);
+    expect(screen.getByText("Warp Drive").className).toContain("text-gray-400");
+  });
+});

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -1,4 +1,5 @@
 export { default as Badge } from "./Badge.jsx";
+export { default as StatusBadge } from "./StatusBadge.jsx";
 export { default as Button } from "./Button.jsx";
 export { default as Input } from "./Input.jsx";
 export { default as Select } from "./Select.jsx";

--- a/frontend/src/lib/statusColors.js
+++ b/frontend/src/lib/statusColors.js
@@ -1,5 +1,11 @@
 // Shared status-to-badge-class mappings (static for Tailwind purge safety)
 //
+// DEPRECATED (UX epic #808): prefer the per-axis descriptor registry +
+// <StatusBadge model field value /> in src/lib/statusDescriptors.js. These flat
+// maps can't express multi-axis status (a sales order has 4 status axes) and
+// drift per screen. Kept for the Tailwind-purge-safe class strings still used
+// by un-migrated callers; migrate opportunistically per workbench.
+//
 // Each domain (sales orders, production, purchasing, etc.) has its own
 // status vocabulary, but the visual palette is consistent: bg-X-500/20
 // with text-X-400.  Domain-specific maps re-export or extend these base

--- a/frontend/src/lib/statusDescriptors.js
+++ b/frontend/src/lib/statusDescriptors.js
@@ -139,6 +139,23 @@ export const STATUS_DESCRIPTORS = {
   },
 };
 
+/**
+ * Own-property lookup through the registry. Avoids inherited keys
+ * (`__proto__`, `constructor`, `toString`, ...) resolving to Object.prototype
+ * members, which would make a malformed value falsely "match".
+ * @returns {object|undefined} the registered entry, or undefined.
+ */
+function lookupEntry(model, field, value) {
+  const has = (obj, key) =>
+    obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+  if (!has(STATUS_DESCRIPTORS, model)) return undefined;
+  const fields = STATUS_DESCRIPTORS[model];
+  if (!has(fields, field)) return undefined;
+  const values = fields[field];
+  if (!has(values, value)) return undefined;
+  return values[value];
+}
+
 /** Title-case an unknown status value: `partially_shipped` → `Partially Shipped`. */
 function titleCase(value) {
   return String(value)
@@ -163,7 +180,7 @@ export function getDescriptor(model, field, value) {
   if (value === null || value === undefined || value === "") {
     return { label: "—", tone: "neutral", terminal: false };
   }
-  const entry = STATUS_DESCRIPTORS[model]?.[field]?.[value];
+  const entry = lookupEntry(model, field, value);
   if (entry) {
     return { label: entry.label, tone: entry.tone, terminal: !!entry.terminal };
   }
@@ -172,7 +189,7 @@ export function getDescriptor(model, field, value) {
 
 /** True if (model, field, value) has a registered descriptor (not a fallback). */
 export function hasDescriptor(model, field, value) {
-  return Boolean(STATUS_DESCRIPTORS[model]?.[field]?.[value]);
+  return lookupEntry(model, field, value) !== undefined;
 }
 
 export default getDescriptor;

--- a/frontend/src/lib/statusDescriptors.js
+++ b/frontend/src/lib/statusDescriptors.js
@@ -1,0 +1,178 @@
+/**
+ * Per-axis status descriptors (UX Foundation, epic #808).
+ *
+ * FilaOps status is MULTI-AXIS: a SalesOrder carries status / payment_status /
+ * fulfillment_status / mrp_status; a ProductionOrder carries status + qc_status.
+ * The same string can mean different things on different axes (`completed` is
+ * terminal on a sales order but a production order's terminal value is
+ * `complete`). A single flat status→color map can't express that, which is why
+ * ~33 ad-hoc maps drifted apart.
+ *
+ * This registry is keyed by (model, field) → value → { label, tone, terminal }.
+ * `tone` is one of the 6 Badge variants (success/warning/danger/info/neutral/
+ * purple). `terminal` marks end-states (validated against status_config.py).
+ *
+ * Reconciliations baked in:
+ *  - ProductionOrder.status canonical is `complete` (PR-0); the `completed`
+ *    spelling (legacy rows / the sales-order convention) aliases to the SAME
+ *    descriptor so both render identically.
+ *  - `qc_hold` is a live ProductionOrder.status written by record_qc_inspection
+ *    but absent from the ProductionOrderStatus enum — registered here.
+ *  - `conditional` is a live qc_status accepted by the service but absent from
+ *    the QCStatus enum — registered here.
+ */
+
+/** @typedef {'success'|'warning'|'danger'|'info'|'neutral'|'purple'} Tone */
+/** @typedef {{ label: string, tone: Tone, terminal: boolean }} StatusDescriptor */
+
+// Registry: model → field → value → { label, tone, terminal? }. A missing
+// `terminal` means false (normalized in getDescriptor).
+export const STATUS_DESCRIPTORS = {
+  sales_order: {
+    status: {
+      pending_confirmation: { label: "Pending Confirmation", tone: "warning" },
+      draft: { label: "Draft", tone: "neutral" },
+      pending: { label: "Pending", tone: "warning" },
+      confirmed: { label: "Confirmed", tone: "info" },
+      in_production: { label: "In Production", tone: "purple" },
+      ready_to_ship: { label: "Ready to Ship", tone: "info" },
+      shipped: { label: "Shipped", tone: "success" },
+      delivered: { label: "Delivered", tone: "success" },
+      completed: { label: "Completed", tone: "success", terminal: true },
+      cancelled: { label: "Cancelled", tone: "danger", terminal: true },
+      on_hold: { label: "On Hold", tone: "warning" },
+    },
+    payment_status: {
+      pending: { label: "Unpaid", tone: "warning" },
+      partial: { label: "Partial", tone: "warning" },
+      paid: { label: "Paid", tone: "success", terminal: true },
+      refunded: { label: "Refunded", tone: "neutral", terminal: true },
+      overdue: { label: "Overdue", tone: "danger" },
+    },
+    fulfillment_status: {
+      pending: { label: "Pending", tone: "warning" },
+      ready: { label: "Ready", tone: "info" },
+      short_closed: { label: "Short-Closed", tone: "neutral", terminal: true },
+      shipped: { label: "Shipped", tone: "success", terminal: true },
+    },
+    // mrp_status is currently never written (dead axis); seeded minimally so a
+    // future value renders gracefully rather than blank.
+    mrp_status: {
+      pending: { label: "MRP Pending", tone: "warning" },
+      planned: { label: "Planned", tone: "info" },
+    },
+  },
+
+  production_order: {
+    status: {
+      draft: { label: "Draft", tone: "neutral" },
+      released: { label: "Released", tone: "info" },
+      in_progress: { label: "In Progress", tone: "purple" },
+      on_hold: { label: "On Hold", tone: "warning" },
+      short: { label: "Short", tone: "warning" },
+      complete: { label: "Complete", tone: "success", terminal: true },
+      // alias of `complete` (legacy / sales-order spelling) — see PR-0.
+      completed: { label: "Complete", tone: "success", terminal: true },
+      qc_hold: { label: "QC Hold", tone: "warning" },
+      scrapped: { label: "Scrapped", tone: "danger", terminal: true },
+      cancelled: { label: "Cancelled", tone: "danger", terminal: true },
+      split: { label: "Split", tone: "neutral", terminal: true },
+    },
+    qc_status: {
+      not_required: { label: "Not Required", tone: "neutral", terminal: true },
+      pending: { label: "QC Pending", tone: "warning" },
+      passed: { label: "Passed", tone: "success", terminal: true },
+      failed: { label: "Failed", tone: "danger" },
+      waived: { label: "Waived", tone: "info", terminal: true },
+      conditional: { label: "Conditional", tone: "warning" },
+    },
+  },
+
+  production_order_operation: {
+    status: {
+      pending: { label: "Pending", tone: "neutral" },
+      queued: { label: "Queued", tone: "info" },
+      running: { label: "Running", tone: "purple" },
+      complete: { label: "Complete", tone: "success", terminal: true },
+      skipped: { label: "Skipped", tone: "neutral", terminal: true },
+    },
+  },
+
+  purchase_order: {
+    status: {
+      draft: { label: "Draft", tone: "neutral" },
+      ordered: { label: "Ordered", tone: "info" },
+      shipped: { label: "Shipped", tone: "purple" },
+      received: { label: "Received", tone: "success", terminal: true },
+      closed: { label: "Closed", tone: "success", terminal: true },
+      cancelled: { label: "Cancelled", tone: "danger", terminal: true },
+    },
+  },
+
+  payment: {
+    status: {
+      pending: { label: "Pending", tone: "warning" },
+      completed: { label: "Completed", tone: "success", terminal: true },
+      failed: { label: "Failed", tone: "danger" },
+      voided: { label: "Voided", tone: "neutral", terminal: true },
+    },
+  },
+
+  spool: {
+    status: {
+      active: { label: "Active", tone: "success" },
+      empty: { label: "Empty", tone: "neutral", terminal: true },
+      expired: { label: "Expired", tone: "danger" },
+      damaged: { label: "Damaged", tone: "warning" },
+    },
+  },
+
+  printer: {
+    status: {
+      offline: { label: "Offline", tone: "neutral" },
+      idle: { label: "Idle", tone: "success" },
+      printing: { label: "Printing", tone: "info" },
+      paused: { label: "Paused", tone: "warning" },
+      error: { label: "Error", tone: "danger" },
+      maintenance: { label: "Maintenance", tone: "warning" },
+    },
+  },
+};
+
+/** Title-case an unknown status value: `partially_shipped` → `Partially Shipped`. */
+function titleCase(value) {
+  return String(value)
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Resolve the display descriptor for a status value on a given axis.
+ *
+ * Never throws. An unregistered value falls back to a title-cased label with a
+ * neutral tone, so a new backend status renders gracefully instead of blank.
+ *
+ * @param {string} model - e.g. 'production_order'
+ * @param {string} field - the status axis, e.g. 'status' | 'qc_status'
+ * @param {string|null|undefined} value
+ * @returns {StatusDescriptor}
+ */
+export function getDescriptor(model, field, value) {
+  if (value === null || value === undefined || value === "") {
+    return { label: "—", tone: "neutral", terminal: false };
+  }
+  const entry = STATUS_DESCRIPTORS[model]?.[field]?.[value];
+  if (entry) {
+    return { label: entry.label, tone: entry.tone, terminal: !!entry.terminal };
+  }
+  return { label: titleCase(value), tone: "neutral", terminal: false };
+}
+
+/** True if (model, field, value) has a registered descriptor (not a fallback). */
+export function hasDescriptor(model, field, value) {
+  return Boolean(STATUS_DESCRIPTORS[model]?.[field]?.[value]);
+}
+
+export default getDescriptor;

--- a/frontend/src/lib/statusDescriptors.test.js
+++ b/frontend/src/lib/statusDescriptors.test.js
@@ -51,6 +51,20 @@ describe("getDescriptor", () => {
     expect(getDescriptor("unknown_model", "status", "anything").label).toBe("Anything");
   });
 
+  it("does not treat inherited Object keys as registered descriptors", () => {
+    // Plain bracket access would resolve __proto__/constructor/toString to
+    // Object.prototype members; the lookup must use own-property checks.
+    for (const evil of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+      expect(hasDescriptor("production_order", "status", evil)).toBe(false);
+      const d = getDescriptor("production_order", "status", evil);
+      expect(typeof d.label).toBe("string"); // never undefined
+      expect(d.tone).toBe("neutral");
+      // an inherited model/field key must not resolve either
+      expect(hasDescriptor("toString", "status", "complete")).toBe(false);
+      expect(hasDescriptor("production_order", "constructor", "complete")).toBe(false);
+    }
+  });
+
   it("returns a placeholder for null/undefined/empty value", () => {
     for (const v of [null, undefined, ""]) {
       expect(getDescriptor("sales_order", "status", v)).toEqual({

--- a/frontend/src/lib/statusDescriptors.test.js
+++ b/frontend/src/lib/statusDescriptors.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { getDescriptor, hasDescriptor, STATUS_DESCRIPTORS } from "./statusDescriptors";
+import {
+  SALES_ORDER_COLORS,
+  PRODUCTION_ORDER_COLORS,
+  PRODUCTION_ORDER_BADGE_CONFIGS,
+  PURCHASE_ORDER_COLORS,
+  PAYMENT_COLORS,
+  SPOOL_COLORS,
+  PRINTER_COLORS,
+} from "./statusColors";
+
+describe("getDescriptor", () => {
+  it("reconciles the production-order complete/completed drift to one descriptor", () => {
+    const complete = getDescriptor("production_order", "status", "complete");
+    const completed = getDescriptor("production_order", "status", "completed");
+    expect(complete).toEqual({ label: "Complete", tone: "success", terminal: true });
+    expect(completed).toEqual(complete);
+  });
+
+  it("defines qc_status='conditional' (live value absent from the enum)", () => {
+    expect(hasDescriptor("production_order", "qc_status", "conditional")).toBe(true);
+    expect(getDescriptor("production_order", "qc_status", "conditional").tone).toBe("warning");
+  });
+
+  it("defines status='qc_hold' (live value absent from the enum)", () => {
+    expect(hasDescriptor("production_order", "status", "qc_hold")).toBe(true);
+  });
+
+  it("maps payment_status='overdue' to a danger tone", () => {
+    expect(getDescriptor("sales_order", "payment_status", "overdue")).toEqual({
+      label: "Overdue",
+      tone: "danger",
+      terminal: false,
+    });
+  });
+
+  it("the same string differs across axes (multi-axis)", () => {
+    // 'completed' is terminal-green on a sales order...
+    expect(getDescriptor("sales_order", "status", "completed").terminal).toBe(true);
+    // ...while a production order's terminal value is 'complete'.
+    expect(getDescriptor("production_order", "status", "complete").terminal).toBe(true);
+  });
+
+  it("falls back gracefully for an unknown value (title-cased, neutral, never throws)", () => {
+    expect(getDescriptor("production_order", "status", "warp_drive")).toEqual({
+      label: "Warp Drive",
+      tone: "neutral",
+      terminal: false,
+    });
+    expect(getDescriptor("unknown_model", "status", "anything").label).toBe("Anything");
+  });
+
+  it("returns a placeholder for null/undefined/empty value", () => {
+    for (const v of [null, undefined, ""]) {
+      expect(getDescriptor("sales_order", "status", v)).toEqual({
+        label: "—",
+        tone: "neutral",
+        terminal: false,
+      });
+    }
+  });
+});
+
+describe("descriptor registry coverage", () => {
+  // Every value in the legacy color maps must have a registered descriptor, so
+  // migrating a screen off statusColors never loses a status.
+  it.each([
+    ["sales_order", "status", SALES_ORDER_COLORS],
+    ["production_order", "status", PRODUCTION_ORDER_COLORS],
+    ["production_order", "status", PRODUCTION_ORDER_BADGE_CONFIGS],
+    ["purchase_order", "status", PURCHASE_ORDER_COLORS],
+    ["payment", "status", PAYMENT_COLORS],
+    ["spool", "status", SPOOL_COLORS],
+    ["printer", "status", PRINTER_COLORS],
+  ])("%s.%s covers every legacy color-map value", (model, field, colorMap) => {
+    for (const value of Object.keys(colorMap)) {
+      expect(hasDescriptor(model, field, value)).toBe(true);
+    }
+  });
+
+  it("only uses the 6 Badge tones across the whole registry", () => {
+    const tones = new Set(["success", "warning", "danger", "info", "neutral", "purple"]);
+    for (const fields of Object.values(STATUS_DESCRIPTORS)) {
+      for (const values of Object.values(fields)) {
+        for (const d of Object.values(values)) {
+          expect(tones.has(d.tone)).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe("terminal flags match the status_config.py transition tables", () => {
+  // Hardcoded from backend/app/core/status_config.py terminal sets (empty
+  // transition target). Guards against descriptor/state-machine drift.
+  it.each([
+    ["production_order", "status", "complete", true],
+    ["production_order", "status", "cancelled", true],
+    ["production_order", "status", "split", true],
+    ["production_order", "status", "in_progress", false],
+    ["production_order", "status", "short", false],
+    ["sales_order", "status", "completed", true],
+    ["sales_order", "status", "cancelled", true],
+    ["sales_order", "status", "delivered", false],
+    ["sales_order", "status", "shipped", false],
+    ["production_order", "qc_status", "passed", true],
+    ["production_order", "qc_status", "waived", true],
+    ["production_order", "qc_status", "pending", false],
+    ["production_order", "qc_status", "failed", false],
+    ["production_order_operation", "status", "complete", true],
+    ["production_order_operation", "status", "skipped", true],
+    ["production_order_operation", "status", "running", false],
+  ])("%s.%s=%s terminal=%s", (model, field, value, terminal) => {
+    expect(getDescriptor(model, field, value).terminal).toBe(terminal);
+  });
+});


### PR DESCRIPTION
**Foundation F2 of the print-farm-OS UX program (epic #808).** The per-axis status descriptor + `StatusBadge` primitive — the display-layer half of the spine, and where the `complete`/`completed` reconciliation is finished.

## Why
Status is **multi-axis** — a `SalesOrder` carries `status` / `payment_status` / `fulfillment_status` / `mrp_status`; a `ProductionOrder` carries `status` + `qc_status`. The same string means different things across axes (`completed` is terminal on a sales order; a production order's terminal value is `complete`). A flat status→color map can't express that, which is why ~33 ad-hoc maps drifted apart.

## What
- **`src/lib/statusDescriptors.js`** — a registry keyed `(model, field) → value → { label, tone, terminal }`, with `getDescriptor()` / `hasDescriptor()` and a graceful title-cased neutral fallback (a new backend value renders, never blanks/throws). Grounded in `status_config.py` enums + the existing color maps.
- **`src/components/ui/StatusBadge.jsx`** — `<StatusBadge model field value />` → resolves the descriptor and renders `<Badge variant={tone}>`. Exported from the `ui` barrel.
- `statusColors.js` gets a deprecation pointer (kept for Tailwind-purge-safe class strings; migrate per workbench later).

## Reconciliations baked in (from PR-0 + the adversarial review)
- ProductionOrder canonical is `complete`; **`completed` aliases to the same descriptor** so legacy/sales-order spelling renders identically (acceptance-tested).
- **`qc_hold`** (a live `status` written by `record_qc_inspection` but absent from the enum) and **`conditional`** (a live `qc_status` accepted by the service but absent from the enum) are registered.

## Tests
`complete`/`completed` reconciliation, `conditional`/`qc_hold` defined, multi-axis divergence, unknown→fallback, null→placeholder, **coverage over every legacy color-map value**, the 6-tone invariant, **terminal-flag agreement with the `status_config.py` transition tables**, and `StatusBadge` rendering the correct tone.

## Scope
Builds the primitive; doesn't rip out existing `statusColors` callers (that's per-workbench migration). Next Foundation PR: the multi-axis next-action contract (F3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable, color-coded status badge component with consistent labeled rendering across the app.
  * Expanded status interpretation to support additional status values and aliases, with sensible fallback labels for unfamiliar entries.

* **Bug Fixes**
  * Improved safe rendering for blank or unknown status values (no empty/incorrect output).
  * Ensured equivalent status variants (e.g., “complete” vs “completed”) display with the same badge.

* **Tests**
  * Added test coverage for the status descriptor logic and the badge component to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->