### PR TITLE
feat(quality): QC inspection measurements + in/out-of-spec (#784 step 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **QC inspection measurements (#784).** `POST /api/v1/production-orders/{id}/qc` accepts a `measurements` list (characteristic, nominal, lower/upper limit, measured value, unit) stored as exact `Numeric` (SPC-ready). The inspection history returns each measurement with a computed `is_within_spec` (true/false vs the limits, or null when no value or no limits are defined).
 - **QC defect taxonomy + waive attribution (#784).** New configurable defect reasons (`GET/POST /api/v1/production-orders/defect-reasons`, `/all`, `PATCH /{id}`) with free-form category and a `minor|major|critical` severity. Recording a QC inspection (`POST /production-orders/{id}/qc`) now accepts a `defect_reason_id` and, on a `waived` result, attributes the waive to the operator (`waiver_user_id`); the inspection history exposes the defect reason and waiver.
 
 ### Changed

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1379,6 +1379,7 @@ async def record_qc_inspection(
         defect_reason_id=request.defect_reason_id,
         # A waive is attributed to the operator performing it.
         waiver_user_id=current_user.id if request.result.value == "waived" else None,
+        measurements=[m.model_dump() for m in request.measurements],
     )
 
     db.commit()

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -556,7 +556,9 @@ class QCInspection(Base):
         "QCInspectionMeasurement",
         back_populates="inspection",
         cascade="all, delete-orphan",
-        order_by="QCInspectionMeasurement.sequence",
+        # id is the tie-breaker so equal sequence values keep a stable
+        # (insertion) order rather than being nondeterministic.
+        order_by="(QCInspectionMeasurement.sequence, QCInspectionMeasurement.id)",
     )
     photos = relationship(
         "QCInspectionPhoto",

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -3,7 +3,7 @@ Production Order Pydantic Schemas
 
 Manufacturing Orders (MOs) for tracking production of finished goods.
 """
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
 from typing import Any, Dict, Optional, List
 from datetime import datetime, date
 from decimal import Decimal
@@ -577,6 +577,18 @@ class QCMeasurementInput(BaseModel):
     measured_value: Optional[Decimal] = Field(None, description="Actual measured value")
     unit: Optional[str] = Field(None, max_length=20, description="e.g. mm, g")
     sequence: Optional[int] = Field(None, description="Display order; defaults to input order")
+
+    @model_validator(mode="after")
+    def _limits_ordered(self):
+        # A transposed LSL/USL would make is_within_spec contradictory; reject it
+        # at the boundary instead.
+        if (
+            self.lower_limit is not None
+            and self.upper_limit is not None
+            and self.lower_limit > self.upper_limit
+        ):
+            raise ValueError("lower_limit cannot be greater than upper_limit")
+        return self
 
 
 class QCMeasurementRecord(BaseModel):

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -3,7 +3,7 @@ Production Order Pydantic Schemas
 
 Manufacturing Orders (MOs) for tracking production of finished goods.
 """
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 from typing import Any, Dict, Optional, List
 from datetime import datetime, date
 from decimal import Decimal
@@ -568,6 +568,47 @@ class ScrapReasonsResponse(BaseModel):
 # QC Inspection Schemas
 # ============================================================================
 
+class QCMeasurementInput(BaseModel):
+    """One SPC measurement captured during a QC inspection (#784)."""
+    characteristic: str = Field(..., max_length=100, description="What was measured, e.g. 'bore diameter'")
+    nominal: Optional[Decimal] = Field(None, description="Target value")
+    lower_limit: Optional[Decimal] = Field(None, description="Lower spec limit (LSL)")
+    upper_limit: Optional[Decimal] = Field(None, description="Upper spec limit (USL)")
+    measured_value: Optional[Decimal] = Field(None, description="Actual measured value")
+    unit: Optional[str] = Field(None, max_length=20, description="e.g. mm, g")
+    sequence: Optional[int] = Field(None, description="Display order; defaults to input order")
+
+
+class QCMeasurementRecord(BaseModel):
+    """One stored measurement, with computed in/out-of-spec."""
+    id: int
+    characteristic: str
+    nominal: Optional[Decimal] = None
+    lower_limit: Optional[Decimal] = None
+    upper_limit: Optional[Decimal] = None
+    measured_value: Optional[Decimal] = None
+    unit: Optional[str] = None
+    sequence: int = 0
+
+    @computed_field
+    @property
+    def is_within_spec(self) -> Optional[bool]:
+        """True/False vs spec limits; None when not determinable (no measured
+        value, or no limits defined)."""
+        if self.measured_value is None:
+            return None
+        if self.lower_limit is None and self.upper_limit is None:
+            return None
+        if self.lower_limit is not None and self.measured_value < self.lower_limit:
+            return False
+        if self.upper_limit is not None and self.measured_value > self.upper_limit:
+            return False
+        return True
+
+    class Config:
+        from_attributes = True
+
+
 class QCInspectionRequest(BaseModel):
     """Request to perform QC inspection on a production order"""
     result: QCStatus = Field(
@@ -597,6 +638,10 @@ class QCInspectionRequest(BaseModel):
     defect_reason_id: Optional[int] = Field(
         None,
         description="Structured defect classification (DefectReason id), for failed/conditional results.",
+    )
+    measurements: List[QCMeasurementInput] = Field(
+        default_factory=list,
+        description="SPC measurements captured during this inspection.",
     )
 
     class Config:
@@ -642,6 +687,7 @@ class QCInspectionRecord(BaseModel):
     defect_reason_id: Optional[int] = None
     defect_reason: Optional[DefectReasonBrief] = None
     waiver_user_id: Optional[int] = None
+    measurements: List[QCMeasurementRecord] = Field(default_factory=list)
     inspected_at: Optional[datetime] = None
 
     class Config:

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -627,6 +627,7 @@ def record_qc_inspection(
     notes: Optional[str] = None,
     defect_reason_id: Optional[int] = None,
     waiver_user_id: Optional[int] = None,
+    measurements: Optional[list] = None,
 ) -> dict:
     """
     Record QC inspection results for a production order.
@@ -789,6 +790,24 @@ def record_qc_inspection(
 
     db.flush()
     inspection_id = inspection.id
+
+    # Persist any SPC measurements captured with this inspection (#784 step 5).
+    # Each row is keyed to the inspection; sequence defaults to input order.
+    if measurements:
+        from app.models.production_order import QCInspectionMeasurement
+        for idx, m in enumerate(measurements):
+            seq = m.get("sequence")
+            db.add(QCInspectionMeasurement(
+                qc_inspection_id=inspection_id,
+                characteristic=m["characteristic"],
+                nominal=m.get("nominal"),
+                lower_limit=m.get("lower_limit"),
+                upper_limit=m.get("upper_limit"),
+                measured_value=m.get("measured_value"),
+                unit=m.get("unit"),
+                sequence=seq if seq is not None else idx,
+            ))
+        db.flush()
 
     inspection_result = {
         "order_id": order_id,

--- a/backend/tests/test_qc_measurements.py
+++ b/backend/tests/test_qc_measurements.py
@@ -1,0 +1,68 @@
+"""#784 step 5 — SPC measurements captured with a QC inspection are persisted
+and surfaced (with computed in/out-of-spec) in the inspection history."""
+from decimal import Decimal
+
+QC = "/api/v1/production-orders/{id}/qc"
+HIST = "/api/v1/production-orders/{id}/qc-inspections"
+
+
+def _make_po(make_product, make_production_order):
+    product = make_product()
+    return make_production_order(
+        product_id=product.id, status="complete",
+        quantity=Decimal("5"), quantity_completed=Decimal("5"),
+    )
+
+
+class TestQCMeasurements:
+    def test_measurements_recorded_with_spec_flags(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        r = client.post(QC.format(id=po.id), json={
+            "result": "passed",
+            "measurements": [
+                {"characteristic": "bore_dia", "nominal": "10.0", "lower_limit": "9.95",
+                 "upper_limit": "10.05", "measured_value": "10.012", "unit": "mm"},
+                {"characteristic": "height", "lower_limit": "20", "upper_limit": "21",
+                 "measured_value": "21.5", "unit": "mm"},
+                {"characteristic": "note_only", "measured_value": "5"},  # no limits
+            ],
+        })
+        assert r.status_code == 200, r.text
+
+        ms = client.get(HIST.format(id=po.id)).json()["inspections"][0]["measurements"]
+        assert len(ms) == 3
+        # default ordering follows input order
+        assert [m["characteristic"] for m in ms] == ["bore_dia", "height", "note_only"]
+        assert ms[0]["is_within_spec"] is True    # 10.012 within [9.95, 10.05]
+        assert ms[1]["is_within_spec"] is False   # 21.5 > 21
+        assert ms[2]["is_within_spec"] is None     # no limits -> not determinable
+        assert abs(float(ms[0]["measured_value"]) - 10.012) < 1e-6  # exact Numeric round-trip
+
+    def test_inspection_without_measurements(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        client.post(QC.format(id=po.id), json={"result": "passed"})
+        rec = client.get(HIST.format(id=po.id)).json()["inspections"][0]
+        assert rec["measurements"] == []
+
+    def test_explicit_sequence_orders_output(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        client.post(QC.format(id=po.id), json={
+            "result": "passed",
+            "measurements": [
+                {"characteristic": "b", "sequence": 2, "measured_value": "1"},
+                {"characteristic": "a", "sequence": 1, "measured_value": "2"},
+            ],
+        })
+        ms = client.get(HIST.format(id=po.id)).json()["inspections"][0]["measurements"]
+        assert [m["characteristic"] for m in ms] == ["a", "b"]
+
+    def test_value_at_limit_is_in_spec(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        client.post(QC.format(id=po.id), json={
+            "result": "passed",
+            "measurements": [
+                {"characteristic": "edge", "lower_limit": "1.0", "upper_limit": "2.0", "measured_value": "2.0"},
+            ],
+        })
+        ms = client.get(HIST.format(id=po.id)).json()["inspections"][0]["measurements"]
+        assert ms[0]["is_within_spec"] is True  # boundary is inclusive

--- a/backend/tests/test_qc_measurements.py
+++ b/backend/tests/test_qc_measurements.py
@@ -66,3 +66,26 @@ class TestQCMeasurements:
         })
         ms = client.get(HIST.format(id=po.id)).json()["inspections"][0]["measurements"]
         assert ms[0]["is_within_spec"] is True  # boundary is inclusive
+
+    def test_inverted_limits_rejected(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        r = client.post(QC.format(id=po.id), json={
+            "result": "passed",
+            "measurements": [
+                {"characteristic": "x", "lower_limit": "10", "upper_limit": "5", "measured_value": "7"},
+            ],
+        })
+        assert r.status_code == 422  # transposed LSL/USL rejected at the boundary
+
+    def test_equal_sequence_keeps_insertion_order(self, client, db, make_product, make_production_order):
+        po = _make_po(make_product, make_production_order)
+        client.post(QC.format(id=po.id), json={
+            "result": "passed",
+            "measurements": [
+                {"characteristic": "first", "sequence": 1, "measured_value": "1"},
+                {"characteristic": "second", "sequence": 1, "measured_value": "2"},
+            ],
+        })
+        ms = client.get(HIST.format(id=po.id)).json()["inspections"][0]["measurements"]
+        # equal sequence -> id tie-breaker preserves insertion order
+        assert [m["characteristic"] for m in ms] == ["first", "second"]


### PR DESCRIPTION
**#784 roadmap step 5 — QC inspection measurements.** Backend-only; feeds the Quality UI Codex is building. Builds on the `095` `qc_inspection_measurements` table (already on `main`).

## What
`POST /api/v1/production-orders/{id}/qc` now accepts a `measurements` list captured during the inspection:

```json
{ "result": "passed", "measurements": [
  { "characteristic": "bore_dia", "nominal": "10.0", "lower_limit": "9.95",
    "upper_limit": "10.05", "measured_value": "10.012", "unit": "mm" }
]}
```

Each is persisted as an exact `Numeric(18,4)` (**SPC-ready**, never Float) `qc_inspection_measurements` row keyed to the inspection. The inspection **history** (`/qc-inspections`) returns each measurement with a computed **`is_within_spec`**:
- `true` / `false` vs the limits (boundary inclusive)
- `null` when not determinable (no measured value, or no limits defined)

`sequence` defaults to input order, so the UI gets a stable list.

## Where
- **schemas** — `QCMeasurementInput` (request) + `QCMeasurementRecord` (output, with the computed `is_within_spec`); `measurements` added to `QCInspectionRequest` and `QCInspectionRecord`.
- **service** — `record_qc_inspection` persists the rows (lazy `QCInspectionMeasurement` import, per the file's convention).
- **endpoint** — `/qc` threads `request.measurements` through.

## Tests
`test_qc_measurements.py`: record-with-spec-flags (within / over / no-limits), no-measurements, explicit-sequence ordering, boundary-inclusive. Ruff + compile clean; `is_within_spec` logic verified directly.

Part of the #784 backend sequence (Claude owns backend; Codex builds the Quality UI). Next: step 6 — photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QC inspections now accept multiple structured measurement entries (characteristic, nominal, limits, measured value, unit).
  * QC inspection history now returns per-measurement spec compliance status (in-spec/out-of-spec, or empty/unknown when limits or values are missing).
* **Bug Fixes**
  * QC submissions now persist measurement details and correctly preserve ordering (including support for explicit sequence and stable ordering ties).
  * Submissions with inverted limits (lower limit greater than upper limit) are rejected with validation errors.
  * QC inspections submitted without measurements return an empty measurements list in history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->