### PR TITLE
feat(ux): multi-axis next-action contract adapters (#808 Foundation F3)

### DIFF
--- a/frontend/src/lib/nextActions.js
+++ b/frontend/src/lib/nextActions.js
@@ -11,7 +11,8 @@
  * `can_*`/`is_*` order guards). They must NOT recompute readiness — otherwise a
  * cockpit badge and a detail panel could disagree, which is the disconnected-
  * pages problem this program exists to kill. No fetch here; given a payload they
- * return a deterministic NextAction[].
+ * return a deterministic NextAction[]. Malformed elements are skipped, never
+ * thrown on.
  */
 
 /** @typedef {'critical'|'high'|'medium'|'low'} Severity */
@@ -48,6 +49,9 @@ const AXIS_BY_REFERENCE_TYPE = {
 
 const SEVERITY_BY_PRIORITY = { 1: "critical", 2: "high", 3: "medium", 4: "low" };
 const SEVERITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
+const severityRank = (s) => (SEVERITY_RANK[s] ?? 9);
+
+const isObject = (x) => x != null && typeof x === "object";
 
 /** Map a backend priority int (1=most urgent) to a severity; unknown → 'low'. */
 export function severityFromPriority(priority) {
@@ -56,47 +60,55 @@ export function severityFromPriority(priority) {
 
 /**
  * Project command-center ActionItems into NextActions (one per item).
+ * Malformed (non-object) entries are skipped.
  * @param {Array} actionItems - ActionItem[] from /command-center/action-items
  * @returns {NextAction[]}
  */
 export function fromActionItems(actionItems) {
   if (!Array.isArray(actionItems)) return [];
-  return actionItems.map((item) => {
+  return actionItems.flatMap((item) => {
+    if (!isObject(item)) return [];
     const primary = (item.suggested_actions || [])[0] || {};
     const hasTarget = item.entity_type != null && item.entity_id != null;
-    return {
-      axis: AXIS_BY_ACTION_TYPE[item.type] || "other",
-      label: item.title || primary.label || "Action needed",
-      reason: item.description || undefined,
-      severity: severityFromPriority(item.priority),
-      verb: primary.action_type || undefined,
-      href: primary.url || undefined,
-      target: hasTarget
-        ? { type: item.entity_type, id: item.entity_id, code: item.entity_code || undefined }
-        : undefined,
-      enabled: true,
-    };
+    return [
+      {
+        axis: AXIS_BY_ACTION_TYPE[item.type] || "other",
+        label: item.title || primary.label || "Action needed",
+        reason: item.description || undefined,
+        severity: severityFromPriority(item.priority),
+        verb: primary.action_type || undefined,
+        href: primary.url || undefined,
+        target: hasTarget
+          ? { type: item.entity_type, id: item.entity_id, code: item.entity_code || undefined }
+          : undefined,
+        enabled: true,
+      },
+    ];
   });
 }
 
 /**
  * Project a ProductionOrderBlockingIssues payload's resolution_actions[].
+ * Malformed (non-object) entries are skipped.
  * @param {Object} blockingIssues - { resolution_actions: ResolutionAction[] }
  * @returns {NextAction[]}
  */
 export function fromResolutionActions(blockingIssues) {
   const actions = blockingIssues?.resolution_actions;
   if (!Array.isArray(actions)) return [];
-  return actions.map((a) => {
+  return actions.flatMap((a) => {
+    if (!isObject(a)) return [];
     const hasTarget = a.reference_type != null && a.reference_id != null;
-    return {
-      axis: AXIS_BY_REFERENCE_TYPE[a.reference_type] || "production",
-      label: a.action,
-      reason: a.impact || undefined,
-      severity: severityFromPriority(a.priority),
-      target: hasTarget ? { type: a.reference_type, id: a.reference_id } : undefined,
-      enabled: true,
-    };
+    return [
+      {
+        axis: AXIS_BY_REFERENCE_TYPE[a.reference_type] || "production",
+        label: a.action,
+        reason: a.impact || undefined,
+        severity: severityFromPriority(a.priority),
+        target: hasTarget ? { type: a.reference_type, id: a.reference_id } : undefined,
+        enabled: true,
+      },
+    ];
   });
 }
 
@@ -108,7 +120,7 @@ export function fromResolutionActions(blockingIssues) {
  * @returns {NextAction[]}
  */
 export function fromOrderGuards(order) {
-  if (!order || typeof order !== "object") return [];
+  if (!isObject(order)) return [];
   const out = [];
   const target =
     order.id != null
@@ -152,28 +164,33 @@ const dedupeKey = (a) =>
   `${a.axis}|${a.target?.type || ""}|${a.target?.id ?? ""}|${a.verb || a.label}`;
 
 /**
- * Merge NextAction lists into an axis-keyed map, de-duplicating across sources
- * and sorting each lane by severity (critical first). This is what the Command
- * Center renders as lanes.
+ * Merge NextAction lists into an axis-keyed map. De-duplicates across sources,
+ * keeping the HIGHEST-severity action for a given key (a later `critical` is not
+ * dropped behind an earlier `low`), and sorts each lane by severity. Malformed
+ * entries are skipped. This is what the Command Center renders as lanes.
  * @param {...NextAction[]} lists
  * @returns {Record<string, NextAction[]>}
  */
 export function mergeByAxis(...lists) {
-  const seen = new Set();
-  const byAxis = {};
+  const best = new Map(); // dedupeKey → highest-severity action seen
   for (const list of lists) {
     for (const action of list || []) {
+      if (!isObject(action)) continue;
       const key = dedupeKey(action);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      if (!byAxis[action.axis]) byAxis[action.axis] = [];
-      byAxis[action.axis].push(action);
+      const existing = best.get(key);
+      // strict < keeps the first-seen entry on a severity tie
+      if (!existing || severityRank(action.severity) < severityRank(existing.severity)) {
+        best.set(key, action);
+      }
     }
   }
+  const byAxis = {};
+  for (const action of best.values()) {
+    if (!byAxis[action.axis]) byAxis[action.axis] = [];
+    byAxis[action.axis].push(action);
+  }
   for (const axis of Object.keys(byAxis)) {
-    byAxis[axis].sort(
-      (x, y) => (SEVERITY_RANK[x.severity] ?? 9) - (SEVERITY_RANK[y.severity] ?? 9)
-    );
+    byAxis[axis].sort((x, y) => severityRank(x.severity) - severityRank(y.severity));
   }
   return byAxis;
 }

--- a/frontend/src/lib/nextActions.js
+++ b/frontend/src/lib/nextActions.js
@@ -1,0 +1,179 @@
+/**
+ * Multi-axis next-action contract (UX Foundation, epic #808).
+ *
+ * The Command Center is a thin aggregator over a single "next-action" shape that
+ * any module emits. Status in FilaOps is multi-axis (a sales order can need
+ * payment AND production AND fulfillment at once), so the contract is a LIST
+ * keyed by axis — never one action per record.
+ *
+ * These adapters are pure PROJECTIONS over surfaces the backend already
+ * computes (command-center /action-items, production /blocking-issues, and the
+ * `can_*`/`is_*` order guards). They must NOT recompute readiness — otherwise a
+ * cockpit badge and a detail panel could disagree, which is the disconnected-
+ * pages problem this program exists to kill. No fetch here; given a payload they
+ * return a deterministic NextAction[].
+ */
+
+/** @typedef {'critical'|'high'|'medium'|'low'} Severity */
+/** @typedef {{ type: string, id: number, code?: string }} ActionTarget */
+/**
+ * @typedef {Object} NextAction
+ * @property {string} axis - 'payment'|'fulfillment'|'production'|'qc'|'supply'|'maintenance'|'other'
+ * @property {string} label
+ * @property {string} [reason]
+ * @property {Severity} severity
+ * @property {string} [verb] - a UI handler key (e.g. 'record_payment')
+ * @property {string} [href] - deep link
+ * @property {ActionTarget} [target]
+ * @property {boolean} enabled
+ * @property {string} [disabledReason]
+ */
+
+// Command-center ActionItemType → cockpit lane axis.
+const AXIS_BY_ACTION_TYPE = {
+  blocked_po: "production",
+  overrunning_op: "production",
+  idle_resource: "production",
+  overdue_so: "fulfillment",
+  due_today_so: "fulfillment",
+  maintenance_due: "maintenance",
+};
+
+// reference_type (blocking-issue resolution) → axis.
+const AXIS_BY_REFERENCE_TYPE = {
+  production_order: "production",
+  purchase_order: "supply",
+  sales_order: "fulfillment",
+};
+
+const SEVERITY_BY_PRIORITY = { 1: "critical", 2: "high", 3: "medium", 4: "low" };
+const SEVERITY_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
+
+/** Map a backend priority int (1=most urgent) to a severity; unknown → 'low'. */
+export function severityFromPriority(priority) {
+  return SEVERITY_BY_PRIORITY[priority] || "low";
+}
+
+/**
+ * Project command-center ActionItems into NextActions (one per item).
+ * @param {Array} actionItems - ActionItem[] from /command-center/action-items
+ * @returns {NextAction[]}
+ */
+export function fromActionItems(actionItems) {
+  if (!Array.isArray(actionItems)) return [];
+  return actionItems.map((item) => {
+    const primary = (item.suggested_actions || [])[0] || {};
+    const hasTarget = item.entity_type != null && item.entity_id != null;
+    return {
+      axis: AXIS_BY_ACTION_TYPE[item.type] || "other",
+      label: item.title || primary.label || "Action needed",
+      reason: item.description || undefined,
+      severity: severityFromPriority(item.priority),
+      verb: primary.action_type || undefined,
+      href: primary.url || undefined,
+      target: hasTarget
+        ? { type: item.entity_type, id: item.entity_id, code: item.entity_code || undefined }
+        : undefined,
+      enabled: true,
+    };
+  });
+}
+
+/**
+ * Project a ProductionOrderBlockingIssues payload's resolution_actions[].
+ * @param {Object} blockingIssues - { resolution_actions: ResolutionAction[] }
+ * @returns {NextAction[]}
+ */
+export function fromResolutionActions(blockingIssues) {
+  const actions = blockingIssues?.resolution_actions;
+  if (!Array.isArray(actions)) return [];
+  return actions.map((a) => {
+    const hasTarget = a.reference_type != null && a.reference_id != null;
+    return {
+      axis: AXIS_BY_REFERENCE_TYPE[a.reference_type] || "production",
+      label: a.action,
+      reason: a.impact || undefined,
+      severity: severityFromPriority(a.priority),
+      target: hasTarget ? { type: a.reference_type, id: a.reference_id } : undefined,
+      enabled: true,
+    };
+  });
+}
+
+/**
+ * Project a sales order's serialized guard booleans into NextActions, reading
+ * each guard DEFENSIVELY (a guard that isn't serialized yet simply yields no
+ * action — the projection never fabricates readiness).
+ * @param {Object} order - a SalesOrderResponse-shaped object
+ * @returns {NextAction[]}
+ */
+export function fromOrderGuards(order) {
+  if (!order || typeof order !== "object") return [];
+  const out = [];
+  const target =
+    order.id != null
+      ? { type: "sales_order", id: order.id, code: order.order_number || undefined }
+      : undefined;
+
+  if (order.is_paid === false) {
+    out.push({
+      axis: "payment",
+      label: "Collect payment",
+      severity: order.payment_status === "overdue" ? "high" : "medium",
+      verb: "record_payment",
+      target,
+      enabled: true,
+    });
+  }
+  if (order.can_start_production === true) {
+    out.push({
+      axis: "production",
+      label: "Start production",
+      severity: "medium",
+      verb: "start_production",
+      target,
+      enabled: true,
+    });
+  }
+  if (order.is_ready_to_ship === true) {
+    out.push({
+      axis: "fulfillment",
+      label: "Ship order",
+      severity: "high",
+      verb: "ship",
+      target,
+      enabled: true,
+    });
+  }
+  return out;
+}
+
+const dedupeKey = (a) =>
+  `${a.axis}|${a.target?.type || ""}|${a.target?.id ?? ""}|${a.verb || a.label}`;
+
+/**
+ * Merge NextAction lists into an axis-keyed map, de-duplicating across sources
+ * and sorting each lane by severity (critical first). This is what the Command
+ * Center renders as lanes.
+ * @param {...NextAction[]} lists
+ * @returns {Record<string, NextAction[]>}
+ */
+export function mergeByAxis(...lists) {
+  const seen = new Set();
+  const byAxis = {};
+  for (const list of lists) {
+    for (const action of list || []) {
+      const key = dedupeKey(action);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (!byAxis[action.axis]) byAxis[action.axis] = [];
+      byAxis[action.axis].push(action);
+    }
+  }
+  for (const axis of Object.keys(byAxis)) {
+    byAxis[axis].sort(
+      (x, y) => (SEVERITY_RANK[x.severity] ?? 9) - (SEVERITY_RANK[y.severity] ?? 9)
+    );
+  }
+  return byAxis;
+}

--- a/frontend/src/lib/nextActions.test.js
+++ b/frontend/src/lib/nextActions.test.js
@@ -78,6 +78,12 @@ describe("fromActionItems", () => {
     expect(fromActionItems(undefined)).toEqual([]);
     expect(fromActionItems({})).toEqual([]);
   });
+
+  it("skips malformed (null/non-object) array elements without throwing", () => {
+    const out = fromActionItems([null, item("blocked_po", 1), "junk", undefined, 42]);
+    expect(out).toHaveLength(1);
+    expect(out[0].axis).toBe("production");
+  });
 });
 
 describe("fromResolutionActions", () => {
@@ -103,6 +109,14 @@ describe("fromResolutionActions", () => {
     expect(fromResolutionActions(null)).toEqual([]);
     expect(fromResolutionActions({})).toEqual([]);
     expect(fromResolutionActions({ resolution_actions: "nope" })).toEqual([]);
+  });
+
+  it("skips malformed resolution-action elements without throwing", () => {
+    const out = fromResolutionActions({
+      resolution_actions: [null, { priority: 2, action: "Do it", reference_type: "production_order", reference_id: 1 }, 7],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].label).toBe("Do it");
   });
 });
 
@@ -152,6 +166,19 @@ describe("mergeByAxis", () => {
   it("dedupes identical actions across sources", () => {
     const a = { axis: "payment", label: "Collect payment", verb: "record_payment", target: { type: "sales_order", id: 3 }, severity: "high", enabled: true };
     const grouped = mergeByAxis([a], [{ ...a }]);
+    expect(grouped.payment).toHaveLength(1);
+  });
+
+  it("keeps the highest-severity action when a key is duplicated", () => {
+    const base = { axis: "production", label: "Start", verb: "start_production", target: { type: "sales_order", id: 5 }, enabled: true };
+    // low arrives first, critical later with the same dedupe key
+    const grouped = mergeByAxis([{ ...base, severity: "low" }], [{ ...base, severity: "critical" }]);
+    expect(grouped.production).toHaveLength(1);
+    expect(grouped.production[0].severity).toBe("critical");
+  });
+
+  it("skips malformed entries without throwing", () => {
+    const grouped = mergeByAxis([null, { axis: "payment", label: "Pay", severity: "high", enabled: true }, "junk"]);
     expect(grouped.payment).toHaveLength(1);
   });
 

--- a/frontend/src/lib/nextActions.test.js
+++ b/frontend/src/lib/nextActions.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  severityFromPriority,
+  fromActionItems,
+  fromResolutionActions,
+  fromOrderGuards,
+  mergeByAxis,
+} from "./nextActions";
+
+describe("severityFromPriority", () => {
+  it("maps backend priority ints to severities", () => {
+    expect(severityFromPriority(1)).toBe("critical");
+    expect(severityFromPriority(2)).toBe("high");
+    expect(severityFromPriority(3)).toBe("medium");
+    expect(severityFromPriority(4)).toBe("low");
+    expect(severityFromPriority(99)).toBe("low");
+  });
+});
+
+describe("fromActionItems", () => {
+  const item = (type, priority, extra = {}) => ({
+    id: `${type}_1`,
+    type,
+    priority,
+    title: `${type} title`,
+    description: `${type} desc`,
+    entity_type: "production_order",
+    entity_id: 7,
+    entity_code: "WO-7",
+    suggested_actions: [{ label: "Go", url: "/admin/production/7", action_type: "navigate" }],
+    ...extra,
+  });
+
+  it("maps each ActionItemType to the correct axis", () => {
+    const out = fromActionItems([
+      item("blocked_po", 1),
+      item("overrunning_op", 3),
+      item("idle_resource", 4),
+      item("overdue_so", 1),
+      item("due_today_so", 2),
+      item("maintenance_due", 2),
+    ]);
+    expect(out.map((a) => a.axis)).toEqual([
+      "production",
+      "production",
+      "production",
+      "fulfillment",
+      "fulfillment",
+      "maintenance",
+    ]);
+  });
+
+  it("projects label/severity/href/target from the item + primary suggested action", () => {
+    const [a] = fromActionItems([item("blocked_po", 1)]);
+    expect(a).toMatchObject({
+      axis: "production",
+      label: "blocked_po title",
+      reason: "blocked_po desc",
+      severity: "critical",
+      verb: "navigate",
+      href: "/admin/production/7",
+      target: { type: "production_order", id: 7, code: "WO-7" },
+      enabled: true,
+    });
+  });
+
+  it("tolerates missing suggested_actions and unknown types", () => {
+    const out = fromActionItems([
+      { id: "x", type: "mystery", priority: 2, title: "Hmm", entity_type: "thing", entity_id: 1 },
+    ]);
+    expect(out[0].axis).toBe("other");
+    expect(out[0].href).toBeUndefined();
+    expect(out[0].target).toEqual({ type: "thing", id: 1, code: undefined });
+  });
+
+  it("returns [] for non-array input", () => {
+    expect(fromActionItems(null)).toEqual([]);
+    expect(fromActionItems(undefined)).toEqual([]);
+    expect(fromActionItems({})).toEqual([]);
+  });
+});
+
+describe("fromResolutionActions", () => {
+  it("projects resolution_actions with axis from reference_type and severity from priority", () => {
+    const out = fromResolutionActions({
+      resolution_actions: [
+        { priority: 1, action: "Order PLA", impact: "unblocks 2 WOs", reference_type: "purchase_order", reference_id: 5 },
+        { priority: 3, action: "Reassign printer", impact: "", reference_type: "production_order", reference_id: 9 },
+      ],
+    });
+    expect(out[0]).toMatchObject({
+      axis: "supply",
+      label: "Order PLA",
+      reason: "unblocks 2 WOs",
+      severity: "critical",
+      target: { type: "purchase_order", id: 5 },
+    });
+    expect(out[1].axis).toBe("production");
+    expect(out[1].severity).toBe("medium");
+  });
+
+  it("returns [] when there are no resolution actions", () => {
+    expect(fromResolutionActions(null)).toEqual([]);
+    expect(fromResolutionActions({})).toEqual([]);
+    expect(fromResolutionActions({ resolution_actions: "nope" })).toEqual([]);
+  });
+});
+
+describe("fromOrderGuards", () => {
+  it("emits a payment action when unpaid (overdue → high)", () => {
+    const out = fromOrderGuards({ id: 3, order_number: "SO-3", is_paid: false, payment_status: "overdue" });
+    expect(out).toEqual([
+      {
+        axis: "payment",
+        label: "Collect payment",
+        severity: "high",
+        verb: "record_payment",
+        target: { type: "sales_order", id: 3, code: "SO-3" },
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("emits production + fulfillment actions from the guards (multi-axis)", () => {
+    const out = fromOrderGuards({
+      id: 4,
+      is_paid: true,
+      can_start_production: true,
+      is_ready_to_ship: true,
+    });
+    expect(out.map((a) => a.axis).sort()).toEqual(["fulfillment", "production"]);
+  });
+
+  it("emits nothing when guards are absent (projection never fabricates readiness)", () => {
+    expect(fromOrderGuards({ id: 1 })).toEqual([]);
+    expect(fromOrderGuards(null)).toEqual([]);
+    expect(fromOrderGuards("nope")).toEqual([]);
+  });
+});
+
+describe("mergeByAxis", () => {
+  it("groups actions by axis, sorting each lane by severity", () => {
+    const grouped = mergeByAxis(
+      [{ axis: "production", label: "B", severity: "low", enabled: true }],
+      [{ axis: "production", label: "A", severity: "critical", enabled: true }],
+      [{ axis: "payment", label: "Pay", severity: "high", enabled: true }]
+    );
+    expect(Object.keys(grouped).sort()).toEqual(["payment", "production"]);
+    expect(grouped.production.map((a) => a.label)).toEqual(["A", "B"]); // critical before low
+  });
+
+  it("dedupes identical actions across sources", () => {
+    const a = { axis: "payment", label: "Collect payment", verb: "record_payment", target: { type: "sales_order", id: 3 }, severity: "high", enabled: true };
+    const grouped = mergeByAxis([a], [{ ...a }]);
+    expect(grouped.payment).toHaveLength(1);
+  });
+
+  it("a sales order needing payment + production surfaces on two axes", () => {
+    const grouped = mergeByAxis(
+      fromOrderGuards({ id: 9, is_paid: false, payment_status: "pending", can_start_production: true })
+    );
+    expect(Object.keys(grouped).sort()).toEqual(["payment", "production"]);
+  });
+});


### PR DESCRIPTION
**Foundation F3 of the print-farm-OS UX program (epic #808)** — the conceptual core of the spine.

## What
A single next-action contract any module emits, as a **list keyed by axis** (a sales order can need payment *and* production *and* fulfillment at once — one-action-per-record would hide two of them). The Command Center aggregates these into lanes.

`src/lib/nextActions.js` — pure **projection** adapters over surfaces the backend *already* computes. They must not recompute readiness, so a cockpit badge and a detail panel can never disagree (the disconnected-pages problem this program kills):
- `fromActionItems()` — command-center `/action-items` → `NextAction[]`; axis inferred from `ActionItemType`, severity from priority, deep-link + target carried.
- `fromResolutionActions()` — a `ProductionOrderBlockingIssues` payload's `resolution_actions[]` → `NextAction[]`; axis from `reference_type`.
- `fromOrderGuards()` — a sales order's `can_*`/`is_*` guards → `NextAction[]`, read **defensively** (a guard not yet serialized yields no action — the projection never fabricates readiness).
- `mergeByAxis()` — dedupe across sources, group by axis, sort each lane by severity.

No fetch — given a payload the adapters return deterministic output.

## Tests
`nextActions.test.js`: all 6 `ActionItemType` axis mappings, severity/target/href projection, missing-suggested-actions tolerance, resolution-action `reference_type`→axis, multi-axis guard emission, dedupe + severity sort, and null-safety on every adapter.

## Sequence
This is the contract + adapters. The two pieces that make it *visible* follow: **F3b** serializes the now-correct `can_*`/`is_*` guards onto the response schemas (so `fromOrderGuards` lights up), and **F4** refactors the existing Command Center to render these lanes via the new shape + `StatusBadge`. Grounded against the real `ActionItem`/`SuggestedAction`/`ResolutionAction` shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the app’s “next actions” to unify multiple backend signals into a single, consistent action list.
  * Actions are now routed into appropriate lanes and presented in a stable priority-based order (highest severity first), with duplicates consolidated.
  * Improved resilience to missing or malformed action data to reduce empty or broken action states.
* **Tests**
  * Added unit tests covering action projection, merging/deduplication, severity mapping, and edge-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->