### PR TITLE
feat(ux): serialize can_*/is_* guards onto SO + PO list responses (#808 F3b)

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -313,6 +313,13 @@ def build_list_response(order: ProductionOrder, db: Session) -> ProductionOrderL
         actual_material_cost=order.actual_material_cost,
         actual_labor_cost=order.actual_labor_cost,
         actual_total_cost=order.actual_total_cost,
+        # QC status + computed guards for the next-action contract (#808).
+        # qc_status was previously omitted, so the list always reported the
+        # "not_required" default regardless of the real value.
+        qc_status=order.qc_status or "not_required",
+        is_ready_for_qc=order.is_ready_for_qc,
+        can_close=order.can_close,
+        is_qc_required=order.is_qc_required,
         created_at=order.created_at,
     )
 

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -166,6 +166,12 @@ def build_sales_order_response(order: SalesOrder, db: Session) -> SalesOrderResp
         "created_at": order.created_at,
         "updated_at": order.updated_at,
         "confirmed_at": getattr(order, "confirmed_at", None),
+        # Computed guard flags for the next-action contract (#808)
+        "is_paid": order.is_paid,
+        "is_cancellable": order.is_cancellable,
+        "can_start_production": order.can_start_production,
+        "is_ready_to_ship": order.is_ready_to_ship,
+        "is_complete": order.is_complete,
         "lines": lines,
     }
 

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -247,6 +247,10 @@ class ProductionOrderListResponse(BaseModel):
 
     # QC Status
     qc_status: str = "not_required"
+    # Computed guard flags (UX next-action contract, #808)
+    is_ready_for_qc: bool = False
+    can_close: bool = False
+    is_qc_required: bool = False
 
     due_date: Optional[date] = None
     scheduled_start: Optional[datetime] = None

--- a/backend/app/schemas/sales_order.py
+++ b/backend/app/schemas/sales_order.py
@@ -305,6 +305,15 @@ class SalesOrderResponse(SalesOrderBase):
     closed_short_at: Optional[datetime] = None
     close_short_reason: Optional[str] = None
 
+    # Computed guard flags (UX next-action contract, #808) — surfaced so the
+    # cockpit/workbench PROJECT next-actions from these instead of re-deriving
+    # readiness client-side (which would drift from the model's @property logic).
+    is_paid: bool = False
+    is_cancellable: bool = False
+    can_start_production: bool = False
+    is_ready_to_ship: bool = False
+    is_complete: bool = False
+
     # Timestamps
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/api/v1/test_response_guard_serialization.py
+++ b/backend/tests/api/v1/test_response_guard_serialization.py
@@ -1,0 +1,59 @@
+"""F3b (#808): the response builders serialize the model @property guards so the
+UX next-action contract can PROJECT from them instead of re-deriving readiness."""
+from decimal import Decimal
+
+from app.api.v1.endpoints.sales_orders import build_sales_order_response
+from app.api.v1.endpoints.production_orders import build_list_response
+
+
+class TestSalesOrderResponseGuards:
+    def test_serializes_guard_flags(self, db, make_sales_order, finished_good):
+        so = make_sales_order(
+            product_id=finished_good.id, status="confirmed", payment_status="paid"
+        )
+        resp = build_sales_order_response(so, db)
+        assert resp.is_paid is True
+        assert resp.can_start_production is True  # confirmed + paid
+        assert resp.is_cancellable is True  # 'confirmed' is cancellable
+        assert resp.is_ready_to_ship is False  # not ready_to_ship
+        assert resp.is_complete is False
+
+    def test_unpaid_pending_order_guards(self, db, make_sales_order, finished_good):
+        so = make_sales_order(
+            product_id=finished_good.id, status="pending", payment_status="pending"
+        )
+        resp = build_sales_order_response(so, db)
+        assert resp.is_paid is False
+        assert resp.can_start_production is False  # not confirmed
+        assert resp.is_complete is False
+
+
+class TestProductionListResponseGuards:
+    def test_serializes_real_qc_status_and_guards(self, db, make_production_order, finished_good):
+        # status='complete' + qc_status='pending' => ready for QC, not closable.
+        po = make_production_order(
+            product_id=finished_good.id,
+            status="complete",
+            qc_status="pending",
+            quantity=5,
+            quantity_completed=Decimal("5"),
+        )
+        resp = build_list_response(po, db)
+        # Regression: qc_status used to default to "not_required" (never passed).
+        assert resp.qc_status == "pending"
+        assert resp.is_ready_for_qc is True
+        assert resp.is_qc_required is True
+        assert resp.can_close is False  # pending not in {passed, not_required, waived}
+
+    def test_passed_qc_is_closable(self, db, make_production_order, finished_good):
+        po = make_production_order(
+            product_id=finished_good.id,
+            status="complete",
+            qc_status="passed",
+            quantity=5,
+            quantity_completed=Decimal("5"),
+        )
+        resp = build_list_response(po, db)
+        assert resp.qc_status == "passed"
+        assert resp.can_close is True
+        assert resp.is_ready_for_qc is False  # qc no longer pending


### PR DESCRIPTION
**Foundation F3b of the print-farm-OS UX program (epic #808).** The small backend touch that lights up F3's `fromOrderGuards` adapter.

## What
Exposes the models' computed `can_*`/`is_*` guards on the responses, so the cockpit/workbench **project** readiness from the contract instead of re-deriving it client-side (which would drift from the `@property` logic).

- **`SalesOrderResponse`** + its shared builder dict (`build_sales_order_response`): `is_paid`, `is_cancellable`, `can_start_production`, `is_ready_to_ship`, `is_complete`.
- **`ProductionOrderListResponse`** + `build_list_response`: `is_ready_for_qc`, `can_close`, `is_qc_required` — **and `qc_status`**, which `build_list_response` previously *omitted*, so the PO list always reported the `"not_required"` default regardless of the real value (latent bug; the cockpit QC-due lane needs the real status).

All are pure reads of existing guards (now correct after PR-0). Schema fields are optional with defaults, so any other construction path stays valid (additive, non-breaking).

## Tests
`test_response_guard_serialization.py`: SO guards for paid/confirmed vs unpaid/pending; PO list real `qc_status` + `is_ready_for_qc`/`can_close` for pending vs passed QC (the latter also pins the qc_status-omission regression).

## Sequence
With F3b, `fromOrderGuards` has real data to project. The last Foundation PR — **F4** — refactors the existing Command Center to render the next-action lanes via the unified shape + `StatusBadge`, and the spine goes visibly live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more order-status indicators in sales order responses, including payment, cancellation, production start, shipping, and completion readiness.
  * Added QC-related indicators to production order list responses, including whether an order is ready for QC, closable, or requires QC.

* **Bug Fixes**
  * Corrected QC status handling so list views now show the actual QC state instead of always defaulting to a generic value.

* **Tests**
  * Added coverage for the new response fields and their expected behavior across different order states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->