### PR TITLE
feat(quality): first-pass yield from first inspection row, not qc_status cache (#784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Quality metrics — true first-pass yield (#784).** `GET /api/v1/quality/metrics` now derives `first_pass_yield`, `passed`, `failed`, and `total_inspections` from each order's **first `qc_inspections` row** instead of the `ProductionOrder.qc_status` cache. The cache is last-write-wins, so an order that failed initial inspection and was later re-inspected or waived to "passed" previously counted as a first-pass success and inflated the yield. **Expect FPY to move** (typically downward) where re-inspections occur — this is the corrected value, not a regression. Orders inspected before inspection rows were recorded are not counted in the metric.
+
 ## [4.1.0] - 2026-06-20
 
 ### Added

--- a/backend/app/services/quality_service.py
+++ b/backend/app/services/quality_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session, joinedload
 from app.models.production_order import (
     ProductionOrder,
     ProductionOrderOperation,
+    QCInspection,
     ScrapRecord,
 )
 from app.models.scrap_reason import ScrapReason
@@ -63,10 +64,15 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
     """
     Calculate quality metrics for the given period.
 
+    Counts are sourced from each order's FIRST qc_inspections row (#784), not
+    the ProductionOrder.qc_status cache. The cache is last-write-wins, so an
+    order that failed initial inspection but was re-inspected or waived to
+    "passed" would otherwise count as a first-pass success and inflate FPY.
+
     Returns:
-    - total_inspections: Count of orders with a QC result in the period
-    - passed: Orders that passed QC
-    - failed: Orders that failed QC
+    - total_inspections: Orders whose first QC inspection landed in the period
+    - passed: Orders that passed their FIRST inspection
+    - failed: Orders that failed their FIRST inspection
     - first_pass_yield: passed / (passed + failed) as a percentage
     - pending_inspections: Current queue depth
     - scrap_rate: scrapped qty / (completed + scrapped) qty as a percentage
@@ -74,28 +80,37 @@ def get_quality_metrics(db: Session, days: int = 30) -> dict:
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
-    # Count inspections by result (orders inspected within the period)
+    # First-pass yield must come from each order's FIRST inspection row, not the
+    # qc_status cache. The earliest qc_inspections row per order = min(id):
+    # ids are monotonic so this is tie-free, unlike inspected_at timestamps.
+    first_inspection_ids = (
+        db.query(func.min(QCInspection.id))
+        .group_by(QCInspection.production_order_id)
+        .scalar_subquery()
+    )
     result_counts = (
         db.query(
-            ProductionOrder.qc_status,
-            func.count(ProductionOrder.id).label("cnt"),
+            QCInspection.result,
+            func.count(QCInspection.id).label("cnt"),
         )
         .filter(
-            ProductionOrder.qc_inspected_at >= cutoff,
-            ProductionOrder.qc_status.in_(["passed", "failed", "waived"]),
+            QCInspection.id.in_(first_inspection_ids),
+            QCInspection.inspected_at >= cutoff,
         )
-        .group_by(ProductionOrder.qc_status)
+        .group_by(QCInspection.result)
         .all()
     )
 
-    counts = {row.qc_status: row.cnt for row in result_counts}
+    counts = {row.result: row.cnt for row in result_counts}
     passed = counts.get("passed", 0)
     failed = counts.get("failed", 0)
     waived = counts.get("waived", 0)
-    total_inspections = passed + failed + waived
+    conditional = counts.get("conditional", 0)
+    total_inspections = passed + failed + waived + conditional
 
-    # First-pass yield = passed / (passed + failed). Waived parts are excluded
-    # from the yield (they neither cleanly passed nor failed inspection).
+    # First-pass yield = passed / (passed + failed). Waived and conditional
+    # first inspections are excluded from the ratio — they neither cleanly
+    # passed nor failed inspection.
     fpy_denom = passed + failed
     first_pass_yield = (
         round((passed / fpy_denom) * 100, 1)

--- a/backend/tests/test_quality_dashboard.py
+++ b/backend/tests/test_quality_dashboard.py
@@ -11,6 +11,20 @@ Covers:
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+from app.models.production_order import QCInspection
+
+
+def _add_inspection(db, po_id, result, when):
+    """Append a qc_inspections row — the #784 first-pass source of truth.
+
+    Flushes after each insert so auto-increment ids reflect call order, which is
+    what get_quality_metrics relies on (first inspection = min(id) per order).
+    """
+    insp = QCInspection(production_order_id=po_id, result=result, inspected_at=when)
+    db.add(insp)
+    db.flush()
+    return insp
+
 
 # =============================================================================
 # Inspection Queue
@@ -110,19 +124,16 @@ class TestQualityMetrics:
         product = make_product()
         now = datetime.now(timezone.utc)
 
-        # 3 passed, 1 failed → yield = 75%
+        # 3 orders pass first inspection, 1 fails → yield = 75%
         for _ in range(3):
-            make_production_order(
-                product_id=product.id, status="closed",
-                qc_status="passed", qc_inspected_at=now,
-                quantity=Decimal("10"),
+            po = make_production_order(
+                product_id=product.id, status="closed", quantity=Decimal("10"),
             )
-        make_production_order(
-            product_id=product.id, status="qc_hold",
-            qc_status="failed", qc_inspected_at=now,
-            quantity=Decimal("10"),
+            _add_inspection(db, po.id, "passed", now)
+        po_failed = make_production_order(
+            product_id=product.id, status="qc_hold", quantity=Decimal("10"),
         )
-        db.flush()
+        _add_inspection(db, po_failed.id, "failed", now)
 
         resp = client.get("/api/v1/quality/metrics?days=30")
         data = resp.json()
@@ -130,6 +141,58 @@ class TestQualityMetrics:
         assert data["failed"] == 1
         assert data["total_inspections"] == 4
         assert data["first_pass_yield"] == 75.0
+
+    def test_fpy_uses_first_inspection_not_qc_status_cache(
+        self, client, db, make_product, make_production_order
+    ):
+        """An order that FAILED first inspection then passed re-inspection must
+        count as a first-pass FAILURE — even though the qc_status cache says
+        'passed'. This is the whole reason FPY reads the first row (#784)."""
+        product = make_product()
+        now = datetime.now(timezone.utc)
+        po = make_production_order(
+            product_id=product.id, status="closed",
+            qc_status="passed", quantity=Decimal("10"),  # misleading cache
+        )
+        # First inspection FAILED (smaller id), re-inspection PASSED (larger id).
+        _add_inspection(db, po.id, "failed", now)
+        _add_inspection(db, po.id, "passed", now)
+
+        data = client.get("/api/v1/quality/metrics?days=30").json()
+        assert data["passed"] == 0
+        assert data["failed"] == 1
+        assert data["first_pass_yield"] == 0.0  # NOT 100 from the stale cache
+
+    def test_fpy_excludes_waived_and_conditional(
+        self, client, db, make_product, make_production_order
+    ):
+        product = make_product()
+        now = datetime.now(timezone.utc)
+        po_p = make_production_order(product_id=product.id, quantity=Decimal("10"))
+        po_w = make_production_order(product_id=product.id, quantity=Decimal("10"))
+        po_c = make_production_order(product_id=product.id, quantity=Decimal("10"))
+        _add_inspection(db, po_p.id, "passed", now)
+        _add_inspection(db, po_w.id, "waived", now)
+        _add_inspection(db, po_c.id, "conditional", now)
+
+        data = client.get("/api/v1/quality/metrics?days=30").json()
+        assert data["passed"] == 1
+        assert data["total_inspections"] == 3  # passed + waived + conditional
+        # waived + conditional excluded from the ratio → 1 / 1 = 100%
+        assert data["first_pass_yield"] == 100.0
+
+    def test_fpy_respects_period_window(
+        self, client, db, make_product, make_production_order
+    ):
+        """A first inspection older than the window is excluded."""
+        product = make_product()
+        old = datetime.now(timezone.utc) - timedelta(days=45)
+        po = make_production_order(product_id=product.id, quantity=Decimal("10"))
+        _add_inspection(db, po.id, "passed", old)
+
+        data = client.get("/api/v1/quality/metrics?days=30").json()
+        assert data["total_inspections"] == 0
+        assert data["first_pass_yield"] is None
 
     def test_pending_count(self, client, db, make_product, make_production_order):
         product = make_product()


### PR DESCRIPTION
**#784 roadmap step 2 — true first-pass yield.** Backend-only; feeds the Quality UI slice Codex will build.

## Problem
`GET /api/v1/quality/metrics` derived `first_pass_yield`, `passed`, `failed`, and `total_inspections` from the `ProductionOrder.qc_status` cache. That cache is **last-write-wins**, so an order that *failed* its initial inspection and was later re-inspected (or waived) to "passed" counted as a **first-pass success** — inflating FPY. That's not first-pass yield; it's "eventual pass" yield.

## Fix
Source the counts from each order's **first `qc_inspections` row** (the append-only inspection history added in #783/#800):
- First inspection per order = `min(id)` grouped by `production_order_id` — ids are monotonic, so this is **tie-free** (unlike `inspected_at`, which can collide).
- The period filter applies to that first row's `inspected_at`.
- `waived` and `conditional` first inspections are excluded from the FPY ratio (neither a clean pass nor a clean fail), consistent with the prior waived handling.

The model docstring already anticipated this: *"true first-pass yield (first row per order) [is] derivable."*

## KPI shift (documented in CHANGELOG)
**Expect FPY to move**, typically downward, wherever re-inspections occur — this is the corrected value, not a regression. Orders inspected before inspection rows were recorded aren't counted in the metric.

## Tests
`test_quality_dashboard.py` — rewrote the calc test to seed inspection rows, and added:
- `test_fpy_uses_first_inspection_not_qc_status_cache` — order with cache `qc_status="passed"` but inspections `[failed, passed]` → counts as a **first-pass failure** (FPY 0.0, not 100).
- `test_fpy_excludes_waived_and_conditional` — `passed/waived/conditional` first rows → FPY 100 (1/1), `total_inspections` 3.
- `test_fpy_respects_period_window` — a first inspection older than the window is excluded.

Ruff + compile clean locally; backend tests run in CI (local Postgres auth unavailable).

Part of the #784 backend sequence (Claude owns backend; Codex builds the Quality UI on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected first-pass yield and related quality metrics so they now reflect each order’s first inspection result, improving accuracy after re-inspections or waivers.
  * Quality metric counts now exclude orders without an inspection record in the selected time window, preventing inflated results.
  * Updated the dashboard calculations to handle waived and conditional inspections more consistently in totals and yield reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->