### PR TITLE
docs: reconcile FEATURE-CATALOG quality entry with actual QMS scope

### DIFF
--- a/docs/FEATURE-CATALOG.md
+++ b/docs/FEATURE-CATALOG.md
@@ -136,7 +136,7 @@
 | 53 | Material-Printer Compatibility Validation | Validates filament material type and diameter against printer nozzle and platform specs before scheduling; suggests compatible alternatives | ✅ Complete |
 | 54 | Scheduling Sequence Enforcement | Operations must be scheduled in sequence order; attempting to schedule out of order returns a validation error with next-available slot suggestion | ✅ Complete |
 | 55 | Scheduling Conflict Slot Suggestion | When a requested time slot is taken, returns the next available slot on that work center | ✅ Complete |
-| 56 | Quality Dashboard | Inspection queue, pass/fail metrics, scrap analysis, and trend charts for QC managers | ✅ Complete |
+| 56 | Quality Module | Selectable QC rigor (off/basic/full), per-product quality plans with variable + attribute characteristics, plan-driven inspection with measurements, defect taxonomy, inspection photos, and a configurable inspection gate (off/warn/block). SPC trend charts and control charts are PRO. | ✅ Complete |
 
 ### Supply Chain (v4.0.0)
 


### PR DESCRIPTION
## Summary
- Updates FEATURE-CATALOG entry #56 from the stale "Quality Dashboard — trend charts" description to accurately reflect Core QMS: selectable rigor (off/basic/full), quality plans, plan-driven inspection, defect taxonomy, photos, and the inspection gate (off/warn/block).
- Explicitly notes SPC trend/control charts are PRO.

## Context
Core QMS (#784) is fully shipped — 15 PRs merged. The old catalog entry over-promised PRO features as Core.

## Test plan
- [ ] Verify FEATURE-CATALOG.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the manufacturing scheduling and quality feature catalog to reflect the latest quality experience.
  * Replaced the older quality dashboard description with a broader quality module covering QC rigor settings, per-product quality plans, inspection workflows, configurable inspection gates, and SPC trend/control charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->