### PR TITLE
fix(intake): clear, actionable message on server-slice timeout

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -1160,7 +1160,24 @@ export default function AdminIntakeStudio() {
       // drop the response so it can't re-apply stale parse/seed state or toast.
       if (isStaleUpload()) return;
       if (!res.ok) {
-        toast.error(data.detail || `Parse failed (${res.status})`);
+        // A large/complex plate can exceed the worker's slice-time limit. The
+        // backend maps that to 504 (SlicerWorkerTimeoutError); an edge proxy can
+        // surface the same slow-slice cause as 524. The raw detail isn't
+        // actionable, so for the timeout case point the operator at the reliable
+        // path — slice locally in Bambu Studio and drop the exported .gcode.3mf,
+        // which imports without any server slice. Longer toast so it stays
+        // readable; `willSlice` scopes this to runs that actually sliced (a
+        // pre-sliced .gcode.3mf parse never hits the slice timeout).
+        if (willSlice && (res.status === 504 || res.status === 524)) {
+          toast.error(
+            "This file is too large or complex to slice on the server — it timed " +
+              "out. Slice it in Bambu Studio and drop the exported .gcode.3mf (it " +
+              "imports instantly), or pick a lighter plate.",
+            14000,
+          );
+        } else {
+          toast.error(data.detail || `Parse failed (${res.status})`);
+        }
         return;
       }
       setPendingMesh(null);


### PR DESCRIPTION
## What
When a server-side slice times out, Intake Studio showed the generic worker error and otherwise looked like a silent bounce back to the plate picker. This adds a clear, actionable message for that specific case.

## Why (seen live)
Dropping a 14-plate raw `.3mf` (XL goose from Thangs), plate 1 hit the worker's hard slice-time limit:
- worker `POST /slice` → **504 at exactly 300s** (`SLICER_WORKER_TIMEOUT_SECONDS=300`)
- backend `_map_worker_error` maps `SlicerWorkerTimeoutError` → **504**
- the FE `!res.ok` branch showed `data.detail || "Parse failed (504)"` → not actionable

Plate 2 (lighter) sliced fine in ~52s, so the engine is healthy — purely a slow-slice UX gap.

## Change
In `uploadIntakeFile`, the `!res.ok` branch special-cases the slice timeout (`504`/`524` on a run where `willSlice` is true) with a 14s toast:
> This file is too large or complex to slice on the server — it timed out. Slice it in Bambu Studio and drop the exported .gcode.3mf (it imports instantly), or pick a lighter plate.

Other errors keep their real `data.detail`; the picker stays intact for retry. `willSlice` scopes this to actual slice runs (a pre-sliced `.gcode.3mf` parse never hits the slice timeout).

## Testing
- `npm run build` green; the changed file lints clean. (The repo's other ~212 lint problems are pre-existing — quality-workstream test/config eslint env gaps — not from this PR.)
- No existing test harness for `AdminIntakeStudio.jsx`; the change is a localized error-message branch.

## Follow-up (not here)
- Async slicing (submit + poll) is the real fix for big files / the public quoter; this message is the graceful failure in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload error messaging for intake parsing timeouts.
  * When a slicing request times out, operators now see clearer guidance to retry with Bambu Studio, upload the exported `.gcode.3mf`, or choose a lighter plate.
  * Other parsing errors continue to show the existing error details as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->