### PR TITLE
feat(ux): Command Center renders multi-axis next-action lanes (#808 Foundation F4)

### DIFF
--- a/frontend/src/components/command-center/NextActionCard.jsx
+++ b/frontend/src/components/command-center/NextActionCard.jsx
@@ -1,0 +1,74 @@
+/**
+ * NextActionCard — renders a single NextAction (UX Foundation F4, epic #808).
+ *
+ * Consumes the unified next-action shape from `lib/nextActions.js` rather than a
+ * raw ActionItem, so every surface that emits NextActions (cockpit, blocking
+ * issues, order guards) renders identically. Severity drives the accent; the
+ * primary deep-link is the one quick action. Disabled actions show their reason
+ * instead of a dead link.
+ */
+import { Link } from "react-router-dom";
+import { Badge } from "../ui";
+import { severityTone } from "./axisMeta";
+
+// Severity → left-accent classes (mirrors the cockpit's prior priority styling).
+const SEVERITY_ACCENT = {
+  critical: "border-red-500/50 bg-red-500/10",
+  high: "border-orange-500/50 bg-orange-500/10",
+  medium: "border-yellow-500/50 bg-yellow-500/10",
+  low: "border-blue-500/40 bg-blue-500/5",
+};
+
+const SEVERITY_LABEL = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export default function NextActionCard({ action }) {
+  if (!action || typeof action !== "object") return null;
+
+  const accent = SEVERITY_ACCENT[action.severity] || SEVERITY_ACCENT.low;
+  const code = action.target?.code;
+  const canLink = action.enabled !== false && !!action.href;
+
+  return (
+    <div className={`border rounded-lg p-4 ${accent}`} data-testid="next-action-card">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="text-white font-medium truncate">{action.label}</h4>
+            {code && <span className="text-xs text-gray-400">{code}</span>}
+          </div>
+          {action.reason && (
+            <p className="text-gray-400 text-sm mt-1">{action.reason}</p>
+          )}
+        </div>
+        <Badge variant={severityTone(action.severity)} size="sm">
+          {SEVERITY_LABEL[action.severity] || "Low"}
+        </Badge>
+      </div>
+
+      {(canLink || action.disabledReason) && (
+        <div className="mt-3">
+          {canLink ? (
+            <Link
+              to={action.href}
+              className="inline-block text-sm px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition-colors"
+            >
+              {action.verbLabel || "Open"} →
+            </Link>
+          ) : (
+            <span
+              className="text-xs text-gray-500"
+              title={action.disabledReason || undefined}
+            >
+              {action.disabledReason}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/command-center/NextActionLane.jsx
+++ b/frontend/src/components/command-center/NextActionLane.jsx
@@ -1,0 +1,45 @@
+/**
+ * NextActionLane — one axis's worth of next-actions (UX Foundation F4, #808).
+ *
+ * A lane = an axis (Production / Fulfillment / Payment / ...). The header shows
+ * the axis Badge + a count; the body is severity-sorted NextActionCards (the
+ * sort happens upstream in mergeByAxis). An empty lane renders a quiet
+ * "all clear" line rather than disappearing, so a lane the caller chooses to
+ * show never collapses into nothing.
+ */
+import { Badge } from "../ui";
+import NextActionCard from "./NextActionCard";
+import { axisLabel, axisTone } from "./axisMeta";
+
+function LaneHeader({ axis, count }) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <Badge variant={axisTone(axis)} size="sm">
+        {axisLabel(axis)}
+      </Badge>
+      <span className="text-xs text-gray-500">{count}</span>
+    </div>
+  );
+}
+
+export default function NextActionLane({ axis, actions = [] }) {
+  const list = Array.isArray(actions) ? actions : [];
+
+  return (
+    <div data-testid={`next-action-lane-${axis}`}>
+      <LaneHeader axis={axis} count={list.length} />
+      {list.length === 0 ? (
+        <p className="text-sm text-gray-500 px-1">Nothing needs attention here.</p>
+      ) : (
+        <div className="space-y-3">
+          {list.map((action, i) => (
+            <NextActionCard
+              key={`${action.axis}-${action.target?.id ?? i}-${action.verb || action.label}`}
+              action={action}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/command-center/__tests__/NextActionCard.test.jsx
+++ b/frontend/src/components/command-center/__tests__/NextActionCard.test.jsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import NextActionCard from "../NextActionCard";
+
+const renderCard = (action) =>
+  render(
+    <MemoryRouter>
+      <NextActionCard action={action} />
+    </MemoryRouter>
+  );
+
+describe("NextActionCard", () => {
+  it("renders label, reason, target code, and a severity badge", () => {
+    renderCard({
+      axis: "production",
+      label: "PO blocked",
+      reason: "Out of PLA",
+      severity: "critical",
+      target: { type: "production_order", id: 7, code: "WO-7" },
+      enabled: true,
+    });
+    expect(screen.getByText("PO blocked")).toBeTruthy();
+    expect(screen.getByText("Out of PLA")).toBeTruthy();
+    expect(screen.getByText("WO-7")).toBeTruthy();
+    expect(screen.getByText("Critical")).toBeTruthy(); // severity badge
+  });
+
+  it("renders the deep-link with verbLabel when enabled + href", () => {
+    renderCard({
+      axis: "supply",
+      label: "Order filament",
+      severity: "high",
+      verbLabel: "View PO",
+      href: "/admin/purchasing/3",
+      enabled: true,
+    });
+    const link = screen.getByRole("link", { name: /View PO/ });
+    expect(link.getAttribute("href")).toBe("/admin/purchasing/3");
+  });
+
+  it("defaults the button label to 'Open' when no verbLabel", () => {
+    renderCard({ axis: "fulfillment", label: "Ship it", severity: "high", href: "/x", enabled: true });
+    expect(screen.getByRole("link", { name: /Open/ })).toBeTruthy();
+  });
+
+  it("shows the disabled reason instead of a link when not actionable", () => {
+    renderCard({
+      axis: "payment",
+      label: "Collect payment",
+      severity: "medium",
+      enabled: false,
+      disabledReason: "Awaiting invoice",
+    });
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("Awaiting invoice")).toBeTruthy();
+  });
+
+  it("renders nothing for a null/invalid action", () => {
+    const { container } = renderCard(null);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/command-center/__tests__/NextActionLane.test.jsx
+++ b/frontend/src/components/command-center/__tests__/NextActionLane.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import NextActionLane from "../NextActionLane";
+
+const renderLane = (props) =>
+  render(
+    <MemoryRouter>
+      <NextActionLane {...props} />
+    </MemoryRouter>
+  );
+
+describe("NextActionLane", () => {
+  it("renders the axis label, count, and a card per action", () => {
+    renderLane({
+      axis: "production",
+      actions: [
+        { axis: "production", label: "A", severity: "critical", enabled: true },
+        { axis: "production", label: "B", severity: "low", enabled: true },
+      ],
+    });
+    expect(screen.getByText("Production")).toBeTruthy(); // axis badge
+    expect(screen.getByText("2")).toBeTruthy(); // count
+    expect(screen.getAllByTestId("next-action-card")).toHaveLength(2);
+  });
+
+  it("shows an empty-state line (not a collapse) when the lane has no actions", () => {
+    renderLane({ axis: "payment", actions: [] });
+    expect(screen.getByText("Payment")).toBeTruthy();
+    expect(screen.getByText(/Nothing needs attention/)).toBeTruthy();
+    expect(screen.queryByTestId("next-action-card")).toBeNull();
+  });
+
+  it("tolerates a non-array actions prop", () => {
+    renderLane({ axis: "supply", actions: undefined });
+    expect(screen.getByText("Supply")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/command-center/__tests__/axisMeta.test.js
+++ b/frontend/src/components/command-center/__tests__/axisMeta.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { axisLabel, axisTone, severityTone, orderedLanes } from "../axisMeta";
+
+describe("axisMeta", () => {
+  it("labels and tones known axes; falls back gracefully for unknown", () => {
+    expect(axisLabel("production")).toBe("Production");
+    expect(axisTone("production")).toBe("purple");
+    expect(axisLabel("weird_axis")).toBe("Weird Axis");
+    expect(axisTone("weird_axis")).toBe("neutral");
+  });
+
+  it("maps severity to the F2 badge tones", () => {
+    expect(severityTone("critical")).toBe("danger");
+    expect(severityTone("high")).toBe("warning");
+    expect(severityTone("medium")).toBe("info");
+    expect(severityTone("low")).toBe("neutral");
+    expect(severityTone("nonsense")).toBe("neutral");
+  });
+
+  it("orders lanes by AXIS_ORDER, unknown axes last", () => {
+    // production (0) before payment (4); 'zzz' is unknown → last.
+    const lanes = orderedLanes({ payment: [1], production: [2], zzz: [3] });
+    expect(lanes.map(([axis]) => axis)).toEqual(["production", "payment", "zzz"]);
+    // pairs preserve the original action arrays
+    expect(lanes[0][1]).toEqual([2]);
+  });
+
+  it("returns [] for empty/falsy input", () => {
+    expect(orderedLanes(null)).toEqual([]);
+    expect(orderedLanes(undefined)).toEqual([]);
+    expect(orderedLanes({})).toEqual([]);
+  });
+});

--- a/frontend/src/components/command-center/axisMeta.js
+++ b/frontend/src/components/command-center/axisMeta.js
@@ -1,0 +1,77 @@
+/**
+ * Presentation layer for next-action lanes (UX Foundation F4, epic #808).
+ *
+ * The axis taxonomy itself lives in `lib/nextActions.js` (the pure data layer).
+ * This module holds only display concerns — lane labels, Badge tones, and the
+ * canonical lane order — so the adapters stay free of UI vocabulary.
+ *
+ * Tones are the 6 Badge variants from F2 (success/warning/danger/info/neutral/
+ * purple), so lanes and status badges share one visual language.
+ */
+
+export const AXIS_META = {
+  production: { label: "Production", tone: "purple" },
+  fulfillment: { label: "Fulfillment", tone: "info" },
+  payment: { label: "Payment", tone: "warning" },
+  supply: { label: "Supply", tone: "warning" },
+  qc: { label: "Quality", tone: "info" },
+  maintenance: { label: "Maintenance", tone: "warning" },
+  other: { label: "Other", tone: "neutral" },
+};
+
+// Canonical lane order so the cockpit layout is stable across refreshes.
+// Floor-work axes first, commercial axes after, catch-all last.
+export const AXIS_ORDER = [
+  "production",
+  "qc",
+  "fulfillment",
+  "supply",
+  "payment",
+  "maintenance",
+  "other",
+];
+
+// severity → Badge tone (the F2 6-tone vocabulary).
+const SEVERITY_TONE = {
+  critical: "danger",
+  high: "warning",
+  medium: "info",
+  low: "neutral",
+};
+
+const titleCase = (s) =>
+  String(s || "")
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ") || "Other";
+
+/** Lane display label for an axis; unknown axes are title-cased. */
+export function axisLabel(axis) {
+  return AXIS_META[axis]?.label || titleCase(axis);
+}
+
+/** Lane Badge tone for an axis; unknown axes are neutral. */
+export function axisTone(axis) {
+  return AXIS_META[axis]?.tone || "neutral";
+}
+
+/** Severity → Badge tone; unknown severity is neutral. */
+export function severityTone(severity) {
+  return SEVERITY_TONE[severity] || "neutral";
+}
+
+/**
+ * Order an axis-keyed map (the output of mergeByAxis) into a stable
+ * [axis, actions][] array by AXIS_ORDER. Axes not in AXIS_ORDER sort last,
+ * alphabetically. Empty/falsy input yields [].
+ */
+export function orderedLanes(byAxis) {
+  const rank = (a) => {
+    const i = AXIS_ORDER.indexOf(a);
+    return i === -1 ? AXIS_ORDER.length : i;
+  };
+  return Object.keys(byAxis || {})
+    .sort((a, b) => rank(a) - rank(b) || a.localeCompare(b))
+    .map((axis) => [axis, byAxis[axis]]);
+}

--- a/frontend/src/components/command-center/index.js
+++ b/frontend/src/components/command-center/index.js
@@ -4,3 +4,5 @@
 export { default as AlertCard } from './AlertCard';
 export { default as MachineStatusGrid } from './MachineStatusGrid';
 export { default as SummaryCard } from './SummaryCard';
+export { default as NextActionCard } from './NextActionCard';
+export { default as NextActionLane } from './NextActionLane';

--- a/frontend/src/lib/nextActions.js
+++ b/frontend/src/lib/nextActions.js
@@ -24,6 +24,7 @@
  * @property {string} [reason]
  * @property {Severity} severity
  * @property {string} [verb] - a UI handler key (e.g. 'record_payment')
+ * @property {string} [verbLabel] - human label for the action button (e.g. 'View PO')
  * @property {string} [href] - deep link
  * @property {ActionTarget} [target]
  * @property {boolean} enabled
@@ -77,6 +78,7 @@ export function fromActionItems(actionItems) {
         reason: item.description || undefined,
         severity: severityFromPriority(item.priority),
         verb: primary.action_type || undefined,
+        verbLabel: primary.label || undefined,
         href: primary.url || undefined,
         target: hasTarget
           ? { type: item.entity_type, id: item.entity_id, code: item.entity_code || undefined }

--- a/frontend/src/lib/nextActions.test.js
+++ b/frontend/src/lib/nextActions.test.js
@@ -58,6 +58,7 @@ describe("fromActionItems", () => {
       reason: "blocked_po desc",
       severity: "critical",
       verb: "navigate",
+      verbLabel: "Go",
       href: "/admin/production/7",
       target: { type: "production_order", id: 7, code: "WO-7" },
       enabled: true,

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -14,7 +14,7 @@
  * cycle — EXCEPT suggestions carrying a maintenance_warning (hard block).
  * canAutoDispatch() from DispatchChip enforces this guard.
  */
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useCommandCenter from '../hooks/useCommandCenter';
 import SummaryCard from '../components/command-center/SummaryCard';
@@ -166,6 +166,16 @@ export default function CommandCenter() {
     error,
     refetch
   } = useCommandCenter(true, 60000); // Auto-refresh every 60s
+
+  // Project the flat ActionItem list through the multi-axis next-action
+  // contract ONCE, then drive both the header count and the lane render from
+  // it. mergeByAxis dedupes by key, so deriving the count from the raw
+  // actionItems length would overcount vs the cards actually shown (#808 F4).
+  const laneEntries = useMemo(
+    () => orderedLanes(mergeByAxis(fromActionItems(actionItems))),
+    [actionItems]
+  );
+  const actionCount = laneEntries.reduce((sum, [, actions]) => sum + actions.length, 0);
 
   // ─── Dispatch suggestions fetch ──────────────────────────────────────────
   const refreshSuggestions = useCallback(async () => {
@@ -363,26 +373,23 @@ export default function CommandCenter() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
               Action Items
-              {actionItems.length > 0 && (
+              {actionCount > 0 && (
                 <span className="text-sm font-normal text-[var(--color-text-muted,theme(colors.gray.400))]">
-                  ({actionItems.length})
+                  ({actionCount})
                 </span>
               )}
             </h2>
             {loading ? (
               <ActionItemsSkeleton />
-            ) : actionItems.length === 0 ? (
+            ) : actionCount === 0 ? (
               <AllClearState />
             ) : (
-              // Project the flat ActionItem list through the multi-axis
-              // next-action contract: group by axis into severity-sorted lanes
-              // (#808 F4). Same payload, no new backend calls.
+              // Render the projected axis lanes (severity-sorted, deduped).
+              // Same payload, no new backend calls (#808 F4).
               <div className="space-y-5">
-                {orderedLanes(mergeByAxis(fromActionItems(actionItems))).map(
-                  ([axis, actions]) => (
-                    <NextActionLane key={axis} axis={axis} actions={actions} />
-                  )
-                )}
+                {laneEntries.map(([axis, actions]) => (
+                  <NextActionLane key={axis} axis={axis} actions={actions} />
+                ))}
               </div>
             )}
           </section>

--- a/frontend/src/pages/CommandCenter.jsx
+++ b/frontend/src/pages/CommandCenter.jsx
@@ -18,7 +18,9 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useCommandCenter from '../hooks/useCommandCenter';
 import SummaryCard from '../components/command-center/SummaryCard';
-import AlertCard from '../components/command-center/AlertCard';
+import NextActionLane from '../components/command-center/NextActionLane';
+import { orderedLanes } from '../components/command-center/axisMeta';
+import { fromActionItems, mergeByAxis } from '../lib/nextActions';
 import MachineStatusGrid from '../components/command-center/MachineStatusGrid';
 import OperationSchedulerModal from '../components/production/OperationSchedulerModal';
 import { canAutoDispatch, confirmDispatch } from '../components/command-center/DispatchChip';
@@ -372,22 +374,15 @@ export default function CommandCenter() {
             ) : actionItems.length === 0 ? (
               <AllClearState />
             ) : (
-              <div className="space-y-3">
-                {actionItems.map((item) => (
-                  <AlertCard
-                    key={item.id}
-                    type={item.type}
-                    priority={item.priority}
-                    title={item.title}
-                    description={item.description}
-                    entityType={item.entity_type}
-                    entityId={item.entity_id}
-                    entityCode={item.entity_code}
-                    suggestedActions={item.suggested_actions}
-                    createdAt={item.created_at}
-                    metadata={item.metadata}
-                  />
-                ))}
+              // Project the flat ActionItem list through the multi-axis
+              // next-action contract: group by axis into severity-sorted lanes
+              // (#808 F4). Same payload, no new backend calls.
+              <div className="space-y-5">
+                {orderedLanes(mergeByAxis(fromActionItems(actionItems))).map(
+                  ([axis, actions]) => (
+                    <NextActionLane key={axis} axis={axis} actions={actions} />
+                  )
+                )}
               </div>
             )}
           </section>


### PR DESCRIPTION
**Foundation F4 of the print-farm-OS UX program (epic #808) — the payoff.** The Command Center now renders the multi-axis next-action contract. This is the first *visibly live* piece of the spine.

## What changed
The cockpit was a flat list of `AlertCard`s. It now **projects** the same `/command-center/action-items` payload through the F3 contract:

```
fromActionItems(items) → mergeByAxis() → orderedLanes()
```

…rendering one severity-sorted **lane per axis** (Production / Fulfillment / Payment / Supply / Quality / Maintenance). Same data, **no new backend calls**. The disconnected-pages problem dies here: the cockpit and every detail surface now read one shared shape, so a badge in the cockpit can't disagree with a badge on a detail page.

## New files (presentation layer — kept out of the pure adapters)
- **`axisMeta.js`** — lane labels, Badge tones (the F2 6-tone vocabulary), canonical lane order, `severity→tone`, and `orderedLanes()`.
- **`NextActionCard.jsx`** — one card per `NextAction`: severity accent + Badge, target code, reason, and the primary deep-link. Disabled actions show their reason instead of a dead link.
- **`NextActionLane.jsx`** — axis header (Badge + count) + cards; an empty lane shows a quiet "nothing needs attention" line rather than collapsing.

Also: `fromActionItems` now carries **`verbLabel`** (the suggested action's label) so a cockpit button reads "View PO" instead of a generic "Open".

## Verification
- **Unit (CI):** `axisMeta` ordering/tone/fallback; `NextActionCard` render/link/disabled/null; `NextActionLane` header + count + cards + empty-state.
- **Transform (node, against the live dev payload):** the 3 seeded action items → **Production × 2 + Fulfillment × 1**, with `verbLabel` + `href` preserved and severity-sorted.
- **Live preview:** the refactored cockpit Vite-mounts clean — "Command Center" renders with **zero** console errors referencing the new components (the only console noise is the dev backend's expired auth session, an environment limit). An authenticated lane screenshot is gated behind the dev mock's credentials; happy to capture it once the preview session is re-authed.

## Sequence
This completes the Foundation spine (normalizer → status descriptor → next-action contract → serialized guards → **cockpit lanes**). Next: vertical slices — **S0** (Purchasing "why buy this"), **S3** (Quality UI, surfacing #784), **S2** (operator handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Command Center now groups action items into axis lanes with per-lane counts, consistent ordering, and an empty-state message.
  * Each next action card displays severity, label, optional target code and reason, with deep-linking when possible (using the verb label or “Open”).
* **Bug Fixes**
  * Improved robustness for missing/invalid actions (cards render nothing) and safer handling when lanes receive non-array or missing actions.
  * Non-linkable actions now clearly show disabled reason text instead of rendering a link.
* **Tests**
  * Added unit tests covering card rendering, lane behavior, and axis/severity tone mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->