### PR TITLE
fix(shipping): block status=shipped bypass that skipped inventory + COGS (#838)

### DIFF
--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -950,9 +950,11 @@ def update_shipping_info(
 
     # Shipping (status -> 'shipped', shipped_at, inventory relief, COGS) happens
     # ONLY in ship_order(). This endpoint edits tracking metadata; it must never
-    # flip an unshipped order to 'shipped', which would set shipment evidence
-    # with no inventory or GL movement — silent corruption (#838).
-    if shipped_at is not None and order.status != "shipped":
+    # flip a not-yet-shipped order to a shipped state, which would set shipment
+    # evidence with no inventory or GL movement — silent corruption (#838).
+    # 'shipped', 'delivered', and 'completed' are all post-shipment states.
+    already_shipped = order.status in SHIPPED_ORDER_STATUSES
+    if shipped_at is not None and not already_shipped:
         raise HTTPException(
             status_code=400,
             detail=(
@@ -968,8 +970,9 @@ def update_shipping_info(
     if carrier:
         order.carrier = carrier
 
-    # Allow correcting/recording the ship timestamp on an already-shipped order.
-    if shipped_at is not None and order.status == "shipped":
+    # Allow correcting/recording the ship timestamp on an order that has already
+    # shipped (shipped / delivered / completed) — pure metadata, no ledger impact.
+    if shipped_at is not None and already_shipped:
         order.shipped_at = shipped_at
 
     return order

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -835,6 +835,20 @@ def update_sales_order_status(
     order = get_sales_order(db, order_id)
     old_status = order.status
 
+    # Shipping must go through ship_order() so inventory is relieved and COGS
+    # posts. Flipping to 'shipped' via a bare status update sets shipment
+    # evidence (shipped_at) with no inventory or GL movement — silent stock
+    # overstatement + missing COGS (#838).
+    if new_status == "shipped":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Orders cannot be marked shipped via status update. Use "
+                "POST /sales-orders/<order_id>/ship so inventory and COGS "
+                "post correctly."
+            ),
+        )
+
     try:
         validate_sales_order_transition(old_status, new_status)
     except StatusTransitionError as exc:
@@ -845,9 +859,6 @@ def update_sales_order_status(
     # Set timestamps based on status
     if new_status == "confirmed" and old_status in ("pending", "pending_confirmation"):
         order.confirmed_at = datetime.now(timezone.utc)
-
-    if new_status == "shipped":
-        order.shipped_at = datetime.now(timezone.utc)
 
     if new_status == "delivered":
         order.delivered_at = datetime.now(timezone.utc)
@@ -936,7 +947,20 @@ def update_shipping_info(
 ) -> SalesOrder:
     """Update shipping information for an order."""
     order = get_sales_order(db, order_id)
-    is_shipping = order.shipped_at is None and shipped_at is not None
+
+    # Shipping (status -> 'shipped', shipped_at, inventory relief, COGS) happens
+    # ONLY in ship_order(). This endpoint edits tracking metadata; it must never
+    # flip an unshipped order to 'shipped', which would set shipment evidence
+    # with no inventory or GL movement — silent corruption (#838).
+    if shipped_at is not None and order.status != "shipped":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Cannot mark an order shipped here. Use "
+                "POST /sales-orders/<order_id>/ship so inventory and COGS "
+                "post correctly."
+            ),
+        )
 
     if tracking_number:
         order.tracking_number = tracking_number
@@ -944,21 +968,9 @@ def update_shipping_info(
     if carrier:
         order.carrier = carrier
 
-    if shipped_at:
+    # Allow correcting/recording the ship timestamp on an already-shipped order.
+    if shipped_at is not None and order.status == "shipped":
         order.shipped_at = shipped_at
-        order.status = "shipped"
-
-    if is_shipping:
-        record_order_event(
-            db=db,
-            order_id=order_id,
-            event_type="shipped",
-            title="Order shipped",
-            description=f"Shipped via {carrier or 'carrier'}" + (f", tracking: {tracking_number}" if tracking_number else ""),
-            user_id=user_id,
-            metadata_key="tracking_number" if tracking_number else None,
-            metadata_value=tracking_number,
-        )
 
     return order
 

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -543,8 +543,8 @@ class TestUpdateStatus:
         data = response.json()
         assert data.get("confirmed_at") is not None
 
-    def test_shipped_sets_shipped_at(self, client, db, make_sales_order, make_product):
-        """Marking as shipped should set shipped_at timestamp."""
+    def test_status_update_to_shipped_is_blocked(self, client, db, make_sales_order, make_product):
+        """Shipping must go through POST /ship, not a bare status flip (#838)."""
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(product_id=product.id, status="ready_to_ship")
         db.flush()
@@ -552,9 +552,12 @@ class TestUpdateStatus:
         response = client.patch(f"{BASE_URL}/{so.id}/status", json={
             "status": "shipped",
         })
-        assert response.status_code == 200
-        data = response.json()
-        assert data.get("shipped_at") is not None
+        assert response.status_code == 400
+        assert "ship" in response.json()["detail"].lower()
+        # No corruption: status and shipment evidence untouched.
+        got = client.get(f"{BASE_URL}/{so.id}").json()
+        assert got["status"] == "ready_to_ship"
+        assert got["shipped_at"] is None
 
     def test_delivered_sets_delivered_at(self, client, db, make_sales_order, make_product):
         """Marking as delivered should set delivered_at timestamp."""
@@ -656,8 +659,8 @@ class TestUpdateShipping:
         assert data["tracking_number"] == "1Z999AA10123456784"
         assert data["carrier"] == "UPS"
 
-    def test_update_shipping_with_shipped_at(self, client, db, make_sales_order, make_product):
-        """Setting shipped_at should also update order status to 'shipped'."""
+    def test_update_shipping_with_shipped_at_is_blocked(self, client, db, make_sales_order, make_product):
+        """PATCH /shipping cannot mark an unshipped order shipped — use POST /ship (#838)."""
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(product_id=product.id, status="ready_to_ship")
         db.flush()
@@ -667,10 +670,12 @@ class TestUpdateShipping:
             "carrier": "USPS",
             "shipped_at": "2026-01-15T10:00:00",
         })
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "shipped"
-        assert data["shipped_at"] is not None
+        assert response.status_code == 400
+        assert "ship" in response.json()["detail"].lower()
+        # No corruption: status and shipment evidence untouched.
+        got = client.get(f"{BASE_URL}/{so.id}").json()
+        assert got["status"] == "ready_to_ship"
+        assert got["shipped_at"] is None
 
     def test_update_shipping_nonexistent_order(self, client):
         response = client.patch(f"{BASE_URL}/999999/shipping", json={

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1017,6 +1017,19 @@ class TestUpdateShippingInfo:
         ).all()
         assert events == []
 
+    def test_corrects_shipped_at_on_delivered_and_completed(self, db, make_sales_order):
+        """shipped_at correction is allowed on all post-ship states, not just 'shipped'."""
+        from datetime import datetime, timezone
+        for status in ("delivered", "completed"):
+            so = make_sales_order(status=status)
+            ts = datetime.now(timezone.utc)
+            result = sales_order_service.update_shipping_info(
+                db, so.id, user_id=1, tracking_number="TRK-D", shipped_at=ts
+            )
+            assert result.status == status
+            assert result.shipped_at == ts
+            assert result.tracking_number == "TRK-D"
+
 
 # =============================================================================
 # update_shipping_address

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -789,20 +789,27 @@ class TestUpdateSalesOrderStatus:
 
         with pytest.raises(HTTPException) as exc_info:
             sales_order_service.update_sales_order_status(
-                db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
+                db, so.id, "delivered", user_id=1, user_email="test@filaops.dev"
             )
 
         assert exc_info.value.status_code == 400
         assert "Invalid sales order status transition" in exc_info.value.detail
         assert so.status == "pending"
 
-    def test_shipped_sets_shipped_at(self, db, make_sales_order):
-        """Setting status to shipped sets shipped_at."""
+    def test_status_update_to_shipped_is_blocked(self, db, make_sales_order):
+        """Shipping must go through POST /ship, not a bare status flip (#838)."""
         so = make_sales_order(status="ready_to_ship")
-        result = sales_order_service.update_sales_order_status(
-            db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
-        )
-        assert result.shipped_at is not None
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.update_sales_order_status(
+                db, so.id, "shipped", user_id=1, user_email="test@filaops.dev"
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "ship" in exc_info.value.detail
+        # No corruption: status and shipment evidence are untouched.
+        assert so.status == "ready_to_ship"
+        assert so.shipped_at is None
 
     def test_delivered_sets_delivered_at(self, db, make_sales_order):
         """Setting status to delivered sets delivered_at."""
@@ -972,24 +979,28 @@ class TestUpdateShippingInfo:
         )
         assert result.carrier == "UPS"
 
-    def test_shipped_at_sets_status_to_shipped(self, db, make_sales_order):
-        """Providing shipped_at transitions status to shipped."""
+    def test_shipped_at_on_unshipped_order_is_blocked(self, db, make_sales_order):
+        """shipped_at cannot ship an order here — that must go through POST /ship (#838)."""
         from datetime import datetime, timezone
         so = make_sales_order(status="in_production")
         now = datetime.now(timezone.utc)
 
-        result = sales_order_service.update_shipping_info(
-            db, so.id, user_id=1, shipped_at=now
-        )
-        assert result.status == "shipped"
-        assert result.shipped_at == now
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.update_shipping_info(
+                db, so.id, user_id=1, shipped_at=now
+            )
 
-    def test_records_shipped_event_on_first_ship(self, db, make_sales_order):
-        """Shipping event is recorded on the initial ship."""
+        assert exc_info.value.status_code == 400
+        # No corruption: status and shipment evidence are untouched.
+        assert so.status == "in_production"
+        assert so.shipped_at is None
+
+    def test_updates_tracking_on_shipped_order_without_event(self, db, make_sales_order):
+        """Tracking edits on an already-shipped order succeed and post no ship event."""
         from datetime import datetime, timezone
-        so = make_sales_order(status="in_production")
+        so = make_sales_order(status="shipped")
 
-        sales_order_service.update_shipping_info(
+        result = sales_order_service.update_shipping_info(
             db, so.id, user_id=1,
             carrier="USPS",
             tracking_number="TRK123",
@@ -997,11 +1008,14 @@ class TestUpdateShippingInfo:
         )
         db.flush()
 
+        assert result.tracking_number == "TRK123"
+        assert result.carrier == "USPS"
+        assert result.status == "shipped"
         events = db.query(OrderEvent).filter(
             OrderEvent.sales_order_id == so.id,
             OrderEvent.event_type == "shipped",
         ).all()
-        assert len(events) >= 1
+        assert events == []
 
 
 # =============================================================================

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -485,9 +485,20 @@ export default function AdminShipping() {
   };
 
   const handleMarkShipped = async (orderId) => {
+    // Ship through POST /ship (relieves inventory + posts COGS), not a bare
+    // status flip. The button only shows for orders that already have a
+    // tracking number, so reuse the order's saved carrier/tracking (#838).
+    const order = orders.find((o) => o.id === orderId);
+    if (!order?.tracking_number) {
+      toast.error("Add a tracking number before shipping");
+      return;
+    }
     setSaving(true);
     try {
-      await api.patch(`/api/v1/sales-orders/${orderId}/status`, { status: "shipped" });
+      await api.post(`/api/v1/sales-orders/${orderId}/ship`, {
+        carrier: order.carrier || "USPS",
+        tracking_number: order.tracking_number,
+      });
       toast.success("Order marked as shipped");
       fetchOrders();
       setExpandedOrder(null);

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -493,10 +493,14 @@ export default function AdminShipping() {
       toast.error("Add a tracking number before shipping");
       return;
     }
+    if (!order.carrier) {
+      toast.error("Add a carrier before shipping");
+      return;
+    }
     setSaving(true);
     try {
       await api.post(`/api/v1/sales-orders/${orderId}/ship`, {
-        carrier: order.carrier || "USPS",
+        carrier: order.carrier,
         tracking_number: order.tracking_number,
       });
       toast.success("Order marked as shipped");


### PR DESCRIPTION
## Summary
PR-1 of the shipping-correctness epic #839. Closes the #838 corruption: two service functions could mark an order `shipped` (setting `shipped_at`) **without relieving inventory or posting COGS** — silent stock overstatement + missing COGS, which also poisoned `resolve_legacy_fulfillment` repair via false shipment evidence.

### Changes
- **`update_sales_order_status`** — rejects `→ shipped` with a 400 directing callers to `POST /{order_id}/ship` (the only path that posts inventory + GL). All other transitions (confirmed/in_production/delivered/completed/cancelled/on_hold) are unaffected.
- **`update_shipping_info`** — no longer flips an unshipped order to `shipped`; it edits tracking/carrier metadata and allows ship-timestamp correction **only on already-shipped orders**. Removed the now-dead "shipped" `OrderEvent` (the real ship path in `ship_order` already records it).
- **`AdminShipping.handleMarkShipped`** — rerouted from `PATCH /status {status:'shipped'}` to `POST /{id}/ship`, reusing the order's saved carrier/tracking. Legitimate errors (missing address, material-backed order) now correctly surface to the operator instead of being silently swallowed.

### Verification
- `283 passed` across `test_sales_orders.py` + `test_sales_order_service.py` (updated 4 tests that locked in the old behavior; the new tests assert the block **and** prove no corruption via a follow-up GET).
- `ruff` clean; the only ESLint findings in `AdminShipping.jsx` are pre-existing (#734), none on changed lines.
- Adversarial ERP review (Opus): verdict **SHIP** — no legitimate caller broken, audit trail preserved, ERP-correct.

### Scope
Intentionally narrow. The `fulfillment_shipping.py` engine paths and the dual-GL reconciliation are PR-3; line-linked `shipped_quantity` writing is PR-2. A **third latent bypass** (`order_status.py:154` `update_so_status(..., "shipped")`, currently dormant) was found during review and is logged on #839 for PR-3.

Refs #838 #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the admin “Ship” action to call the dedicated ship endpoint using the order’s carrier and tracking number.

* **Bug Fixes**
  * Prevented orders from being marked as shipped via general status edits.
  * Restricted `shipped_at` updates so they only apply when the order is already in a shipped-family state; invalid requests no longer change status or shipment timestamps.
  * Improved admin error handling when shipping is attempted without required tracking details.

* **Tests**
  * Revised API and service tests to verify blocked transitions and that order state remains unchanged on invalid updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->