### PR TITLE
fix(shipping): close the update_so_status 'shipped' bypass (#839 PR-3)

### DIFF
--- a/backend/app/services/order_status.py
+++ b/backend/app/services/order_status.py
@@ -137,6 +137,18 @@ class OrderStatusService:
         Raises:
             ValueError: If transition is invalid
         """
+        # Shipping carries inventory + COGS side effects that must go through
+        # ship_order() (POST /{id}/ship). Setting 'shipped' here would set
+        # shipped_at + fulfillment_status with NO inventory relief or GL entry —
+        # the #838 corruption class. Block it even when skip_validation=True;
+        # use resolve_legacy_fulfillment() for brownfield close-out.
+        if new_status == "shipped":
+            raise ValueError(
+                "Cannot set status 'shipped' via update_so_status: shipping must "
+                "go through ship_order() so inventory and COGS post correctly. "
+                "Use resolve_legacy_fulfillment() for brownfield close-out."
+            )
+
         if not skip_validation:
             is_valid, error = self.validate_so_transition(so.status, new_status)
             if not is_valid:

--- a/backend/app/services/order_status.py
+++ b/backend/app/services/order_status.py
@@ -39,8 +39,11 @@ class OrderStatusService:
         "payment_failed": ["pending_payment", "cancelled"],  # Allow retry
         "confirmed": ["in_production", "ready_to_ship", "on_hold", "cancelled"],
         "in_production": ["ready_to_ship", "on_hold", "cancelled"],
-        "ready_to_ship": ["shipped", "partially_shipped", "on_hold"],
-        "partially_shipped": ["shipped", "on_hold"],
+        # 'shipped' is reached only via ship_order() (which posts inventory +
+        # COGS); update_so_status() guards it (#839), so it is intentionally not
+        # a valid target of the generic transition validator.
+        "ready_to_ship": ["partially_shipped", "on_hold"],
+        "partially_shipped": ["on_hold"],
         "shipped": ["delivered"],
         "delivered": ["completed"],
         "on_hold": ["confirmed", "in_production", "ready_to_ship", "cancelled"],

--- a/backend/tests/services/test_order_status_service.py
+++ b/backend/tests/services/test_order_status_service.py
@@ -21,7 +21,6 @@ class TestValidateSOTransition:
         ("pending_payment", "confirmed"),
         ("confirmed", "in_production"),
         ("in_production", "ready_to_ship"),
-        ("ready_to_ship", "shipped"),
         ("shipped", "delivered"),
         ("delivered", "completed"),
     ])
@@ -31,6 +30,7 @@ class TestValidateSOTransition:
 
     @pytest.mark.parametrize("from_s, to_s", [
         ("draft", "shipped"),
+        ("ready_to_ship", "shipped"),  # shipped only via ship_order() (#839)
         ("cancelled", "draft"),
         ("completed", "draft"),
         ("shipped", "draft"),

--- a/backend/tests/services/test_order_status_service.py
+++ b/backend/tests/services/test_order_status_service.py
@@ -96,14 +96,17 @@ class TestUpdateSOStatus:
         assert updated.status == "confirmed"
         assert updated.confirmed_at is not None
 
-    def test_update_so_to_shipped_sets_fulfillment(self, db, make_sales_order, make_product):
+    def test_update_so_to_shipped_is_blocked(self, db, make_sales_order, make_product):
+        # Shipping must go through ship_order() (inventory + COGS); the status
+        # setter cannot flip to 'shipped', even with skip_validation (#838/#839).
         product = make_product()
         so = make_sales_order(product_id=product.id, status="ready_to_ship")
         svc = OrderStatusService()
-        updated = svc.update_so_status(db, so, "shipped")
-        assert updated.status == "shipped"
-        assert updated.fulfillment_status == "shipped"
-        assert updated.shipped_at is not None
+        with pytest.raises(ValueError, match="ship_order"):
+            svc.update_so_status(db, so, "shipped")
+        with pytest.raises(ValueError, match="ship_order"):
+            svc.update_so_status(db, so, "shipped", skip_validation=True)
+        assert so.status == "ready_to_ship"
 
     def test_update_so_to_cancelled_sets_timestamp(self, db, make_sales_order, make_product):
         product = make_product()
@@ -118,14 +121,16 @@ class TestUpdateSOStatus:
         so = make_sales_order(product_id=product.id, status="draft")
         svc = OrderStatusService()
         with pytest.raises(ValueError, match="Invalid SO status transition"):
-            svc.update_so_status(db, so, "shipped")
+            svc.update_so_status(db, so, "delivered")
 
     def test_skip_validation_allows_any_transition(self, db, make_sales_order, make_product):
         product = make_product()
         so = make_sales_order(product_id=product.id, status="draft")
         svc = OrderStatusService()
-        updated = svc.update_so_status(db, so, "shipped", skip_validation=True)
-        assert updated.status == "shipped"
+        # skip_validation bypasses the transition machine for a normally-invalid
+        # hop (draft -> delivered); 'shipped' stays blocked regardless (see above).
+        updated = svc.update_so_status(db, so, "delivered", skip_validation=True)
+        assert updated.status == "delivered"
 
 
 class TestUpdateWOStatus:

--- a/backend/tests/services/test_status_sync_services.py
+++ b/backend/tests/services/test_status_sync_services.py
@@ -212,7 +212,7 @@ class TestOrderStatusServiceUpdateSO:
             unit_price=Decimal("10.00"), status="draft"
         )
         with pytest.raises(ValueError, match="Invalid SO status"):
-            self.svc.update_so_status(db, so, "shipped")
+            self.svc.update_so_status(db, so, "delivered")
 
     def test_update_so_skip_validation(self, db, make_product, make_sales_order):
         product = make_product(selling_price=Decimal("10.00"))
@@ -220,8 +220,10 @@ class TestOrderStatusServiceUpdateSO:
             product_id=product.id, quantity=1,
             unit_price=Decimal("10.00"), status="draft"
         )
-        result = self.svc.update_so_status(db, so, "shipped", skip_validation=True)
-        assert result.status == "shipped"
+        # skip_validation bypasses the transition machine for a normally-invalid
+        # hop; 'shipped' stays blocked regardless (covered elsewhere).
+        result = self.svc.update_so_status(db, so, "delivered", skip_validation=True)
+        assert result.status == "delivered"
 
     def test_confirmed_sets_timestamp(self, db, make_product, make_sales_order):
         product = make_product(selling_price=Decimal("10.00"))
@@ -457,15 +459,17 @@ class TestUpdateSOStatusSideEffects:
     def setup_method(self):
         self.svc = OrderStatusService()
 
-    def test_shipped_sets_timestamps(self, db, make_product, make_sales_order):
+    def test_shipped_via_status_is_blocked(self, db, make_product, make_sales_order):
+        # ship_order() owns the shipped transition (inventory + COGS); the bare
+        # status setter must refuse it so it can't set shipped_at without a
+        # ledger effect (#838/#839).
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(
             product_id=product.id, quantity=1,
             unit_price=Decimal("10.00"), status="ready_to_ship"
         )
-        result = self.svc.update_so_status(db, so, "shipped")
-        assert result.shipped_at is not None
-        assert result.fulfillment_status == "shipped"
+        with pytest.raises(ValueError, match="ship_order"):
+            self.svc.update_so_status(db, so, "shipped")
 
     def test_delivered_sets_timestamps(self, db, make_product, make_sales_order):
         product = make_product(selling_price=Decimal("10.00"))


### PR DESCRIPTION
## Summary
PR-3 of the shipping-correctness epic #839 — closes the third (dormant) status→shipped bypass surfaced during the PR-1 review.

`OrderStatusService.update_so_status` could set `status='shipped'` (and `shipped_at` + `fulfillment_status='shipped'`) with **no inventory relief and no GL entry** — the same corruption class as #838 — and it fired even under `skip_validation=True`. It now raises and directs callers to `ship_order()` (`POST /{id}/ship`), the canonical path that posts inventory + COGS, or `resolve_legacy_fulfillment()` for brownfield close-out.

- **No production caller** passes `'shipped'` here (the app only drives `in_production` / `ready_to_ship`), so this is pure insurance — nothing in the live flow breaks.
- Only `'shipped'` is blocked. `'delivered'` / `'completed'` are post-ship milestones with no inventory/GL effect and remain valid.
- Test callers updated: the transition-machine tests now use `'delivered'`; two tests assert the block (including under `skip_validation`).

## Verification
- 90 status/sync tests pass; 96 integration + ship-path tests pass (full business cycle, quote-to-cash, fulfillment, `TestShipOrder`/`TestShipOrderShippedQuantity`). Ruff clean.

## Engine-2 carrier handlers — out of scope (PRO prerequisite, #842)
The `fulfillment_shipping.py` carrier handlers (`buy_shipping_label`, `ship_from_stock`, `mark_order_shipped`, consolidated) call `shipping_service.buy_label`, which **raises `NotImplementedError` in Core** ("requires FilaOps Pro") — they're dead in Core, so their inline-recording defects (dual-GL TOCTOU, negative stock, dropped COGS) are unreachable. The correct fix is to route their recording through `ship_order` before PRO lights up carrier integration — tracked in #842 so PRO inherits correctness, not corruption.

Refs #839 #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sales orders from being marked as **Shipped** through the general status transition and status-update paths.
  * Direct attempts to set **Shipped** now fail immediately with a clear error indicating to use the dedicated shipping flow instead (including legacy close-out where applicable).
  * Kept `skip_validation` behavior for other transitions, while continuing to block **Shipped**.
* **Tests**
  * Updated coverage to reflect the new **Shipped** handling and `skip_validation` rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->