### PR TITLE
feat(production): enforce billing-before-release server-side

### DIFF
--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -180,7 +180,15 @@ class SalesOrder(Base):
 
     @property
     def can_start_production(self) -> bool:
-        """Check if order can start production"""
+        """Payment-readiness hint for the cockpit next-actions.
+
+        NOTE: this is a payment-only signal, NOT the authoritative
+        production-release gate. The gate enforced server-side in
+        ``sales_order_production_service.billing_release_satisfied()`` also
+        accepts an issued invoice (net-terms customers), which this property
+        cannot see without a per-order query. Read this as "payment received?",
+        not "may release production?".
+        """
         return (
             self.status == "confirmed" and
             self.payment_status in ["paid", "partial"]

--- a/backend/app/services/sales_order_production_service.py
+++ b/backend/app/services/sales_order_production_service.py
@@ -406,7 +406,17 @@ def generate_production_orders(
             )
         )
 
-    if not billing_release_satisfied(db, order):
+    # Only enforce the billing gate when this call will actually release work.
+    # A confirmed line_item order whose lines are all material-only (or already
+    # covered) creates zero production orders — that no-op must not be turned
+    # into a 400. (quote_based always creates a PO here, or 400s on a missing
+    # quote further down.)
+    if order.order_type == "line_item":
+        will_release_work = bool(set(producible_line_ids) - covered_line_ids)
+    else:
+        will_release_work = True
+
+    if will_release_work and not billing_release_satisfied(db, order):
         raise HTTPException(
             status_code=400,
             detail=(

--- a/backend/app/services/sales_order_production_service.py
+++ b/backend/app/services/sales_order_production_service.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 from fastapi import HTTPException
-from sqlalchemy import desc
+from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
@@ -288,6 +288,38 @@ def create_production_orders_for_sales_order(
 # Generate Production Orders
 # =============================================================================
 
+def billing_release_satisfied(db: Session, order: SalesOrder) -> bool:
+    """Whether billing has been INITIATED enough to release production.
+
+    Production may be released once billing is under way — either a payment
+    recorded (prepay customers) or an invoice issued/sent (net-terms
+    customers). It deliberately does NOT require full payment: many customers
+    are billed net-30 and pay after the work ships.
+
+    Mirrors ``isBillingReleaseSatisfied()`` in
+    ``frontend/src/pages/admin/OrderDetail.jsx`` — keep the two in sync.
+    """
+    if order.payment_status == "paid":
+        return True
+
+    # Any completed payment on the order (covers partial prepay).
+    from app.models.payment import Payment
+    paid = db.query(func.coalesce(func.sum(Payment.amount), 0)).filter(
+        Payment.sales_order_id == order.id,
+        Payment.status == "completed",
+    ).scalar()
+    if paid and Decimal(str(paid)) > 0:
+        return True
+
+    # An issued invoice (sent / partially paid / paid) — the net-terms path.
+    from app.models.invoice import Invoice
+    issued = db.query(Invoice.id).filter(
+        Invoice.sales_order_id == order.id,
+        Invoice.status.in_(["sent", "partially_paid", "paid"]),
+    ).first()
+    return issued is not None
+
+
 def generate_production_orders(
     db: Session,
     order_id: int,
@@ -372,6 +404,15 @@ def generate_production_orders(
                 f"Work orders can only be generated while the order is in Confirmed status; "
                 f"this order is {order.status.replace('_', ' ')}."
             )
+        )
+
+    if not billing_release_satisfied(db, order):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Billing must be initiated before production release: record a "
+                "payment or issue (send) an invoice for this order."
+            ),
         )
 
     created_orders = []

--- a/backend/tests/services/test_legacy_order_health.py
+++ b/backend/tests/services/test_legacy_order_health.py
@@ -139,7 +139,7 @@ class TestLegacyWOCoverage:
         uncovered lines still get new WOs on a confirmed order."""
         p1 = make_product(selling_price=Decimal("10.00"))
         p2 = make_product(selling_price=Decimal("20.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, p1.id, quantity=1)
         line2 = _make_order_line(db, so.id, p2.id, quantity=2)
         _make_legacy_wo(
@@ -163,7 +163,7 @@ class TestLegacyWOCoverage:
         """Cancelled WOs (linked or legacy NULL-linked) must not block
         regeneration — an order whose WOs were all cancelled gets new ones."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         line = _make_order_line(db, so.id, product.id, quantity=2)
         _make_legacy_wo(
             db,

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1701,7 +1701,7 @@ class TestGenerateProductionOrders:
     ):
         """Existing line-level POs do not block release of uncovered lines."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         line1 = _make_order_line(db, so.id, product.id, quantity=1)
         line2 = _make_order_line(db, so.id, product.id, quantity=2)
 
@@ -1755,9 +1755,49 @@ class TestGenerateProductionOrders:
         assert result["message"] == "Production orders already exist"
         assert "PO-EXIST-QB-001" in result["existing_orders"]
 
+    def test_rejects_confirmed_order_without_billing(self, db, make_sales_order, make_product):
+        """Billing must be initiated (payment or issued invoice) before release."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="confirmed", payment_status="pending", order_type="line_item"
+        )
+        _make_order_line(db, so.id, product.id, quantity=1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert exc_info.value.status_code == 400
+        assert "billing" in exc_info.value.detail.lower()
+
+    def test_allows_release_with_issued_invoice_and_no_payment(
+        self, db, make_sales_order, make_product
+    ):
+        """Net-terms path: an issued (sent) invoice satisfies billing even when
+        no payment has been recorded."""
+        from datetime import date
+        from app.models.invoice import Invoice
+
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="confirmed", payment_status="pending", order_type="line_item"
+        )
+        _make_order_line(db, so.id, product.id, quantity=1)
+        db.add(Invoice(
+            invoice_number=f"INV-BILL-{so.id}",
+            sales_order_id=so.id,
+            payment_terms="net_30",
+            due_date=date.today(),
+            subtotal=Decimal("10.00"),
+            total=Decimal("10.00"),
+            status="sent",
+        ))
+        db.flush()
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 1
+
     def test_rejects_line_item_order_with_no_lines(self, db, make_sales_order):
         """line_item order with no lines raises 400."""
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
 
         with pytest.raises(HTTPException) as exc_info:
             sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1767,7 +1807,7 @@ class TestGenerateProductionOrders:
     def test_creates_po_for_line_item_order(self, db, make_sales_order, make_product):
         """Creates a production order for each line item."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=3)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1785,7 +1825,7 @@ class TestGenerateProductionOrders:
         """Creates one PO per line item."""
         p1 = make_product(selling_price=Decimal("10.00"))
         p2 = make_product(selling_price=Decimal("20.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, p1.id, quantity=2)
         _make_order_line(db, so.id, p2.id, quantity=5)
 
@@ -1795,7 +1835,7 @@ class TestGenerateProductionOrders:
     def test_confirmed_order_transitions_to_in_production(self, db, make_sales_order, make_product):
         """Confirmed order transitions to in_production after PO creation."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=1)
 
         sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1806,7 +1846,7 @@ class TestGenerateProductionOrders:
     def test_records_production_started_event(self, db, make_sales_order, make_product):
         """Records a production_started event after PO creation."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=1)
 
         sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -1820,7 +1860,7 @@ class TestGenerateProductionOrders:
 
     def test_rejects_quote_based_order_without_quote(self, db, make_sales_order):
         """quote_based order without a quote_id raises 400."""
-        so = make_sales_order(status="confirmed", order_type="quote_based")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="quote_based")
         # quote_id is None by default
 
         with pytest.raises(HTTPException) as exc_info:
@@ -1855,6 +1895,7 @@ class TestGenerateProductionOrders:
 
         so = make_sales_order(
             status="confirmed",
+            payment_status="paid",
             order_type="quote_based",
             product_id=product.id,
             quote_id=quote.id,
@@ -2659,6 +2700,7 @@ class TestGenerateProductionOrdersQuoteBased:
 
         so = make_sales_order(
             status="confirmed",
+            payment_status="paid",
             order_type="quote_based",
             quote_id=quote.id,
         )
@@ -2905,7 +2947,7 @@ class TestCopyRoutingToOperations:
              "setup_time_minutes": 0, "run_time_minutes": 10},
         ])
 
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, fg.id, quantity=2)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -3061,7 +3103,7 @@ class TestGenerateProductionOrdersErrorCopy:
     def test_confirmed_order_succeeds(self, db, make_sales_order, make_product):
         """Confirmed order with producible lines creates work orders successfully."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         _make_order_line(db, so.id, product.id, quantity=2)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -3078,7 +3120,7 @@ class TestGenerateProductionOrdersLineLinkage:
     def test_line_item_wo_carries_line_id(self, db, make_sales_order, make_product):
         """WOs created for line_item orders must have sales_order_line_id set."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         line = _make_order_line(db, so.id, product.id, quantity=3)
 
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
@@ -3094,7 +3136,7 @@ class TestGenerateProductionOrdersLineLinkage:
         """Each WO carries the ID of its specific line."""
         p1 = make_product(selling_price=Decimal("10.00"))
         p2 = make_product(selling_price=Decimal("20.00"))
-        so = make_sales_order(status="confirmed", order_type="line_item")
+        so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")
         line1 = _make_order_line(db, so.id, p1.id, quantity=1)
         line2 = _make_order_line(db, so.id, p2.id, quantity=2)
 
@@ -3133,6 +3175,7 @@ class TestGenerateProductionOrdersLineLinkage:
 
         so = make_sales_order(
             status="confirmed",
+            payment_status="paid",
             order_type="quote_based",
             product_id=product.id,
             quote_id=quote.id,

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1795,6 +1795,50 @@ class TestGenerateProductionOrders:
         result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
         assert len(result["created_orders"]) == 1
 
+    def test_allows_release_with_completed_payment(self, db, make_sales_order, make_product):
+        """Prepay path via the payment ledger: a completed Payment (not merely
+        payment_status='paid') satisfies billing."""
+        from app.models.payment import Payment
+
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            status="confirmed", payment_status="pending", order_type="line_item"
+        )
+        _make_order_line(db, so.id, product.id, quantity=1)
+        db.add(Payment(
+            payment_number=f"PAY-BILL-{so.id}",
+            sales_order_id=so.id,
+            amount=Decimal("10.00"),
+            payment_method="cash",
+            status="completed",
+        ))
+        db.flush()
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert len(result["created_orders"]) == 1
+
+    def test_service_only_order_no_op_not_billing_gated(self, db, make_sales_order):
+        """A confirmed line_item order with only non-producible (service) lines
+        creates zero production orders — a no-op that must NOT be turned into a
+        billing 400, even with no payment or invoice (CodeRabbit #853)."""
+        so = make_sales_order(
+            status="confirmed", payment_status="pending", order_type="line_item"
+        )
+        db.add(SalesOrderLine(
+            sales_order_id=so.id,
+            line_type="service",
+            product_id=None,
+            material_inventory_id=None,
+            description="Design service",
+            quantity=Decimal("1"),
+            unit_price=Decimal("5.00"),
+            total=Decimal("5.00"),
+        ))
+        db.flush()
+
+        result = sales_order_service.generate_production_orders(db, so.id, "test@filaops.dev")
+        assert result["created_orders"] == []
+
     def test_rejects_line_item_order_with_no_lines(self, db, make_sales_order):
         """line_item order with no lines raises 400."""
         so = make_sales_order(status="confirmed", payment_status="paid", order_type="line_item")


### PR DESCRIPTION
## What & why

The OrderDetail UI already blocks production release until **billing is initiated**, but the backend `generate_production_orders` only checked `status == "confirmed"` — so a direct API call could release work orders with no invoice and no payment. This makes "bill before you build" a real, server-enforced policy (defense-in-depth), matching the existing UI gate.

Per the product decision: **not all customers prepay**, so the gate is satisfied by *either* a recorded payment (prepay) *or* an **issued/sent invoice** (net-terms) — it does **not** require full payment.

## Changes
- `billing_release_satisfied(db, order)` — billing counts as initiated when `payment_status == "paid"`, any completed payment exists, **or** an invoice is `sent`/`partially_paid`/`paid`. Mirrors `isBillingReleaseSatisfied()` in `OrderDetail.jsx`.
- `generate_production_orders` now returns `400` when billing isn't initiated (after the confirmed-status check).
- `can_start_production` documented as a **payment-only** cockpit hint — it can't see invoices without a per-order query, so the service helper is authoritative and is the one that honors the net-terms path.

## Tests
- Existing production-generation tests now bill their confirmed orders (prepay path).
- Added `test_rejects_confirmed_order_without_billing` and `test_allows_release_with_issued_invoice_and_no_payment` (proves an issued invoice alone releases production — the net-terms case).
- `313 passed` across the sales / production / legacy suites; ruff clean.

> Note: two pre-existing failures in `test_admin_orders.py` (CSV import `unit_price` NotNullViolation) are unrelated to this change — they fail on clean `main` and this PR doesn't touch the import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Production order release now checks that billing requirements are met before work can begin.
  * Release is allowed when an order is marked paid, when a qualifying invoice exists (including partially paid), or when completed payment records are present.
  * Added clearer error messaging when billing hasn’t been initiated/recorded yet.
  * No-op production release cases (no producible work) are no longer blocked by the billing check.
* **Tests**
  * Updated and added scenarios to cover billing-gated production release paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->