### PR TITLE
feat(quality): migration 095 schema foundation — defect_reasons, measurements, photos (#784)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,7 @@
 """Database models - FilaOps Open Source Core"""
 from app.models.item_category import ItemCategory
 from app.models.product import Product
-from app.models.production_order import ProductionOrder, ProductionOrderOperation, ProductionOrderOperationMaterial, ScrapRecord, QCInspection
+from app.models.production_order import ProductionOrder, ProductionOrderOperation, ProductionOrderOperationMaterial, ScrapRecord, QCInspection, QCInspectionMeasurement, QCInspectionPhoto
 from app.models.print_job import PrintJob
 from app.models.inventory import Inventory, InventoryTransaction, InventoryLocation
 from app.models.sales_order import SalesOrder, SalesOrderLine
@@ -24,6 +24,7 @@ from app.models.company_settings import CompanySettings
 from app.models.uom import UnitOfMeasure
 from app.models.uom import UnitOfMeasure as UOM
 from app.models.scrap_reason import ScrapReason
+from app.models.defect_reason import DefectReason
 from app.models.adjustment_reason import AdjustmentReason
 from app.models.order_event import OrderEvent
 from app.models.purchasing_event import PurchasingEvent
@@ -104,6 +105,8 @@ __all__ = [
     "ProductionOrderOperationMaterial",
     "ScrapRecord",
     "QCInspection",
+    "QCInspectionMeasurement",
+    "QCInspectionPhoto",
     # MRP
     "MRPRun",
     "PlannedOrder",
@@ -119,6 +122,8 @@ __all__ = [
     "UOM",
     # Scrap Reasons
     "ScrapReason",
+    # Defect Reasons (QC taxonomy)
+    "DefectReason",
     # Adjustment Reasons
     "AdjustmentReason",
     # Order Events (Activity Timeline)

--- a/backend/app/models/defect_reason.py
+++ b/backend/app/models/defect_reason.py
@@ -37,7 +37,7 @@ class DefectReason(Base):
         ),
     )
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True)  # PK is auto-indexed; no redundant ix_*_id
     code = Column(String(50), unique=True, nullable=False, index=True)  # e.g. "layer_shift"
     name = Column(String(100), nullable=False)  # Display name
     description = Column(Text, nullable=True)

--- a/backend/app/models/defect_reason.py
+++ b/backend/app/models/defect_reason.py
@@ -1,0 +1,63 @@
+"""
+Defect Reason model
+
+A configurable taxonomy of QC defect reasons (#784). Distinct from
+``ScrapReason``: a scrap reason explains why material was destroyed; a defect
+reason classifies *what was wrong* at inspection (category + severity), and is
+referenced by ``QCInspection.defect_reason_id`` so failed inspections carry a
+structured, reportable cause rather than only free text.
+
+Maintainer decision (locked): a dedicated table, NOT reused ``ScrapReason``.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Integer,
+    String,
+    Text,
+)
+
+from app.db.base import Base
+
+
+class DefectReason(Base):
+    """A configurable QC defect classification (category + severity)."""
+
+    __tablename__ = "defect_reasons"
+    __table_args__ = (
+        # Mirror migration 095 so create_all (tests/self-host) enforces the same
+        # severity domain the migration does on a real deployment.
+        CheckConstraint(
+            "severity IN ('minor', 'major', 'critical')",
+            name="ck_defect_reasons_severity",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(50), unique=True, nullable=False, index=True)  # e.g. "layer_shift"
+    name = Column(String(100), nullable=False)  # Display name
+    description = Column(Text, nullable=True)
+
+    # Grouping for reporting, e.g. "dimensional", "cosmetic", "functional".
+    # Free-form (categories are operator-configurable), unlike severity.
+    category = Column(String(50), nullable=True)
+    # AQL-style severity. CHECK-constrained at the DB so it cannot drift.
+    severity = Column(String(20), nullable=True)  # minor | major | critical
+
+    active = Column(Boolean, default=True, nullable=False)
+    sequence = Column(Integer, default=0)  # ordering in dropdowns
+
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    def __repr__(self):
+        return f"<DefectReason {self.code}: {self.name} ({self.severity})>"

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -525,6 +525,20 @@ class QCInspection(Base):
     failure_reason = Column(Text, nullable=True)
     notes = Column(Text, nullable=True)
 
+    # Structured defect classification (#784) — links a failed inspection to a
+    # configurable DefectReason. Nullable: a pass/waive carries no defect.
+    defect_reason_id = Column(
+        Integer,
+        ForeignKey("defect_reasons.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # Who waived (when result='waived'). Core keeps the attributed waive on the
+    # immutable inspection row; NCR / hold-and-disposition is deferred to PRO.
+    waiver_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
     inspected_at = Column(
         DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )
@@ -536,6 +550,89 @@ class QCInspection(Base):
     production_order = relationship("ProductionOrder", backref="qc_inspections")
     production_operation = relationship("ProductionOrderOperation")
     inspector = relationship("User", foreign_keys=[inspector_user_id])
+    defect_reason = relationship("DefectReason")
+    waiver = relationship("User", foreign_keys=[waiver_user_id])
+    measurements = relationship(
+        "QCInspectionMeasurement",
+        back_populates="inspection",
+        cascade="all, delete-orphan",
+        order_by="QCInspectionMeasurement.sequence",
+    )
+    photos = relationship(
+        "QCInspectionPhoto",
+        back_populates="inspection",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self):
         return f"<QCInspection {self.id}: PO {self.production_order_id} -> {self.result}>"
+
+
+class QCInspectionMeasurement(Base):
+    """A single quantitative measurement taken during an inspection (#784).
+
+    Numeric (not Float) so values are exact and SPC-ready. Spec limits are
+    optional — a measurement may be recorded without a defined tolerance.
+    """
+
+    __tablename__ = "qc_inspection_measurements"
+
+    id = Column(Integer, primary_key=True, index=True)
+    qc_inspection_id = Column(
+        Integer,
+        ForeignKey("qc_inspections.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    characteristic = Column(String(100), nullable=False)  # what was measured
+    nominal = Column(Numeric(18, 4), nullable=True)  # target value
+    lower_limit = Column(Numeric(18, 4), nullable=True)  # LSL
+    upper_limit = Column(Numeric(18, 4), nullable=True)  # USL
+    measured_value = Column(Numeric(18, 4), nullable=True)
+    unit = Column(String(20), nullable=True)  # mm, g, ...
+    sequence = Column(Integer, default=0, nullable=False)
+    created_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    inspection = relationship("QCInspection", back_populates="measurements")
+
+    def __repr__(self):
+        return (
+            f"<QCInspectionMeasurement {self.characteristic}="
+            f"{self.measured_value}{self.unit or ''}>"
+        )
+
+
+class QCInspectionPhoto(Base):
+    """A photo attached to a QC inspection (#784).
+
+    Its own table — NOT a reuse of purchase_order_documents — though the column
+    conventions (local path / external url / storage type) mirror that table.
+    """
+
+    __tablename__ = "qc_inspection_photos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    qc_inspection_id = Column(
+        Integer,
+        ForeignKey("qc_inspections.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    file_name = Column(String(255), nullable=False)
+    file_path = Column(String(500), nullable=True)  # local path
+    file_url = Column(String(1000), nullable=True)  # external URL
+    storage_type = Column(String(50), nullable=False, default="local")  # local | s3
+    mime_type = Column(String(100), nullable=True)
+    file_size = Column(Integer, nullable=True)  # bytes
+    caption = Column(String(255), nullable=True)
+    uploaded_by = Column(String(100), nullable=True)
+    created_at = Column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    inspection = relationship("QCInspection", back_populates="photos")
+
+    def __repr__(self):
+        return f"<QCInspectionPhoto {self.id}: inspection {self.qc_inspection_id}>"

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -577,7 +577,7 @@ class QCInspectionMeasurement(Base):
 
     __tablename__ = "qc_inspection_measurements"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True)  # PK auto-indexed; no redundant ix_*_id
     qc_inspection_id = Column(
         Integer,
         ForeignKey("qc_inspections.id", ondelete="CASCADE"),
@@ -613,7 +613,7 @@ class QCInspectionPhoto(Base):
 
     __tablename__ = "qc_inspection_photos"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id = Column(Integer, primary_key=True)  # PK auto-indexed; no redundant ix_*_id
     qc_inspection_id = Column(
         Integer,
         ForeignKey("qc_inspections.id", ondelete="CASCADE"),

--- a/backend/migrations/versions/095_qc_defect_measurement_photo_schema.py
+++ b/backend/migrations/versions/095_qc_defect_measurement_photo_schema.py
@@ -1,0 +1,149 @@
+"""qc defect reasons, inspection measurements & photos
+
+Revision ID: 095
+Revises: 094
+Create Date: 2026-06-25
+
+#784 step 3 — schema foundation for the remaining Quality capabilities:
+- ``defect_reasons``: a configurable defect taxonomy (free-form category +
+  CHECK-constrained severity). Distinct from ``scrap_reasons`` (which explains
+  why material was destroyed); this classifies what was wrong at inspection.
+- ``qc_inspections`` gains ``defect_reason_id`` (FK SET NULL) and
+  ``waiver_user_id`` (FK SET NULL). The attributed waive stays on the immutable
+  inspection row; NCR / hold-and-disposition is PRO scope.
+- ``qc_inspection_measurements``: SPC-ready Numeric measurements per inspection.
+- ``qc_inspection_photos``: photo evidence per inspection (its own table — NOT
+  a reuse of ``purchase_order_documents``).
+
+Additive — no existing data touched. Index names and constraints mirror the
+model declarations so ``create_all`` (tests/self-host) and Alembic (deploy)
+produce identical schema.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "095"
+down_revision = "094"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1) Defect taxonomy. severity is CHECK-constrained at the DB so it cannot
+    #    drift the way an unconstrained VARCHAR could.
+    op.create_table(
+        "defect_reasons",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("code", sa.String(50), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("category", sa.String(50), nullable=True),
+        sa.Column("severity", sa.String(20), nullable=True),
+        sa.Column("active", sa.Boolean, nullable=False, server_default=sa.text("true")),
+        sa.Column("sequence", sa.Integer, nullable=True, server_default="0"),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "severity IN ('minor', 'major', 'critical')",
+            name="ck_defect_reasons_severity",
+        ),
+    )
+    op.create_index("ix_defect_reasons_code", "defect_reasons", ["code"], unique=True)
+
+    # 2) qc_inspections: structured defect link + attributed waiver.
+    #    defect_reasons must exist before the FK column is added (above).
+    op.add_column(
+        "qc_inspections",
+        sa.Column(
+            "defect_reason_id",
+            sa.Integer,
+            sa.ForeignKey("defect_reasons.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "qc_inspections",
+        sa.Column(
+            "waiver_user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_qc_inspections_defect_reason_id", "qc_inspections", ["defect_reason_id"]
+    )
+
+    # 3) Measurements — Numeric (not Float) so values are exact / SPC-ready.
+    op.create_table(
+        "qc_inspection_measurements",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "qc_inspection_id",
+            sa.Integer,
+            sa.ForeignKey("qc_inspections.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("characteristic", sa.String(100), nullable=False),
+        sa.Column("nominal", sa.Numeric(18, 4), nullable=True),
+        sa.Column("lower_limit", sa.Numeric(18, 4), nullable=True),
+        sa.Column("upper_limit", sa.Numeric(18, 4), nullable=True),
+        sa.Column("measured_value", sa.Numeric(18, 4), nullable=True),
+        sa.Column("unit", sa.String(20), nullable=True),
+        sa.Column("sequence", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_qc_inspection_measurements_qc_inspection_id",
+        "qc_inspection_measurements",
+        ["qc_inspection_id"],
+    )
+
+    # 4) Photos — own table; column conventions mirror purchase_order_documents.
+    op.create_table(
+        "qc_inspection_photos",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "qc_inspection_id",
+            sa.Integer,
+            sa.ForeignKey("qc_inspections.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("file_name", sa.String(255), nullable=False),
+        sa.Column("file_path", sa.String(500), nullable=True),
+        sa.Column("file_url", sa.String(1000), nullable=True),
+        sa.Column("storage_type", sa.String(50), nullable=False, server_default="local"),
+        sa.Column("mime_type", sa.String(100), nullable=True),
+        sa.Column("file_size", sa.Integer, nullable=True),
+        sa.Column("caption", sa.String(255), nullable=True),
+        sa.Column("uploaded_by", sa.String(100), nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_qc_inspection_photos_qc_inspection_id",
+        "qc_inspection_photos",
+        ["qc_inspection_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_qc_inspection_photos_qc_inspection_id", table_name="qc_inspection_photos"
+    )
+    op.drop_table("qc_inspection_photos")
+
+    op.drop_index(
+        "ix_qc_inspection_measurements_qc_inspection_id",
+        table_name="qc_inspection_measurements",
+    )
+    op.drop_table("qc_inspection_measurements")
+
+    op.drop_index(
+        "ix_qc_inspections_defect_reason_id", table_name="qc_inspections"
+    )
+    op.drop_column("qc_inspections", "waiver_user_id")
+    op.drop_column("qc_inspections", "defect_reason_id")
+
+    op.drop_index("ix_defect_reasons_code", table_name="defect_reasons")
+    op.drop_table("defect_reasons")

--- a/backend/tests/test_qc_schema_foundation.py
+++ b/backend/tests/test_qc_schema_foundation.py
@@ -1,0 +1,135 @@
+"""Schema-foundation smoke tests for #784 (migration 095).
+
+Exercises the new tables/columns end-to-end against the test DB's create_all
+schema: defect_reasons (+ severity CHECK), qc_inspections.defect_reason_id /
+waiver_user_id, qc_inspection_measurements (exact Numeric), qc_inspection_photos,
+and ORM cascade delete of an inspection's children.
+"""
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from app.models.defect_reason import DefectReason
+from app.models.production_order import (
+    QCInspection,
+    QCInspectionMeasurement,
+    QCInspectionPhoto,
+)
+from app.models.user import User
+
+
+def _inspection(db, po_id, result="failed", **kw):
+    insp = QCInspection(production_order_id=po_id, result=result, **kw)
+    db.add(insp)
+    db.flush()
+    return insp
+
+
+class TestDefectReason:
+    def test_create_and_link_to_inspection(self, db, make_product, make_production_order):
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        reason = DefectReason(
+            code="layer_shift", name="Layer Shift",
+            category="dimensional", severity="major",
+        )
+        db.add(reason)
+        db.flush()
+
+        insp = _inspection(db, po.id, result="failed", defect_reason_id=reason.id)
+        assert insp.defect_reason.code == "layer_shift"
+        assert insp.defect_reason.severity == "major"
+
+    def test_severity_check_rejects_unknown_value(self, db):
+        db.add(DefectReason(code="bogus", name="Bogus", severity="catastrophic"))
+        with pytest.raises(IntegrityError):
+            db.flush()
+        db.rollback()
+
+    def test_severity_is_optional(self, db):
+        r = DefectReason(code="uncategorized", name="Uncategorized")
+        db.add(r)
+        db.flush()
+        assert r.severity is None  # NULL passes the CHECK
+
+    def test_code_is_unique(self, db):
+        db.add(DefectReason(code="dup", name="First"))
+        db.flush()
+        db.add(DefectReason(code="dup", name="Second"))
+        with pytest.raises(IntegrityError):
+            db.flush()
+        db.rollback()
+
+
+class TestInspectionMeasurementsAndPhotos:
+    def test_measurements_are_exact_numeric(self, db, make_product, make_production_order):
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        insp = _inspection(db, po.id, result="passed")
+        db.add(QCInspectionMeasurement(
+            qc_inspection_id=insp.id, characteristic="bore_dia",
+            nominal=Decimal("10.0000"), lower_limit=Decimal("9.9500"),
+            upper_limit=Decimal("10.0500"), measured_value=Decimal("10.0123"),
+            unit="mm",
+        ))
+        db.flush()
+        # Numeric(18,4) — exact, no float drift
+        assert insp.measurements[0].measured_value == Decimal("10.0123")
+        assert insp.measurements[0].unit == "mm"
+
+    def test_photo_attaches_to_inspection(self, db, make_product, make_production_order):
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        insp = _inspection(db, po.id, result="failed")
+        db.add(QCInspectionPhoto(
+            qc_inspection_id=insp.id, file_name="defect.jpg",
+            storage_type="local", mime_type="image/jpeg", caption="weld void",
+        ))
+        db.flush()
+        assert len(insp.photos) == 1
+        assert insp.photos[0].file_name == "defect.jpg"
+
+    def test_orm_cascade_deletes_children(self, db, make_product, make_production_order):
+        """ORM-side delete exercises relationship cascade='all, delete-orphan'."""
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        insp = _inspection(db, po.id, result="failed")
+        db.add(QCInspectionMeasurement(qc_inspection_id=insp.id, characteristic="h"))
+        db.add(QCInspectionPhoto(qc_inspection_id=insp.id, file_name="p.jpg"))
+        db.flush()
+        insp_id = insp.id
+
+        db.delete(insp)
+        db.flush()
+        assert db.query(QCInspectionMeasurement).filter_by(qc_inspection_id=insp_id).count() == 0
+        assert db.query(QCInspectionPhoto).filter_by(qc_inspection_id=insp_id).count() == 0
+
+    def test_db_level_cascade_deletes_children(self, db, make_product, make_production_order):
+        """Raw-SQL delete bypasses the ORM cascade, so this exercises the
+        migration's DB-side ON DELETE CASCADE — the constraint that protects
+        integrity regardless of access path."""
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        insp = _inspection(db, po.id, result="failed")
+        db.add(QCInspectionMeasurement(qc_inspection_id=insp.id, characteristic="h"))
+        db.add(QCInspectionPhoto(qc_inspection_id=insp.id, file_name="p.jpg"))
+        db.flush()
+        insp_id = insp.id
+
+        db.execute(text("DELETE FROM qc_inspections WHERE id = :id"), {"id": insp_id})
+        db.expire_all()
+        assert db.query(QCInspectionMeasurement).filter_by(qc_inspection_id=insp_id).count() == 0
+        assert db.query(QCInspectionPhoto).filter_by(qc_inspection_id=insp_id).count() == 0
+
+
+class TestWaiverLink:
+    def test_waiver_user_is_attributed(self, db, make_product, make_production_order):
+        user = db.query(User).first()
+        assert user is not None  # conftest seeds a default user
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        insp = _inspection(db, po.id, result="waived", waiver_user_id=user.id)
+        assert insp.waiver_user_id == user.id
+        assert insp.waiver is not None


### PR DESCRIPTION
**#784 roadmap step 3 — schema foundation.** Backend-only; the keystone the remaining Quality capabilities (waive, defect dimension, measurements, photos) build on. Codex's Quality UI slice will consume the endpoints layered on top in later steps.

## What lands (migration `095`, additive)
- **`defect_reasons`** — configurable defect taxonomy: `code`/`name`/`description`, free-form `category`, and a CHECK-constrained `severity` (`minor`|`major`|`critical`). A **dedicated table**, not a reuse of `scrap_reasons` (which explains destroyed material; this classifies what was wrong at inspection).
- **`qc_inspections`** gains `defect_reason_id` (FK → `defect_reasons`, `SET NULL`) and `waiver_user_id` (FK → `users`, `SET NULL`). The attributed **waive** stays on the immutable inspection row; NCR / hold-and-disposition is PRO scope.
- **`qc_inspection_measurements`** — SPC-ready `Numeric(18,4)` measurements per inspection (`nominal`/`lower_limit`/`upper_limit`/`measured_value`/`unit`/`sequence`). Numeric, never Float.
- **`qc_inspection_photos`** — photo evidence per inspection; its **own table** (column conventions mirror `purchase_order_documents`, not a reuse).

## Parity (the schema-divergence trap)
Tests build schema via `create_all` (models); deploy runs Alembic. They **must** match. Verified mechanically:
- `configure_mappers()` — relationships valid (incl. the dual `User` FK: `inspector` + `waiver`).
- **Offline `alembic upgrade 094:095 --sql`** renders correct Postgres DDL — CHECK constraint, both FKs `ON DELETE SET NULL`, child FKs `ON DELETE CASCADE`, and all four index names (`ix_defect_reasons_code` UNIQUE, `ix_qc_inspections_defect_reason_id`, `ix_qc_inspection_measurements_qc_inspection_id`, `ix_qc_inspection_photos_qc_inspection_id`) **exactly matching** the models' `index=True` auto-names.
- Mirrors the `093_add_qc_inspections` pattern; chain `093 → 094 → 095` is linear.

## Tests (`test_qc_schema_foundation.py`)
defect-reason link · severity CHECK rejection · unique `code` · exact `Numeric` measurements · photo attach · **both** ORM cascade *and* DB-side `ON DELETE CASCADE` (raw-SQL delete, so the migration's constraint is exercised, not just the relationship) · waiver attribution.

Ruff + compile + mapper/DDL render clean locally; backend tests (incl. `alembic upgrade head`) run in CI. Reviewed by the domain agent — no blocking issues; migration↔model parity confirmed exact.

Part of the #784 backend sequence (Claude owns backend; Codex builds the Quality UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable quality check defect reasons with severity levels and activation/order controls.
  * Extended quality inspections to capture defect/waiver attribution.
  * Added per-inspection numeric measurements and photo evidence for richer inspection records.
* **Bug Fixes**
  * Ensured inspection-linked measurements and photos are reliably removed together (ORM cascade and DB cascade).
  * Preserved exact numeric precision for measurement values.
* **Tests**
  * Added schema smoke tests covering severity rules, uniqueness, measurement precision, photo/inspection linking, cascade deletion, and waiver attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->