### PR TITLE
fix(accounting): void/refund must reconcile the linked invoice + over-refund guard

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -22,6 +22,7 @@ from app.services.payment_service import (
     outstanding_balance_summary,
     generate_payment_number,
     record_payment_and_reconcile,
+    resync_invoice_paid_from_payments,
     reverse_payment_receipt,
     sales_order_total,
     update_order_payment_status,
@@ -127,6 +128,26 @@ async def record_refund(
             detail=f"Sales order {refund_data.sales_order_id} not found"
         )
 
+    # Guard against over-refunding: a refund cannot exceed the net amount
+    # actually collected on the order (completed payments minus prior refunds).
+    net_collected = Decimal(str(
+        db.query(func.coalesce(func.sum(Payment.amount), 0))
+        .filter(
+            Payment.sales_order_id == order.id,
+            Payment.status == "completed",
+        )
+        .scalar() or 0
+    ))
+    refund_amount = abs(Decimal(str(refund_data.amount)))
+    if refund_amount > net_collected:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Refund ${refund_amount:.2f} exceeds net payments collected "
+                f"${net_collected:.2f} on this order"
+            ),
+        )
+
     # Create refund record (negative amount)
     payment = Payment(
         payment_number=generate_payment_number(db),
@@ -146,6 +167,11 @@ async def record_refund(
 
     # Update order payment status
     update_order_payment_status(db, order)
+
+    # Keep the linked invoice's AR view in step with the ledger — the refund
+    # is a completed negative payment, so the invoice's amount_paid/status
+    # must drop accordingly (it previously stayed marked Paid).
+    resync_invoice_paid_from_payments(db, sales_order_id=order.id)
 
     # Record order event for activity timeline
     event = OrderEvent(
@@ -400,7 +426,10 @@ async def update_payment(
 
     if update_data.status is not None:
         old_status = payment.status
-        if old_status == "completed" and update_data.status != "completed":
+        reversed_completed = (
+            old_status == "completed" and update_data.status != "completed"
+        )
+        if reversed_completed:
             reverse_payment_receipt(
                 db,
                 payment,
@@ -412,6 +441,12 @@ async def update_payment(
         # If status changed, update order payment status
         if old_status != update_data.status:
             update_order_payment_status(db, payment.sales_order)
+            # Keep the linked invoice's AR view in step with the ledger when a
+            # completed payment is reversed via the status field.
+            if reversed_completed and payment.sales_order_id:
+                resync_invoice_paid_from_payments(
+                    db, sales_order_id=payment.sales_order_id
+                )
 
     db.commit()
     db.refresh(payment)
@@ -442,7 +477,8 @@ async def void_payment(
             detail="Payment is already voided"
         )
 
-    if payment.status == "completed":
+    was_completed = payment.status == "completed"
+    if was_completed:
         reverse_payment_receipt(
             db,
             payment,
@@ -455,6 +491,11 @@ async def void_payment(
     order = db.query(SalesOrder).filter(SalesOrder.id == payment.sales_order_id).first()
     if order:
         update_order_payment_status(db, order)
+        # Sync the linked invoice's AR view: a voided payment no longer counts
+        # as completed, so the invoice must drop back off Paid (it previously
+        # stayed Paid, understating AR and blocking re-payment).
+        if was_completed:
+            resync_invoice_paid_from_payments(db, sales_order_id=order.id)
 
     db.commit()
 

--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -120,8 +120,17 @@ async def record_refund(
 
     Amount is stored as negative value.
     """
-    # Verify order exists
-    order = db.query(SalesOrder).filter(SalesOrder.id == refund_data.sales_order_id).first()
+    # Lock the order row FOR UPDATE so the over-refund guard is atomic: two
+    # concurrent refunds would otherwise both read the same net_collected and
+    # both pass before either is persisted, allowing a combined over-refund.
+    # Serializing on the order row forces the second refund to re-read the sum
+    # after the first commits.
+    order = (
+        db.query(SalesOrder)
+        .filter(SalesOrder.id == refund_data.sales_order_id)
+        .with_for_update()
+        .first()
+    )
     if not order:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -414,3 +414,56 @@ def _reconcile_invoice(db: Session, *, invoice, payment: Payment) -> None:
         locked.paid_at = payment.payment_date or datetime.now(timezone.utc)
     elif new_paid > 0:
         locked.status = "partially_paid"
+
+
+def resync_invoice_paid_from_payments(db: Session, *, sales_order_id: int):
+    """Recompute the order's invoice amount_paid / status from its completed
+    payments (refunds count as negative), under a row lock.
+
+    Called after a payment is voided or refunded so the invoice's AR view
+    matches the ledger. Previously void/refund reversed the GL and the order
+    status but left the invoice marked Paid, understating AR and blocking
+    re-payment (#846 audit). Drift-free: it sums the source-of-truth payments
+    rather than incrementally adjusting, so repeated calls converge.
+
+    Does NOT touch the invoice-receivable GL — the invoice is still issued
+    (revenue earned, AR reopened by the reversed payment-receipt entry); only
+    the invoice's bookkeeping metadata is synced. Does NOT commit.
+
+    Returns the locked invoice, or None if the order has no invoice.
+    """
+    from app.models.invoice import Invoice as _Invoice
+
+    locked = (
+        db.query(_Invoice)
+        .filter(_Invoice.sales_order_id == sales_order_id)
+        .with_for_update()
+        .first()
+    )
+    if locked is None:
+        return None
+
+    net = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
+        Payment.sales_order_id == sales_order_id,
+        Payment.status == "completed",
+    ).scalar()
+    net = _money(net or 0)
+    if net < 0:
+        net = Decimal("0")
+
+    locked.amount_paid = net
+    if locked.total and net >= _money(locked.total):
+        locked.status = "paid"
+        if not locked.paid_at:
+            locked.paid_at = datetime.now(timezone.utc)
+    elif net > 0:
+        locked.status = "partially_paid"
+        locked.paid_at = None
+    else:
+        # Fully unpaid again — reopen AR. Keep an issued invoice at 'sent';
+        # never resurrect a draft, and don't disturb void/cancelled invoices.
+        if locked.status in ("paid", "partially_paid"):
+            locked.status = "sent"
+        locked.paid_at = None
+
+    return locked

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -443,6 +443,12 @@ def resync_invoice_paid_from_payments(db: Session, *, sales_order_id: int):
     if locked is None:
         return None
 
+    # A cancelled/voided invoice is terminal and out of the AR picture — leave
+    # it entirely unchanged so a later void/refund can't resurrect it into
+    # paid/partially_paid.
+    if locked.status in ("cancelled", "voided"):
+        return locked
+
     net = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
         Payment.sales_order_id == sales_order_id,
         Payment.status == "completed",

--- a/backend/tests/api/v1/test_payments.py
+++ b/backend/tests/api/v1/test_payments.py
@@ -465,7 +465,8 @@ class TestInvoiceArSyncOnReversal:
         )
 
         # Void the payment.
-        assert client.delete(f"{BASE_URL}/{payment_id}").status_code == 204
+        void_resp = client.delete(f"{BASE_URL}/{payment_id}")
+        assert void_resp.status_code == 204
 
         invoice = _reload_invoice(db, invoice.id)
         # The invoice must no longer read as Paid; AR is reopened.
@@ -522,4 +523,28 @@ class TestInvoiceArSyncOnReversal:
             "payment_method": "credit_card",
         })
         payment_id = resp.json()["id"]
-        assert client.delete(f"{BASE_URL}/{payment_id}").status_code == 204
+        void_resp = client.delete(f"{BASE_URL}/{payment_id}")
+        assert void_resp.status_code == 204
+
+    def test_cancelled_invoice_not_resurrected_by_refund(self, client, db, test_order):
+        resp = client.post(BASE_URL, json={
+            "sales_order_id": test_order.id,
+            "amount": "500.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+        invoice = _make_invoice(
+            db, test_order, total="500.00", amount_paid="500.00", status="cancelled"
+        )
+
+        # A refund must not transition a terminal (cancelled) invoice back into
+        # a paid/partially_paid state.
+        resp = client.post(f"{BASE_URL}/refund", json={
+            "sales_order_id": test_order.id,
+            "amount": "200.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+
+        invoice = _reload_invoice(db, invoice.id)
+        assert invoice.status == "cancelled"

--- a/backend/tests/api/v1/test_payments.py
+++ b/backend/tests/api/v1/test_payments.py
@@ -418,3 +418,108 @@ class TestVoidPayment:
     def test_void_payment_unauthorized(self, unauthed_client):
         resp = unauthed_client.delete(f"{BASE_URL}/1")
         assert resp.status_code == 401
+
+
+def _make_invoice(db, order, *, total, amount_paid, status):
+    """Create an Invoice linked to an order in a given paid state."""
+    from datetime import date
+    from app.models.invoice import Invoice
+
+    inv = Invoice(
+        invoice_number=f"INV-TEST-{uuid.uuid4().hex[:8]}",
+        sales_order_id=order.id,
+        payment_terms="net_30",
+        due_date=date.today(),
+        subtotal=Decimal(str(total)),
+        total=Decimal(str(total)),
+        amount_paid=Decimal(str(amount_paid)),
+        status=status,
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+def _reload_invoice(db, invoice_id):
+    from app.models.invoice import Invoice
+    db.expire_all()
+    return db.query(Invoice).filter(Invoice.id == invoice_id).first()
+
+
+class TestInvoiceArSyncOnReversal:
+    """#846 audit critical: voiding/refunding a payment must keep the linked
+    invoice's amount_paid/status in step with the ledger (it previously stayed
+    marked Paid, understating AR and blocking re-payment)."""
+
+    def test_void_reverts_paid_invoice_to_unpaid(self, client, db, test_order):
+        # A $500 payment is collected and the invoice is marked fully paid.
+        resp = client.post(BASE_URL, json={
+            "sales_order_id": test_order.id,
+            "amount": "500.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+        payment_id = resp.json()["id"]
+        invoice = _make_invoice(
+            db, test_order, total="500.00", amount_paid="500.00", status="paid"
+        )
+
+        # Void the payment.
+        assert client.delete(f"{BASE_URL}/{payment_id}").status_code == 204
+
+        invoice = _reload_invoice(db, invoice.id)
+        # The invoice must no longer read as Paid; AR is reopened.
+        assert invoice.amount_paid == Decimal("0.00")
+        assert invoice.status == "sent"
+        assert invoice.paid_at is None
+
+    def test_refund_reduces_invoice_amount_paid(self, client, db, test_order):
+        resp = client.post(BASE_URL, json={
+            "sales_order_id": test_order.id,
+            "amount": "500.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+        invoice = _make_invoice(
+            db, test_order, total="500.00", amount_paid="500.00", status="paid"
+        )
+
+        # Refund $200 of the $500 collected.
+        resp = client.post(f"{BASE_URL}/refund", json={
+            "sales_order_id": test_order.id,
+            "amount": "200.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+
+        invoice = _reload_invoice(db, invoice.id)
+        assert invoice.amount_paid == Decimal("300.00")
+        assert invoice.status == "partially_paid"
+
+    def test_over_refund_rejected(self, client, test_order):
+        # Only $100 collected...
+        resp = client.post(BASE_URL, json={
+            "sales_order_id": test_order.id,
+            "amount": "100.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 201
+
+        # ...so a $200 refund must be rejected.
+        resp = client.post(f"{BASE_URL}/refund", json={
+            "sales_order_id": test_order.id,
+            "amount": "200.00",
+            "payment_method": "credit_card",
+        })
+        assert resp.status_code == 400
+        assert "exceeds net payments collected" in resp.json()["detail"].lower()
+
+    def test_void_without_invoice_still_succeeds(self, client, test_order):
+        # No invoice on the order — void must not error on the missing invoice.
+        resp = client.post(BASE_URL, json={
+            "sales_order_id": test_order.id,
+            "amount": "100.00",
+            "payment_method": "credit_card",
+        })
+        payment_id = resp.json()["id"]
+        assert client.delete(f"{BASE_URL}/{payment_id}").status_code == 204


### PR DESCRIPTION
## GTM audit critical (data integrity)

Found by the #846 backward functional audit. Voiding or refunding a payment reversed the GL and the order's `payment_status` but **never touched the linked invoice** — it stayed marked `Paid` with `amount_paid` unchanged. Result: AR was understated, and the invoice couldn't be re-paid (`record_payment` rejects `paid` invoices). Refunds additionally had **no over-refund guard**, so a refund could exceed what was ever collected and push the order to a phantom credit balance.

### What changed
- **`resync_invoice_paid_from_payments()`** (new): recomputes the invoice's `amount_paid` / `status` from the **sum of the order's completed payments** (refunds are negative). Drift-free and idempotent — it sums the source of truth rather than incrementally adjusting.
  - It does **not** touch the invoice-receivable GL: the invoice is still issued (revenue earned, AR reopened by the reversed payment-receipt entry). Only the invoice's bookkeeping metadata is synced.
- Wired into **`void_payment`**, **`record_refund`**, and the **`update_payment`** status-change path.
- **`record_refund`** now rejects a refund that exceeds net payments collected on the order.

### Verification
- `void` reverts a fully-paid invoice to `sent` / `amount_paid = 0` (AR reopened).
- A partial refund moves the invoice to `partially_paid` with the reduced `amount_paid`.
- An over-refund returns `400`.
- Void on an order with no invoice still succeeds (no false coupling).
- `404 passed` across the payment / invoice / accounting / posting suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice accounts-receivable synchronization after refunds, voids, and payment status reversals.
  * Refunds now adjust the invoice “paid” state based on completed payment history, reopening balances when applicable.
  * Added protection against over-refunding, returning an HTTP 400 when the requested refund exceeds net collected amounts.
* **Tests**
  * Added automated coverage for invoice AR resync behavior across void, refund, and edge cases (including terminal cancelled invoices and missing invoices).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->