### PR TITLE
feat(quality): waive attribution + defect-reason dimension on QC (#784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **QC defect taxonomy + waive attribution (#784).** New configurable defect reasons (`GET/POST /api/v1/production-orders/defect-reasons`, `/all`, `PATCH /{id}`) with free-form category and a `minor|major|critical` severity. Recording a QC inspection (`POST /production-orders/{id}/qc`) now accepts a `defect_reason_id` and, on a `waived` result, attributes the waive to the operator (`waiver_user_id`); the inspection history exposes the defect reason and waiver.
+
 ### Changed
 
 - **Quality metrics — true first-pass yield (#784).** `GET /api/v1/quality/metrics` now derives `first_pass_yield`, `passed`, `failed`, and `total_inspections` from each order's **first `qc_inspections` row** instead of the `ProductionOrder.qc_status` cache. The cache is last-write-wins, so an order that failed initial inspection and was later re-inspected or waived to "passed" previously counted as a first-pass success and inflated the yield. **Expect FPY to move** (typically downward) where re-inspections occur — this is the corrected value, not a regression. Orders inspected before inspection rows were recorded are not counted in the metric.

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -430,6 +430,78 @@ async def get_status_transitions(
     }
 
 
+# ---------------------------------------------------------------------------
+# Defect reasons (#784) — configurable QC defect taxonomy. These are STATIC
+# routes and MUST be declared before the dynamic GET /{order_id} below, or
+# Starlette matches "defect-reasons" as an order_id and returns 422.
+# ---------------------------------------------------------------------------
+@router.get("/defect-reasons", response_model=DefectReasonsResponse)
+async def get_defect_reasons(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonsResponse:
+    """List active defect reasons (codes + details) for QC dropdowns."""
+    reasons = defect_reason_service.get_defect_reasons(db)
+    return DefectReasonsResponse(
+        reasons=[r.code for r in reasons],
+        details=[DefectReasonDetail.model_validate(r) for r in reasons],
+    )
+
+
+@router.get("/defect-reasons/all", response_model=List[DefectReasonDetail])
+async def get_all_defect_reasons(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> List[DefectReasonDetail]:
+    """List all defect reasons, including inactive."""
+    reasons = defect_reason_service.get_defect_reasons(db, include_inactive=True)
+    return [DefectReasonDetail.model_validate(r) for r in reasons]
+
+
+@router.post("/defect-reasons", response_model=DefectReasonDetail)
+async def create_defect_reason(
+    request: DefectReasonCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonDetail:
+    """Create a defect reason."""
+    reason = defect_reason_service.create_defect_reason(
+        db,
+        code=request.code,
+        name=request.name,
+        description=request.description,
+        category=request.category,
+        severity=request.severity,
+        sequence=request.sequence or 0,
+    )
+    db.commit()
+    db.refresh(reason)
+    return DefectReasonDetail.model_validate(reason)
+
+
+@router.patch("/defect-reasons/{reason_id}", response_model=DefectReasonDetail)
+async def update_defect_reason(
+    reason_id: int,
+    request: DefectReasonUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonDetail:
+    """Update a defect reason; pass active=false to deactivate."""
+    reason = defect_reason_service.update_defect_reason(
+        db,
+        reason_id,
+        name=request.name,
+        description=request.description,
+        category=request.category,
+        severity=request.severity,
+        sequence=request.sequence,
+        active=request.active,
+    )
+    db.commit()
+    db.refresh(reason)
+    return DefectReasonDetail.model_validate(reason)
+
+
 @router.get("/{order_id}", response_model=ProductionOrderResponse)
 async def get_production_order(
     order_id: int,
@@ -594,77 +666,6 @@ async def delete_scrap_reason(
     production_order_service.delete_scrap_reason(db, reason_id)
     db.commit()
     return {"message": "Scrap reason deleted"}
-
-
-# ---------------------------------------------------------------------------
-# Defect reasons (#784) — configurable QC defect taxonomy. Static routes; must
-# precede the dynamic /{order_id} routes below.
-# ---------------------------------------------------------------------------
-@router.get("/defect-reasons", response_model=DefectReasonsResponse)
-async def get_defect_reasons(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> DefectReasonsResponse:
-    """List active defect reasons (codes + details) for QC dropdowns."""
-    reasons = defect_reason_service.get_defect_reasons(db)
-    return DefectReasonsResponse(
-        reasons=[r.code for r in reasons],
-        details=[DefectReasonDetail.model_validate(r) for r in reasons],
-    )
-
-
-@router.get("/defect-reasons/all", response_model=List[DefectReasonDetail])
-async def get_all_defect_reasons(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> List[DefectReasonDetail]:
-    """List all defect reasons, including inactive."""
-    reasons = defect_reason_service.get_defect_reasons(db, include_inactive=True)
-    return [DefectReasonDetail.model_validate(r) for r in reasons]
-
-
-@router.post("/defect-reasons", response_model=DefectReasonDetail)
-async def create_defect_reason(
-    request: DefectReasonCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> DefectReasonDetail:
-    """Create a defect reason."""
-    reason = defect_reason_service.create_defect_reason(
-        db,
-        code=request.code,
-        name=request.name,
-        description=request.description,
-        category=request.category,
-        severity=request.severity,
-        sequence=request.sequence or 0,
-    )
-    db.commit()
-    db.refresh(reason)
-    return DefectReasonDetail.model_validate(reason)
-
-
-@router.patch("/defect-reasons/{reason_id}", response_model=DefectReasonDetail)
-async def update_defect_reason(
-    reason_id: int,
-    request: DefectReasonUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> DefectReasonDetail:
-    """Update a defect reason; pass active=false to deactivate."""
-    reason = defect_reason_service.update_defect_reason(
-        db,
-        reason_id,
-        name=request.name,
-        description=request.description,
-        category=request.category,
-        severity=request.severity,
-        sequence=request.sequence,
-        active=request.active,
-    )
-    db.commit()
-    db.refresh(reason)
-    return DefectReasonDetail.model_validate(reason)
 
 
 @router.get("/qc-statuses", response_model=QCStatusesResponse)

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -78,6 +78,13 @@ from app.schemas.resource_scheduling import (
 )
 from app.services.blocking_issues import get_production_order_blocking_issues
 from app.services import production_order_service
+from app.services import defect_reason_service
+from app.schemas.defect_reason import (
+    DefectReasonCreate,
+    DefectReasonUpdate,
+    DefectReasonDetail,
+    DefectReasonsResponse,
+)
 from app.services.resource_scheduling import (
     find_conflicts,
     find_next_available_slot,
@@ -587,6 +594,77 @@ async def delete_scrap_reason(
     production_order_service.delete_scrap_reason(db, reason_id)
     db.commit()
     return {"message": "Scrap reason deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Defect reasons (#784) — configurable QC defect taxonomy. Static routes; must
+# precede the dynamic /{order_id} routes below.
+# ---------------------------------------------------------------------------
+@router.get("/defect-reasons", response_model=DefectReasonsResponse)
+async def get_defect_reasons(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonsResponse:
+    """List active defect reasons (codes + details) for QC dropdowns."""
+    reasons = defect_reason_service.get_defect_reasons(db)
+    return DefectReasonsResponse(
+        reasons=[r.code for r in reasons],
+        details=[DefectReasonDetail.model_validate(r) for r in reasons],
+    )
+
+
+@router.get("/defect-reasons/all", response_model=List[DefectReasonDetail])
+async def get_all_defect_reasons(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> List[DefectReasonDetail]:
+    """List all defect reasons, including inactive."""
+    reasons = defect_reason_service.get_defect_reasons(db, include_inactive=True)
+    return [DefectReasonDetail.model_validate(r) for r in reasons]
+
+
+@router.post("/defect-reasons", response_model=DefectReasonDetail)
+async def create_defect_reason(
+    request: DefectReasonCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonDetail:
+    """Create a defect reason."""
+    reason = defect_reason_service.create_defect_reason(
+        db,
+        code=request.code,
+        name=request.name,
+        description=request.description,
+        category=request.category,
+        severity=request.severity,
+        sequence=request.sequence or 0,
+    )
+    db.commit()
+    db.refresh(reason)
+    return DefectReasonDetail.model_validate(reason)
+
+
+@router.patch("/defect-reasons/{reason_id}", response_model=DefectReasonDetail)
+async def update_defect_reason(
+    reason_id: int,
+    request: DefectReasonUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> DefectReasonDetail:
+    """Update a defect reason; pass active=false to deactivate."""
+    reason = defect_reason_service.update_defect_reason(
+        db,
+        reason_id,
+        name=request.name,
+        description=request.description,
+        category=request.category,
+        severity=request.severity,
+        sequence=request.sequence,
+        active=request.active,
+    )
+    db.commit()
+    db.refresh(reason)
+    return DefectReasonDetail.model_validate(reason)
 
 
 @router.get("/qc-statuses", response_model=QCStatusesResponse)
@@ -1282,6 +1360,9 @@ async def record_qc_inspection(
         quantity_failed=request.quantity_failed,
         failure_reason=request.failure_reason,
         notes=request.notes,
+        defect_reason_id=request.defect_reason_id,
+        # A waive is attributed to the operator performing it.
+        waiver_user_id=current_user.id if request.result.value == "waived" else None,
     )
 
     db.commit()
@@ -1296,6 +1377,7 @@ async def record_qc_inspection(
         qc_notes=order.qc_notes,
         qc_inspected_by=order.qc_inspected_by,
         qc_inspected_at=order.qc_inspected_at,
+        defect_reason_id=inspection.get("defect_reason_id"),
         sales_order_updated=False,
         sales_order_status=None,
         message=f"QC {order.qc_status} recorded for {order.code}",

--- a/backend/app/schemas/defect_reason.py
+++ b/backend/app/schemas/defect_reason.py
@@ -1,0 +1,57 @@
+"""Defect Reason schemas (#784) — QC defect taxonomy.
+
+Mirrors the scrap-reason schema conventions, adding `category` (free-form) and
+`severity` (CHECK-constrained minor|major|critical at the DB).
+"""
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DefectReasonBrief(BaseModel):
+    """Compact defect-reason summary embedded in a QC inspection record."""
+    id: int
+    code: str
+    name: str
+    severity: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class DefectReasonCreate(BaseModel):
+    code: str = Field(..., max_length=50, description="Stable code, e.g. 'layer_shift'")
+    name: str = Field(..., max_length=100, description="Display name")
+    description: Optional[str] = None
+    category: Optional[str] = Field(None, max_length=50, description="e.g. dimensional, cosmetic, functional")
+    severity: Optional[str] = Field(None, description="minor | major | critical")
+    sequence: int = Field(0, description="Ordering in dropdowns")
+
+
+class DefectReasonUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    severity: Optional[str] = None
+    sequence: Optional[int] = None
+    active: Optional[bool] = None
+
+
+class DefectReasonDetail(BaseModel):
+    id: int
+    code: str
+    name: str
+    description: Optional[str] = None
+    category: Optional[str] = None
+    severity: Optional[str] = None
+    sequence: int = 0
+    active: bool
+
+    class Config:
+        from_attributes = True
+
+
+class DefectReasonsResponse(BaseModel):
+    """Active defect reasons — codes for quick lookup + full details."""
+    reasons: List[str]
+    details: List[DefectReasonDetail]

--- a/backend/app/schemas/defect_reason.py
+++ b/backend/app/schemas/defect_reason.py
@@ -29,9 +29,11 @@ class DefectReasonCreate(BaseModel):
 
 
 class DefectReasonUpdate(BaseModel):
-    name: Optional[str] = None
+    # max_length mirrors the ORM columns (100/50) so an over-long value is a
+    # 422 at the boundary, not a 500 IntegrityError at commit.
+    name: Optional[str] = Field(None, max_length=100)
     description: Optional[str] = None
-    category: Optional[str] = None
+    category: Optional[str] = Field(None, max_length=50)
     severity: Optional[str] = None
     sequence: Optional[int] = None
     active: Optional[bool] = None

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -9,6 +9,8 @@ from datetime import datetime, date
 from decimal import Decimal
 from enum import Enum
 
+from app.schemas.defect_reason import DefectReasonBrief
+
 
 # ============================================================================
 # Enums
@@ -592,14 +594,19 @@ class QCInspectionRequest(BaseModel):
         max_length=2000,
         description="Inspector notes about the QC inspection"
     )
+    defect_reason_id: Optional[int] = Field(
+        None,
+        description="Structured defect classification (DefectReason id), for failed/conditional results.",
+    )
 
     class Config:
         json_schema_extra = {
             "example": {
-                "result": "passed",
+                "result": "failed",
                 "quantity_passed": 9,
                 "quantity_failed": 1,
                 "failure_reason": "1 unit warped on the corner",
+                "defect_reason_id": 3,
                 "notes": "All units inspected. Surface finish acceptable."
             }
         }
@@ -614,6 +621,7 @@ class QCInspectionResponse(BaseModel):
     qc_notes: Optional[str] = None
     qc_inspected_by: Optional[str] = None
     qc_inspected_at: Optional[datetime] = None
+    defect_reason_id: Optional[int] = None
     sales_order_updated: bool = False
     sales_order_status: Optional[str] = None
     message: str
@@ -631,6 +639,9 @@ class QCInspectionRecord(BaseModel):
     inspector_name: Optional[str] = None
     failure_reason: Optional[str] = None
     notes: Optional[str] = None
+    defect_reason_id: Optional[int] = None
+    defect_reason: Optional[DefectReasonBrief] = None
+    waiver_user_id: Optional[int] = None
     inspected_at: Optional[datetime] = None
 
     class Config:

--- a/backend/app/services/defect_reason_service.py
+++ b/backend/app/services/defect_reason_service.py
@@ -1,0 +1,99 @@
+"""Defect Reason service (#784) — manage the QC defect taxonomy.
+
+Standalone functions over the DefectReason reference table (free-form category +
+CHECK-constrained severity). Mirrors the scrap-reason service conventions. No
+hard delete: defect reasons are referenced by immutable qc_inspections rows, so
+they are deactivated (active=False), never removed.
+"""
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.defect_reason import DefectReason
+
+# Mirrors the migration 095 / model CHECK on defect_reasons.severity.
+VALID_SEVERITIES = ("minor", "major", "critical")
+
+
+def _validate_severity(severity: Optional[str]) -> None:
+    if severity is not None and severity not in VALID_SEVERITIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"severity must be one of {VALID_SEVERITIES}, got '{severity}'",
+        )
+
+
+def get_defect_reasons(db: Session, include_inactive: bool = False) -> list[DefectReason]:
+    """List defect reasons (active-only by default), ordered for dropdowns."""
+    query = db.query(DefectReason)
+    if not include_inactive:
+        query = query.filter(DefectReason.active.is_(True))
+    return query.order_by(DefectReason.sequence, DefectReason.name).all()
+
+
+def get_defect_reason(db: Session, reason_id: int) -> DefectReason:
+    """Fetch one defect reason or 404."""
+    reason = db.query(DefectReason).filter(DefectReason.id == reason_id).first()
+    if not reason:
+        raise HTTPException(status_code=404, detail="Defect reason not found")
+    return reason
+
+
+def create_defect_reason(
+    db: Session,
+    *,
+    code: str,
+    name: str,
+    description: Optional[str] = None,
+    category: Optional[str] = None,
+    severity: Optional[str] = None,
+    sequence: int = 0,
+) -> DefectReason:
+    """Create a defect reason. Code must be unique."""
+    _validate_severity(severity)
+    existing = db.query(DefectReason).filter(DefectReason.code == code).first()
+    if existing:
+        raise HTTPException(
+            status_code=400, detail=f"Defect reason with code '{code}' already exists"
+        )
+    reason = DefectReason(
+        code=code,
+        name=name,
+        description=description,
+        category=category,
+        severity=severity,
+        sequence=sequence,
+        active=True,
+    )
+    db.add(reason)
+    return reason
+
+
+def update_defect_reason(
+    db: Session,
+    reason_id: int,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    category: Optional[str] = None,
+    severity: Optional[str] = None,
+    sequence: Optional[int] = None,
+    active: Optional[bool] = None,
+) -> DefectReason:
+    """Patch a defect reason; pass active=False to deactivate."""
+    reason = get_defect_reason(db, reason_id)
+    if severity is not None:
+        _validate_severity(severity)
+        reason.severity = severity
+    if name is not None:
+        reason.name = name
+    if description is not None:
+        reason.description = description
+    if category is not None:
+        reason.category = category
+    if sequence is not None:
+        reason.sequence = sequence
+    if active is not None:
+        reason.active = active
+    return reason

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -690,6 +690,22 @@ def record_qc_inspection(
                 detail="a defect_reason cannot be attached to a 'passed' inspection",
             )
 
+    # Symmetric guard for the waiver: it may only attribute a 'waived' result,
+    # and the user must exist — an explicit 400 beats a 500 FK IntegrityError on
+    # an unknown id, and keeps waiver attribution off non-waive history (#784).
+    if waiver_user_id is not None:
+        from app.models.user import User
+        if qc_status != "waived":
+            raise HTTPException(
+                status_code=400,
+                detail="waiver_user_id is only allowed on a 'waived' inspection",
+            )
+        if not db.query(User.id).filter(User.id == waiver_user_id).first():
+            raise HTTPException(
+                status_code=400,
+                detail=f"waiver_user_id {waiver_user_id} does not exist",
+            )
+
     # Derive whole-order pass/fail quantities when the caller does not supply
     # them (e.g. the /qc endpoint, where QC is a binary pass/fail on the order).
     # When exactly ONE side is given, derive the other as its COMPLEMENT to the

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -625,6 +625,8 @@ def record_qc_inspection(
     quantity_failed: Optional[int] = None,
     failure_reason: Optional[str] = None,
     notes: Optional[str] = None,
+    defect_reason_id: Optional[int] = None,
+    waiver_user_id: Optional[int] = None,
 ) -> dict:
     """
     Record QC inspection results for a production order.
@@ -660,6 +662,16 @@ def record_qc_inspection(
             raise HTTPException(
                 status_code=400,
                 detail=f"{_name} cannot be negative (got {_val})",
+            )
+
+    # Validate the defect reason exists before writing the immutable row. The FK
+    # would also reject it, but an explicit 400 beats a 500 IntegrityError (#784).
+    if defect_reason_id is not None:
+        from app.models.defect_reason import DefectReason
+        if not db.query(DefectReason.id).filter(DefectReason.id == defect_reason_id).first():
+            raise HTTPException(
+                status_code=400,
+                detail=f"defect_reason_id {defect_reason_id} does not exist",
             )
 
     # Derive whole-order pass/fail quantities when the caller does not supply
@@ -737,6 +749,8 @@ def record_qc_inspection(
         inspector_name=inspector,
         failure_reason=failure_reason,
         notes=notes,
+        defect_reason_id=defect_reason_id,
+        waiver_user_id=waiver_user_id,
         inspected_at=inspected_at,
     )
     db.add(inspection)
@@ -753,6 +767,7 @@ def record_qc_inspection(
         "quantity_failed": quantity_failed,
         "failure_reason": failure_reason,
         "notes": notes,
+        "defect_reason_id": defect_reason_id,
         "inspected_at": inspected_at.isoformat(),
         "inspection_id": inspection_id,
     }

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -664,14 +664,30 @@ def record_qc_inspection(
                 detail=f"{_name} cannot be negative (got {_val})",
             )
 
-    # Validate the defect reason exists before writing the immutable row. The FK
-    # would also reject it, but an explicit 400 beats a 500 IntegrityError (#784).
+    # Validate the defect reason before writing the immutable row. Explicit 400s
+    # beat a 500 IntegrityError and keep QC history clean (#784):
+    #  - must exist; must be active (deactivated reasons are historical-only);
+    #  - a clean 'passed' carries no defect. failed/conditional/waived may — a
+    #    waive records the very defect being accepted.
     if defect_reason_id is not None:
         from app.models.defect_reason import DefectReason
-        if not db.query(DefectReason.id).filter(DefectReason.id == defect_reason_id).first():
+        reason = (
+            db.query(DefectReason).filter(DefectReason.id == defect_reason_id).first()
+        )
+        if reason is None:
             raise HTTPException(
                 status_code=400,
                 detail=f"defect_reason_id {defect_reason_id} does not exist",
+            )
+        if not reason.active:
+            raise HTTPException(
+                status_code=400,
+                detail=f"defect_reason_id {defect_reason_id} is inactive; pick an active reason",
+            )
+        if qc_status == "passed":
+            raise HTTPException(
+                status_code=400,
+                detail="a defect_reason cannot be attached to a 'passed' inspection",
             )
 
     # Derive whole-order pass/fail quantities when the caller does not supply

--- a/backend/tests/test_defect_reasons.py
+++ b/backend/tests/test_defect_reasons.py
@@ -5,6 +5,11 @@ dimension on POST /production-orders/{id}/qc.
 """
 from decimal import Decimal
 
+import pytest
+from fastapi import HTTPException
+
+from app.services import production_order_service
+
 BASE = "/api/v1/production-orders/defect-reasons"
 
 
@@ -121,3 +126,26 @@ class TestQCInspectionDefectAndWaive:
         rec = client.get(self.HIST.format(id=po.id)).json()["inspections"][0]
         assert rec["waiver_user_id"] is None
         assert rec["defect_reason"] is None
+
+
+class TestWaiverServiceGuard:
+    """The /qc endpoint only sets waiver_user_id on a waived result, but the
+    service guards a direct caller too (symmetric to defect_reason)."""
+
+    def test_waiver_rejected_on_non_waived_result(self, db, make_product, make_production_order):
+        from app.models.user import User
+        user = db.query(User).first()
+        po = _make_po(make_product, make_production_order)
+        with pytest.raises(HTTPException) as exc:
+            production_order_service.record_qc_inspection(
+                db, po.id, inspector="x", qc_status="failed", waiver_user_id=user.id,
+            )
+        assert exc.value.status_code == 400
+
+    def test_waiver_rejected_for_unknown_user(self, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        with pytest.raises(HTTPException) as exc:
+            production_order_service.record_qc_inspection(
+                db, po.id, inspector="x", qc_status="waived", waiver_user_id=999999,
+            )
+        assert exc.value.status_code == 400

--- a/backend/tests/test_defect_reasons.py
+++ b/backend/tests/test_defect_reasons.py
@@ -1,0 +1,98 @@
+"""#784 step 4 — defect-reason taxonomy endpoints + QC inspection wiring.
+
+Covers the defect-reasons CRUD endpoints and the waive-end-to-end + defect
+dimension on POST /production-orders/{id}/qc.
+"""
+from decimal import Decimal
+
+BASE = "/api/v1/production-orders/defect-reasons"
+
+
+def _make_po(make_product, make_production_order):
+    product = make_product()
+    return make_production_order(
+        product_id=product.id, status="completed",
+        quantity=Decimal("5"), quantity_completed=Decimal("5"),
+    )
+
+
+class TestDefectReasonCRUD:
+    def test_empty_list(self, client):
+        resp = client.get(BASE)
+        assert resp.status_code == 200
+        assert resp.json()["details"] == []
+
+    def test_create_and_list(self, client):
+        r = client.post(BASE, json={
+            "code": "layer_shift", "name": "Layer Shift",
+            "category": "dimensional", "severity": "major",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["code"] == "layer_shift"
+        assert body["severity"] == "major"
+        assert body["active"] is True
+
+        listing = client.get(BASE).json()
+        assert "layer_shift" in listing["reasons"]
+
+    def test_duplicate_code_rejected(self, client):
+        client.post(BASE, json={"code": "dup", "name": "A"})
+        r = client.post(BASE, json={"code": "dup", "name": "B"})
+        assert r.status_code == 400
+
+    def test_invalid_severity_rejected(self, client):
+        r = client.post(BASE, json={"code": "bad", "name": "Bad", "severity": "catastrophic"})
+        assert r.status_code == 400
+
+    def test_deactivate_hides_from_active_list(self, client):
+        created = client.post(BASE, json={"code": "old", "name": "Old"}).json()
+        patched = client.patch(f"{BASE}/{created['id']}", json={"active": False})
+        assert patched.status_code == 200
+        assert patched.json()["active"] is False
+
+        assert "old" not in client.get(BASE).json()["reasons"]
+        all_codes = [d["code"] for d in client.get(f"{BASE}/all").json()]
+        assert "old" in all_codes  # still present when including inactive
+
+
+class TestQCInspectionDefectAndWaive:
+    QC = "/api/v1/production-orders/{id}/qc"
+    HIST = "/api/v1/production-orders/{id}/qc-inspections"
+
+    def test_record_inspection_with_defect_reason(self, client, db, make_product, make_production_order):
+        reason = client.post(BASE, json={"code": "warp", "name": "Warping", "severity": "minor"}).json()
+        po = _make_po(make_product, make_production_order)
+
+        r = client.post(self.QC.format(id=po.id), json={
+            "result": "failed", "quantity_failed": 1,
+            "defect_reason_id": reason["id"], "failure_reason": "warped corner",
+        })
+        assert r.status_code == 200, r.text
+        assert r.json()["defect_reason_id"] == reason["id"]
+
+        rec = client.get(self.HIST.format(id=po.id)).json()["inspections"][0]
+        assert rec["defect_reason_id"] == reason["id"]
+        assert rec["defect_reason"]["code"] == "warp"
+        assert rec["defect_reason"]["severity"] == "minor"
+
+    def test_unknown_defect_reason_rejected(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        r = client.post(self.QC.format(id=po.id), json={"result": "failed", "defect_reason_id": 999999})
+        assert r.status_code == 400
+
+    def test_waive_attributes_to_current_user(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        r = client.post(self.QC.format(id=po.id), json={"result": "waived", "notes": "accepted as-is"})
+        assert r.status_code == 200, r.text
+
+        rec = client.get(self.HIST.format(id=po.id)).json()["inspections"][0]
+        assert rec["result"] == "waived"
+        assert rec["waiver_user_id"] is not None  # attributed to the operator
+
+    def test_pass_has_no_waiver(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        client.post(self.QC.format(id=po.id), json={"result": "passed"})
+        rec = client.get(self.HIST.format(id=po.id)).json()["inspections"][0]
+        assert rec["waiver_user_id"] is None
+        assert rec["defect_reason"] is None

--- a/backend/tests/test_defect_reasons.py
+++ b/backend/tests/test_defect_reasons.py
@@ -10,8 +10,9 @@ BASE = "/api/v1/production-orders/defect-reasons"
 
 def _make_po(make_product, make_production_order):
     product = make_product()
+    # 'complete' is the canonical runtime ProductionOrder status (not 'completed').
     return make_production_order(
-        product_id=product.id, status="completed",
+        product_id=product.id, status="complete",
         quantity=Decimal("5"), quantity_completed=Decimal("5"),
     )
 
@@ -80,6 +81,30 @@ class TestQCInspectionDefectAndWaive:
         po = _make_po(make_product, make_production_order)
         r = client.post(self.QC.format(id=po.id), json={"result": "failed", "defect_reason_id": 999999})
         assert r.status_code == 400
+
+    def test_inactive_defect_reason_rejected(self, client, db, make_product, make_production_order):
+        reason = client.post(BASE, json={"code": "retired", "name": "Retired"}).json()
+        client.patch(f"{BASE}/{reason['id']}", json={"active": False})
+        po = _make_po(make_product, make_production_order)
+        r = client.post(self.QC.format(id=po.id), json={"result": "failed", "defect_reason_id": reason["id"]})
+        assert r.status_code == 400
+
+    def test_defect_reason_on_passed_rejected(self, client, db, make_product, make_production_order):
+        reason = client.post(BASE, json={"code": "p_def", "name": "P Defect"}).json()
+        po = _make_po(make_product, make_production_order)
+        # a clean pass carries no defect
+        r = client.post(self.QC.format(id=po.id), json={"result": "passed", "defect_reason_id": reason["id"]})
+        assert r.status_code == 400
+
+    def test_defect_reason_allowed_on_waive(self, client, db, make_product, make_production_order):
+        reason = client.post(BASE, json={"code": "w_def", "name": "Waived Defect", "severity": "minor"}).json()
+        po = _make_po(make_product, make_production_order)
+        # a waive records the defect being accepted
+        r = client.post(self.QC.format(id=po.id), json={"result": "waived", "defect_reason_id": reason["id"]})
+        assert r.status_code == 200, r.text
+        rec = client.get(self.HIST.format(id=po.id)).json()["inspections"][0]
+        assert rec["defect_reason"]["code"] == "w_def"
+        assert rec["waiver_user_id"] is not None
 
     def test_waive_attributes_to_current_user(self, client, db, make_product, make_production_order):
         po = _make_po(make_product, make_production_order)


### PR DESCRIPTION
**#784 roadmap step 4 — waive end-to-end + defect-reason dimension.** Backend-only; gives Codex's Quality UI real endpoints to build against. Builds on the `095` schema (merged in #816).

## Defect taxonomy (configurable)
New `defect_reason_service` + schemas + endpoints on the production-orders router:
- `GET /production-orders/defect-reasons` — active reasons (codes + details) for QC dropdowns
- `GET /production-orders/defect-reasons/all` — includes inactive
- `POST /production-orders/defect-reasons` — create
- `PATCH /production-orders/defect-reasons/{id}` — update / deactivate

Free-form `category`; `severity` validated to `minor|major|critical` (mirrors the migration `095` CHECK). **No hard delete** — defect reasons are referenced by immutable `qc_inspections` rows, so they're deactivated, not removed (mirrors the scrap-reason convention).

## Wired into QC recording
- `record_qc_inspection` now accepts `defect_reason_id` (validated up front — explicit `400` beats a `500` IntegrityError) and `waiver_user_id`.
- `POST /production-orders/{id}/qc` passes the `defect_reason_id` and, **on a `waived` result, attributes the waive to the operator** (`waiver_user_id = current_user.id`). The attributed waive lives on the immutable inspection row; NCR/disposition stays PRO scope.
- The QC **history** (`/qc-inspections`) now exposes the nested `defect_reason` (id/code/name/severity) + `waiver_user_id`; the POST response echoes `defect_reason_id`.

## Tests
`test_defect_reasons.py`: CRUD (create/list/duplicate-code `400`/invalid-severity `400`/deactivate-hides-from-active), inspection-with-defect-reason (nested reason surfaces in history), unknown-reason `400`, **waive attribution** (waiver_user_id set), and pass-has-no-waiver.

Ruff + compile + import/route-registration verified locally; backend tests (incl. `alembic upgrade head`) run in CI.

Part of the #784 backend sequence — Claude owns backend; Codex builds the Quality UI on top. Next: step 5 (measurements endpoints) → step 6 (photos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable QC defect taxonomy with endpoints to list active/all defect reasons and create/update (including activation/deactivation).
  * QC inspections now support an optional defect reason and expose defect-reason details in inspection history, including waiver attribution when a result is waived.
* **Bug Fixes**
  * Quality Dashboard first-pass yield (FPY) now derives results from the first QC inspection row per order (not cached QC status), fixing inflated yield totals and excluding orders without QC inspection rows.
* **Tests**
  * Expanded defect-reason and QC inspection coverage, including waiver guard behavior and validation cases.
* **Documentation**
  * Updated changelog with QC defect taxonomy and FPY calculation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->