### PR TITLE
fix(inventory): manual adjustment is a signed delta, not an absolute set

### DIFF
--- a/backend/app/api/v1/endpoints/admin/inventory_transactions.py
+++ b/backend/app/api/v1/endpoints/admin/inventory_transactions.py
@@ -41,6 +41,7 @@ class TransactionCreate(BaseModel):
     serial_number: Optional[str] = None
     notes: Optional[str] = None
     to_location_id: Optional[int] = None
+    reason_code: Optional[str] = None
 
 
 class TransactionResponse(BaseModel):
@@ -193,6 +194,7 @@ async def create_transaction(
             serial_number=request.serial_number,
             notes=request.notes,
             to_location_id=request.to_location_id,
+            reason_code=request.reason_code,
         )
     except ValueError as e:
         detail = str(e)

--- a/backend/app/services/inventory_transaction_service.py
+++ b/backend/app/services/inventory_transaction_service.py
@@ -392,6 +392,8 @@ def create_transaction(
     # signed Decimal deltas, transaction row + on_hand updated together.
     # Handle transfers (two ledger rows: issue out, receipt in)
     if transaction_type == "transfer":
+        if quantity <= 0:
+            raise ValueError("Transfer quantity must be greater than zero")
         if on_hand < quantity:
             raise ValueError(
                 f"Insufficient inventory for transfer. "
@@ -429,21 +431,39 @@ def create_transaction(
             reason_code=reason_code,
         )
     else:
-        if transaction_type == "receipt":
+        if transaction_type == "adjustment":
+            # Adjustment is a SIGNED DELTA: a positive value adds stock, a
+            # negative value removes it. Setting an exact absolute count is the
+            # reconciliation /count endpoint's job, not this one. This is the
+            # only caller-facing quantity whose sign carries meaning, so the
+            # form labels it "(+/-)" — historically this branch treated the
+            # value as a new ABSOLUTE on-hand, which silently wiped stock when
+            # an operator typed a magnitude expecting a delta.
+            if quantity == 0:
+                raise ValueError("Adjustment quantity must be non-zero")
+            if on_hand + quantity < 0:
+                raise ValueError(
+                    f"Adjustment would drive on-hand below zero. "
+                    f"On hand: {inventory.on_hand_quantity}, adjustment: {quantity}"
+                )
             quantity_delta = quantity
-        elif transaction_type in ["issue", "consumption", "scrap"]:
-            if on_hand < quantity:
+        else:
+            # receipt / issue / consumption / scrap take a positive magnitude;
+            # the direction is implied by the type, so a non-positive value is
+            # always an error (it would silently reverse the intended movement).
+            if quantity <= 0:
                 raise ValueError(
-                    f"Insufficient inventory. "
-                    f"On hand: {inventory.on_hand_quantity}, requested: {quantity}"
+                    f"{transaction_type} quantity must be greater than zero"
                 )
-            quantity_delta = -quantity
-        else:  # adjustment — caller passes the new ABSOLUTE quantity (set-style)
-            quantity_delta = quantity - on_hand
-            if quantity_delta == 0:
-                raise ValueError(
-                    "Adjustment results in no change to on-hand quantity"
-                )
+            if transaction_type == "receipt":
+                quantity_delta = quantity
+            else:  # issue, consumption, scrap
+                if on_hand < quantity:
+                    raise ValueError(
+                        f"Insufficient inventory. "
+                        f"On hand: {inventory.on_hand_quantity}, requested: {quantity}"
+                    )
+                quantity_delta = -quantity
 
         transaction = inventory_ledger.post(
             db,

--- a/backend/tests/api/v1/test_inventory_transactions.py
+++ b/backend/tests/api/v1/test_inventory_transactions.py
@@ -3,6 +3,7 @@ Tests for admin inventory transactions API endpoints.
 
 Endpoints under: /api/v1/admin/inventory/transactions
 """
+import pytest
 from decimal import Decimal
 
 
@@ -396,6 +397,30 @@ class TestValidation:
             "location_id": 1,
             "transaction_type": "receipt",
             "quantity": "-5",
+        })
+        assert resp.status_code == 400
+        assert "greater than zero" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize("txn_type", ["issue", "consumption", "scrap"])
+    def test_negative_directional_quantity_rejected(self, client, finished_good, txn_type):
+        # issue/consumption/scrap share the same quantity <= 0 guard as receipt.
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": txn_type,
+            "quantity": "-5",
+        })
+        assert resp.status_code == 400
+        assert "greater than zero" in resp.json()["detail"].lower()
+
+    def test_negative_transfer_rejected(self, client, db, finished_good):
+        second_loc = _create_second_location(db)
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "transfer",
+            "quantity": "-5",
+            "to_location_id": second_loc.id,
         })
         assert resp.status_code == 400
         assert "greater than zero" in resp.json()["detail"].lower()

--- a/backend/tests/api/v1/test_inventory_transactions.py
+++ b/backend/tests/api/v1/test_inventory_transactions.py
@@ -3,7 +3,6 @@ Tests for admin inventory transactions API endpoints.
 
 Endpoints under: /api/v1/admin/inventory/transactions
 """
-import pytest
 from decimal import Decimal
 
 
@@ -195,18 +194,99 @@ class TestCreateIssue:
 
 
 class TestCreateAdjustment:
-    """Adjustment transactions set on-hand to the specified quantity."""
+    """Adjustment applies a SIGNED DELTA to on-hand (+adds / -removes).
 
-    def test_adjustment_sets_quantity(self, client, finished_good):
+    Regression guard for the audit critical: a positive value must ADD to
+    on-hand, NOT set on-hand to that number — the old set-style behavior
+    silently wiped stock when an operator typed a magnitude expecting a delta.
+    """
+
+    @staticmethod
+    def _on_hand(db, product_id, location_id=1):
+        from app.models.inventory import Inventory
+        db.expire_all()
+        inv = db.query(Inventory).filter(
+            Inventory.product_id == product_id,
+            Inventory.location_id == location_id,
+        ).first()
+        return Decimal(str(inv.on_hand_quantity)) if inv else Decimal("0")
+
+    def test_positive_adjustment_adds_not_sets(self, client, db, finished_good):
+        _create_receipt(client, finished_good.id, 200)
+        before = self._on_hand(db, finished_good.id)
+
         resp = client.post(BASE_URL, json={
             "product_id": finished_good.id,
             "location_id": 1,
             "transaction_type": "adjustment",
-            "quantity": "42",
+            "quantity": "5",
         })
         assert resp.status_code == 201
-        assert resp.json()["transaction_type"] == "adjustment"
-        assert Decimal(resp.json()["quantity"]) == Decimal("42")
+        # +5 ADDS to the existing on-hand; it must NOT collapse on-hand to 5.
+        assert self._on_hand(db, finished_good.id) == before + Decimal("5")
+
+    def test_negative_adjustment_removes(self, client, db, finished_good):
+        _create_receipt(client, finished_good.id, 200)
+        before = self._on_hand(db, finished_good.id)
+
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "adjustment",
+            "quantity": "-5",
+        })
+        assert resp.status_code == 201
+        assert self._on_hand(db, finished_good.id) == before - Decimal("5")
+
+    def test_adjustment_cannot_drive_on_hand_negative(self, client, db, finished_good):
+        _create_receipt(client, finished_good.id, 10)
+        before = self._on_hand(db, finished_good.id)
+
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "adjustment",
+            "quantity": str(-(before + Decimal("5"))),
+        })
+        assert resp.status_code == 400
+        assert "below zero" in resp.json()["detail"].lower()
+
+    def test_zero_adjustment_rejected(self, client, finished_good):
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "adjustment",
+            "quantity": "0",
+        })
+        assert resp.status_code == 400
+        assert "non-zero" in resp.json()["detail"].lower()
+
+    def test_adjustment_persists_reason_code(self, client, db, finished_good):
+        _create_receipt(client, finished_good.id, 50)
+
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "adjustment",
+            "quantity": "-3",
+            "reason_code": "DAMAGED",
+        })
+        assert resp.status_code == 201
+
+        from app.models.inventory import InventoryTransaction
+        db.expire_all()
+        txn = (
+            db.query(InventoryTransaction)
+            .filter(
+                InventoryTransaction.product_id == finished_good.id,
+                InventoryTransaction.transaction_type == "adjustment",
+            )
+            .order_by(InventoryTransaction.id.desc())
+            .first()
+        )
+        assert txn is not None
+        # The admin schema previously omitted reason_code, so it never persisted.
+        assert txn.reason_code == "DAMAGED"
 
 
 class TestCreateTransfer:
@@ -307,6 +387,18 @@ class TestValidation:
         })
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"].lower()
+
+    def test_negative_receipt_rejected(self, client, finished_good):
+        # A non-positive magnitude on a directional type would silently reverse
+        # the movement (a negative "receipt" removing stock), so it's rejected.
+        resp = client.post(BASE_URL, json={
+            "product_id": finished_good.id,
+            "location_id": 1,
+            "transaction_type": "receipt",
+            "quantity": "-5",
+        })
+        assert resp.status_code == 400
+        assert "greater than zero" in resp.json()["detail"].lower()
 
     def test_location_not_found(self, client, finished_good):
         resp = client.post(BASE_URL, json={

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -1111,27 +1111,39 @@ class TestCreateTransactionAdmin:
                 location_id=loc.id,
             )
 
-    def test_adjustment_sets_on_hand(self, db, make_product):
+    def test_adjustment_applies_signed_delta(self, db, make_product):
         product = make_product(unit="EA", item_type="finished_good")
         loc = _make_location(db, name="Adjust WH", code="ADJ")
         _make_inventory(db, product.id, loc.id, Decimal("100"))
 
-        result = inventory_transaction_service.create_transaction(
+        # +75 ADDS to on-hand (100 -> 175); it must NOT set on-hand to 75.
+        inventory_transaction_service.create_transaction(
             db,
             product_id=product.id,
             transaction_type="adjustment",
             quantity=Decimal("75"),
             created_by="test-user",
             location_id=loc.id,
-            notes="Cycle count",
+            notes="Found extra stock",
         )
-
         inv = db.query(Inventory).filter(
             Inventory.product_id == product.id,
             Inventory.location_id == loc.id,
         ).first()
-        # Admin service adjustment sets on_hand to quantity directly
-        assert float(inv.on_hand_quantity) == 75.0
+        assert float(inv.on_hand_quantity) == 175.0
+
+        # A negative adjustment removes (175 -> 125).
+        inventory_transaction_service.create_transaction(
+            db,
+            product_id=product.id,
+            transaction_type="adjustment",
+            quantity=Decimal("-50"),
+            created_by="test-user",
+            location_id=loc.id,
+            notes="Damaged",
+        )
+        db.refresh(inv)
+        assert float(inv.on_hand_quantity) == 125.0
 
     def test_transfer_missing_to_location(self, db, make_product):
         product = make_product(unit="EA", item_type="finished_good")

--- a/frontend/src/pages/admin/AdminInventoryTransactions.jsx
+++ b/frontend/src/pages/admin/AdminInventoryTransactions.jsx
@@ -1061,7 +1061,9 @@ export default function AdminInventoryTransactions() {
 
               <div>
                 <label className="block text-sm font-medium text-gray-400 mb-1">
-                  Quantity *
+                  {formData.transaction_type === "adjustment"
+                    ? "Quantity adjustment (+/-) *"
+                    : "Quantity *"}
                 </label>
                 <input
                   type="number"
@@ -1073,6 +1075,13 @@ export default function AdminInventoryTransactions() {
                   }
                   className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white"
                 />
+                {formData.transaction_type === "adjustment" && (
+                  <p className="mt-1 text-xs text-gray-500">
+                    Signed change to on-hand: a positive number adds stock, a
+                    negative number removes it. To set an exact counted
+                    quantity, use Reconciliation instead.
+                  </p>
+                )}
               </div>
 
               <div>


### PR DESCRIPTION
## GTM audit critical (data integrity)

Found by the #846 backward functional audit. The manual **New Transaction → Adjustment** path treated the typed quantity as the *new absolute on-hand* (`delta = quantity - on_hand`), but the field is the same "Quantity" that means a *magnitude* for receipt/issue. An operator typing `5` to remove 5 units instead **set on-hand to 5** and posted a phantom write-down for the difference — silent stock + GL corruption.

### What changed
- **Adjustment is now a signed delta** (`+` adds, `-` removes), guarded so it can't drive on-hand below zero. Setting an exact counted quantity stays the reconciliation `/count` endpoint's job.
- **Receipt / issue / consumption / scrap / transfer** now reject a non-positive quantity (a negative magnitude would silently reverse the movement).
- **Dropped-reason fix** (related audit finding): `TransactionCreate` omitted `reason_code`, so the adjustment-reason dropdown's value was discarded by FastAPI before reaching the ledger. Added to the schema + passed through.
- **Form** labels the field `Quantity adjustment (+/-)` with helper text and points users to Reconciliation for absolute counts.

### Verification
- Rewrote the two tests that asserted the old set-style behavior.
- Added: signed-delta add/remove, below-zero guard, zero-rejection, reason-code persistence, negative-receipt rejection.
- `500 passed` across the inventory / transaction / items / spool suites; `app/` changes are ruff-clean.

`create_transaction` in `inventory_transaction_service.py` has exactly one caller (the admin manual-transaction endpoint), so the semantics change has no other blast radius; reconciliation/cycle-count use separate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional reason code to inventory transactions.
* **Bug Fixes**
  * Adjustments now apply as signed deltas (+ increases stock, − decreases stock) instead of setting an absolute quantity.
  * Improved validation across transaction types to reject zero, negative, and overdrawn quantity scenarios (including transfers).
* **UI Updates**
  * Updated the admin “Create Transaction” form to clarify that adjustment quantities are signed and added a short explanatory note.
* **Tests**
  * Expanded and updated automated coverage for the new quantity and reason code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->