### PR TITLE
fix(api): constrain production-order detail routes to /{order_id:int} (route shadow)

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -494,7 +494,8 @@ async def get_scrap_reasons(
                 active=r.active,
             )
             for r in reasons
-        ]
+        ],
+        descriptions={r.code: (r.description or r.name or "") for r in reasons},
     )
 
 
@@ -594,16 +595,19 @@ async def get_qc_statuses(
     current_user: User = Depends(get_current_user),
 ) -> QCStatusesResponse:
     """Get valid QC status values."""
+    # Build descriptions by iterating actual enum members (keyed by value), so a
+    # description for an enum value that no longer exists can't raise at runtime.
+    descriptions = {
+        "not_required": "No inspection required",
+        "pending": "Awaiting inspection",
+        "in_progress": "Inspection in progress",
+        "passed": "Passed quality check",
+        "failed": "Failed quality check",
+        "waived": "Failed but accepted (waived)",
+    }
     return {
         "statuses": [s.value for s in QCStatus],
-        "descriptions": {
-            QCStatus.NOT_REQUIRED.value: "No inspection required",
-            QCStatus.PENDING.value: "Awaiting inspection",
-            QCStatus.IN_PROGRESS.value: "Inspection in progress",
-            QCStatus.PASSED.value: "Passed quality check",
-            QCStatus.FAILED.value: "Failed quality check",
-            QCStatus.WAIVED.value: "Failed but accepted (waived)",
-        }
+        "descriptions": {s.value: descriptions.get(s.value, "") for s in QCStatus},
     }
 
 
@@ -612,16 +616,19 @@ async def get_operation_statuses(
     current_user: User = Depends(get_current_user),
 ) -> OperationStatusesResponse:
     """Get valid operation status values."""
+    # Iterate actual members (keyed by value). The previous version referenced
+    # OperationStatus.PAUSED, which is not a member — a latent 500 that was
+    # hidden while this route was shadowed by GET /{order_id}.
+    descriptions = {
+        "pending": "Not started",
+        "queued": "Waiting in queue",
+        "running": "Currently running",
+        "complete": "Finished",
+        "skipped": "Skipped",
+    }
     return {
         "statuses": [s.value for s in OperationStatus],
-        "descriptions": {
-            OperationStatus.PENDING.value: "Not started",
-            OperationStatus.QUEUED.value: "Waiting in queue",
-            OperationStatus.RUNNING.value: "Currently running",
-            OperationStatus.PAUSED.value: "Temporarily paused",
-            OperationStatus.COMPLETE.value: "Finished",
-            OperationStatus.SKIPPED.value: "Skipped",
-        }
+        "descriptions": {s.value: descriptions.get(s.value, "") for s in OperationStatus},
     }
 
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -590,24 +590,37 @@ async def delete_scrap_reason(
     return {"message": "Scrap reason deleted"}
 
 
+# Human-readable descriptions for the status enums, keyed by enum VALUE. Kept at
+# module scope (not inline) so test_production_route_shadow can assert they cover
+# every enum member — a new/renamed value then fails loudly at CI instead of
+# silently returning a blank description. The endpoints still `.get(..., "")` so
+# a drift slip degrades gracefully at runtime rather than 500-ing (#818).
+QC_STATUS_DESCRIPTIONS = {
+    "not_required": "No inspection required",
+    "pending": "Awaiting inspection",
+    "in_progress": "Inspection in progress",
+    "passed": "Passed quality check",
+    "failed": "Failed quality check",
+    "waived": "Failed but accepted (waived)",
+}
+
+OPERATION_STATUS_DESCRIPTIONS = {
+    "pending": "Not started",
+    "queued": "Waiting in queue",
+    "running": "Currently running",
+    "complete": "Finished",
+    "skipped": "Skipped",
+}
+
+
 @router.get("/qc-statuses", response_model=QCStatusesResponse)
 async def get_qc_statuses(
     current_user: User = Depends(get_current_user),
 ) -> QCStatusesResponse:
     """Get valid QC status values."""
-    # Build descriptions by iterating actual enum members (keyed by value), so a
-    # description for an enum value that no longer exists can't raise at runtime.
-    descriptions = {
-        "not_required": "No inspection required",
-        "pending": "Awaiting inspection",
-        "in_progress": "Inspection in progress",
-        "passed": "Passed quality check",
-        "failed": "Failed quality check",
-        "waived": "Failed but accepted (waived)",
-    }
     return {
         "statuses": [s.value for s in QCStatus],
-        "descriptions": {s.value: descriptions.get(s.value, "") for s in QCStatus},
+        "descriptions": {s.value: QC_STATUS_DESCRIPTIONS.get(s.value, "") for s in QCStatus},
     }
 
 
@@ -616,19 +629,11 @@ async def get_operation_statuses(
     current_user: User = Depends(get_current_user),
 ) -> OperationStatusesResponse:
     """Get valid operation status values."""
-    # Iterate actual members (keyed by value). The previous version referenced
-    # OperationStatus.PAUSED, which is not a member — a latent 500 that was
-    # hidden while this route was shadowed by GET /{order_id}.
-    descriptions = {
-        "pending": "Not started",
-        "queued": "Waiting in queue",
-        "running": "Currently running",
-        "complete": "Finished",
-        "skipped": "Skipped",
-    }
     return {
         "statuses": [s.value for s in OperationStatus],
-        "descriptions": {s.value: descriptions.get(s.value, "") for s in OperationStatus},
+        "descriptions": {
+            s.value: OPERATION_STATUS_DESCRIPTIONS.get(s.value, "") for s in OperationStatus
+        },
     }
 
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -423,7 +423,7 @@ async def get_status_transitions(
     }
 
 
-@router.get("/{order_id}", response_model=ProductionOrderResponse)
+@router.get("/{order_id:int}", response_model=ProductionOrderResponse)
 async def get_production_order(
     order_id: int,
     db: Session = Depends(get_db),
@@ -434,7 +434,7 @@ async def get_production_order(
     return build_production_order_response(order, db)
 
 
-@router.put("/{order_id}", response_model=ProductionOrderResponse)
+@router.put("/{order_id:int}", response_model=ProductionOrderResponse)
 async def update_production_order(
     order_id: int,
     request: ProductionOrderUpdate,
@@ -458,7 +458,7 @@ async def update_production_order(
     return build_production_order_response(order, db)
 
 
-@router.delete("/{order_id}", response_model=MessageResponse)
+@router.delete("/{order_id:int}", response_model=MessageResponse)
 async def delete_production_order(
     order_id: int,
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -595,10 +595,13 @@ async def delete_scrap_reason(
 # every enum member — a new/renamed value then fails loudly at CI instead of
 # silently returning a blank description. The endpoints still `.get(..., "")` so
 # a drift slip degrades gracefully at runtime rather than 500-ing (#818).
+#
+# NOTE: these endpoints import QCStatus/OperationStatus from app.core.status_config
+# (NOT the schemas enums of the same name), so the keys mirror that enum's members
+# — status_config.QCStatus has no `in_progress`. (Discrepancy logged separately.)
 QC_STATUS_DESCRIPTIONS = {
     "not_required": "No inspection required",
     "pending": "Awaiting inspection",
-    "in_progress": "Inspection in progress",
     "passed": "Passed quality check",
     "failed": "Failed quality check",
     "waived": "Failed but accepted (waived)",

--- a/backend/tests/test_production_route_shadow.py
+++ b/backend/tests/test_production_route_shadow.py
@@ -20,7 +20,7 @@ class TestStaticRoutesNotShadowed:
         r = client.get(f"{PREFIX}/qc-statuses")
         assert r.status_code == 200, r.text
         body = r.json()
-        assert "statuses" in body and "in_progress" in body["statuses"]
+        assert "statuses" in body and "passed" in body["statuses"]
 
     def test_operation_statuses_resolves(self, client):
         r = client.get(f"{PREFIX}/operation-statuses")
@@ -45,11 +45,11 @@ class TestStatusDescriptionCoverage:
     blank description in the API."""
 
     def test_qc_status_descriptions_cover_all_members(self):
-        from app.api.v1.endpoints.production_orders import QC_STATUS_DESCRIPTIONS
-        from app.schemas.production_order import QCStatus
+        # Import the SAME QCStatus the endpoint uses (status_config, not schemas)
+        # so the map is checked against the enum actually iterated.
+        from app.api.v1.endpoints.production_orders import QC_STATUS_DESCRIPTIONS, QCStatus
         assert set(QC_STATUS_DESCRIPTIONS) == {m.value for m in QCStatus}
 
     def test_operation_status_descriptions_cover_all_members(self):
-        from app.api.v1.endpoints.production_orders import OPERATION_STATUS_DESCRIPTIONS
-        from app.schemas.production_order import OperationStatus
+        from app.api.v1.endpoints.production_orders import OPERATION_STATUS_DESCRIPTIONS, OperationStatus
         assert set(OPERATION_STATUS_DESCRIPTIONS) == {m.value for m in OperationStatus}

--- a/backend/tests/test_production_route_shadow.py
+++ b/backend/tests/test_production_route_shadow.py
@@ -18,6 +18,12 @@ class TestStaticRoutesNotShadowed:
     def test_qc_statuses_resolves(self, client):
         r = client.get(f"{PREFIX}/qc-statuses")
         assert r.status_code == 200, r.text
+        body = r.json()
+        assert "statuses" in body and "in_progress" in body["statuses"]
+
+    def test_operation_statuses_resolves(self, client):
+        r = client.get(f"{PREFIX}/operation-statuses")
+        assert r.status_code == 200, r.text
         assert "statuses" in r.json()
 
     def test_detail_route_still_works_for_int(self, client, db, make_product, make_production_order):

--- a/backend/tests/test_production_route_shadow.py
+++ b/backend/tests/test_production_route_shadow.py
@@ -2,9 +2,10 @@
 shadowed by the dynamic detail route.
 
 The bare detail routes are constrained to ``/{order_id:int}``, so a non-integer
-single segment (``/scrap-reasons``, ``/qc-statuses``, ``/defect-reasons``) falls
-through to its static handler instead of being parsed as an order_id → 422.
-(cortex observation #193.)
+single segment (``/scrap-reasons``, ``/qc-statuses``, ``/operation-statuses``)
+falls through to its static handler instead of being parsed as an order_id → 422.
+(``/defect-reasons`` is added in #817 and covered by its own suite.) Also guards
+the status-description maps against enum drift. (cortex observation #193.)
 """
 PREFIX = "/api/v1/production-orders"
 
@@ -36,3 +37,19 @@ class TestStaticRoutesNotShadowed:
     def test_detail_route_404_for_missing_int(self, client):
         r = client.get(f"{PREFIX}/999999")
         assert r.status_code == 404
+
+
+class TestStatusDescriptionCoverage:
+    """Drift guard: every status enum member must have an explicit description,
+    so a new/renamed value fails HERE (at CI) rather than silently serving a
+    blank description in the API."""
+
+    def test_qc_status_descriptions_cover_all_members(self):
+        from app.api.v1.endpoints.production_orders import QC_STATUS_DESCRIPTIONS
+        from app.schemas.production_order import QCStatus
+        assert set(QC_STATUS_DESCRIPTIONS) == {m.value for m in QCStatus}
+
+    def test_operation_status_descriptions_cover_all_members(self):
+        from app.api.v1.endpoints.production_orders import OPERATION_STATUS_DESCRIPTIONS
+        from app.schemas.production_order import OperationStatus
+        assert set(OPERATION_STATUS_DESCRIPTIONS) == {m.value for m in OperationStatus}

--- a/backend/tests/test_production_route_shadow.py
+++ b/backend/tests/test_production_route_shadow.py
@@ -1,0 +1,32 @@
+"""Regression: static GET routes under /production-orders must resolve, not be
+shadowed by the dynamic detail route.
+
+The bare detail routes are constrained to ``/{order_id:int}``, so a non-integer
+single segment (``/scrap-reasons``, ``/qc-statuses``, ``/defect-reasons``) falls
+through to its static handler instead of being parsed as an order_id → 422.
+(cortex observation #193.)
+"""
+PREFIX = "/api/v1/production-orders"
+
+
+class TestStaticRoutesNotShadowed:
+    def test_scrap_reasons_resolves(self, client):
+        r = client.get(f"{PREFIX}/scrap-reasons")
+        assert r.status_code == 200, r.text
+        assert "details" in r.json()
+
+    def test_qc_statuses_resolves(self, client):
+        r = client.get(f"{PREFIX}/qc-statuses")
+        assert r.status_code == 200, r.text
+        assert "statuses" in r.json()
+
+    def test_detail_route_still_works_for_int(self, client, db, make_product, make_production_order):
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        r = client.get(f"{PREFIX}/{po.id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["id"] == po.id
+
+    def test_detail_route_404_for_missing_int(self, client):
+        r = client.get(f"{PREFIX}/999999")
+        assert r.status_code == 404


### PR DESCRIPTION
**Fixes a pre-existing route-shadow bug** surfaced while adding `/defect-reasons` in #817 (cortex observation #193).

## The bug
The bare `GET/PUT/DELETE /{order_id}` detail routes are declared **before** several single-segment static routes — `GET /scrap-reasons`, `GET /qc-statuses`. Starlette matches routes in declaration order, so a request to `/production-orders/scrap-reasons` matched `/{order_id}` with `order_id="scrap-reasons"` → **422** (`path.order_id` int-parse error). The static handler never ran, so the **scrap-reason dropdown and qc-status fetch were silently broken**.

## The fix
Constrain the three bare detail routes to `/{order_id:int}`. Starlette's `int` converter compiles to a digits-only regex, so:
- `/scrap-reasons`, `/qc-statuses`, `/defect-reasons` **fall through** to their static handlers ✅
- integer ids (`/123`) still route to the detail endpoint ✅

Verified: the detail regex rejects `/scrap-reasons` and matches `/123`. This fixes the whole class in one place (more robust than re-ordering each static route).

**Behavior note:** `GET /production-orders/<non-int>` now returns **404** (no route match) instead of 422 — strictly more correct, and no test or caller depends on the old 422.

## Tests
`test_production_route_shadow.py`: `GET /scrap-reasons` + `/qc-statuses` resolve (200); the detail route still works for an int id and 404s for a missing one. (These fail on `main` today.)

Independent of, and complementary to, #817 (which moved `/defect-reasons` before `/{order_id}` by ordering). Both land cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `/scrap-reasons`, `/qc-statuses`, and `/operation-statuses` responses with a new top-level `descriptions` mapping alongside existing `details`.
* **Bug Fixes**
  * Updated production-order routing so the detail endpoint only matches integer `order_id`, avoiding conflicts with static status endpoints and preserving 404 behavior for missing records.
* **Tests**
  * Added regression coverage for static vs dynamic `/api/v1/production-orders` routes and verified the expected JSON keys and values, including description coverage across all status enum members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->