### PR TITLE
feat(ui): #846 first vertical slice — Shipping + OrderDetail (functional audit + Workbench re-skin + can-ship)

### DIFF
--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -262,7 +262,7 @@ async def get_can_ship_batch(
     Returns {order_id: {can_ship: bool, reasons: [str, ...]}} for every order
     currently in 'ready_to_ship' (capped at 500).
     """
-    from app.services.inventory_service import get_or_create_default_location
+    from app.services.inventory_service import get_default_location
 
     orders = (
         db.query(SalesOrder)
@@ -277,7 +277,9 @@ async def get_can_ship_batch(
     # Pre-fetch everything once so per-order cost is zero additional queries —
     # 4 backend queries total regardless of how many orders are ready_to_ship
     # (orders+lines, location, existing-product check, inventory snapshot).
-    location_id = get_or_create_default_location(db).id
+    # Read-only: never create a warehouse from this GET preflight.
+    default_loc = get_default_location(db)
+    location_id = default_loc.id if default_loc else None
 
     candidate_ids: set[int] = set()
     for order in orders:
@@ -296,7 +298,7 @@ async def get_can_ship_batch(
             Inventory.product_id.in_(existing_product_ids),
             Inventory.location_id == location_id,
         ).all()
-    } if existing_product_ids else {}
+    } if (existing_product_ids and location_id is not None) else {}
 
     return {
         order.id: sales_order_service.can_ship_reasons(

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -3,6 +3,7 @@ Sales Order Management Endpoints
 
 Handles converting quotes to sales orders and order lifecycle management.
 """
+from datetime import date
 from decimal import Decimal
 from typing import List, Optional
 
@@ -435,6 +436,9 @@ async def get_user_sales_orders(
     ),
     sort_by: str = Query("order_date", description="Sort field"),
     sort_order: str = Query("desc", description="Sort order: asc or desc"),
+    shipped_after: Optional[date] = Query(
+        None, description="Only orders shipped on or after this date (YYYY-MM-DD)"
+    ),
     source: Optional[str] = Query(None, description="Filter by source (manual, portal, api, squarespace, woocommerce)"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -495,6 +499,7 @@ async def get_user_sales_orders(
             status_filter=status_filter,
             statuses=status,
             source=source,
+            shipped_after=shipped_after,
             skip=0,
             limit=10000,  # Get all for fulfillment filtering
             sort_by="order_date",
@@ -551,6 +556,7 @@ async def get_user_sales_orders(
         status_filter=status_filter,
         statuses=status,
         source=source,
+        shipped_after=shipped_after,
         skip=skip,
         limit=limit,
         sort_by=sort_by,

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -655,6 +655,37 @@ async def get_order_fulfillment_status(
     return result
 
 
+@router.get("/{order_id}/can-ship")
+async def get_order_can_ship(
+    order_id: int,
+    current_user: User = Depends(get_current_staff_user),
+    db: Session = Depends(get_db),
+):
+    """Preflight for ONE order, in ANY status: can ship_order() ship it right now?
+
+    The single-order complement to the batch GET /can-ship. The batch route is
+    scoped to 'ready_to_ship' (it backs the AdminShipping queue); this one works
+    for an order in any status so the OrderDetail page can answer "why can't I
+    ship this yet?" — e.g. "status is in_production", "no shipping address" —
+    instead of letting the UI advertise a Ship action the backend would 409.
+
+    Routes through the SAME can_ship_reasons() helper that ship_order() enforces,
+    so the surfaced gate can never disagree with the actual ship gate (#845/#846).
+
+    Returns {can_ship: bool, reasons: [str, ...]}.
+    """
+    order = (
+        db.query(SalesOrder)
+        .options(joinedload(SalesOrder.lines))
+        .filter(SalesOrder.id == order_id)
+        .first()
+    )
+    if not order:
+        raise HTTPException(status_code=404, detail=f"Sales order {order_id} not found")
+
+    return sales_order_service.can_ship_reasons(db, order)
+
+
 class MaterialRequirementItem(BaseModel):
     """Single material requirement for a sales order."""
     product_id: int

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -8,13 +8,14 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import desc
 
 from app.db.session import get_db
 from app.models.user import User
 from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.product import Product
+from app.models.inventory import Inventory
 from app.models.material import MaterialInventory
 from app.models.shipping_event import ShippingEvent
 from app.logging_config import get_logger
@@ -43,6 +44,7 @@ from app.schemas.shipping_event import (
     ShippingEventListResponse,
 )
 from app.api.v1.endpoints.auth import get_current_user
+from app.api.v1.deps import get_current_staff_user
 from app.services.event_service import record_shipping_event
 from app.core.status_config import (
     SalesOrderStatus,
@@ -238,6 +240,73 @@ async def get_payment_statuses(
             PaymentStatus.REFUNDED.value: "Payment refunded",
             PaymentStatus.OVERDUE.value: "Payment is overdue",
         },
+    }
+
+
+@router.get("/can-ship")
+async def get_can_ship_batch(
+    current_user: User = Depends(get_current_staff_user),
+    db: Session = Depends(get_db),
+):
+    """Preflight: which 'ready_to_ship' orders can ship_order() actually ship right now?
+
+    Batch, read-only, no row locks — backs the AdminShipping list so the UI
+    never disagrees with ship_order()'s real gate (#845/#846). Declared here,
+    BEFORE the bare GET /{order_id} route below, so it isn't shadowed by it —
+    same route-ordering issue fixed for production-order routes in #818.
+
+    Cost is O(1) backend queries regardless of how many orders are in
+    'ready_to_ship' (bounded list + one default-location lookup + one batch
+    inventory read), not O(orders) — see can_ship_reasons()/sales_order_fulfillment_service.
+
+    Returns {order_id: {can_ship: bool, reasons: [str, ...]}} for every order
+    currently in 'ready_to_ship' (capped at 500).
+    """
+    from app.services.inventory_service import get_or_create_default_location
+
+    orders = (
+        db.query(SalesOrder)
+        .options(joinedload(SalesOrder.lines))
+        .filter(SalesOrder.status == "ready_to_ship")
+        .limit(500)
+        .all()
+    )
+    if not orders:
+        return {}
+
+    # Pre-fetch everything once so per-order cost is zero additional queries —
+    # 4 backend queries total regardless of how many orders are ready_to_ship
+    # (orders+lines, location, existing-product check, inventory snapshot).
+    location_id = get_or_create_default_location(db).id
+
+    candidate_ids: set[int] = set()
+    for order in orders:
+        candidate_ids |= sales_order_service._candidate_product_ids(order)
+
+    existing_product_ids = {
+        pid for (pid,) in db.query(Product.id).filter(Product.id.in_(candidate_ids)).all()
+    } if candidate_ids else set()
+
+    inventory_snapshot = {
+        inv.product_id: (
+            Decimal(str(inv.on_hand_quantity)),
+            Decimal(str(inv.allocated_quantity)),
+        )
+        for inv in db.query(Inventory).filter(
+            Inventory.product_id.in_(existing_product_ids),
+            Inventory.location_id == location_id,
+        ).all()
+    } if existing_product_ids else {}
+
+    return {
+        order.id: sales_order_service.can_ship_reasons(
+            db,
+            order,
+            location_id=location_id,
+            existing_product_ids=existing_product_ids,
+            inventory_snapshot=inventory_snapshot,
+        )
+        for order in orders
     }
 
 

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -276,6 +276,15 @@ def convert_and_generate_notes(
     return total_qty, notes
 
 
+def get_default_location(db: Session) -> Optional[InventoryLocation]:
+    """Read-only counterpart to get_or_create_default_location.
+
+    Returns the default warehouse, or None if none exists yet. Never INSERTs,
+    so it is safe for GET preflight endpoints and read-only DB replicas.
+    """
+    return db.query(InventoryLocation).filter(InventoryLocation.type == "warehouse").first()
+
+
 def get_or_create_default_location(db: Session) -> InventoryLocation:
     """Get or create the default warehouse location."""
     location = db.query(InventoryLocation).filter(InventoryLocation.type == "warehouse").first()

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -325,6 +325,31 @@ def get_or_create_inventory(
     return inventory
 
 
+def get_inventory_snapshot(
+    db: Session,
+    product_id: int,
+    location_id: int,
+) -> tuple[Decimal, Decimal]:
+    """Read-only (on_hand, allocated) snapshot for a product at a location.
+
+    No row lock and no insert-on-miss — safe to call from a GET/preflight path
+    with many products in a loop. Do NOT use this where a write follows; use
+    inventory_ledger.get_or_create_inventory_row (which locks) for that.
+    A missing row reads as (0, 0), matching how a never-stocked product is
+    treated everywhere else in inventory math.
+    """
+    inventory = db.query(Inventory).filter(
+        Inventory.product_id == product_id,
+        Inventory.location_id == location_id,
+    ).first()
+    if not inventory:
+        return Decimal("0"), Decimal("0")
+    return (
+        Decimal(str(inventory.on_hand_quantity)),
+        Decimal(str(inventory.allocated_quantity)),
+    )
+
+
 def validate_inventory_consistency(
     db: Session,
     product_id: Optional[int] = None,

--- a/backend/app/services/sales_order_fulfillment_service.py
+++ b/backend/app/services/sales_order_fulfillment_service.py
@@ -38,6 +38,12 @@ _MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE = (
 # Mirrors SHIPPED_ORDER_STATUSES in frontend/src/pages/admin/OrderDetail.jsx.
 SHIPPED_ORDER_STATUSES = {"shipped", "delivered", "completed"}
 
+# Full-ship correctness only. Partial / mixed-lot shipping is the separate
+# #726 feature; until it lands, 'ready_to_ship' is the only shippable state.
+# ship_order() and can_ship_reasons() both import this single constant so the
+# UI preflight and the actual ship gate can never drift apart (#845/#846).
+SHIPPABLE_STATUSES = frozenset({"ready_to_ship"})
+
 # Order-level fulfillment_status values that count as shipment evidence.
 # Grounded in order_status.py which sets "shipped"/"delivered" on those
 # transitions; "fulfilled" is accepted defensively for older data.
@@ -191,6 +197,58 @@ def _create_shipment_gl_entry(
         txn.journal_entry_id = journal_entry.id
 
 
+def _candidate_product_ids(order: "SalesOrder") -> set[int]:
+    """Product ids `order` would demand if shipped (no query — reads loaded lines)."""
+    if order.lines:
+        return {line.product_id for line in order.lines if line.product_id}
+    if order.product_id:
+        return {order.product_id}
+    return set()
+
+
+def _aggregate_shippable_demand(
+    db: Session,
+    order: "SalesOrder",
+    *,
+    existing_product_ids: Optional[set[int]] = None,
+) -> dict[int, Decimal]:
+    """Per-product FG demand for shipping `order`, summed across its lines.
+
+    Two lines that share a product_id are summed into one entry. Lines whose
+    Product row no longer exists are skipped — issue_shipped_goods does the
+    same, so a deleted-product line must never 409 a shippable order.
+
+    Single implementation shared by ship_order() (which locks each row before
+    checking) and can_ship_reasons() (which reads a non-locking snapshot) —
+    extracting this is what makes "exact parity between the two" a structural
+    guarantee instead of something to remember to keep in sync (#845/#846).
+
+    Pass `existing_product_ids` (pre-fetched once across many orders) to avoid
+    a per-order Product existence query — see can_ship_reasons() batch usage.
+    """
+    candidate_ids = _candidate_product_ids(order)
+    if existing_product_ids is None:
+        from app.models.product import Product
+        existing_ids = {
+            pid for (pid,) in db.query(Product.id).filter(Product.id.in_(candidate_ids)).all()
+        } if candidate_ids else set()
+    else:
+        existing_ids = candidate_ids & existing_product_ids
+
+    demand_by_product: dict[int, Decimal] = {}
+    if order.lines:
+        for line in order.lines:
+            if line.product_id and line.product_id in existing_ids:
+                demand_by_product[line.product_id] = (
+                    demand_by_product.get(line.product_id, Decimal("0"))
+                    + Decimal(str(line.quantity))
+                )
+    elif order.product_id and order.product_id in existing_ids:
+        demand_by_product[order.product_id] = Decimal(str(order.quantity or 1))
+
+    return demand_by_product
+
+
 def ship_order(
     db: Session,
     order_id: int,
@@ -223,10 +281,6 @@ def ship_order(
     from app.services.inventory_ledger import get_or_create_inventory_row
     from app.services.event_service import record_shipping_event
 
-    # Full-ship correctness only. Partial / mixed-lot shipping is the separate
-    # #726 feature; until it lands, 'ready_to_ship' is the only shippable state.
-    shippable_statuses = frozenset({"ready_to_ship"})
-
     # Serialize concurrent ship attempts on this order (#838/MF4). Lock a plain
     # single-table row first — Postgres can't FOR UPDATE a collection join.
     locked = (
@@ -242,7 +296,7 @@ def ship_order(
     # ship sees status='shipped' set by the first and 409s (TOCTOU guard).
     # 'ready_to_ship' is the status machine's gate for an order cleared to ship;
     # it blocks shipping draft/confirmed/in-production orders.
-    if locked.status not in shippable_statuses:
+    if locked.status not in SHIPPABLE_STATUSES:
         raise HTTPException(
             status_code=409,
             detail=(
@@ -272,33 +326,8 @@ def ship_order(
     # are summed), lock each FG row, and compare available (on_hand - allocated,
     # matching the relief gate). The row lock is held for the rest of this
     # transaction, so two orders racing the same FG row serialize here.
-    from app.models.product import Product
-
     _location = get_or_create_default_location(db)
-
-    # Only consider products that still exist — issue_shipped_goods skips lines
-    # whose Product row is gone, so the pre-check must skip them too (otherwise
-    # a deleted-product line would 409 a shippable order).
-    _candidate_ids: set[int] = set()
-    if order.lines:
-        _candidate_ids.update(_l.product_id for _l in order.lines if _l.product_id)
-    elif order.product_id:
-        _candidate_ids.add(order.product_id)
-    _existing_ids = {
-        pid
-        for (pid,) in db.query(Product.id).filter(Product.id.in_(_candidate_ids)).all()
-    } if _candidate_ids else set()
-
-    _demand_by_product: dict[int, Decimal] = {}
-    if order.lines:
-        for _line in order.lines:
-            if _line.product_id and _line.product_id in _existing_ids:
-                _demand_by_product[_line.product_id] = (
-                    _demand_by_product.get(_line.product_id, Decimal("0"))
-                    + Decimal(str(_line.quantity))
-                )
-    elif order.product_id and order.product_id in _existing_ids:
-        _demand_by_product[order.product_id] = Decimal(str(order.quantity or 1))
+    _demand_by_product = _aggregate_shippable_demand(db, order)
 
     for _product_id, _needed in _demand_by_product.items():
         _inv = get_or_create_inventory_row(db, _product_id, _location.id)
@@ -398,6 +427,75 @@ def ship_order(
         "shipped_at": order.shipped_at.isoformat(),
         "label_url": None,
     }
+
+
+def can_ship_reasons(
+    db: Session,
+    order: "SalesOrder",
+    *,
+    location_id: Optional[int] = None,
+    existing_product_ids: Optional[set[int]] = None,
+    inventory_snapshot: Optional[dict[int, tuple[Decimal, Decimal]]] = None,
+) -> dict:
+    """Preflight: would ship_order() accept this order right now?
+
+    Read-only — takes NO row lock and is safe to call from a GET. Checks the
+    SAME conditions, in the SAME order, that ship_order() itself enforces
+    (status -> address -> material-backed -> inventory), reusing the same
+    SHIPPABLE_STATUSES constant and _aggregate_shippable_demand() helper, so a
+    "can_ship: true" here means ship_order will not 400/409 a moment later for
+    the same reason. It is a preflight, not a guarantee: ship_order() re-checks
+    every one of these under a row lock at ship time, which is the only place
+    a concurrent-order race is actually resolved (#838/MF4).
+
+    Reasons are deliberately conservative (no raw on-hand/allocated numbers)
+    to avoid exposing exact stock counts on a list view (#845/#846).
+
+    Called with no optional args, this does its own queries (location lookup,
+    existing-product check, one inventory read per product) — fine for a
+    single order. A caller checking MANY orders (the AdminShipping batch
+    endpoint) should pre-fetch `location_id`, `existing_product_ids`, and
+    `inventory_snapshot` ONCE and pass them to every call, so the batch cost
+    stays O(1) backend queries instead of O(orders).
+
+    Returns {"can_ship": bool, "reasons": [str, ...]}.
+    """
+    from app.services.inventory_service import (
+        get_inventory_snapshot,
+        get_or_create_default_location,
+    )
+
+    reasons: list[str] = []
+
+    if order.status not in SHIPPABLE_STATUSES:
+        reasons.append(f"Order is {order.status!r}; it must be 'ready_to_ship' to ship.")
+        # Every other check assumes a shippable order; nothing else is actionable yet.
+        return {"can_ship": False, "reasons": reasons}
+
+    if not order.shipping_address_line1 or not order.shipping_city:
+        reasons.append("Order has no shipping address.")
+
+    if _has_material_backed_lines(order):
+        reasons.append(_MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE)
+
+    if location_id is None:
+        location_id = get_or_create_default_location(db).id
+
+    demand_by_product = _aggregate_shippable_demand(
+        db, order, existing_product_ids=existing_product_ids
+    )
+    for product_id, needed in demand_by_product.items():
+        if inventory_snapshot is not None:
+            on_hand, allocated = inventory_snapshot.get(
+                product_id, (Decimal("0"), Decimal("0"))
+            )
+        else:
+            on_hand, allocated = get_inventory_snapshot(db, product_id, location_id)
+        available = on_hand - allocated
+        if available < needed:
+            reasons.append(f"Insufficient inventory for product {product_id}.")
+
+    return {"can_ship": not reasons, "reasons": reasons}
 
 
 # =============================================================================

--- a/backend/app/services/sales_order_fulfillment_service.py
+++ b/backend/app/services/sales_order_fulfillment_service.py
@@ -462,7 +462,7 @@ def can_ship_reasons(
     """
     from app.services.inventory_service import (
         get_inventory_snapshot,
-        get_or_create_default_location,
+        get_default_location,
     )
 
     reasons: list[str] = []
@@ -478,8 +478,11 @@ def can_ship_reasons(
     if _has_material_backed_lines(order):
         reasons.append(_MATERIAL_SHIPMENT_GL_UNSUPPORTED_MESSAGE)
 
-    if location_id is None:
-        location_id = get_or_create_default_location(db).id
+    # Read-only: never create a warehouse from a preflight GET. Only resolve a
+    # location when we'll actually query inventory ourselves (no snapshot given).
+    if location_id is None and inventory_snapshot is None:
+        default_loc = get_default_location(db)
+        location_id = default_loc.id if default_loc else None
 
     demand_by_product = _aggregate_shippable_demand(
         db, order, existing_product_ids=existing_product_ids
@@ -489,6 +492,9 @@ def can_ship_reasons(
             on_hand, allocated = inventory_snapshot.get(
                 product_id, (Decimal("0"), Decimal("0"))
             )
+        elif location_id is None:
+            # No warehouse exists yet → no stock anywhere.
+            on_hand, allocated = Decimal("0"), Decimal("0")
         else:
             on_hand, allocated = get_inventory_snapshot(db, product_id, location_id)
         available = on_hand - allocated

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -11,7 +11,7 @@ sales_order_shared.py).  Every name this module previously exposed is
 re-exported below, so existing imports keep working unchanged.
 """
 import io
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Optional
 
@@ -115,6 +115,7 @@ def list_sales_orders(
     status_filter: Optional[str] = None,
     statuses: Optional[list[str]] = None,
     source: Optional[str] = None,
+    shipped_after: Optional[date] = None,
     skip: int = 0,
     limit: int = 50,
     sort_by: str = "order_date",
@@ -157,6 +158,10 @@ def list_sales_orders(
     # Source filtering
     if source:
         query = query.filter(SalesOrder.source == source)
+
+    # Shipped on-or-after filter (backs the Shipping "Shipped Today" widget).
+    if shipped_after:
+        query = query.filter(SalesOrder.shipped_at >= shipped_after)
 
     # Sorting — "order_date" maps to created_at (SalesOrder has no order_date column)
     if sort_by == "customer_name":

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -52,8 +52,11 @@ from app.services.sales_order_fulfillment_service import (
     _SHIPMENT_EVIDENCE_FULFILLMENT_STATUSES,  # noqa: F401
     _SHIPMENT_TRANSACTION_COST_TYPES,  # noqa: F401
     SHIPPED_ORDER_STATUSES,  # noqa: F401
+    SHIPPABLE_STATUSES,  # noqa: F401
+    _candidate_product_ids,  # noqa: F401
     _create_shipment_gl_entry,  # noqa: F401
     _has_material_backed_lines,  # noqa: F401
+    can_ship_reasons,  # noqa: F401
     has_shipment_evidence,  # noqa: F401
     resolve_legacy_fulfillment,  # noqa: F401
     ship_order,  # noqa: F401

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -1370,6 +1370,107 @@ class TestCanShipBatch:
         )
 
 
+class TestCanShipSingleOrder:
+    """#846: GET /sales-orders/{order_id}/can-ship — the single-order, any-status
+    complement to the batch endpoint, used by OrderDetail to gate its Ship button
+    on the SAME backend reasons ship_order() enforces."""
+
+    @pytest.fixture
+    def customer_client(self, db):
+        from app.models.user import User
+        from app.core.security import create_access_token
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.db.session import get_db
+
+        user = db.query(User).filter(User.id == 3).first()
+        if not user:
+            user = User(
+                id=3, email="customer@filaops.dev",
+                password_hash="not-a-real-hash",
+                first_name="Customer", last_name="User",
+                account_type="customer",
+            )
+            db.add(user)
+            db.flush()
+        token = create_access_token(user_id=3)
+
+        def _override_get_db():
+            try:
+                yield db
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = _override_get_db
+        with TestClient(app, raise_server_exceptions=False) as c:
+            c.headers["Authorization"] = f"Bearer {token}"
+            yield c
+        app.dependency_overrides.clear()
+
+    def test_requires_auth(self, unauthed_client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        db.flush()
+        response = unauthed_client.get(f"{BASE_URL}/{so.id}/can-ship")
+        assert response.status_code == 401
+
+    def test_rejects_non_staff(self, customer_client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        db.flush()
+        response = customer_client.get(f"{BASE_URL}/{so.id}/can-ship")
+        assert response.status_code == 403
+
+    def test_nonexistent_order_404(self, client):
+        response = client.get(f"{BASE_URL}/999999/can-ship")
+        assert response.status_code == 404
+
+    def test_ready_order_with_stock_is_can_ship_true(self, client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        so.shipping_address_line1 = "1 Ship Way"
+        so.shipping_city = "Portland"
+        db.flush()
+        _seed_ship_inventory(db, product.id)
+
+        response = client.get(f"{BASE_URL}/{so.id}/can-ship")
+        assert response.status_code == 200
+        assert response.json() == {"can_ship": True, "reasons": []}
+
+    def test_in_production_order_included_with_reason(self, client, db, make_sales_order, make_product):
+        """The differentiator vs the batch route: a non-ready order is NOT
+        excluded here — it returns can_ship=False with a status reason, so
+        OrderDetail can explain *why* it isn't shippable yet."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="in_production")
+        so.shipping_address_line1 = "1 Ship Way"
+        so.shipping_city = "Portland"
+        db.flush()
+        _seed_ship_inventory(db, product.id)
+
+        response = client.get(f"{BASE_URL}/{so.id}/can-ship")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["can_ship"] is False
+        assert len(data["reasons"]) >= 1
+
+    def test_no_address_returns_reason(self, client, db, make_sales_order, make_product):
+        """Stock present + ready_to_ship but no shipping address — fulfillment
+        readiness alone would say 'shippable'; the real gate must not."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        so.shipping_address_line1 = None
+        so.shipping_city = None
+        db.flush()
+        _seed_ship_inventory(db, product.id)
+
+        response = client.get(f"{BASE_URL}/{so.id}/can-ship")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["can_ship"] is False
+        assert len(data["reasons"]) >= 1
+
+
 # =============================================================================
 # Required Orders (MRP Cascade) -- GET /api/v1/sales-orders/{id}/required-orders
 # =============================================================================

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -241,6 +241,37 @@ class TestListSalesOrders:
         order_numbers = [o["order_number"] for o in data]
         assert so.order_number in order_numbers
 
+    def test_list_shipped_after_filters_by_ship_date(
+        self, client, db, make_product, make_sales_order
+    ):
+        """shipped_after must exclude orders shipped before the given date.
+
+        Backs the AdminShipping "Shipped Today" widget, which queries
+        ?status=shipped&shipped_after=<today>. Regression: the endpoint
+        previously declared no shipped_after param, so FastAPI dropped it and
+        the widget returned every shipped order instead of just today's.
+        """
+        from datetime import datetime, timedelta
+
+        product = make_product(selling_price=Decimal("10.00"))
+        today = datetime.now().replace(hour=8, minute=0, second=0, microsecond=0)
+        recent = make_sales_order(
+            product_id=product.id, status="shipped", shipped_at=today
+        )
+        old = make_sales_order(
+            product_id=product.id,
+            status="shipped",
+            shipped_at=today - timedelta(days=10),
+        )
+        db.flush()
+
+        cutoff = today.date().isoformat()
+        response = client.get(f"{BASE_URL}?status=shipped&shipped_after={cutoff}")
+        assert response.status_code == 200
+        numbers = [o["order_number"] for o in response.json()]
+        assert recent.order_number in numbers
+        assert old.order_number not in numbers
+
 
 # =============================================================================
 # Get single order

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -1241,6 +1241,135 @@ class TestShipOrder:
         assert response.json()["tracking_number"] == "1Z999AA10123456784"
 
 
+class TestCanShipBatch:
+    """#845/#846: GET /sales-orders/can-ship preflight."""
+
+    @pytest.fixture
+    def customer_client(self, db):
+        """TestClient authenticated as a non-staff (customer) user — used to
+        verify /can-ship rejects non-staff (staff = admin or operator)."""
+        from app.models.user import User
+        from app.core.security import create_access_token
+        from fastapi.testclient import TestClient
+        from app.main import app
+        from app.db.session import get_db
+
+        user = db.query(User).filter(User.id == 3).first()
+        if not user:
+            user = User(
+                id=3, email="customer@filaops.dev",
+                password_hash="not-a-real-hash",
+                first_name="Customer", last_name="User",
+                account_type="customer",
+            )
+            db.add(user)
+            db.flush()
+        token = create_access_token(user_id=3)
+
+        def _override_get_db():
+            try:
+                yield db
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = _override_get_db
+        with TestClient(app, raise_server_exceptions=False) as c:
+            c.headers["Authorization"] = f"Bearer {token}"
+            yield c
+        app.dependency_overrides.clear()
+
+    def test_requires_auth(self, unauthed_client):
+        response = unauthed_client.get(f"{BASE_URL}/can-ship")
+        assert response.status_code == 401
+
+    def test_rejects_non_staff(self, customer_client):
+        response = customer_client.get(f"{BASE_URL}/can-ship")
+        assert response.status_code == 403
+
+    def test_not_shadowed_by_order_id_route(self, client):
+        """Regression for the #818 route-shadow class: GET /can-ship must hit
+        this endpoint, not be swallowed as order_id='can-ship' by the bare
+        GET /{order_id} detail route."""
+        response = client.get(f"{BASE_URL}/can-ship")
+        assert response.status_code == 200
+        assert isinstance(response.json(), dict)
+
+    def test_ready_order_with_stock_is_can_ship_true(self, client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        so.shipping_address_line1 = "1 Ship Way"
+        so.shipping_city = "Portland"
+        db.flush()
+        _seed_ship_inventory(db, product.id)
+
+        response = client.get(f"{BASE_URL}/can-ship")
+        assert response.status_code == 200
+        data = response.json()
+        assert str(so.id) in data or so.id in data
+        entry = data.get(str(so.id), data.get(so.id))
+        assert entry == {"can_ship": True, "reasons": []}
+
+    def test_non_ready_orders_excluded(self, client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="in_production")
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/can-ship")
+        assert response.status_code == 200
+        data = response.json()
+        assert str(so.id) not in data and so.id not in data
+
+    def test_short_order_is_can_ship_false(self, client, db, make_sales_order, make_product):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="ready_to_ship")
+        so.shipping_address_line1 = "1 Ship Way"
+        so.shipping_city = "Portland"
+        db.flush()
+        _seed_ship_inventory(db, product.id, on_hand=Decimal("0"))
+
+        response = client.get(f"{BASE_URL}/can-ship")
+        data = response.json()
+        entry = data.get(str(so.id), data.get(so.id))
+        assert entry["can_ship"] is False
+        assert len(entry["reasons"]) >= 1
+
+    def test_query_count_does_not_scale_with_order_count(self, client, db, make_sales_order, make_product):
+        """The whole point of the batch design: a fixed, small number of SQL
+        queries regardless of how many ready_to_ship orders exist."""
+        from sqlalchemy import event
+        from app.db.session import engine
+
+        products = [make_product(selling_price=Decimal("10.00")) for _ in range(8)]
+        for p in products:
+            _seed_ship_inventory(db, p.id)
+        orders = []
+        for p in products:
+            so = make_sales_order(product_id=p.id, status="ready_to_ship")
+            so.shipping_address_line1 = "1 Ship Way"
+            so.shipping_city = "Portland"
+            orders.append(so)
+        db.flush()
+
+        counts = {"many": 0}
+
+        def _count_many(*a, **kw):
+            counts["many"] += 1
+
+        event.listen(engine, "before_cursor_execute", _count_many)
+        try:
+            response = client.get(f"{BASE_URL}/can-ship")
+        finally:
+            event.remove(engine, "before_cursor_execute", _count_many)
+
+        assert response.status_code == 200
+        # Bounded: orders+lines, location, existing-products, inventory ≈ a
+        # handful of queries — not anywhere near one-per-order (8).
+        assert counts["many"] < 8, (
+            f"can-ship issued {counts['many']} queries for 8 orders — "
+            "looks like a per-order query crept back in"
+        )
+
+
 # =============================================================================
 # Required Orders (MRP Cascade) -- GET /api/v1/sales-orders/{id}/required-orders
 # =============================================================================

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -2225,9 +2225,10 @@ class TestCanShipReasons:
         result = sales_order_service.can_ship_reasons(db, so)
         assert result["can_ship"] is False
         assert len(result["reasons"]) == 1
-        # Conservative: no on-hand/available numbers leaked into the reason text.
-        assert "3" not in result["reasons"][0]
-        assert "10" not in result["reasons"][0]
+        # Conservative: names the product but leaks no on-hand/demand quantities.
+        # (Assert the exact format rather than a digit-substring check — the
+        # product id itself may contain a 3 or 10.)
+        assert result["reasons"][0] == f"Insufficient inventory for product {p.id}."
 
     def test_duplicate_product_lines_aggregate_demand(self, db, make_sales_order, make_product):
         p = make_product(selling_price=Decimal("10.00"))

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -2090,6 +2090,131 @@ class TestShipOrderShippedQuantity:
         assert line.shipped_quantity == Decimal("2")  # not double-credited
 
 
+class TestCanShipReasons:
+    """#845/#846: can_ship_reasons() preflight — exact parity with ship_order()."""
+
+    def _ready_order(self, db, make_sales_order, product_id):
+        return make_sales_order(
+            status="ready_to_ship",
+            order_type="line_item",
+            product_id=product_id,
+            shipping_address_line1="1 Ship Way",
+            shipping_city="Portland",
+            shipping_state="OR",
+            shipping_zip="97201",
+        )
+
+    def test_ready_order_with_stock_can_ship(self, db, make_sales_order, make_product):
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=2)
+        _seed_fg_inventory(db, p.id)
+
+        result = sales_order_service.can_ship_reasons(db, so)
+        assert result == {"can_ship": True, "reasons": []}
+
+    def test_not_ready_to_ship_short_circuits(self, db, make_sales_order, make_product):
+        p = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="in_production", product_id=p.id)
+        result = sales_order_service.can_ship_reasons(db, so)
+        assert result["can_ship"] is False
+        assert len(result["reasons"]) == 1
+        assert "ready_to_ship" in result["reasons"][0]
+
+    def test_no_address_is_a_reason(self, db, make_sales_order, make_product):
+        p = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(status="ready_to_ship", order_type="line_item", product_id=p.id)
+        _make_order_line(db, so.id, p.id, quantity=1)
+        _seed_fg_inventory(db, p.id)
+
+        result = sales_order_service.can_ship_reasons(db, so)
+        assert result["can_ship"] is False
+        assert any("address" in r.lower() for r in result["reasons"])
+
+    def test_insufficient_inventory_is_a_reason_no_raw_numbers(self, db, make_sales_order, make_product):
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=10)
+        _seed_fg_inventory(db, p.id, on_hand=Decimal("3"))
+
+        result = sales_order_service.can_ship_reasons(db, so)
+        assert result["can_ship"] is False
+        assert len(result["reasons"]) == 1
+        # Conservative: no on-hand/available numbers leaked into the reason text.
+        assert "3" not in result["reasons"][0]
+        assert "10" not in result["reasons"][0]
+
+    def test_duplicate_product_lines_aggregate_demand(self, db, make_sales_order, make_product):
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=2)
+        _make_order_line(db, so.id, p.id, quantity=3)
+        _seed_fg_inventory(db, p.id, on_hand=Decimal("5"))  # exactly the summed demand
+
+        assert sales_order_service.can_ship_reasons(db, so)["can_ship"] is True
+
+        _seed_fg_inventory(db, p.id, on_hand=Decimal("4"))  # now short by 1
+        assert sales_order_service.can_ship_reasons(db, so)["can_ship"] is False
+
+    def test_excluded_product_line_does_not_block(self, db, make_sales_order, make_product):
+        """A line whose product_id is absent from existing_product_ids must be
+        excluded from demand — this is the real, reachable mechanism that
+        protects the batch endpoint from a product that vanished between the
+        existing-products query and the per-order check (Product rows can't
+        be hard-deleted while referenced by a line — FK-enforced — but the
+        batch path's pre-fetched existing_product_ids is what issue_shipped_goods's
+        'if not product: continue' mirrors, so this is what's actually tested)."""
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=2)
+        # No inventory seeded — if the line's demand were (wrongly) counted,
+        # needed=2 > available=0 would make this order falsely unshippable.
+
+        result = sales_order_service.can_ship_reasons(
+            db, so, existing_product_ids=set(),  # simulates "product not found"
+        )
+        assert result == {"can_ship": True, "reasons": []}
+
+    def test_agrees_with_ship_order_on_the_same_order(self, db, make_sales_order, make_product):
+        """A 'true' from can_ship_reasons must mean ship_order() will succeed."""
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=2)
+        _seed_fg_inventory(db, p.id)
+
+        assert sales_order_service.can_ship_reasons(db, so)["can_ship"] is True
+        # Should not raise.
+        sales_order_service.ship_order(
+            db, so.id, user_id=1, user_email="test@filaops.dev",
+            carrier="USPS", tracking_number="TRK-CANSHIP-1",
+        )
+
+    def test_batch_args_match_default_args(self, db, make_sales_order, make_product):
+        """Pre-fetched location/existing-ids/inventory-snapshot must give the
+        same verdict as the no-args (per-order-query) path — the batch
+        endpoint's whole point is reusing the same logic, not a parallel one."""
+        from app.services.inventory_service import get_or_create_default_location
+
+        p = make_product(selling_price=Decimal("10.00"))
+        so = self._ready_order(db, make_sales_order, p.id)
+        _make_order_line(db, so.id, p.id, quantity=2)
+        _seed_fg_inventory(db, p.id, on_hand=Decimal("1"))  # short
+
+        default_result = sales_order_service.can_ship_reasons(db, so)
+
+        location_id = get_or_create_default_location(db).id
+        batch_result = sales_order_service.can_ship_reasons(
+            db, so,
+            location_id=location_id,
+            existing_product_ids={p.id},
+            inventory_snapshot={p.id: (Decimal("1"), Decimal("0"))},
+        )
+        assert default_result == batch_result == {
+            "can_ship": False,
+            "reasons": ["Insufficient inventory for product {}.".format(p.id)],
+        }
+
+
 # =============================================================================
 # convert_quote_to_sales_order
 # =============================================================================

--- a/frontend/src/components/ActivityTimeline.jsx
+++ b/frontend/src/components/ActivityTimeline.jsx
@@ -17,8 +17,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
       </svg>
     ),
-    color: "text-blue-400",
-    bgColor: "bg-blue-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   note_added: {
     icon: (
@@ -26,8 +26,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
       </svg>
     ),
-    color: "text-gray-400",
-    bgColor: "bg-gray-500/20",
+    color: "text-[var(--ink-3)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   payment_received: {
     icon: (
@@ -35,8 +35,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   payment_refunded: {
     icon: (
@@ -44,8 +44,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
       </svg>
     ),
-    color: "text-red-400",
-    bgColor: "bg-red-500/20",
+    color: "text-[var(--status-red)]",
+    bgColor: "bg-[var(--status-red-tint)]",
   },
   production_started: {
     icon: (
@@ -54,8 +54,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-purple-400",
-    bgColor: "bg-purple-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   production_completed: {
     icon: (
@@ -63,8 +63,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   qc_passed: {
     icon: (
@@ -72,8 +72,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   qc_failed: {
     icon: (
@@ -81,8 +81,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
       </svg>
     ),
-    color: "text-red-400",
-    bgColor: "bg-red-500/20",
+    color: "text-[var(--status-red)]",
+    bgColor: "bg-[var(--status-red-tint)]",
   },
   shipped: {
     icon: (
@@ -90,8 +90,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
       </svg>
     ),
-    color: "text-cyan-400",
-    bgColor: "bg-cyan-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   delivered: {
     icon: (
@@ -99,8 +99,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   address_updated: {
     icon: (
@@ -109,8 +109,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
     ),
-    color: "text-gray-400",
-    bgColor: "bg-gray-500/20",
+    color: "text-[var(--ink-3)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   cancelled: {
     icon: (
@@ -118,8 +118,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
       </svg>
     ),
-    color: "text-red-400",
-    bgColor: "bg-red-500/20",
+    color: "text-[var(--status-red)]",
+    bgColor: "bg-[var(--status-red-tint)]",
   },
   on_hold: {
     icon: (
@@ -127,8 +127,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-yellow-400",
-    bgColor: "bg-yellow-500/20",
+    color: "text-[var(--status-amber)]",
+    bgColor: "bg-[var(--status-amber-tint)]",
   },
   resumed: {
     icon: (
@@ -137,8 +137,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   created: {
     icon: (
@@ -146,8 +146,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
       </svg>
     ),
-    color: "text-emerald-400",
-    bgColor: "bg-emerald-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
 };
 
@@ -157,8 +157,8 @@ const defaultConfig = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),
-  color: "text-gray-400",
-  bgColor: "bg-gray-500/20",
+  color: "text-[var(--ink-3)]",
+  bgColor: "bg-[var(--paper-sunk)]",
 };
 
 export default function ActivityTimeline({ orderId, className = "" }) {
@@ -200,14 +200,14 @@ export default function ActivityTimeline({ orderId, className = "" }) {
   if (loading) {
     return (
       <div className={`flex items-center justify-center py-8 ${className}`}>
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className={`text-red-400 text-sm py-4 ${className}`}>
+      <div className={`text-[var(--status-red)] text-sm py-4 ${className}`}>
         Failed to load activity: {error}
       </div>
     );
@@ -215,7 +215,7 @@ export default function ActivityTimeline({ orderId, className = "" }) {
 
   if (events.length === 0) {
     return (
-      <div className={`text-gray-500 text-sm py-6 text-center ${className}`}>
+      <div className={`text-[var(--ink-4)] text-sm py-6 text-center ${className}`}>
         No activity recorded yet
       </div>
     );
@@ -237,7 +237,7 @@ export default function ActivityTimeline({ orderId, className = "" }) {
                 <span className={config.color}>{config.icon}</span>
               </div>
               {!isLast && (
-                <div className="w-0.5 flex-1 bg-gray-700 mt-2"></div>
+                <div className="w-0.5 flex-1 bg-[var(--rule-hair)] mt-2"></div>
               )}
             </div>
 
@@ -245,15 +245,15 @@ export default function ActivityTimeline({ orderId, className = "" }) {
             <div className="flex-1 pb-4">
               <div className="flex items-start justify-between">
                 <div>
-                  <p className="text-white font-medium text-sm">{event.title}</p>
+                  <p className="text-[var(--ink)] font-medium text-sm">{event.title}</p>
                   {event.description && (
-                    <p className="text-gray-400 text-sm mt-1">
+                    <p className="text-[var(--ink-3)] text-sm mt-1">
                       {event.description}
                     </p>
                   )}
                   {event.old_value && event.new_value && (
-                    <p className="text-gray-500 text-xs mt-1">
-                      <span className="text-gray-600">{event.old_value}</span>
+                    <p className="text-[var(--ink-4)] text-xs mt-1">
+                      <span className="text-[var(--ink-4)]">{event.old_value}</span>
                       <span className="mx-2">→</span>
                       <span className={config.color}>{event.new_value}</span>
                     </p>
@@ -262,10 +262,10 @@ export default function ActivityTimeline({ orderId, className = "" }) {
                 <div className="text-right flex-shrink-0 ml-4">
                   <RelativeDate
                     date={event.created_at}
-                    className="text-gray-500 text-xs"
+                    className="text-[var(--ink-4)] text-xs"
                   />
                   {event.user_name && (
-                    <p className="text-gray-600 text-xs mt-0.5">
+                    <p className="text-[var(--ink-4)] text-xs mt-0.5">
                       by {event.user_name}
                     </p>
                   )}

--- a/frontend/src/components/ShippingTimeline.jsx
+++ b/frontend/src/components/ShippingTimeline.jsx
@@ -16,8 +16,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
       </svg>
     ),
-    color: "text-blue-400",
-    bgColor: "bg-blue-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   package_created: {
     icon: (
@@ -25,8 +25,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
       </svg>
     ),
-    color: "text-purple-400",
-    bgColor: "bg-purple-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   picked_up: {
     icon: (
@@ -34,8 +34,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
       </svg>
     ),
-    color: "text-cyan-400",
-    bgColor: "bg-cyan-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   in_transit: {
     icon: (
@@ -43,8 +43,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0" />
       </svg>
     ),
-    color: "text-yellow-400",
-    bgColor: "bg-yellow-500/20",
+    color: "text-[var(--status-amber)]",
+    bgColor: "bg-[var(--status-amber-tint)]",
   },
   out_for_delivery: {
     icon: (
@@ -53,8 +53,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
     ),
-    color: "text-orange-400",
-    bgColor: "bg-orange-500/20",
+    color: "text-[var(--status-amber)]",
+    bgColor: "bg-[var(--status-amber-tint)]",
   },
   delivered: {
     icon: (
@@ -62,8 +62,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
       </svg>
     ),
-    color: "text-green-400",
-    bgColor: "bg-green-500/20",
+    color: "text-[var(--status-green)]",
+    bgColor: "bg-[var(--status-green-tint)]",
   },
   delivery_attempted: {
     icon: (
@@ -71,8 +71,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
-    color: "text-yellow-400",
-    bgColor: "bg-yellow-500/20",
+    color: "text-[var(--status-amber)]",
+    bgColor: "bg-[var(--status-amber-tint)]",
   },
   returned: {
     icon: (
@@ -80,8 +80,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
       </svg>
     ),
-    color: "text-red-400",
-    bgColor: "bg-red-500/20",
+    color: "text-[var(--status-red)]",
+    bgColor: "bg-[var(--status-red-tint)]",
   },
   exception: {
     icon: (
@@ -89,8 +89,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
       </svg>
     ),
-    color: "text-red-400",
-    bgColor: "bg-red-500/20",
+    color: "text-[var(--status-red)]",
+    bgColor: "bg-[var(--status-red-tint)]",
   },
   address_corrected: {
     icon: (
@@ -98,8 +98,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
       </svg>
     ),
-    color: "text-gray-400",
-    bgColor: "bg-gray-500/20",
+    color: "text-[var(--ink-3)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
   customs_cleared: {
     icon: (
@@ -107,8 +107,8 @@ const eventConfig = {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
       </svg>
     ),
-    color: "text-indigo-400",
-    bgColor: "bg-indigo-500/20",
+    color: "text-[var(--ink-2)]",
+    bgColor: "bg-[var(--paper-sunk)]",
   },
 };
 
@@ -118,8 +118,8 @@ const defaultConfig = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),
-  color: "text-gray-400",
-  bgColor: "bg-gray-500/20",
+  color: "text-[var(--ink-3)]",
+  bgColor: "bg-[var(--paper-sunk)]",
 };
 
 // Format location from city, state, zip
@@ -170,14 +170,14 @@ export default function ShippingTimeline({ orderId, className = "" }) {
   if (loading) {
     return (
       <div className={`flex items-center justify-center py-8 ${className}`}>
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-cyan-500"></div>
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className={`text-red-400 text-sm py-4 ${className}`}>
+      <div className={`text-[var(--status-red)] text-sm py-4 ${className}`}>
         Failed to load shipping events: {error}
       </div>
     );
@@ -185,7 +185,7 @@ export default function ShippingTimeline({ orderId, className = "" }) {
 
   if (events.length === 0) {
     return (
-      <div className={`text-gray-500 text-sm py-6 text-center ${className}`}>
+      <div className={`text-[var(--ink-4)] text-sm py-6 text-center ${className}`}>
         No shipping events recorded yet
       </div>
     );
@@ -208,7 +208,7 @@ export default function ShippingTimeline({ orderId, className = "" }) {
                 <span className={config.color}>{config.icon}</span>
               </div>
               {!isLast && (
-                <div className="w-0.5 flex-1 bg-gray-700 mt-2"></div>
+                <div className="w-0.5 flex-1 bg-[var(--rule-hair)] mt-2"></div>
               )}
             </div>
 
@@ -216,14 +216,14 @@ export default function ShippingTimeline({ orderId, className = "" }) {
             <div className="flex-1 pb-4">
               <div className="flex items-start justify-between">
                 <div>
-                  <p className="text-white font-medium text-sm">{event.title}</p>
+                  <p className="text-[var(--ink)] font-medium text-sm">{event.title}</p>
                   {event.description && (
-                    <p className="text-gray-400 text-sm mt-1">
+                    <p className="text-[var(--ink-3)] text-sm mt-1">
                       {event.description}
                     </p>
                   )}
                   {location && (
-                    <p className="text-gray-500 text-xs mt-1 flex items-center gap-1">
+                    <p className="text-[var(--ink-4)] text-xs mt-1 flex items-center gap-1">
                       <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
                       </svg>
@@ -231,23 +231,23 @@ export default function ShippingTimeline({ orderId, className = "" }) {
                     </p>
                   )}
                   {event.tracking_number && (
-                    <p className="text-gray-500 text-xs mt-1">
-                      <span className="text-gray-600">Tracking:</span> {event.tracking_number}
+                    <p className="text-[var(--ink-4)] text-xs mt-1">
+                      <span className="text-[var(--ink-4)]">Tracking:</span> {event.tracking_number}
                     </p>
                   )}
                 </div>
                 <div className="text-right flex-shrink-0 ml-4">
                   <RelativeDate
                     date={event.event_timestamp || event.created_at}
-                    className="text-gray-500 text-xs"
+                    className="text-[var(--ink-4)] text-xs"
                   />
                   {event.carrier && (
-                    <p className="text-gray-600 text-xs mt-0.5">
+                    <p className="text-[var(--ink-4)] text-xs mt-0.5">
                       {event.carrier}
                     </p>
                   )}
                   {event.source && event.source !== "manual" && (
-                    <span className="inline-block mt-1 px-1.5 py-0.5 text-[10px] bg-gray-700 text-gray-400 rounded">
+                    <span className="inline-block mt-1 px-1.5 py-0.5 text-[10px] bg-[var(--paper-sunk)] text-[var(--ink-3)] rounded">
                       {event.source === "carrier_api" ? "Carrier API" : event.source}
                     </span>
                   )}

--- a/frontend/src/components/orders/BlockingIssuesPanel.jsx
+++ b/frontend/src/components/orders/BlockingIssuesPanel.jsx
@@ -12,16 +12,16 @@ import { useBlockingIssues } from '../../hooks/useBlockingIssues';
 function StatusBadge({ canProceed, blockingCount }) {
   if (canProceed) {
     return (
-      <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-green-500/20 text-green-400 border border-green-500/30">
-        <span className="w-2 h-2 rounded-full bg-green-400"></span>
+      <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-[var(--status-green-tint)] text-[var(--status-green)] border border-[var(--status-green)]/30">
+        <span className="w-2 h-2 rounded-full bg-[var(--status-green)]"></span>
         Ready
       </span>
     );
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-red-500/20 text-red-400 border border-red-500/30">
-      <span className="w-2 h-2 rounded-full bg-red-400"></span>
+    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium bg-[var(--status-red-tint)] text-[var(--status-red)] border border-[var(--status-red)]/30">
+      <span className="w-2 h-2 rounded-full bg-[var(--status-red)]"></span>
       {blockingCount} Blocking Issue{blockingCount !== 1 ? 's' : ''}
     </span>
   );
@@ -77,13 +77,13 @@ function IssueIcon({ type }) {
 function getSeverityColors(severity) {
   switch (severity) {
     case 'blocking':
-      return 'text-red-400 bg-red-500/10';
+      return 'text-[var(--status-red)] bg-[var(--status-red-tint)]';
     case 'warning':
-      return 'text-yellow-400 bg-yellow-500/10';
+      return 'text-[var(--status-amber)] bg-[var(--status-amber-tint)]';
     case 'info':
-      return 'text-blue-400 bg-blue-500/10';
+      return 'text-[var(--ink-3)] bg-[var(--paper-sunk)]';
     default:
-      return 'text-gray-400 bg-gray-500/10';
+      return 'text-[var(--ink-3)] bg-[var(--paper-sunk)]';
   }
 }
 
@@ -100,7 +100,7 @@ function BlockingIssueRow({ issue }) {
       </div>
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium">{issue.message}</p>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="text-xs text-[var(--ink-4)] mt-1">
           {issue.reference_type}: {issue.reference_code}
         </p>
       </div>
@@ -118,20 +118,20 @@ function LineIssuesSection({ lineIssues }) {
 
   return (
     <div className="space-y-3">
-      <h4 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+      <h4 className="text-sm font-medium text-[var(--ink-3)] uppercase tracking-wide">
         Line Issues
       </h4>
       {linesWithIssues.map((line) => (
-        <div key={line.line_number} className="bg-gray-800/50 rounded-lg p-3 space-y-2">
+        <div key={line.line_number} className="bg-[var(--paper-sunk)] rounded-lg p-3 space-y-2">
           <div className="flex justify-between items-start">
             <div>
-              <p className="text-sm font-medium text-white">
+              <p className="text-sm font-medium text-[var(--ink)]">
                 Line {line.line_number}: {line.product_sku}
               </p>
-              <p className="text-xs text-gray-500">{line.product_name}</p>
+              <p className="text-xs text-[var(--ink-4)]">{line.product_name}</p>
             </div>
             {line.quantity_short > 0 && (
-              <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">
+              <span className="text-xs px-2 py-1 rounded bg-[var(--status-red-tint)] text-[var(--status-red)]">
                 Short: {line.quantity_short.toLocaleString()}
               </span>
             )}
@@ -155,14 +155,14 @@ function ShortageStateBadge({ mat }) {
   // covered_by_incoming: short on-hand but open PO(s) cover the full gap
   if (mat.covered_by_incoming) {
     return (
-      <span className="text-xs px-2 py-1 rounded bg-yellow-500/20 text-yellow-400">
+      <span className="text-xs px-2 py-1 rounded bg-[var(--status-amber-tint)] text-[var(--status-amber)]">
         Covered by PO
       </span>
     );
   }
 
   return (
-    <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">
+    <span className="text-xs px-2 py-1 rounded bg-[var(--status-red-tint)] text-[var(--status-red)]">
       Short: {Number(mat.quantity_short).toLocaleString()}
     </span>
   );
@@ -178,30 +178,30 @@ function MaterialIssuesSection({ materialIssues }) {
 
   return (
     <div className="space-y-3">
-      <h4 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+      <h4 className="text-sm font-medium text-[var(--ink-3)] uppercase tracking-wide">
         Material Issues
       </h4>
       {issuesWithShortage.map((mat) => (
-        <div key={mat.product_id} className="bg-gray-800/50 rounded-lg p-3">
+        <div key={mat.product_id} className="bg-[var(--paper-sunk)] rounded-lg p-3">
           <div className="flex justify-between items-start">
             <div>
-              <p className="text-sm font-medium text-white">{mat.product_sku}</p>
-              <p className="text-xs text-gray-500">{mat.product_name}</p>
+              <p className="text-sm font-medium text-[var(--ink)]">{mat.product_sku}</p>
+              <p className="text-xs text-[var(--ink-4)]">{mat.product_name}</p>
             </div>
             <ShortageStateBadge mat={mat} />
           </div>
           <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
             <div>
-              <span className="text-gray-500">Required:</span>
-              <span className="text-white ml-1">{Number(mat.quantity_required).toLocaleString()}</span>
+              <span className="text-[var(--ink-4)]">Required:</span>
+              <span className="text-[var(--ink)] ml-1">{Number(mat.quantity_required).toLocaleString()}</span>
             </div>
             <div>
-              <span className="text-gray-500">Available:</span>
-              <span className="text-white ml-1">{Number(mat.quantity_available).toLocaleString()}</span>
+              <span className="text-[var(--ink-4)]">Available:</span>
+              <span className="text-[var(--ink)] ml-1">{Number(mat.quantity_available).toLocaleString()}</span>
             </div>
             <div>
-              <span className="text-gray-500">Short:</span>
-              <span className={mat.covered_by_incoming ? 'text-yellow-400 ml-1' : 'text-red-400 ml-1'}>
+              <span className="text-[var(--ink-4)]">Short:</span>
+              <span className={mat.covered_by_incoming ? 'text-[var(--status-amber)] ml-1' : 'text-[var(--status-red)] ml-1'}>
                 {Number(mat.quantity_short).toLocaleString()}
               </span>
             </div>
@@ -209,19 +209,19 @@ function MaterialIssuesSection({ materialIssues }) {
           {mat.incoming_supply && (
             <div className={`mt-2 p-2 rounded text-xs ${
               mat.covered_by_incoming
-                ? 'bg-green-500/10 border border-green-500/20'
-                : 'bg-blue-500/10'
+                ? 'bg-[var(--status-green-tint)] border border-[var(--status-green)]/20'
+                : 'bg-[var(--paper-sunk)]'
             }`}>
               {mat.covered_by_incoming ? (
-                <span className="text-green-400 font-medium">Covered by incoming PO: </span>
+                <span className="text-[var(--status-green)] font-medium">Covered by incoming PO: </span>
               ) : (
-                <span className="text-blue-400">Incoming: </span>
+                <span className="text-[var(--ink-3)]">Incoming: </span>
               )}
-              <span className="text-white">
+              <span className="text-[var(--ink)]">
                 {Number(mat.incoming_supply.quantity).toLocaleString()} from {mat.incoming_supply.purchase_order_code}
               </span>
               {mat.incoming_supply.expected_date && (
-                <span className="text-gray-500 ml-1">
+                <span className="text-[var(--ink-4)] ml-1">
                   (ETA: {mat.incoming_supply.expected_date})
                 </span>
               )}
@@ -240,29 +240,29 @@ function ResolutionActionsSection({ actions, onActionClick }) {
   if (!actions || actions.length === 0) return null;
 
   const getPriorityColor = (priority) => {
-    if (priority === 1) return 'text-red-400 bg-red-500/10 border-red-500/30';
-    if (priority === 2) return 'text-yellow-400 bg-yellow-500/10 border-yellow-500/30';
-    return 'text-blue-400 bg-blue-500/10 border-blue-500/30';
+    if (priority === 1) return 'text-[var(--status-red)] bg-[var(--status-red-tint)] border-[var(--status-red)]/30';
+    if (priority === 2) return 'text-[var(--status-amber)] bg-[var(--status-amber-tint)] border-[var(--status-amber)]/30';
+    return 'text-[var(--ink-3)] bg-[var(--paper-sunk)] border-[var(--rule-hair)]';
   };
 
   return (
     <div className="space-y-3">
-      <h4 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+      <h4 className="text-sm font-medium text-[var(--ink-3)] uppercase tracking-wide">
         Suggested Actions
       </h4>
       {actions.map((action, idx) => (
         <button
           key={idx}
           onClick={() => onActionClick?.(action)}
-          className={`w-full text-left p-3 rounded-lg border transition-colors hover:bg-gray-800 ${getPriorityColor(action.priority)}`}
+          className={`w-full text-left p-3 rounded-lg border transition-colors hover:bg-[var(--paper-sunk)] ${getPriorityColor(action.priority)}`}
         >
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-700 flex items-center justify-center text-xs font-bold">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--paper-sunk)] flex items-center justify-center text-xs font-bold">
               {action.priority}
             </span>
             <div className="flex-1">
               <p className="text-sm font-medium">{action.action}</p>
-              <p className="text-xs text-gray-500 mt-1">{action.impact}</p>
+              <p className="text-xs text-[var(--ink-4)] mt-1">{action.impact}</p>
             </div>
             <svg className="w-4 h-4 flex-shrink-0 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -282,16 +282,16 @@ function EstimatedReadyDate({ date, daysUntil }) {
 
   return (
     <div className="flex items-center gap-2 text-sm">
-      <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg className="w-4 h-4 text-[var(--ink-4)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
       </svg>
-      <span className="text-gray-400">Est. Ready:</span>
-      <span className="text-white">{date}</span>
+      <span className="text-[var(--ink-3)]">Est. Ready:</span>
+      <span className="text-[var(--ink)]">{date}</span>
       {daysUntil !== null && daysUntil !== undefined && (
         <span className={`text-xs px-2 py-0.5 rounded ${
-          daysUntil <= 0 ? 'bg-green-500/20 text-green-400' :
-          daysUntil <= 3 ? 'bg-yellow-500/20 text-yellow-400' :
-          'bg-gray-500/20 text-gray-400'
+          daysUntil <= 0 ? 'bg-[var(--status-green-tint)] text-[var(--status-green)]' :
+          daysUntil <= 3 ? 'bg-[var(--status-amber-tint)] text-[var(--status-amber)]' :
+          'bg-[var(--paper-sunk)] text-[var(--ink-3)]'
         }`}>
           {daysUntil <= 0 ? 'Ready now' : `${daysUntil} day${daysUntil !== 1 ? 's' : ''}`}
         </span>
@@ -314,11 +314,11 @@ export function BlockingIssuesPanel({
   // Loading state
   if (loading) {
     return (
-      <div className={`bg-gray-900 border border-gray-800 rounded-xl p-4 ${className}`}>
+      <div className={`bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)] ${className}`}>
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-800 rounded w-1/3"></div>
-          <div className="h-4 bg-gray-800 rounded w-2/3"></div>
-          <div className="h-20 bg-gray-800 rounded"></div>
+          <div className="h-6 bg-[var(--paper-sunk)] rounded w-1/3"></div>
+          <div className="h-4 bg-[var(--paper-sunk)] rounded w-2/3"></div>
+          <div className="h-20 bg-[var(--paper-sunk)] rounded"></div>
         </div>
       </div>
     );
@@ -327,18 +327,18 @@ export function BlockingIssuesPanel({
   // Error state
   if (error) {
     return (
-      <div className={`bg-gray-900 border border-red-500/30 rounded-xl p-4 ${className}`}>
+      <div className={`bg-[var(--paper)] border border-[var(--status-red)]/30 rounded-xl p-4 shadow-[var(--shadow-pop)] ${className}`}>
         <div className="flex items-center gap-3">
-          <svg className="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-[var(--status-red)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div>
-            <p className="text-red-400 font-medium">Failed to load blocking issues</p>
-            <p className="text-sm text-gray-500">{error}</p>
+            <p className="text-[var(--status-red)] font-medium">Failed to load blocking issues</p>
+            <p className="text-sm text-[var(--ink-4)]">{error}</p>
           </div>
           <button
             onClick={refetch}
-            className="ml-auto px-3 py-1 text-sm bg-gray-800 text-gray-300 rounded hover:bg-gray-700"
+            className="ml-auto px-3 py-1 text-sm bg-[var(--paper-sunk)] text-[var(--ink-2)] rounded hover:bg-[var(--rule-hair)]"
           >
             Retry
           </button>
@@ -350,7 +350,7 @@ export function BlockingIssuesPanel({
   // No data state
   if (!data) {
     return (
-      <div className={`bg-gray-900 border border-gray-800 rounded-xl p-4 text-center text-gray-500 ${className}`}>
+      <div className={`bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 text-center text-[var(--ink-4)] shadow-[var(--shadow-pop)] ${className}`}>
         No blocking issues data available
       </div>
     );
@@ -363,19 +363,19 @@ export function BlockingIssuesPanel({
   const blockingCount = data.status_summary?.blocking_count || 0;
 
   return (
-    <div className={`bg-gray-900 border border-gray-800 rounded-xl ${className}`}>
+    <div className={`bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl shadow-[var(--shadow-pop)] ${className}`}>
       {/* Header */}
-      <div className="p-4 border-b border-gray-800">
+      <div className="p-4 border-b border-[var(--rule-hair)]">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h3 className="text-lg font-semibold text-white">
+            <h3 className="text-lg font-semibold text-[var(--ink)]">
               {isSalesOrder ? 'Fulfillment Status' : 'Production Readiness'}
             </h3>
             <StatusBadge canProceed={canProceed} blockingCount={blockingCount} />
           </div>
           <button
             onClick={refetch}
-            className="p-2 text-gray-500 hover:text-white rounded-lg hover:bg-gray-800"
+            className="p-2 text-[var(--ink-4)] hover:text-[var(--ink)] rounded-lg hover:bg-[var(--paper-sunk)]"
             title="Refresh"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -397,16 +397,16 @@ export function BlockingIssuesPanel({
       <div className="p-4 space-y-4">
         {/* Ready message */}
         {canProceed && (
-          <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg">
+          <div className="p-4 bg-[var(--status-green-tint)] border border-[var(--status-green)]/30 rounded-lg">
             <div className="flex items-center gap-3">
-              <svg className="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-6 h-6 text-[var(--status-green)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div>
-                <p className="text-green-400 font-medium">
+                <p className="text-[var(--status-green)] font-medium">
                   {isSalesOrder ? 'Ready to fulfill' : 'Ready to produce'}
                 </p>
-                <p className="text-sm text-gray-400">
+                <p className="text-sm text-[var(--ink-3)]">
                   {isSalesOrder
                     ? 'All items are available for shipping'
                     : 'All materials are available for production'}
@@ -418,13 +418,13 @@ export function BlockingIssuesPanel({
 
         {/* Linked sales order for production orders */}
         {!isSalesOrder && data.linked_sales_order && (
-          <div className="p-3 bg-gray-800/50 rounded-lg">
-            <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Linked Sales Order</p>
-            <p className="text-sm text-white">
+          <div className="p-3 bg-[var(--paper-sunk)] rounded-lg">
+            <p className="text-xs text-[var(--ink-4)] uppercase tracking-wide mb-1">Linked Sales Order</p>
+            <p className="text-sm text-[var(--ink)]">
               {data.linked_sales_order.code} - {data.linked_sales_order.customer}
             </p>
             {data.linked_sales_order.requested_date && (
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-[var(--ink-4)] mt-1">
                 Requested: {data.linked_sales_order.requested_date}
               </p>
             )}
@@ -444,7 +444,7 @@ export function BlockingIssuesPanel({
         {/* Other issues for production orders */}
         {!isSalesOrder && data.other_issues && data.other_issues.length > 0 && (
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-gray-400 uppercase tracking-wide">
+            <h4 className="text-sm font-medium text-[var(--ink-3)] uppercase tracking-wide">
               Other Issues
             </h4>
             {data.other_issues.map((issue, idx) => (

--- a/frontend/src/components/orders/CapacityRequirementsSection.jsx
+++ b/frontend/src/components/orders/CapacityRequirementsSection.jsx
@@ -18,10 +18,10 @@ export default function CapacityRequirementsSection({
   if (capacityRequirements.length === 0) return null;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       <button
         onClick={() => onToggle("capacityRequirements")}
-        className="flex items-center gap-2 text-lg font-semibold text-white hover:text-gray-300 mb-4"
+        className="flex items-center gap-2 text-lg font-semibold text-[var(--ink)] hover:text-[var(--ink-2)] mb-4"
       >
         <svg
           className={`w-5 h-5 transition-transform ${expandedSections.capacityRequirements ? "rotate-90" : ""}`}
@@ -36,39 +36,39 @@ export default function CapacityRequirementsSection({
       {expandedSections.capacityRequirements && (
         <table className="w-full">
           <thead>
-            <tr className="border-b border-gray-700">
-              <th className="text-left p-2 text-gray-400">Operation</th>
-              <th className="text-left p-2 text-gray-400">Work Center</th>
-              <th className="text-right p-2 text-gray-400">Setup (min)</th>
-              <th className="text-right p-2 text-gray-400">Run (min)</th>
-              <th className="text-right p-2 text-gray-400">Total (hrs)</th>
+            <tr className="border-b border-[var(--rule-hair)]">
+              <th className="text-left p-2 text-[var(--ink-3)]">Operation</th>
+              <th className="text-left p-2 text-[var(--ink-3)]">Work Center</th>
+              <th className="text-right p-2 text-[var(--ink-3)]">Setup (min)</th>
+              <th className="text-right p-2 text-[var(--ink-3)]">Run (min)</th>
+              <th className="text-right p-2 text-[var(--ink-3)]">Total (hrs)</th>
             </tr>
           </thead>
           <tbody>
             {capacityRequirements.map((op, idx) => (
-              <tr key={idx} className="border-b border-gray-800">
-                <td className="p-2 text-white">
+              <tr key={idx} className="border-b border-[var(--rule-hair)]">
+                <td className="p-2 text-[var(--ink)]">
                   {op.operation_name || op.operation_code || `OP${idx + 1}`}
                 </td>
-                <td className="p-2 text-gray-300">{op.work_center_name}</td>
-                <td className="p-2 text-right text-gray-300">
+                <td className="p-2 text-[var(--ink-2)]">{op.work_center_name}</td>
+                <td className="p-2 text-right text-[var(--ink-2)]">
                   {op.setup_time_minutes?.toFixed(1) || "0.0"}
                 </td>
-                <td className="p-2 text-right text-gray-300">
+                <td className="p-2 text-right text-[var(--ink-2)]">
                   {((op.run_time_minutes || 0) * orderQuantity).toFixed(1)}
                 </td>
-                <td className="p-2 text-right text-white">
+                <td className="p-2 text-right text-[var(--ink)]">
                   {(op.total_time_minutes / 60).toFixed(2)}
                 </td>
               </tr>
             ))}
           </tbody>
           <tfoot>
-            <tr className="bg-gray-800 font-semibold">
-              <td colSpan="4" className="p-2 text-right text-white">
+            <tr className="bg-[var(--paper-sunk)] font-semibold">
+              <td colSpan="4" className="p-2 text-right text-[var(--ink)]">
                 Total Time:
               </td>
-              <td className="p-2 text-right text-white">
+              <td className="p-2 text-right text-[var(--ink)]">
                 {totalCapacityHours.toFixed(2)} hrs
               </td>
             </tr>

--- a/frontend/src/components/orders/FulfillmentProgress.jsx
+++ b/frontend/src/components/orders/FulfillmentProgress.jsx
@@ -81,6 +81,7 @@ export default function FulfillmentProgress({
   error,
   onRefresh,
   onShip,
+  canShip = null,
   closedShort = false,
 }) {
   // Loading state
@@ -237,8 +238,14 @@ export default function FulfillmentProgress({
           </div>
         )}
 
-        {/* Action Buttons */}
-        {summary?.can_ship_complete && onShip && (
+        {/* Ship action — gated on the authoritative can_ship_reasons()
+            preflight (status + address + inventory), the same gate ship_order()
+            enforces, NOT the per-line inventory readiness. This is the #845
+            fix: the button can no longer light up for an order the backend
+            would refuse to ship (missing address, not yet ready_to_ship, …).
+            "Ship Partial" was removed — partial shipment isn't implemented
+            anywhere (tracked as #726), so the control was a dead end. */}
+        {onShip && canShip?.can_ship && (
           <div className="pt-4 border-t border-gray-800">
             <button
               onClick={() => onShip('complete')}
@@ -252,17 +259,18 @@ export default function FulfillmentProgress({
           </div>
         )}
 
-        {!summary?.can_ship_complete && summary?.can_ship_partial && onShip && (
+        {onShip && canShip && !canShip.can_ship && (
           <div className="pt-4 border-t border-gray-800">
-            <button
-              onClick={() => onShip('partial')}
-              className="w-full px-4 py-2.5 bg-yellow-600 text-white font-medium rounded-lg hover:bg-yellow-700 transition-colors flex items-center justify-center gap-2"
-            >
-              Ship Partial ({summary.lines_ready} lines)
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
-            </button>
+            <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2.5">
+              <p className="text-sm font-medium text-amber-400">Not ready to ship</p>
+              {canShip.reasons?.length > 0 && (
+                <ul className="mt-1 space-y-0.5 text-xs text-amber-300/90 list-disc list-inside">
+                  {canShip.reasons.map((reason, i) => (
+                    <li key={i}>{reason}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/orders/FulfillmentProgress.jsx
+++ b/frontend/src/components/orders/FulfillmentProgress.jsx
@@ -5,12 +5,12 @@
 
 // Status badge styles per fulfillment state
 const STATUS_STYLES = {
-  ready_to_ship: 'bg-green-500/20 text-green-400 border-green-500/30',
-  partially_ready: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
-  blocked: 'bg-red-500/20 text-red-400 border-red-500/30',
-  short_closed: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
-  shipped: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
-  cancelled: 'bg-gray-500/20 text-gray-500 border-gray-500/30',
+  ready_to_ship: 'bg-[var(--status-green-tint)] text-[var(--status-green)] border-[var(--status-green)]/30',
+  partially_ready: 'bg-[var(--status-amber-tint)] text-[var(--status-amber)] border-[var(--status-amber)]/30',
+  blocked: 'bg-[var(--status-red-tint)] text-[var(--status-red)] border-[var(--status-red)]/30',
+  short_closed: 'bg-[var(--status-amber-tint)] text-[var(--status-amber)] border-[var(--status-amber)]/30',
+  shipped: 'bg-[var(--paper-sunk)] text-[var(--ink-3)] border-[var(--rule-hair)]',
+  cancelled: 'bg-[var(--paper-sunk)] text-[var(--ink-4)] border-[var(--rule-hair)]',
 };
 
 // Human-readable labels for fulfillment states
@@ -27,10 +27,10 @@ const STATUS_LABELS = {
  * Get progress bar color based on fulfillment percentage
  */
 function getProgressColor(percent) {
-  if (percent === 100) return 'bg-green-500';
-  if (percent >= 50) return 'bg-yellow-500';
-  if (percent > 0) return 'bg-orange-500';
-  return 'bg-red-500';
+  if (percent === 100) return 'bg-[var(--status-green)]';
+  if (percent >= 50) return 'bg-[var(--status-amber)]';
+  if (percent > 0) return 'bg-[var(--status-amber)]';
+  return 'bg-[var(--status-red)]';
 }
 
 /**
@@ -87,11 +87,11 @@ export default function FulfillmentProgress({
   // Loading state
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 mb-4 shadow-[var(--shadow-pop)]">
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-800 rounded w-1/3"></div>
-          <div className="h-4 bg-gray-800 rounded w-2/3"></div>
-          <div className="h-20 bg-gray-800 rounded"></div>
+          <div className="h-6 bg-[var(--paper-sunk)] rounded w-1/3"></div>
+          <div className="h-4 bg-[var(--paper-sunk)] rounded w-2/3"></div>
+          <div className="h-20 bg-[var(--paper-sunk)] rounded"></div>
         </div>
       </div>
     );
@@ -100,19 +100,19 @@ export default function FulfillmentProgress({
   // Error state
   if (error) {
     return (
-      <div className="bg-gray-900 border border-red-500/30 rounded-xl p-4 mb-4">
+      <div className="bg-[var(--paper)] border border-[var(--status-red)]/30 rounded-xl p-4 mb-4 shadow-[var(--shadow-pop)]">
         <div className="flex items-center gap-3">
-          <svg className="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5 text-[var(--status-red)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div>
-            <p className="text-red-400 font-medium">Failed to load fulfillment status</p>
-            <p className="text-sm text-gray-500">{error}</p>
+            <p className="text-[var(--status-red)] font-medium">Failed to load fulfillment status</p>
+            <p className="text-sm text-[var(--ink-4)]">{error}</p>
           </div>
           {onRefresh && (
             <button
               onClick={onRefresh}
-              className="ml-auto px-3 py-1 text-sm bg-gray-800 text-gray-300 rounded hover:bg-gray-700"
+              className="ml-auto px-3 py-1 text-sm bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded hover:bg-[var(--rule-hair)]"
             >
               Retry
             </button>
@@ -125,7 +125,7 @@ export default function FulfillmentProgress({
   // No data state
   if (!fulfillmentStatus) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 text-center text-gray-500 mb-4">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 text-center text-[var(--ink-4)] mb-4 shadow-[var(--shadow-pop)]">
         No fulfillment status data available
       </div>
     );
@@ -141,12 +141,12 @@ export default function FulfillmentProgress({
   const percent = summary?.fulfillment_percent ?? 0;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl mb-4">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl mb-4 shadow-[var(--shadow-pop)]">
       {/* Header */}
-      <div className="p-4 border-b border-gray-800">
+      <div className="p-4 border-b border-[var(--rule-hair)]">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h3 className="text-lg font-semibold text-white">Fulfillment Progress</h3>
+            <h3 className="text-lg font-semibold text-[var(--ink)]">Fulfillment Progress</h3>
             <span className={`px-2 py-1 rounded-full text-xs font-medium border ${STATUS_STYLES[state] || STATUS_STYLES.blocked}`}>
               {STATUS_LABELS[state] || state}
             </span>
@@ -154,7 +154,7 @@ export default function FulfillmentProgress({
           {onRefresh && (
             <button
               onClick={onRefresh}
-              className="p-2 text-gray-500 hover:text-white rounded-lg hover:bg-gray-800"
+              className="p-2 text-[var(--ink-4)] hover:text-[var(--ink)] rounded-lg hover:bg-[var(--paper-sunk)]"
               title="Refresh"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -169,12 +169,12 @@ export default function FulfillmentProgress({
       <div className="p-4 space-y-4">
         {/* Progress Bar */}
         <div>
-          <div className="flex justify-between text-sm text-gray-400 mb-2">
+          <div className="flex justify-between text-sm text-[var(--ink-3)] mb-2">
             <span>{summary?.lines_ready || 0}/{summary?.lines_total || 0} lines ready</span>
             <span>{percent}%</span>
           </div>
           <div
-            className="w-full bg-gray-700 rounded-full h-3"
+            className="w-full bg-[var(--rule-hair)] rounded-full h-3"
             role="progressbar"
             aria-valuenow={percent}
             aria-valuemin={0}
@@ -194,20 +194,20 @@ export default function FulfillmentProgress({
             {lines.map((line) => {
               const isShortClosed = closedShort && !line.is_ready;
               const rowClass = line.is_ready
-                ? 'bg-green-500/10 border border-green-500/20'
+                ? 'bg-[var(--status-green-tint)] border border-[var(--status-green)]/20'
                 : isShortClosed
-                  ? 'bg-amber-500/10 border border-amber-500/20'
-                  : 'bg-red-500/10 border border-red-500/20';
+                  ? 'bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/20'
+                  : 'bg-[var(--status-red-tint)] border border-[var(--status-red)]/20';
               const iconClass = line.is_ready
-                ? 'w-5 h-5 text-green-400'
+                ? 'w-5 h-5 text-[var(--status-green)]'
                 : isShortClosed
-                  ? 'w-5 h-5 text-amber-400'
-                  : 'w-5 h-5 text-red-400';
+                  ? 'w-5 h-5 text-[var(--status-amber)]'
+                  : 'w-5 h-5 text-[var(--status-red)]';
               const labelClass = line.is_ready
-                ? 'text-sm font-medium text-green-400'
+                ? 'text-sm font-medium text-[var(--status-green)]'
                 : isShortClosed
-                  ? 'text-sm font-medium text-amber-400'
-                  : 'text-sm font-medium text-red-400';
+                  ? 'text-sm font-medium text-[var(--status-amber)]'
+                  : 'text-sm font-medium text-[var(--status-red)]';
               const label = line.is_ready
                 ? 'Ready'
                 : isShortClosed
@@ -225,10 +225,10 @@ export default function FulfillmentProgress({
                     ) : (
                       <XCircleIcon className={iconClass} />
                     )}
-                    <span className="text-sm text-white">
+                    <span className="text-sm text-[var(--ink)]">
                       <span className="font-medium">Line {line.line_number}:</span>{' '}
-                      <span className="text-gray-400">{line.product_sku}</span>{' '}
-                      <span className="text-gray-500">({line.quantity_remaining} units)</span>
+                      <span className="text-[var(--ink-3)]">{line.product_sku}</span>{' '}
+                      <span className="text-[var(--ink-4)]">({line.quantity_remaining} units)</span>
                     </span>
                   </div>
                   <span className={labelClass}>{label}</span>
@@ -246,10 +246,10 @@ export default function FulfillmentProgress({
             "Ship Partial" was removed — partial shipment isn't implemented
             anywhere (tracked as #726), so the control was a dead end. */}
         {onShip && canShip?.can_ship && (
-          <div className="pt-4 border-t border-gray-800">
+          <div className="pt-4 border-t border-[var(--rule-hair)]">
             <button
               onClick={() => onShip('complete')}
-              className="w-full px-4 py-2.5 bg-green-600 text-white font-medium rounded-lg hover:bg-green-700 transition-colors flex items-center justify-center gap-2"
+              className="w-full px-4 py-2.5 bg-[var(--orange)] text-white font-medium rounded-lg hover:bg-[var(--orange-press)] transition-colors flex items-center justify-center gap-2"
             >
               Ship Complete Order
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -260,11 +260,11 @@ export default function FulfillmentProgress({
         )}
 
         {onShip && canShip && !canShip.can_ship && (
-          <div className="pt-4 border-t border-gray-800">
-            <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2.5">
-              <p className="text-sm font-medium text-amber-400">Not ready to ship</p>
+          <div className="pt-4 border-t border-[var(--rule-hair)]">
+            <div className="rounded-lg bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/20 px-3 py-2.5">
+              <p className="text-sm font-medium text-[var(--status-amber)]">Not ready to ship</p>
               {canShip.reasons?.length > 0 && (
-                <ul className="mt-1 space-y-0.5 text-xs text-amber-300/90 list-disc list-inside">
+                <ul className="mt-1 space-y-0.5 text-xs text-[var(--status-amber)]/90 list-disc list-inside">
                   {canShip.reasons.map((reason, i) => (
                     <li key={i}>{reason}</li>
                   ))}

--- a/frontend/src/components/orders/LegacyFulfillmentBanner.jsx
+++ b/frontend/src/components/orders/LegacyFulfillmentBanner.jsx
@@ -44,15 +44,15 @@ export default function LegacyFulfillmentBanner({ order, orderId, onResolved }) 
 
   return (
     <>
-        <div className="rounded-xl border border-amber-500/40 bg-amber-950/20 p-4">
+        <div className="rounded-xl border border-[var(--status-amber)]/40 bg-[var(--status-amber-tint)] p-4">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex items-start gap-3">
-              <AlertTriangle className="h-5 w-5 shrink-0 text-amber-400 mt-0.5" />
+              <AlertTriangle className="h-5 w-5 shrink-0 text-[var(--status-amber)] mt-0.5" />
               <div>
-                <p className="text-sm font-semibold text-amber-300">
+                <p className="text-sm font-semibold text-[var(--status-amber)]">
                   Legacy data issue: no shipment on record
                 </p>
-                <p className="mt-1 text-sm text-amber-200/80">
+                <p className="mt-1 text-sm text-[var(--status-amber)]/80">
                   This order&apos;s status says{" "}
                   <span className="font-medium capitalize">
                     {order.status.replace(/_/g, " ")}
@@ -65,13 +65,13 @@ export default function LegacyFulfillmentBanner({ order, orderId, onResolved }) 
             <div className="flex shrink-0 flex-wrap gap-2">
               <button
                 onClick={() => setLegacyResolveAction("close_out")}
-                className="rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white hover:bg-amber-500"
+                className="rounded-lg bg-[var(--orange)] px-3 py-2 text-sm font-medium text-white hover:bg-[var(--orange-press)]"
               >
                 Close Out as Fulfilled
               </button>
               <button
                 onClick={() => setLegacyResolveAction("reopen")}
-                className="rounded-lg border border-amber-500/40 bg-gray-800 px-3 py-2 text-sm font-medium text-amber-200 hover:bg-gray-700"
+                className="rounded-lg border border-[var(--rule-hair)] bg-[var(--paper-sunk)] px-3 py-2 text-sm font-medium text-[var(--ink-2)] hover:bg-[var(--rule-hair)]"
               >
                 Reopen for Shipping
               </button>
@@ -86,23 +86,23 @@ export default function LegacyFulfillmentBanner({ order, orderId, onResolved }) 
           onClick={() => !resolvingLegacy && setLegacyResolveAction(null)}
         >
           <div
-            className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full mx-4"
+            className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 max-w-md w-full mx-4 shadow-[var(--shadow-pop)]"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-lg font-semibold text-white mb-2">
+            <h3 className="text-lg font-semibold text-[var(--ink)] mb-2">
               {legacyResolveAction === "close_out"
                 ? "Close Out as Fulfilled"
                 : "Reopen for Shipping"}
             </h3>
             {legacyResolveAction === "close_out" ? (
-              <p className="text-gray-400 text-sm mb-4">
+              <p className="text-[var(--ink-3)] text-sm mb-4">
                 This records the order as fully shipped (paperwork only). No
                 inventory movements or accounting entries are created — the
                 goods already left under an older FilaOps version. An audit
                 note is added to the order.
               </p>
             ) : (
-              <p className="text-gray-400 text-sm mb-4">
+              <p className="text-[var(--ink-3)] text-sm mb-4">
                 This sets the order back to Ready to Ship so you can ship it
                 through the normal flow (which records inventory and
                 accounting). Invoice and payment are left untouched. An audit
@@ -113,14 +113,14 @@ export default function LegacyFulfillmentBanner({ order, orderId, onResolved }) 
               <button
                 onClick={() => setLegacyResolveAction(null)}
                 disabled={resolvingLegacy}
-                className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50"
+                className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)] disabled:opacity-50"
               >
                 Cancel
               </button>
               <button
                 onClick={handleResolveLegacyFulfillment}
                 disabled={resolvingLegacy}
-                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {resolvingLegacy
                   ? "Working..."

--- a/frontend/src/components/orders/MaterialRequirementsSection.jsx
+++ b/frontend/src/components/orders/MaterialRequirementsSection.jsx
@@ -26,11 +26,11 @@ export default function MaterialRequirementsSection({
   const showShortageAlerts = hasShortages && !isHistorical;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       <div className="flex justify-between items-center mb-4">
         <button
           onClick={() => onToggle("materialRequirements")}
-          className="flex items-center gap-2 text-lg font-semibold text-white hover:text-gray-300"
+          className="flex items-center gap-2 text-lg font-semibold text-[var(--ink)] hover:text-[var(--ink-2)]"
         >
           <svg
             className={`w-5 h-5 transition-transform ${expandedSections.materialRequirements ? "rotate-90" : ""}`}
@@ -42,24 +42,24 @@ export default function MaterialRequirementsSection({
           </svg>
           Material Requirements
           {showShortageAlerts && (
-            <span className="px-2 py-0.5 bg-red-500/20 text-red-400 text-xs rounded-full">
+            <span className="px-2 py-0.5 bg-[var(--status-red-tint)] text-[var(--status-red)] text-xs rounded-full">
               {materialRequirements.filter((r) => r.net_shortage > 0).length} Shortage{materialRequirements.filter((r) => r.net_shortage > 0).length !== 1 ? "s" : ""}
             </span>
           )}
           {isHistorical && (
-            <span className="px-2 py-0.5 bg-gray-500/20 text-gray-400 text-xs rounded-full">
+            <span className="px-2 py-0.5 bg-[var(--paper-sunk)] text-[var(--ink-3)] text-xs rounded-full">
               Reference only
             </span>
           )}
         </button>
         {exploding && (
-          <span className="text-gray-400 text-sm">Calculating...</span>
+          <span className="text-[var(--ink-3)] text-sm">Calculating...</span>
         )}
       </div>
       {expandedSections.materialRequirements && (
         <>
           {materialRequirements.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-[var(--ink-4)]">
               {order.product_id || (order.lines && order.lines.length > 0)
                 ? "No BOM found for this product. Add a BOM to see material requirements."
                 : "No product assigned to this order"}
@@ -68,47 +68,47 @@ export default function MaterialRequirementsSection({
             <>
               <table className="w-full">
                 <thead>
-                  <tr className="border-b border-gray-700">
-                    <th className="text-left p-2 text-gray-400">Component</th>
-                    <th className="text-left p-2 text-gray-400">Operation</th>
-                    <th className="text-right p-2 text-gray-400">Required</th>
-                    <th className="text-right p-2 text-gray-400">Available</th>
-                    <th className="text-right p-2 text-gray-400">Shortage</th>
-                    <th className="text-center p-2 text-gray-400">Actions</th>
+                  <tr className="border-b border-[var(--rule-hair)]">
+                    <th className="text-left p-2 text-[var(--ink-3)]">Component</th>
+                    <th className="text-left p-2 text-[var(--ink-3)]">Operation</th>
+                    <th className="text-right p-2 text-[var(--ink-3)]">Required</th>
+                    <th className="text-right p-2 text-[var(--ink-3)]">Available</th>
+                    <th className="text-right p-2 text-[var(--ink-3)]">Shortage</th>
+                    <th className="text-center p-2 text-[var(--ink-3)]">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {materialRequirements.map((req, idx) => (
                     <tr
                       key={idx}
-                      className={`border-b border-gray-800 ${
-                        req.net_shortage > 0 && !isHistorical ? "bg-red-900/20" : ""
+                      className={`border-b border-[var(--rule-hair)] ${
+                        req.net_shortage > 0 && !isHistorical ? "bg-[var(--status-red-tint)]" : ""
                       }`}
                     >
                       <td className="p-2">
-                        <div className="text-white">{req.product_sku} - {req.product_name}</div>
+                        <div className="text-[var(--ink)]">{req.product_sku} - {req.product_name}</div>
                         {req.material_source === "routing" && (
-                          <span className="text-xs text-blue-400">via routing</span>
+                          <span className="text-xs text-[var(--ink-3)]">via routing</span>
                         )}
                         {req.has_incoming_supply && (
-                          <span className="text-xs text-amber-400 ml-2" title={req.incoming_supply_details?.expected_date ? `Expected: ${req.incoming_supply_details.expected_date}` : ""}>
+                          <span className="text-xs text-[var(--status-amber)] ml-2" title={req.incoming_supply_details?.expected_date ? `Expected: ${req.incoming_supply_details.expected_date}` : ""}>
                             PO pending
                           </span>
                         )}
                       </td>
                       <td className="p-2 text-left">
                         {req.operation_code ? (
-                          <span className="px-2 py-0.5 bg-purple-500/20 text-purple-300 text-xs rounded-full">
+                          <span className="px-2 py-0.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] text-xs rounded-full">
                             {req.operation_code}
                           </span>
                         ) : (
-                          <span className="text-gray-500 text-xs">-</span>
+                          <span className="text-[var(--ink-4)] text-xs">-</span>
                         )}
                       </td>
-                      <td className="p-2 text-right text-white">
+                      <td className="p-2 text-right text-[var(--ink)]">
                         {req.gross_quantity?.toFixed(2) || "0.00"}
                       </td>
-                      <td className="p-2 text-right text-gray-300">
+                      <td className="p-2 text-right text-[var(--ink-2)]">
                         {req.available_quantity?.toFixed(2) || "0.00"}
                       </td>
                       <td className="p-2 text-right">
@@ -116,9 +116,9 @@ export default function MaterialRequirementsSection({
                           className={
                             req.net_shortage > 0
                               ? isHistorical
-                                ? "text-gray-400"
-                                : "text-red-400 font-semibold"
-                              : "text-green-400"
+                                ? "text-[var(--ink-3)]"
+                                : "text-[var(--status-red)] font-semibold"
+                              : "text-[var(--status-green)]"
                           }
                         >
                           {req.net_shortage?.toFixed(2) || "0.00"}
@@ -130,14 +130,14 @@ export default function MaterialRequirementsSection({
                           (req.has_bom ? (
                             <button
                               onClick={() => onCreateWorkOrder(req)}
-                              className="text-purple-400 hover:text-purple-300 text-sm"
+                              className="text-[var(--ink)] hover:text-[var(--orange)] text-sm"
                             >
                               Create WO
                             </button>
                           ) : (
                             <button
                               onClick={() => onCreatePurchaseOrder(req)}
-                              className="text-blue-400 hover:text-blue-300 text-sm"
+                              className="text-[var(--ink)] hover:text-[var(--orange)] text-sm"
                             >
                               Create PO
                             </button>
@@ -147,19 +147,19 @@ export default function MaterialRequirementsSection({
                   ))}
                 </tbody>
                 <tfoot>
-                  <tr className="bg-gray-800 font-semibold">
-                    <td colSpan="4" className="p-2 text-right text-white">
+                  <tr className="bg-[var(--paper-sunk)] font-semibold">
+                    <td colSpan="4" className="p-2 text-right text-[var(--ink)]">
                       {isHistorical ? (
-                        <span className="text-gray-400">Shown for reference</span>
+                        <span className="text-[var(--ink-3)]">Shown for reference</span>
                       ) : materialAvailability?.has_shortages ? (
-                        <span className="text-red-400">
+                        <span className="text-[var(--status-red)]">
                           {materialAvailability.materials_short} of {materialAvailability.total_materials} materials short
                         </span>
                       ) : (
-                        <span className="text-green-400">All materials available</span>
+                        <span className="text-[var(--status-green)]">All materials available</span>
                       )}
                     </td>
-                    <td className="p-2 text-right text-white">
+                    <td className="p-2 text-right text-[var(--ink)]">
                       Est: ${totalMaterialCost.toFixed(2)}
                     </td>
                     <td className="p-2"></td>
@@ -168,19 +168,19 @@ export default function MaterialRequirementsSection({
               </table>
 
               {showShortageAlerts && (
-                <div className="mt-4 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
-                  <p className="text-red-400 text-sm">
+                <div className="mt-4 p-3 bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg">
+                  <p className="text-[var(--status-red)] text-sm">
                     Material shortages detected. Create{" "}
-                    <span className="text-purple-400">Work Orders</span> for
+                    <span className="text-[var(--ink)]">Work Orders</span> for
                     sub-assemblies or{" "}
-                    <span className="text-blue-400">Purchase Orders</span> for raw
+                    <span className="text-[var(--ink)]">Purchase Orders</span> for raw
                     materials.
                   </p>
                 </div>
               )}
               {isHistorical && (
-                <div className="mt-4 p-3 bg-gray-800/60 border border-gray-700 rounded-lg">
-                  <p className="text-gray-400 text-sm">
+                <div className="mt-4 p-3 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg">
+                  <p className="text-[var(--ink-3)] text-sm">
                     Order is {(order?.status || "").replace(/_/g, " ")} —
                     requirements shown for reference; stock is not re-checked.
                   </p>

--- a/frontend/src/components/orders/OrderHeaderActions.jsx
+++ b/frontend/src/components/orders/OrderHeaderActions.jsx
@@ -11,7 +11,7 @@ export default function OrderHeaderActions({ orderId, refreshing, onRefresh }) {
           <button
             onClick={onRefresh}
             disabled={refreshing}
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50"
+            className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)] disabled:opacity-50"
             title="Refresh order data"
           >
             {refreshing ? "Refreshing..." : "\u21BB Refresh"}
@@ -23,7 +23,7 @@ export default function OrderHeaderActions({ orderId, refreshing, onRefresh }) {
                 "_blank"
               )
             }
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)]"
             title="Print packing slip PDF"
           >
             Print Packing Slip

--- a/frontend/src/components/orders/OrderLineItemsTable.jsx
+++ b/frontend/src/components/orders/OrderLineItemsTable.jsx
@@ -199,13 +199,55 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
               )}
             </tbody>
             <tfoot>
+              {/* Break out subtotal / tax / shipping so the Order Total
+                  (grand_total) doesn't look like it disagrees with the line
+                  sum. The label spans cols 1-5 and the amount sits in the
+                  Total column (6); the trailing cell fills the Actions column
+                  when the table is editable so nothing lands under it. */}
               <tr className="border-t border-gray-700">
-                <td colSpan={canEditLines() ? 6 : 5} className="py-3 px-3 text-right text-white font-medium">
+                <td colSpan={5} className="py-2 px-3 text-right text-gray-400">
+                  Subtotal
+                </td>
+                <td className="py-2 px-3 text-right text-gray-300">
+                  ${parseFloat(order.total_price || 0).toFixed(2)}
+                </td>
+                {canEditLines() && <td />}
+              </tr>
+              {parseFloat(order.tax_amount || 0) > 0 && (
+                <tr>
+                  <td colSpan={5} className="py-1 px-3 text-right text-gray-400">
+                    Tax
+                  </td>
+                  <td className="py-1 px-3 text-right text-gray-300">
+                    ${parseFloat(order.tax_amount || 0).toFixed(2)}
+                  </td>
+                  {canEditLines() && <td />}
+                </tr>
+              )}
+              {parseFloat(order.shipping_cost || 0) > 0 && (
+                <tr>
+                  <td colSpan={5} className="py-1 px-3 text-right text-gray-400">
+                    Shipping
+                  </td>
+                  <td className="py-1 px-3 text-right text-gray-300">
+                    ${parseFloat(order.shipping_cost || 0).toFixed(2)}
+                  </td>
+                  {canEditLines() && <td />}
+                </tr>
+              )}
+              <tr className="border-t border-gray-700">
+                <td colSpan={5} className="py-3 px-3 text-right text-white font-medium">
                   Order Total
                 </td>
                 <td className="py-3 px-3 text-right text-green-400 font-bold">
-                  ${parseFloat(order.total_price || 0).toFixed(2)}
+                  ${parseFloat(
+                    order.grand_total ??
+                      (parseFloat(order.total_price || 0) +
+                        parseFloat(order.tax_amount || 0) +
+                        parseFloat(order.shipping_cost || 0))
+                  ).toFixed(2)}
                 </td>
+                {canEditLines() && <td />}
               </tr>
             </tfoot>
           </table>

--- a/frontend/src/components/orders/OrderLineItemsTable.jsx
+++ b/frontend/src/components/orders/OrderLineItemsTable.jsx
@@ -65,11 +65,11 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
   };
 
   return (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-          <h2 className="text-lg font-semibold text-white mb-4">Line Items</h2>
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+          <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Line Items</h2>
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-700 text-gray-400">
+              <tr className="border-b border-[var(--rule-hair)] text-[var(--ink-3)]">
                 <th className="text-left py-2 px-3">Product</th>
                 <th className="text-left py-2 px-3">SKU</th>
                 <th className="text-right py-2 px-3">Qty</th>
@@ -79,7 +79,7 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                 {canEditLines() && <th className="text-center py-2 px-3 w-16"></th>}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-800">
+            <tbody className="divide-y divide-[var(--rule-hair)]">
               {order.lines.map((line, idx) => {
                 const isEditing = editingLineId === line.id;
                 const shipped = parseFloat(line.shipped_quantity || 0);
@@ -87,13 +87,13 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                 const lineCode = line.product_sku || line.material_sku || line.sku || (line.line_type === "service" ? "FEE" : "\u2014");
                 return (
                   <tr key={line.id || idx}>
-                    <td className="py-2 px-3 text-white">
+                    <td className="py-2 px-3 text-[var(--ink)]">
                       {lineLabel}
                     </td>
-                    <td className="py-2 px-3 text-gray-400 font-mono text-xs">
+                    <td className="py-2 px-3 text-[var(--ink-3)] font-mono text-xs">
                       {lineCode}
                     </td>
-                    <td className="py-2 px-3 text-right text-white">
+                    <td className="py-2 px-3 text-right text-[var(--ink)]">
                       {isEditing ? (
                         <input
                           type="number"
@@ -101,22 +101,22 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                           onChange={(e) => setEditQty(e.target.value)}
                           min={shipped}
                           step="1"
-                          className="w-20 bg-gray-800 border border-blue-500 rounded px-2 py-1 text-right text-white text-sm"
+                          className="w-20 bg-[var(--paper-sunk)] border border-[var(--orange)] rounded px-2 py-1 text-right text-[var(--ink)] text-sm"
                           autoFocus
                         />
                       ) : (
                         <span className="flex items-center justify-end gap-1">
                           {line.original_quantity && parseFloat(line.original_quantity) !== parseFloat(line.quantity) && (
-                            <span className="text-gray-500 line-through text-xs">{line.original_quantity}</span>
+                            <span className="text-[var(--ink-4)] line-through text-xs">{line.original_quantity}</span>
                           )}
                           {line.quantity}
                         </span>
                       )}
                     </td>
-                    <td className="py-2 px-3 text-right text-gray-400">
+                    <td className="py-2 px-3 text-right text-[var(--ink-3)]">
                       {shipped > 0 ? shipped : "\u2014"}
                     </td>
-                    <td className="py-2 px-3 text-right text-gray-300">
+                    <td className="py-2 px-3 text-right text-[var(--ink-2)]">
                       {isEditing ? (
                         <input
                           type="number"
@@ -124,13 +124,13 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                           onChange={(e) => setEditPrice(e.target.value)}
                           min="0"
                           step="0.01"
-                          className="w-24 bg-gray-800 border border-blue-500 rounded px-2 py-1 text-right text-white text-sm"
+                          className="w-24 bg-[var(--paper-sunk)] border border-[var(--orange)] rounded px-2 py-1 text-right text-[var(--ink)] text-sm"
                         />
                       ) : (
                         `$${parseFloat(line.unit_price || 0).toFixed(2)}`
                       )}
                     </td>
-                    <td className="py-2 px-3 text-right text-green-400 font-medium">
+                    <td className="py-2 px-3 text-right text-[var(--status-green)] font-medium">
                       ${parseFloat(line.total || 0).toFixed(2)}
                     </td>
                     {canEditLines() && (
@@ -140,14 +140,14 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                             <button
                               onClick={() => handleSaveLineEdit(line.id)}
                               disabled={savingLineEdit || (editQty === "" && editPrice === "") || !editReason.trim()}
-                              className="text-green-400 hover:text-green-300 disabled:opacity-50 text-xs"
+                              className="text-[var(--status-green)] hover:text-[var(--status-green)] disabled:opacity-50 text-xs"
                               title="Save"
                             >
                               {savingLineEdit ? "..." : "\u2713"}
                             </button>
                             <button
                               onClick={() => { setEditingLineId(null); setEditQty(""); setEditPrice(""); setEditReason(""); }}
-                              className="text-gray-400 hover:text-white text-xs"
+                              className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xs"
                               title="Cancel"
                             >
                               \u2717
@@ -162,7 +162,7 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                                 setEditPrice(String(line.unit_price || 0));
                                 setEditReason("");
                               }}
-                              className="text-gray-500 hover:text-blue-400 text-xs"
+                              className="text-[var(--ink-4)] hover:text-[var(--orange)] text-xs"
                               title="Edit line"
                             >
                               Edit
@@ -171,7 +171,7 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                               <button
                                 onClick={() => handleRemoveLine(line)}
                                 disabled={removingLineId === line.id}
-                                className="text-gray-600 hover:text-red-400 disabled:opacity-50 text-xs"
+                                className="text-[var(--ink-4)] hover:text-[var(--status-red)] disabled:opacity-50 text-xs"
                                 title="Remove line"
                               >
                                 {removingLineId === line.id ? "…" : "✕"}
@@ -192,7 +192,7 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                       value={editReason}
                       onChange={(e) => setEditReason(e.target.value)}
                       placeholder="Reason for change (required)..."
-                      className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm placeholder-gray-500 focus:border-blue-500"
+                      className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded px-3 py-1.5 text-[var(--ink)] text-sm placeholder-[var(--ink-4)] focus:border-[var(--orange)]"
                     />
                   </td>
                 </tr>
@@ -204,21 +204,21 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
                   sum. The label spans cols 1-5 and the amount sits in the
                   Total column (6); the trailing cell fills the Actions column
                   when the table is editable so nothing lands under it. */}
-              <tr className="border-t border-gray-700">
-                <td colSpan={5} className="py-2 px-3 text-right text-gray-400">
+              <tr className="border-t border-[var(--rule-hair)]">
+                <td colSpan={5} className="py-2 px-3 text-right text-[var(--ink-3)]">
                   Subtotal
                 </td>
-                <td className="py-2 px-3 text-right text-gray-300">
+                <td className="py-2 px-3 text-right text-[var(--ink-2)]">
                   ${parseFloat(order.total_price || 0).toFixed(2)}
                 </td>
                 {canEditLines() && <td />}
               </tr>
               {parseFloat(order.tax_amount || 0) > 0 && (
                 <tr>
-                  <td colSpan={5} className="py-1 px-3 text-right text-gray-400">
+                  <td colSpan={5} className="py-1 px-3 text-right text-[var(--ink-3)]">
                     Tax
                   </td>
-                  <td className="py-1 px-3 text-right text-gray-300">
+                  <td className="py-1 px-3 text-right text-[var(--ink-2)]">
                     ${parseFloat(order.tax_amount || 0).toFixed(2)}
                   </td>
                   {canEditLines() && <td />}
@@ -226,20 +226,20 @@ export default function OrderLineItemsTable({ order, orderId, onOrderUpdated }) 
               )}
               {parseFloat(order.shipping_cost || 0) > 0 && (
                 <tr>
-                  <td colSpan={5} className="py-1 px-3 text-right text-gray-400">
+                  <td colSpan={5} className="py-1 px-3 text-right text-[var(--ink-3)]">
                     Shipping
                   </td>
-                  <td className="py-1 px-3 text-right text-gray-300">
+                  <td className="py-1 px-3 text-right text-[var(--ink-2)]">
                     ${parseFloat(order.shipping_cost || 0).toFixed(2)}
                   </td>
                   {canEditLines() && <td />}
                 </tr>
               )}
-              <tr className="border-t border-gray-700">
-                <td colSpan={5} className="py-3 px-3 text-right text-white font-medium">
+              <tr className="border-t border-[var(--rule-hair)]">
+                <td colSpan={5} className="py-3 px-3 text-right text-[var(--ink)] font-medium">
                   Order Total
                 </td>
-                <td className="py-3 px-3 text-right text-green-400 font-bold">
+                <td className="py-3 px-3 text-right text-[var(--status-green)] font-bold">
                   ${parseFloat(
                     order.grand_total ??
                       (parseFloat(order.total_price || 0) +

--- a/frontend/src/components/orders/OrderModals.jsx
+++ b/frontend/src/components/orders/OrderModals.jsx
@@ -15,22 +15,22 @@ export function CancelOrderModal({ orderNumber, onCancel, onClose }) {
           className="fixed inset-0 bg-black/70"
           onClick={onClose}
         />
-        <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-xl max-w-md w-full mx-auto p-6">
-          <h3 className="text-lg font-semibold text-white mb-4">
+        <div className="relative bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl shadow-[var(--shadow-pop)] max-w-md w-full mx-auto p-6">
+          <h3 className="text-lg font-semibold text-[var(--ink)] mb-4">
             Cancel Order {orderNumber}?
           </h3>
-          <p className="text-gray-400 mb-4">
+          <p className="text-[var(--ink-3)] mb-4">
             This will cancel the order. The order can still be deleted after
             cancellation.
           </p>
           <div className="mb-4">
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Cancellation Reason (optional)
             </label>
             <textarea
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+              className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               rows={3}
               placeholder="Enter reason for cancellation..."
             />
@@ -38,13 +38,13 @@ export function CancelOrderModal({ orderNumber, onCancel, onClose }) {
           <div className="flex justify-end gap-3">
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+              className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)]"
             >
               Keep Order
             </button>
             <button
               onClick={() => onCancel(reason)}
-              className="px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-500"
+              className="px-4 py-2 bg-[var(--status-amber)] text-white rounded-lg hover:opacity-90"
             >
               Cancel Order
             </button>
@@ -63,24 +63,24 @@ export function DeleteOrderModal({ orderNumber, onDelete, onClose }) {
           className="fixed inset-0 bg-black/70"
           onClick={onClose}
         />
-        <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-xl max-w-md w-full mx-auto p-6">
-          <h3 className="text-lg font-semibold text-white mb-4">
+        <div className="relative bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl shadow-[var(--shadow-pop)] max-w-md w-full mx-auto p-6">
+          <h3 className="text-lg font-semibold text-[var(--ink)] mb-4">
             Delete Order {orderNumber}?
           </h3>
-          <p className="text-gray-400 mb-4">
+          <p className="text-[var(--ink-3)] mb-4">
             This action cannot be undone. All order data, including line
             items and payment records, will be permanently deleted.
           </p>
           <div className="flex justify-end gap-3">
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+              className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)]"
             >
               Keep Order
             </button>
             <button
               onClick={onDelete}
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500"
+              className="px-4 py-2 bg-[var(--status-red)] text-white rounded-lg hover:opacity-90"
             >
               Delete Permanently
             </button>

--- a/frontend/src/components/orders/OrderWorkflowPanel.jsx
+++ b/frontend/src/components/orders/OrderWorkflowPanel.jsx
@@ -99,29 +99,29 @@ export default function OrderWorkflowPanel({
   const getStepClasses = (state) => {
     if (state === "done") {
       return {
-        panel: "border-emerald-500/40 bg-emerald-950/20",
-        icon: "bg-emerald-500/20 text-emerald-300",
-        label: "text-emerald-300",
+        panel: "border-[var(--status-green)]/40 bg-[var(--status-green-tint)]",
+        icon: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+        label: "text-[var(--status-green)]",
       };
     }
     if (state === "active") {
       return {
-        panel: "border-blue-500/50 bg-blue-950/30",
-        icon: "bg-blue-500/20 text-blue-300",
-        label: "text-blue-300",
+        panel: "border-[var(--orange)]/50 bg-[var(--orange-tint)]",
+        icon: "bg-[var(--orange-tint)] text-[var(--orange)]",
+        label: "text-[var(--orange)]",
       };
     }
     if (state === "blocked") {
       return {
-        panel: "border-amber-500/40 bg-amber-950/20",
-        icon: "bg-amber-500/20 text-amber-300",
-        label: "text-amber-300",
+        panel: "border-[var(--status-amber)]/40 bg-[var(--status-amber-tint)]",
+        icon: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+        label: "text-[var(--status-amber)]",
       };
     }
     return {
-      panel: "border-gray-700 bg-gray-900/60",
-      icon: "bg-gray-800 text-gray-400",
-      label: "text-gray-400",
+      panel: "border-[var(--rule-hair)] bg-[var(--paper-sunk)]",
+      icon: "bg-[var(--paper-sunk)] text-[var(--ink-3)]",
+      label: "text-[var(--ink-3)]",
     };
   };
 
@@ -290,15 +290,15 @@ export default function OrderWorkflowPanel({
   };
 
   return (
-      <div className="rounded-xl border border-gray-700 bg-gray-900/60 p-5">
+      <div className="rounded-xl border border-[var(--rule-hair)] bg-[var(--paper)] p-5 shadow-[var(--shadow-pop)]">
         <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-white">Order Workflow</h2>
-            <p className="text-sm text-gray-400">
+            <h2 className="text-lg font-semibold text-[var(--ink)]">Order Workflow</h2>
+            <p className="text-sm text-[var(--ink-3)]">
               Confirm, bill, release production, then fulfill.
             </p>
           </div>
-          <span className="w-fit rounded-full bg-gray-800 px-3 py-1 text-xs font-medium text-gray-300">
+          <span className="w-fit rounded-full bg-[var(--paper-sunk)] px-3 py-1 text-xs font-medium text-[var(--ink-2)]">
             {order.status?.replace(/_/g, " ") || "unknown"}
           </span>
         </div>
@@ -316,15 +316,15 @@ export default function OrderWorkflowPanel({
                       {renderStepIcon(step)}
                     </div>
                     <div>
-                      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-[var(--ink-4)]">
                         Step {index + 1}
                       </div>
-                      <h3 className="text-sm font-semibold text-white">
+                      <h3 className="text-sm font-semibold text-[var(--ink)]">
                         {step.title}
                       </h3>
                     </div>
                   </div>
-                  <span className={`rounded-full bg-gray-950/50 px-2 py-1 text-xs font-medium capitalize ${classes.label}`}>
+                  <span className={`rounded-full bg-[var(--paper-sunk)] px-2 py-1 text-xs font-medium capitalize ${classes.label}`}>
                     {step.state}
                   </span>
                 </div>
@@ -333,7 +333,7 @@ export default function OrderWorkflowPanel({
                   <div className={`text-sm font-medium capitalize ${classes.label}`}>
                     {step.meta || "Waiting"}
                   </div>
-                  <p className="mt-2 text-sm leading-5 text-gray-300">
+                  <p className="mt-2 text-sm leading-5 text-[var(--ink-2)]">
                     {step.detail}
                   </p>
                 </div>
@@ -342,7 +342,7 @@ export default function OrderWorkflowPanel({
                   <button
                     onClick={step.action.onClick}
                     disabled={step.action.disabled}
-                    className="mt-4 w-full rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="mt-4 w-full rounded-lg bg-[var(--orange)] px-3 py-2 text-sm font-medium text-white hover:bg-[var(--orange-press)] disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {step.action.label}
                   </button>
@@ -354,8 +354,8 @@ export default function OrderWorkflowPanel({
 
         {/* Secondary / destructive actions — below workflow steps */}
         {(order.status === "pending_confirmation" || canCancelOrder() || canCloseShort() || canDeleteOrder()) && (
-          <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-gray-700/50 pt-4">
-            <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+          <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-[var(--rule-hair)] pt-4">
+            <span className="text-xs font-medium uppercase tracking-wide text-[var(--ink-4)]">
               Order actions:
             </span>
             {(order.status === "pending" || order.status === "pending_confirmation") && (
@@ -363,14 +363,14 @@ export default function OrderWorkflowPanel({
                 <button
                   onClick={onConfirmOrder}
                   disabled={confirmingOrder}
-                  className="rounded-lg bg-green-700 px-3 py-1.5 text-sm text-white hover:bg-green-600 disabled:opacity-50"
+                  className="rounded-lg bg-[var(--paper-sunk)] px-3 py-1.5 text-sm text-[var(--ink-2)] border border-[var(--rule-hair)] hover:bg-[var(--rule-hair)] disabled:opacity-50"
                 >
                   {confirmingOrder ? "Confirming..." : "Confirm Order"}
                 </button>
                 {order.status === "pending_confirmation" && (
                   <button
                     onClick={onRejectOrder}
-                    className="rounded-lg bg-red-700 px-3 py-1.5 text-sm text-white hover:bg-red-600"
+                    className="rounded-lg bg-[var(--status-red)] px-3 py-1.5 text-sm text-white hover:opacity-90"
                   >
                     Reject Order
                   </button>
@@ -380,7 +380,7 @@ export default function OrderWorkflowPanel({
             {canCancelOrder() && (
               <button
                 onClick={onCancelOrder}
-                className="rounded-lg bg-yellow-700 px-3 py-1.5 text-sm text-white hover:bg-yellow-600"
+                className="rounded-lg bg-[var(--paper-sunk)] px-3 py-1.5 text-sm text-[var(--ink-2)] border border-[var(--rule-hair)] hover:bg-[var(--rule-hair)]"
               >
                 Cancel Order
               </button>
@@ -388,7 +388,7 @@ export default function OrderWorkflowPanel({
             {canCloseShort() && (
               <button
                 onClick={onCloseShort}
-                className="rounded-lg bg-amber-700 px-3 py-1.5 text-sm text-white hover:bg-amber-600"
+                className="rounded-lg bg-[var(--paper-sunk)] px-3 py-1.5 text-sm text-[var(--ink-2)] border border-[var(--rule-hair)] hover:bg-[var(--rule-hair)]"
               >
                 Close Short
               </button>
@@ -396,7 +396,7 @@ export default function OrderWorkflowPanel({
             {canDeleteOrder() && (
               <button
                 onClick={onDeleteOrder}
-                className="rounded-lg bg-red-900 px-3 py-1.5 text-sm text-white hover:bg-red-800 border border-red-700"
+                className="rounded-lg bg-[var(--status-red)] px-3 py-1.5 text-sm text-white hover:opacity-90 border border-[var(--status-red)]"
               >
                 Delete Order
               </button>

--- a/frontend/src/components/orders/PaymentsSection.jsx
+++ b/frontend/src/components/orders/PaymentsSection.jsx
@@ -14,21 +14,21 @@ export default function PaymentsSection({
   const formatCurrency = useFormatCurrency();
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold text-white">Payments</h2>
+        <h2 className="text-lg font-semibold text-[var(--ink)]">Payments</h2>
         <div className="flex gap-2">
           {paymentSummary && paymentSummary.total_paid > 0 && (
             <button
               onClick={onRefund}
-              className="px-3 py-1 bg-red-600/20 hover:bg-red-600/30 text-red-400 rounded text-sm"
+              className="px-3 py-1 bg-[var(--status-red-tint)] hover:bg-[var(--status-red-tint)] text-[var(--status-red)] rounded text-sm"
             >
               Refund
             </button>
           )}
           <button
             onClick={onRecordPayment}
-            className="px-3 py-1 bg-green-600 hover:bg-green-700 text-white rounded text-sm flex items-center gap-1"
+            className="px-3 py-1 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded text-sm flex items-center gap-1"
           >
             <svg
               className="w-4 h-4"
@@ -50,34 +50,34 @@ export default function PaymentsSection({
 
       {/* Payment Summary */}
       {paymentSummary && (
-        <div className="grid grid-cols-4 gap-4 mb-4 p-4 bg-gray-800/50 rounded-lg">
+        <div className="grid grid-cols-4 gap-4 mb-4 p-4 bg-[var(--paper-sunk)] rounded-lg">
           <div>
-            <div className="text-sm text-gray-400">Order Total</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Order Total</div>
+            <div className="text-[var(--ink)] font-medium">
               {formatCurrency(parseFloat(paymentSummary.order_total || 0))}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Paid</div>
-            <div className="text-green-400 font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Paid</div>
+            <div className="text-[var(--status-green)] font-medium">
               {formatCurrency(parseFloat(paymentSummary.total_paid || 0))}
             </div>
           </div>
           {paymentSummary.total_refunded > 0 && (
             <div>
-              <div className="text-sm text-gray-400">Refunded</div>
-              <div className="text-red-400 font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Refunded</div>
+              <div className="text-[var(--status-red)] font-medium">
                 {formatCurrency(parseFloat(paymentSummary.total_refunded || 0))}
               </div>
             </div>
           )}
           <div>
-            <div className="text-sm text-gray-400">Balance Due</div>
+            <div className="text-sm text-[var(--ink-3)]">Balance Due</div>
             <div
               className={`font-medium ${
                 paymentSummary.balance_due > 0
-                  ? "text-yellow-400"
-                  : "text-green-400"
+                  ? "text-[var(--status-amber)]"
+                  : "text-[var(--status-green)]"
               }`}
             >
               {formatCurrency(parseFloat(paymentSummary.balance_due || 0))}
@@ -92,17 +92,17 @@ export default function PaymentsSection({
           {payments.map((payment) => (
             <div
               key={payment.id}
-              className="flex justify-between items-center p-3 bg-gray-800 rounded-lg"
+              className="flex justify-between items-center p-3 bg-[var(--paper-sunk)] rounded-lg"
             >
               <div className="flex items-center gap-3">
                 <div
                   className={`w-8 h-8 rounded-full flex items-center justify-center ${
-                    payment.amount < 0 ? "bg-red-500/20" : "bg-green-500/20"
+                    payment.amount < 0 ? "bg-[var(--status-red-tint)]" : "bg-[var(--status-green-tint)]"
                   }`}
                 >
                   {payment.amount < 0 ? (
                     <svg
-                      className="w-4 h-4 text-red-400"
+                      className="w-4 h-4 text-[var(--status-red)]"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -116,7 +116,7 @@ export default function PaymentsSection({
                     </svg>
                   ) : (
                     <svg
-                      className="w-4 h-4 text-green-400"
+                      className="w-4 h-4 text-[var(--status-green)]"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -131,10 +131,10 @@ export default function PaymentsSection({
                   )}
                 </div>
                 <div>
-                  <div className="text-white font-medium">
+                  <div className="text-[var(--ink)] font-medium">
                     {payment.payment_number}
                   </div>
-                  <div className="text-sm text-gray-400">
+                  <div className="text-sm text-[var(--ink-3)]">
                     {payment.payment_method}
                     {payment.check_number && ` #${payment.check_number}`}
                     {payment.transaction_id && ` - ${payment.transaction_id}`}
@@ -144,12 +144,12 @@ export default function PaymentsSection({
               <div className="text-right">
                 <div
                   className={`font-medium ${
-                    payment.amount < 0 ? "text-red-400" : "text-green-400"
+                    payment.amount < 0 ? "text-[var(--status-red)]" : "text-[var(--status-green)]"
                   }`}
                 >
                   {formatCurrency(Math.abs(parseFloat(payment.amount)))}
                 </div>
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-[var(--ink-4)]">
                   {new Date(payment.payment_date).toLocaleDateString()}
                 </div>
               </div>
@@ -157,7 +157,7 @@ export default function PaymentsSection({
           ))}
         </div>
       ) : (
-        <div className="text-center py-6 text-gray-500">
+        <div className="text-center py-6 text-[var(--ink-4)]">
           No payments recorded yet
         </div>
       )}

--- a/frontend/src/components/orders/ProductionStatusCards.jsx
+++ b/frontend/src/components/orders/ProductionStatusCards.jsx
@@ -14,29 +14,29 @@ export function ProductionProgressSummary({ orders }) {
   const completionPercent = total > 0 ? (completed / total) * 100 : 0;
 
   return (
-    <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 mb-2">
+    <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-2">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm text-gray-400">Overall Progress</span>
-        <span className="text-sm text-white font-medium">{completed}/{total} Complete</span>
+        <span className="text-sm text-[var(--ink-3)]">Overall Progress</span>
+        <span className="text-sm text-[var(--ink)] font-medium">{completed}/{total} Complete</span>
       </div>
-      <div className="w-full bg-gray-700 rounded-full h-2 mb-2">
+      <div className="w-full bg-[var(--rule-hair)] rounded-full h-2 mb-2">
         <div
-          className="bg-green-500 h-2 rounded-full transition-all"
+          className="bg-[var(--status-green)] h-2 rounded-full transition-all"
           style={{ width: `${completionPercent}%` }}
         />
       </div>
       <div className="flex gap-4 text-xs">
         {inProgress > 0 && (
-          <span className="text-purple-400">{inProgress} In Progress</span>
+          <span className="text-[var(--status-amber)]">{inProgress} In Progress</span>
         )}
         {completed > 0 && (
-          <span className="text-green-400">{completed} Complete</span>
+          <span className="text-[var(--status-green)]">{completed} Complete</span>
         )}
         {short > 0 && (
-          <span className="text-amber-400">{short} Short</span>
+          <span className="text-[var(--status-amber)]">{short} Short</span>
         )}
         {scrapped > 0 && (
-          <span className="text-red-400">{scrapped} Scrapped</span>
+          <span className="text-[var(--status-red)]">{scrapped} Scrapped</span>
         )}
       </div>
     </div>
@@ -44,49 +44,49 @@ export function ProductionProgressSummary({ orders }) {
 }
 
 const STATUS_CONFIG = {
-  draft: { color: "bg-gray-500", text: "Draft" },
-  released: { color: "bg-blue-500", text: "Released" },
-  in_progress: { color: "bg-purple-500", text: "In Progress" },
-  short: { color: "bg-amber-500", text: "Short" },
-  complete: { color: "bg-green-500", text: "Complete" },
-  scrapped: { color: "bg-red-500", text: "Scrapped" },
-  closed: { color: "bg-gray-400", text: "Closed" },
+  draft: { color: "bg-[var(--ink-3)]", text: "Draft" },
+  released: { color: "bg-[var(--status-amber)]", text: "Released" },
+  in_progress: { color: "bg-[var(--status-amber)]", text: "In Progress" },
+  short: { color: "bg-[var(--status-amber)]", text: "Short" },
+  complete: { color: "bg-[var(--status-green)]", text: "Complete" },
+  scrapped: { color: "bg-[var(--status-red)]", text: "Scrapped" },
+  closed: { color: "bg-[var(--ink-4)]", text: "Closed" },
 };
 
 const OP_STATUS_CLASS = {
-  complete: "bg-green-500/20 text-green-400",
-  running: "bg-purple-500/20 text-purple-400",
-  queued: "bg-blue-500/20 text-blue-400",
+  complete: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+  running: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  queued: "bg-[var(--paper-sunk)] text-[var(--ink-3)]",
 };
 
 const PROGRESS_BAR_CLASS = {
-  complete: "bg-green-500",
-  scrapped: "bg-red-500",
+  complete: "bg-[var(--status-green)]",
+  scrapped: "bg-[var(--status-red)]",
 };
 
 export function ProductionOrderStatusCard({ order, onViewInProduction, onAcceptShort }) {
-  const status = STATUS_CONFIG[order.status] || { color: "bg-gray-500", text: order.status };
+  const status = STATUS_CONFIG[order.status] || { color: "bg-[var(--ink-3)]", text: order.status };
   const progressPercent = order.quantity_ordered > 0
     ? ((order.quantity_completed || 0) / order.quantity_ordered) * 100
     : 0;
 
   return (
-    <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
+    <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4">
       <div className="flex items-start justify-between mb-3">
         <div>
           <div className="flex items-center gap-2">
-            <span className="text-white font-medium">{order.code || `WO-${order.id}`}</span>
+            <span className="text-[var(--ink)] font-medium">{order.code || `WO-${order.id}`}</span>
             <span className={`px-2 py-0.5 ${status.color} text-white text-xs rounded-full`}>
               {status.text}
             </span>
           </div>
-          <p className="text-sm text-gray-400 mt-1">
+          <p className="text-sm text-[var(--ink-3)] mt-1">
             {order.product_name || order.product_sku || "N/A"}
           </p>
         </div>
         <button
           onClick={onViewInProduction}
-          className="text-blue-400 hover:text-blue-300 text-sm flex items-center gap-1"
+          className="text-[var(--ink-2)] hover:text-[var(--ink)] text-sm flex items-center gap-1"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -101,7 +101,7 @@ export function ProductionOrderStatusCard({ order, onViewInProduction, onAcceptS
         <div className="mt-2 mb-1">
           <button
             onClick={() => onAcceptShort(order)}
-            className="px-3 py-1.5 bg-amber-600 hover:bg-amber-500 text-white text-xs rounded font-medium transition-colors"
+            className="px-3 py-1.5 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white text-xs rounded font-medium transition-colors"
           >
             Accept Short ({order.quantity_completed}/{order.quantity_ordered})
           </button>
@@ -110,36 +110,36 @@ export function ProductionOrderStatusCard({ order, onViewInProduction, onAcceptS
 
       {/* Progress bar */}
       <div className="flex items-center gap-3">
-        <div className="flex-1 bg-gray-700 rounded-full h-1.5">
+        <div className="flex-1 bg-[var(--rule-hair)] rounded-full h-1.5">
           <div
             className={`h-1.5 rounded-full transition-all ${
-              PROGRESS_BAR_CLASS[order.status] || "bg-blue-500"
+              PROGRESS_BAR_CLASS[order.status] || "bg-[var(--status-amber)]"
             }`}
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <span className="text-xs text-gray-400 w-20 text-right">
+        <span className="text-xs text-[var(--ink-3)] w-20 text-right">
           {order.quantity_completed || 0} / {order.quantity_ordered}
         </span>
       </div>
 
       {/* Operations summary if available */}
       {order.operations && order.operations.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-gray-700">
-          <div className="text-xs text-gray-500 mb-2">Operations:</div>
+        <div className="mt-3 pt-3 border-t border-[var(--rule-hair)]">
+          <div className="text-xs text-[var(--ink-4)] mb-2">Operations:</div>
           <div className="flex flex-wrap gap-1">
             {order.operations.slice(0, 5).map((op, idx) => (
               <span
                 key={idx}
                 className={`px-2 py-0.5 rounded text-xs ${
-                  OP_STATUS_CLASS[op.status] || "bg-gray-500/20 text-gray-400"
+                  OP_STATUS_CLASS[op.status] || "bg-[var(--paper-sunk)] text-[var(--ink-3)]"
                 }`}
               >
                 {op.sequence}. {op.operation_name || op.operation_code || "Op"}
               </span>
             ))}
             {order.operations.length > 5 && (
-              <span className="text-xs text-gray-500">+{order.operations.length - 5} more</span>
+              <span className="text-xs text-[var(--ink-4)]">+{order.operations.length - 5} more</span>
             )}
           </div>
         </div>

--- a/frontend/src/components/orders/ProductionStatusCards.jsx
+++ b/frontend/src/components/orders/ProductionStatusCards.jsx
@@ -130,7 +130,7 @@ export function ProductionOrderStatusCard({ order, onViewInProduction, onAcceptS
           <div className="flex flex-wrap gap-1">
             {order.operations.slice(0, 5).map((op, idx) => (
               <span
-                key={idx}
+                key={op.id ?? `${op.sequence}-${op.operation_code ?? op.operation_name ?? idx}`}
                 className={`px-2 py-0.5 rounded text-xs ${
                   OP_STATUS_CLASS[op.status] || "bg-[var(--paper-sunk)] text-[var(--ink-3)]"
                 }`}

--- a/frontend/src/components/orders/ShippingAddressSection.jsx
+++ b/frontend/src/components/orders/ShippingAddressSection.jsx
@@ -62,13 +62,13 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
   };
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold text-white">Shipping Address</h2>
+        <h2 className="text-lg font-semibold text-[var(--ink)]">Shipping Address</h2>
         {!editingAddress && (
           <button
             onClick={handleEditAddress}
-            className="text-blue-400 hover:text-blue-300 text-sm"
+            className="text-[var(--orange)] hover:text-[var(--orange-press)] text-sm"
           >
             Edit
           </button>
@@ -79,7 +79,7 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="col-span-2 md:col-span-1">
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Shipping Charge
               </label>
               <input
@@ -91,13 +91,13 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_cost: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 min="0"
                 step="0.01"
               />
             </div>
             <div className="col-span-2">
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Address Line 1
               </label>
               <input
@@ -109,12 +109,12 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_address_line1: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 placeholder="Street address"
               />
             </div>
             <div className="col-span-2">
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Address Line 2
               </label>
               <input
@@ -126,12 +126,12 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_address_line2: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 placeholder="Apt, suite, etc."
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">City</label>
+              <label className="block text-sm text-[var(--ink-3)] mb-1">City</label>
               <input
                 type="text"
                 value={addressForm.shipping_city}
@@ -141,11 +141,11 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_city: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 State
               </label>
               <input
@@ -157,11 +157,11 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_state: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 ZIP Code
               </label>
               <input
@@ -173,11 +173,11 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_zip: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               />
             </div>
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Country
               </label>
               <input
@@ -189,21 +189,21 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                     shipping_country: e.target.value,
                   })
                 }
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               />
             </div>
           </div>
           <div className="flex justify-end gap-2">
             <button
               onClick={() => setEditingAddress(false)}
-              className="px-4 py-2 text-gray-400 hover:text-white"
+              className="px-4 py-2 text-[var(--ink-3)] hover:text-[var(--ink)]"
             >
               Cancel
             </button>
             <button
               onClick={handleSaveAddress}
               disabled={savingAddress}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
+              className="px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg disabled:opacity-50"
             >
               {savingAddress ? "Saving..." : "Save Address"}
             </button>
@@ -213,20 +213,20 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <div className="text-sm text-gray-400">Shipping Charge</div>
-              <div className="text-white font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Shipping Charge</div>
+              <div className="text-[var(--ink)] font-medium">
                 ${Number.isNaN(shippingCharge) ? "0.00" : shippingCharge.toFixed(2)}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-400">Order Total</div>
-              <div className="text-white font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Order Total</div>
+              <div className="text-[var(--ink)] font-medium">
                 ${Number.isNaN(grandTotal) ? "0.00" : grandTotal.toFixed(2)}
               </div>
             </div>
           </div>
           {order.shipping_address_line1 ? (
-            <div className="text-white">
+            <div className="text-[var(--ink)]">
               <div>{order.shipping_address_line1}</div>
               {order.shipping_address_line2 && (
                 <div>{order.shipping_address_line2}</div>
@@ -235,12 +235,12 @@ export default function ShippingAddressSection({ order, onOrderUpdated }) {
                 {order.shipping_city}, {order.shipping_state}{" "}
                 {order.shipping_zip}
               </div>
-              <div className="text-gray-400">
+              <div className="text-[var(--ink-3)]">
                 {order.shipping_country || "USA"}
               </div>
             </div>
           ) : (
-            <div className="text-yellow-400 flex items-center gap-2">
+            <div className="text-[var(--status-amber)] flex items-center gap-2">
               <svg
                 className="w-5 h-5"
                 fill="none"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -110,6 +110,8 @@
     --glass-border: var(--rule-hair);
     --glass-hi:     transparent;
     --glass-shadow: var(--shadow-pop);
+    --glass-fill:   var(--paper-sunk);
+    --glass-sel:    var(--paper-sunk);
   }
 }
 
@@ -184,6 +186,17 @@ body {
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
   border: 1px solid var(--border-subtle);
+}
+
+/* Reduced-transparency users get a solid, un-blurred bar that matches the dark
+   shell. (The token-aware .glass-topbar replacement lands in the shell slice;
+   data-glass="off" is wired with the theme store in the command-palette slice.) */
+@media (prefers-reduced-transparency: reduce) {
+  .glass {
+    background: rgb(28, 28, 50);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 
 /* Primary glow effect (legacy) */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,49 +1,128 @@
 @import "tailwindcss";
 
 /* =============================================================================
-   BLB3D / FILAOPS ERP - NEO-INDUSTRIAL DESIGN SYSTEM
-   Colors extracted from BLB3D logo:
-   - Primary Blue: #026DF8
-   - Accent Orange: #EE7A08
-   - Background: #0F0F1E
-   ============================================================================= */
+   FILAOPS — INDUSTRIAL WORKBENCH + LIQUID GLASS DESIGN SYSTEM
+   -----------------------------------------------------------------------------
+   Foundation layer (#846 PR-1). Tailwind v4 is CSS-first, so design tokens live
+   here as custom properties (consumed via var() or arbitrary utilities like
+   bg-[var(--paper)]).
 
-/* =============================================================================
-   CSS CUSTOM PROPERTIES
+   This PR is ADDITIVE + cleanup: it introduces the Workbench base tokens, the
+   liquid-glass material tokens, and the day/dim/flat theme scaffolding, and
+   removes genuinely-dead Neo-Industrial CSS. The legacy Neo tokens
+   (--bg-primary, --primary, --text-*, …) are KEPT (marked @deprecated) so the
+   ~40 files that still consume them keep rendering until each screen is migrated
+   to the Workbench tokens in its own slice. They are removed at the end of #846.
    ============================================================================= */
 
 :root {
-  /* Background hierarchy - from logo #0F0F1E */
+  /* ---- Industrial Workbench base tokens (day / default) ----------------- */
+  --paper:        #FAFAF7;
+  --paper-sunk:   #F2F0E9;
+  --ink:          #1F1F1C;
+  --ink-2:        #3D3D38;
+  --ink-3:        #6B6B66;
+  --ink-4:        #94938C;
+  --orange:       #E85D1F;   /* safety-orange — PRIMARY ACTION only, never a status */
+  --orange-press: #C44C15;
+  --orange-tint:  #FBE7DC;
+  --rule-hair:    #E5E3DC;
+  --shadow-pop:   0 1px 2px rgba(31, 31, 28, 0.06), 0 4px 12px rgba(31, 31, 28, 0.08);
+
+  /* ---- Liquid-glass material (floating chrome only) --------------------- */
+  --glass-bg:     rgba(250, 250, 247, 0.66);
+  --glass-blur:   blur(26px) saturate(200%);
+  --glass-border: rgba(255, 255, 255, 0.80);
+  --glass-hi:     rgba(255, 255, 255, 0.95);   /* specular top edge */
+  --glass-shadow: 0 26px 70px -20px rgba(31, 31, 28, 0.40),
+                  0 4px 14px rgba(31, 31, 28, 0.10);
+  --glass-scrim:  rgba(31, 31, 28, 0.16);
+  --glass-fill:   rgba(255, 255, 255, 0.60);   /* keycaps, icon chips, row hover */
+  --glass-sel:    rgba(255, 255, 255, 0.85);   /* keyboard-selected row */
+
+  /* ---- @deprecated Neo-Industrial tokens (removed at end of #846) ------- */
   --bg-primary: #0F0F1E;
   --bg-secondary: #161628;
   --bg-card: #1C1C32;
   --bg-elevated: #242440;
-
-  /* Brand Colors - from BLB3D logo */
   --primary: #026DF8;
   --primary-light: #0088FF;
   --accent: #EE7A08;
   --accent-light: #FF9933;
-
-  /* Status Colors */
   --success: #00c853;
   --warning: #EE7A08;
   --error: #ef4444;
   --info: #026DF8;
-
-  /* Text */
   --text-primary: #fafafa;
   --text-secondary: #a1a1a1;
   --text-muted: #666666;
-
-  /* Borders */
   --border-subtle: #2a2a3a;
   --border-active: #3a3a4a;
-
-  /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 400ms ease;
+}
+
+/* ---- Dim theme: warm dark surfaces ------------------------------------- */
+[data-theme="dim"] {
+  --paper:        #211E18;
+  --paper-sunk:   #2A2620;
+  --ink:          #ECE8DE;
+  --ink-2:        #C7C2B6;
+  --ink-3:        #9A958A;
+  --ink-4:        #746F66;
+  --orange:       #F26C2E;
+  --orange-press: #D5571B;
+  --orange-tint:  #3A2418;
+  --rule-hair:    #34302A;
+  --shadow-pop:   0 1px 2px rgba(0, 0, 0, 0.30), 0 4px 12px rgba(0, 0, 0, 0.40);
+
+  --glass-bg:     rgba(36, 33, 27, 0.62);
+  --glass-blur:   blur(28px) saturate(180%);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-hi:     rgba(255, 255, 255, 0.16);
+  --glass-shadow: 0 26px 70px -20px rgba(0, 0, 0, 0.72),
+                  0 4px 14px rgba(0, 0, 0, 0.50);
+  --glass-scrim:  rgba(0, 0, 0, 0.46);
+  --glass-fill:   rgba(255, 255, 255, 0.06);
+  --glass-sel:    rgba(255, 255, 255, 0.10);
+}
+
+/* ---- Flat opt-out: the canonical solid + shadow material --------------- */
+[data-glass="off"] {
+  --glass-bg:     var(--paper);
+  --glass-blur:   none;
+  --glass-border: var(--rule-hair);
+  --glass-hi:     transparent;
+  --glass-shadow: var(--shadow-pop);
+  --glass-scrim:  rgba(31, 31, 28, 0.28);
+  --glass-fill:   var(--paper-sunk);
+  --glass-sel:    var(--paper-sunk);
+}
+[data-theme="dim"][data-glass="off"] { --glass-scrim: rgba(0, 0, 0, 0.55); }
+
+/* ---- A11y: reduced transparency falls back to the flat material -------- */
+@media (prefers-reduced-transparency: reduce) {
+  :root,
+  [data-theme="dim"] {
+    --glass-bg:     var(--paper);
+    --glass-blur:   none;
+    --glass-border: var(--rule-hair);
+    --glass-hi:     transparent;
+    --glass-shadow: var(--shadow-pop);
+  }
+}
+
+/* ---- A11y: honor reduced motion globally ------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* =============================================================================
@@ -95,10 +174,11 @@ body {
 }
 
 /* =============================================================================
-   COMPONENT UTILITIES
+   COMPONENT UTILITIES (legacy — migrated per-screen during #846)
    ============================================================================= */
 
-/* Glass morphism effect */
+/* Old glassmorphism — still used by the AdminLayout top bar; replaced by the
+   .glass-topbar material when the shell slice lands (#846). */
 .glass {
   background: rgba(28, 28, 50, 0.8);
   -webkit-backdrop-filter: blur(12px);
@@ -106,33 +186,15 @@ body {
   border: 1px solid var(--border-subtle);
 }
 
-/* Primary glow effect */
+/* Primary glow effect (legacy) */
 .glow {
   box-shadow: 0 0 20px -5px rgba(2, 109, 248, 0.4);
 }
 
-/* Accent (orange) glow */
-.glow-accent {
-  box-shadow: 0 0 20px -5px rgba(238, 122, 8, 0.4);
-}
-
-/* Subtle card hover lift */
-.card-hover {
-  transition: all var(--transition-base);
-}
-
-.card-hover:hover {
-  transform: translateY(-2px);
-  box-shadow:
-    0 10px 40px -10px rgba(2, 109, 248, 0.15),
-    0 0 0 1px var(--border-subtle);
-}
-
 /* =============================================================================
-   LOGO ENHANCEMENT STYLES
+   LOGO ENHANCEMENT STYLES (legacy)
    ============================================================================= */
 
-/* Logo container with orange accent glow on hover */
 .logo-container {
   padding: 10px;
   border-radius: 12px;
@@ -146,7 +208,6 @@ body {
   box-shadow: 0 0 20px -5px rgba(238, 122, 8, 0.5);
 }
 
-/* Orange glow for logo image */
 .logo-glow {
   transition: all var(--transition-base);
   filter: drop-shadow(0 0 0 transparent);
@@ -157,7 +218,6 @@ body {
   filter: drop-shadow(0 0 10px rgba(238, 122, 8, 0.4));
 }
 
-/* Subtle breathing glow animation */
 @keyframes logo-breathe {
   0%, 100% {
     filter: drop-shadow(0 0 8px rgba(238, 122, 8, 0.3));
@@ -172,87 +232,14 @@ body {
 }
 
 /* =============================================================================
-   BACKGROUND PATTERNS
+   BACKGROUND PATTERNS (legacy)
    ============================================================================= */
 
-/* Grid pattern for backgrounds */
 .grid-pattern {
   background-image:
     linear-gradient(rgba(2, 109, 248, 0.03) 1px, transparent 1px),
     linear-gradient(90deg, rgba(2, 109, 248, 0.03) 1px, transparent 1px);
   background-size: 40px 40px;
-}
-
-/* Industrial noise texture overlay */
-.noise-overlay {
-  position: relative;
-}
-
-.noise-overlay::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.02'/%3E%3C/svg%3E");
-  pointer-events: none;
-  z-index: 1;
-}
-
-/* =============================================================================
-   STATUS BADGES
-   ============================================================================= */
-
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 9999px;
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.status-badge-pending {
-  background: rgba(234, 179, 8, 0.1);
-  color: #eab308;
-  border: 1px solid rgba(234, 179, 8, 0.2);
-}
-
-.status-badge-processing {
-  background: rgba(2, 109, 248, 0.1);
-  color: #026DF8;
-  border: 1px solid rgba(2, 109, 248, 0.2);
-}
-
-.status-badge-printing {
-  background: rgba(2, 109, 248, 0.1);
-  color: #0088FF;
-  border: 1px solid rgba(2, 109, 248, 0.2);
-}
-
-.status-badge-shipped {
-  background: rgba(168, 85, 247, 0.1);
-  color: #a855f7;
-  border: 1px solid rgba(168, 85, 247, 0.2);
-}
-
-.status-badge-delivered,
-.status-badge-success {
-  background: rgba(0, 200, 83, 0.1);
-  color: #00c853;
-  border: 1px solid rgba(0, 200, 83, 0.2);
-}
-
-.status-badge-error,
-.status-badge-cancelled {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
-  border: 1px solid rgba(239, 68, 68, 0.2);
-}
-
-.status-badge-maintenance {
-  background: rgba(238, 122, 8, 0.1);
-  color: #EE7A08;
-  border: 1px solid rgba(238, 122, 8, 0.2);
 }
 
 /* =============================================================================
@@ -292,76 +279,14 @@ body {
   }
 }
 
-@keyframes slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 20px -5px rgba(2, 109, 248, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 30px -5px rgba(2, 109, 248, 0.5);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -200% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
-}
-
 .animate-slide-in {
   animation: slide-in 0.3s ease-out;
 }
 
-.animate-slide-up {
-  animation: slide-up 0.3s ease-out;
-}
-
-.animate-fade-in {
-  animation: fade-in 0.2s ease-out;
-}
-
-.animate-pulse-glow {
-  animation: pulse-glow 2s infinite ease-in-out;
-}
-
-.animate-shimmer {
-  animation: shimmer 2s infinite linear;
-  background: linear-gradient(
-    90deg,
-    var(--bg-card) 0%,
-    var(--border-subtle) 50%,
-    var(--bg-card) 100%
-  );
-  background-size: 200% 100%;
-}
-
 /* =============================================================================
-   NAVIGATION ACTIVE STATE (NEO-INDUSTRIAL)
+   NAVIGATION ACTIVE STATE (legacy — migrated in the shell slice)
    ============================================================================= */
 
-/* Replace cyan/blue gradient with primary/accent */
 .nav-item-active {
   background: linear-gradient(90deg, rgba(2, 109, 248, 0.2), rgba(238, 122, 8, 0.1));
   border: 1px solid rgba(2, 109, 248, 0.3);
@@ -372,7 +297,6 @@ body {
   border-color: rgba(238, 122, 8, 0.5);
 }
 
-/* Nav item base state */
 .nav-item {
   color: var(--text-secondary);
   transition: all var(--transition-base);
@@ -383,7 +307,6 @@ body {
   color: var(--text-primary);
 }
 
-/* Focus indicators for nav items - enhanced visibility */
 .nav-item:focus-visible {
   outline: none;
   background: var(--bg-card);
@@ -393,52 +316,4 @@ body {
 .nav-item-active:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--accent), 0 0 0 4px rgba(238, 122, 8, 0.3);
-}
-
-/* =============================================================================
-   BUTTON ENHANCEMENTS
-   ============================================================================= */
-
-/* Primary button with glow on hover */
-.btn-primary {
-  background: var(--primary);
-  color: white;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-weight: 500;
-  transition: all var(--transition-base);
-}
-
-.btn-primary:hover {
-  background: var(--primary-light);
-  box-shadow: 0 0 20px -5px rgba(2, 109, 248, 0.5);
-}
-
-/* Accent button */
-.btn-accent {
-  background: var(--accent);
-  color: white;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-weight: 500;
-  transition: all var(--transition-base);
-}
-
-.btn-accent:hover {
-  background: var(--accent-light);
-  box-shadow: 0 0 20px -5px rgba(238, 122, 8, 0.5);
-}
-
-/* Ghost button */
-.btn-ghost {
-  background: transparent;
-  color: var(--text-secondary);
-  padding: 8px 16px;
-  border-radius: 8px;
-  transition: all var(--transition-base);
-}
-
-.btn-ghost:hover {
-  background: var(--bg-card);
-  color: var(--text-primary);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,6 +29,16 @@
   --rule-hair:    #E5E3DC;
   --shadow-pop:   0 1px 2px rgba(31, 31, 28, 0.06), 0 4px 12px rgba(31, 31, 28, 0.08);
 
+  /* ---- Status semantics (locked decision, #846) -------------------------
+     amber = in-progress/working, green = ready/cleared, red = overdue/error.
+     Orange is reserved for primary action and must never double as a status. */
+  --status-amber:      #B45309;
+  --status-amber-tint: #FEF3C7;
+  --status-green:      #15803D;
+  --status-green-tint: #DCFCE7;
+  --status-red:        #DC2626;
+  --status-red-tint:   #FEE2E2;
+
   /* ---- Liquid-glass material (floating chrome only) --------------------- */
   --glass-bg:     rgba(250, 250, 247, 0.66);
   --glass-blur:   blur(26px) saturate(200%);
@@ -76,6 +86,13 @@
   --orange-tint:  #3A2418;
   --rule-hair:    #34302A;
   --shadow-pop:   0 1px 2px rgba(0, 0, 0, 0.30), 0 4px 12px rgba(0, 0, 0, 0.40);
+
+  --status-amber:      #FBBF24;
+  --status-amber-tint: #3D2E0A;
+  --status-green:      #4ADE80;
+  --status-green-tint: #0F2E1A;
+  --status-red:        #F87171;
+  --status-red-tint:   #3A1414;
 
   --glass-bg:     rgba(36, 33, 27, 0.62);
   --glass-blur:   blur(28px) saturate(180%);

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -95,6 +95,13 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
       maximumFractionDigits: 1,
     }).format(value);
 
+  const formatFullCurrency = (value) =>
+    new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency: currency_code,
+      maximumFractionDigits: 2,
+    }).format(value);
+
   const handleMouseMove = (e, index) => {
     if (chartRef.current) {
       const rect = chartRef.current.getBoundingClientRect();
@@ -228,7 +235,7 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
                       </div>
                       <div className="flex justify-between gap-4">
                         <span className="text-[var(--status-green)]">Value:</span>
-                        <span className="text-[var(--ink)] font-mono-data">${d.dailyValue.toFixed(2)}</span>
+                        <span className="text-[var(--ink)] font-mono-data">{formatFullCurrency(d.dailyValue)}</span>
                       </div>
                       <div className="border-t border-[var(--rule-hair)] my-1 pt-1">
                         <div className="flex justify-between gap-4">
@@ -237,7 +244,7 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
                         </div>
                         <div className="flex justify-between gap-4">
                           <span className="text-[var(--ink-3)]">Total Value:</span>
-                          <span className="text-[var(--ink)] font-mono-data">${d.cumulativeValue.toFixed(2)}</span>
+                          <span className="text-[var(--ink)] font-mono-data">{formatFullCurrency(d.cumulativeValue)}</span>
                         </div>
                       </div>
                     </div>
@@ -324,6 +331,7 @@ export default function AdminShipping() {
   const [canShip, setCanShip] = useState({}); // #845: order_id -> {can_ship, reasons[]}
   const [canShipUnavailable, setCanShipUnavailable] = useState(false); // preflight fetch failed — surfaced via a banner (fail-visible)
   const canShipReqRef = useRef(0); // monotonic guard: only the latest fetch writes state
+  const ordersReqRef = useRef(0); // monotonic guard for the orders + preflight refresh
   const [activeTab, setActiveTab] = useState("packaging"); // packaging, needs_label, ready_to_ship
   const [expandedOrder, setExpandedOrder] = useState(null);
   const [trackingForm, setTrackingForm] = useState({ carrier: "USPS", tracking_number: "" });
@@ -374,6 +382,9 @@ export default function AdminShipping() {
   }, [orderIdParam, orders, productionStatus]);
 
   const fetchOrders = async () => {
+    // Only the newest refresh may write state or clear loading (initial load /
+    // manual refresh / post-ship reload can overlap).
+    const requestId = ++ordersReqRef.current;
     setLoading(true);
     try {
       // Fetch orders ready to ship. (qc_passed removed — not a SalesOrder
@@ -383,22 +394,23 @@ export default function AdminShipping() {
       );
 
       const orderList = data.items || data || [];
+      if (requestId !== ordersReqRef.current) return;
       setOrders(orderList);
 
       // Fetch production status for all orders in one batch call
       fetchAllProductionStatuses(orderList);
 
-      // Fetch the can-ship preflight for every ready_to_ship order in one
-      // batch call (#845) — this is the same gate ship_order() itself
-      // enforces, so the UI never disagrees with the backend.
-      fetchCanShip();
+      // Await the can-ship preflight so loading stays true until eligibility is
+      // known — Ship rows must not be interactive before the preflight resolves
+      // (#845). This is the same gate ship_order() enforces.
+      await fetchCanShip();
 
       // Fetch shipped today for metrics
       fetchShippedToday();
     } catch (err) {
-      setError(err.message);
+      if (requestId === ordersReqRef.current) setError(err.message);
     } finally {
-      setLoading(false);
+      if (requestId === ordersReqRef.current) setLoading(false);
     }
   };
 

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -56,7 +56,7 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
   if (loading) {
     return (
       <div className="h-32 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-cyan-500"></div>
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
       </div>
     );
   }
@@ -127,8 +127,8 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
               onClick={() => onPeriodChange(p.key)}
               className={`px-3 py-1 text-xs rounded-md transition-colors ${
                 period === p.key
-                  ? "bg-cyan-600 text-white"
-                  : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                  ? "bg-[var(--ink)] text-[var(--paper)]"
+                  : "bg-[var(--paper-sunk)] text-[var(--ink-3)] hover:text-[var(--ink)]"
               }`}
             >
               {p.label}
@@ -137,17 +137,17 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
         </div>
         <div className="flex gap-4 text-right">
           <div>
-            <p className="text-sm font-semibold text-cyan-400">{data?.total_shipped || 0}</p>
-            <p className="text-xs text-gray-500">shipped</p>
+            <p className="text-sm font-semibold text-[var(--ink)]">{data?.total_shipped || 0}</p>
+            <p className="text-xs text-[var(--ink-4)]">shipped</p>
           </div>
           <div>
-            <p className="text-sm font-semibold text-green-400">{formatCurrency(data?.total_value || 0)}</p>
-            <p className="text-xs text-gray-500">value</p>
+            <p className="text-sm font-semibold text-[var(--status-green)]">{formatCurrency(data?.total_value || 0)}</p>
+            <p className="text-xs text-[var(--ink-4)]">value</p>
           </div>
           {(data?.pipeline_ready > 0 || data?.pipeline_packaging > 0) && (
             <div>
-              <p className="text-sm font-semibold text-yellow-400">{(data?.pipeline_ready || 0) + (data?.pipeline_packaging || 0)}</p>
-              <p className="text-xs text-gray-500">in pipeline</p>
+              <p className="text-sm font-semibold text-[var(--status-amber)]">{(data?.pipeline_ready || 0) + (data?.pipeline_packaging || 0)}</p>
+              <p className="text-xs text-[var(--ink-4)]">in pipeline</p>
             </div>
           )}
         </div>
@@ -155,19 +155,19 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
 
       <div className="flex gap-4 mb-2 text-xs">
         <div className="flex items-center gap-1">
-          <div className="w-2 h-3 bg-cyan-500/30 rounded-sm"></div>
-          <span className="text-gray-500">Daily Shipped</span>
+          <div className="w-2 h-3 bg-[var(--orange-tint)] rounded-sm"></div>
+          <span className="text-[var(--ink-4)]">Daily Shipped</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-3 h-0.5 bg-green-500"></div>
-          <span className="text-gray-400">Cumulative Value</span>
+          <div className="w-3 h-0.5 bg-[var(--status-green)]"></div>
+          <span className="text-[var(--ink-3)]">Cumulative Value</span>
         </div>
       </div>
 
       {dataPoints.length > 0 ? (
         <div ref={chartRef} className="relative" style={{ height: chartHeight }} onMouseLeave={() => setHoveredIndex(null)}>
           <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="w-full h-full">
-            <line x1="0" y1="50" x2="100" y2="50" stroke="#374151" strokeWidth="0.5" />
+            <line x1="0" y1="50" x2="100" y2="50" stroke="var(--rule-hair)" strokeWidth="0.5" />
 
             {dataPoints.map((d, i) => {
               const barWidth = 100 / Math.max(dataPoints.length, 1) * 0.6;
@@ -181,12 +181,12 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
                   width={barWidth}
                   height={barHeight}
                   fill="url(#shippingBarGradient)"
-                  opacity="0.4"
+                  opacity="0.6"
                 />
               );
             })}
 
-            <path d={generateValuePath()} fill="none" stroke="#22c55e" strokeWidth="2" vectorEffect="non-scaling-stroke" />
+            <path d={generateValuePath()} fill="none" stroke="var(--status-green)" strokeWidth="2" vectorEffect="non-scaling-stroke" />
 
             {dataPoints.map((_, i) => {
               const sliceWidth = 100 / dataPoints.length;
@@ -199,45 +199,45 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
               <circle
                 cx={(hoveredIndex / Math.max(cumulativeData.length - 1, 1)) * 100}
                 cy={100 - (cumulativeData[hoveredIndex].cumulativeValue / Math.max(maxCumulativeValue, 1)) * 100}
-                r="3" fill="#22c55e" stroke="white" strokeWidth="1" vectorEffect="non-scaling-stroke"
+                r="3" fill="var(--status-green)" stroke="var(--paper)" strokeWidth="1" vectorEffect="non-scaling-stroke"
               />
             )}
 
             <defs>
               <linearGradient id="shippingBarGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stopColor="#06b6d4" />
-                <stop offset="100%" stopColor="#06b6d4" stopOpacity="0.2" />
+                <stop offset="0%" stopColor="var(--orange)" />
+                <stop offset="100%" stopColor="var(--orange)" stopOpacity="0.15" />
               </linearGradient>
             </defs>
           </svg>
 
           {hoveredIndex !== null && getHoveredData() && (
             <div
-              className="absolute z-10 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-3 pointer-events-none"
+              className="absolute z-10 bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg shadow-[var(--shadow-pop)] p-3 pointer-events-none"
               style={{ left: Math.min(mousePos.x + 10, chartWidth - 150), top: Math.max(mousePos.y - 70, 0), minWidth: '140px' }}
             >
               {(() => {
                 const d = getHoveredData();
                 return (
                   <>
-                    <div className="text-white font-medium text-sm mb-2">{d.date}</div>
+                    <div className="text-[var(--ink)] font-medium text-sm mb-2">{d.date}</div>
                     <div className="space-y-1 text-xs">
                       <div className="flex justify-between gap-4">
-                        <span className="text-cyan-400">Shipped:</span>
-                        <span className="text-white font-medium">{d.shipped}</span>
+                        <span className="text-[var(--ink-3)]">Shipped:</span>
+                        <span className="text-[var(--ink)] font-medium font-mono-data">{d.shipped}</span>
                       </div>
                       <div className="flex justify-between gap-4">
-                        <span className="text-green-400">Value:</span>
-                        <span className="text-white">${d.dailyValue.toFixed(2)}</span>
+                        <span className="text-[var(--status-green)]">Value:</span>
+                        <span className="text-[var(--ink)] font-mono-data">${d.dailyValue.toFixed(2)}</span>
                       </div>
-                      <div className="border-t border-gray-700 my-1 pt-1">
+                      <div className="border-t border-[var(--rule-hair)] my-1 pt-1">
                         <div className="flex justify-between gap-4">
-                          <span className="text-gray-400">Total Shipped:</span>
-                          <span className="text-white">{d.cumulativeShipped}</span>
+                          <span className="text-[var(--ink-3)]">Total Shipped:</span>
+                          <span className="text-[var(--ink)] font-mono-data">{d.cumulativeShipped}</span>
                         </div>
                         <div className="flex justify-between gap-4">
-                          <span className="text-gray-400">Total Value:</span>
-                          <span className="text-white">${d.cumulativeValue.toFixed(2)}</span>
+                          <span className="text-[var(--ink-3)]">Total Value:</span>
+                          <span className="text-[var(--ink)] font-mono-data">${d.cumulativeValue.toFixed(2)}</span>
                         </div>
                       </div>
                     </div>
@@ -248,11 +248,11 @@ function ShippingChart({ data, period, onPeriodChange, loading }) {
           )}
         </div>
       ) : (
-        <div className="h-24 flex items-center justify-center text-gray-500 text-sm">No shipments for this period</div>
+        <div className="h-24 flex items-center justify-center text-[var(--ink-4)] text-sm">No shipments for this period</div>
       )}
 
       {dataPoints.length > 0 && (
-        <div className="flex justify-between text-xs text-gray-500 mt-2">
+        <div className="flex justify-between text-xs text-[var(--ink-4)] mt-2">
           <span>{dataPoints[0]?.date ? parseLocalDate(dataPoints[0].date)?.toLocaleDateString() : ""}</span>
           <span>{dataPoints[dataPoints.length - 1]?.date ? parseLocalDate(dataPoints[dataPoints.length - 1].date)?.toLocaleDateString() : ""}</span>
         </div>
@@ -321,6 +321,7 @@ export default function AdminShipping() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [productionStatus, setProductionStatus] = useState({});
+  const [canShip, setCanShip] = useState({}); // #845: order_id -> {can_ship, reasons[]}
   const [activeTab, setActiveTab] = useState("packaging"); // packaging, needs_label, ready_to_ship
   const [expandedOrder, setExpandedOrder] = useState(null);
   const [trackingForm, setTrackingForm] = useState({ carrier: "USPS", tracking_number: "" });
@@ -373,9 +374,10 @@ export default function AdminShipping() {
   const fetchOrders = async () => {
     setLoading(true);
     try {
-      // Fetch orders ready to ship
+      // Fetch orders ready to ship. (qc_passed removed — not a SalesOrder
+      // status; it matched zero rows. #845)
       const data = await api.get(
-        `/api/v1/sales-orders/?status=confirmed&status=in_production&status=ready_to_ship&status=qc_passed&limit=100`
+        `/api/v1/sales-orders/?status=confirmed&status=in_production&status=ready_to_ship&limit=100`
       );
 
       const orderList = data.items || data || [];
@@ -384,12 +386,26 @@ export default function AdminShipping() {
       // Fetch production status for all orders in one batch call
       fetchAllProductionStatuses(orderList);
 
+      // Fetch the can-ship preflight for every ready_to_ship order in one
+      // batch call (#845) — this is the same gate ship_order() itself
+      // enforces, so the UI never disagrees with the backend.
+      fetchCanShip();
+
       // Fetch shipped today for metrics
       fetchShippedToday();
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchCanShip = async () => {
+    try {
+      const data = await api.get(`/api/v1/sales-orders/can-ship`);
+      setCanShip(data || {});
+    } catch {
+      // Non-critical — Ship action still falls back to a reactive error toast.
     }
   };
 
@@ -497,6 +513,13 @@ export default function AdminShipping() {
       toast.error("Add a carrier before shipping");
       return;
     }
+    // Preflight check (#845) — surface the backend's real blocker before
+    // firing the request, instead of only reacting to a 409 after the fact.
+    const preflight = canShip[orderId] ?? canShip[String(orderId)];
+    if (preflight && !preflight.can_ship) {
+      toast.error(preflight.reasons?.[0] || "Order is not ready to ship");
+      return;
+    }
     setSaving(true);
     try {
       await api.post(`/api/v1/sales-orders/${orderId}/ship`, {
@@ -517,7 +540,10 @@ export default function AdminShipping() {
     window.open(`${API_URL}/api/v1/sales-orders/${orderId}/packing-slip/pdf`, "_blank");
   };
 
-  // Categorize orders into workflow stages
+  // Categorize orders into workflow stages. This is the physical packaging
+  // workflow (where is the order in the packing/labeling process) — distinct
+  // from the backend's can-ship gate, which augments the ready_to_ship tab
+  // below rather than replacing this bucketing (#845).
   const categorizeOrders = () => {
     const packaging = []; // Production not complete
     const needsLabel = []; // Production complete, no tracking
@@ -542,8 +568,8 @@ export default function AdminShipping() {
   const { packaging, needsLabel, readyToShip } = categorizeOrders();
 
   const tabs = [
-    { key: "packaging", label: "Ready for Packaging", count: packaging.length, color: "blue" },
-    { key: "needs_label", label: "Needs Label", count: needsLabel.length, color: "yellow" },
+    { key: "packaging", label: "Ready for Packaging", count: packaging.length, color: "amber" },
+    { key: "needs_label", label: "Needs Label", count: needsLabel.length, color: "amber" },
     { key: "ready_to_ship", label: "Ready to Ship", count: readyToShip.length, color: "green" },
   ];
 
@@ -559,22 +585,25 @@ export default function AdminShipping() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
+      {/* Header — wrapped in its own paper card: the AdminLayout shell behind
+          this page is still the un-migrated dark Neo background (a later
+          #846 slice), so ink-toned text needs its own light surface here
+          rather than floating directly on the shell. */}
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)] flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-xl font-bold text-white">Shipping</h1>
-          <p className="text-gray-500 text-sm">Package, label, and ship orders</p>
+          <h1 className="text-xl font-bold text-[var(--ink)]">Shipping</h1>
+          <p className="text-[var(--ink-4)] text-sm">Package, label, and ship orders</p>
         </div>
         <button
           onClick={fetchOrders}
-          className="px-3 py-1.5 bg-gray-800 text-gray-300 rounded-lg text-sm hover:bg-gray-700"
+          className="px-3 py-1.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] rounded-lg text-sm hover:bg-[var(--rule-hair)]"
         >
           Refresh
         </button>
       </div>
 
       {/* Shipping Trend Chart */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
         <ShippingChart
           data={shippingTrend}
           period={shippingPeriod}
@@ -585,43 +614,43 @@ export default function AdminShipping() {
 
       {/* Metrics Row - Compact */}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-3">
-          <p className="text-gray-500 text-xs">Total Pending</p>
-          <p className="text-xl font-bold text-white">{orders.length}</p>
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg p-3 shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--ink-4)] text-xs">Total Pending</p>
+          <p className="text-xl font-bold text-[var(--ink)]">{orders.length}</p>
         </div>
-        <div className="bg-gray-900 border border-blue-800/50 rounded-lg p-3">
-          <p className="text-blue-400 text-xs">Packaging</p>
-          <p className="text-xl font-bold text-white">{packaging.length}</p>
+        <div className="bg-[var(--paper)] border border-[var(--status-amber-tint)] rounded-lg p-3 shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--status-amber)] text-xs">Packaging</p>
+          <p className="text-xl font-bold text-[var(--ink)]">{packaging.length}</p>
         </div>
-        <div className="bg-gray-900 border border-yellow-800/50 rounded-lg p-3">
-          <p className="text-yellow-400 text-xs">Needs Label</p>
-          <p className="text-xl font-bold text-white">{needsLabel.length}</p>
+        <div className="bg-[var(--paper)] border border-[var(--status-amber-tint)] rounded-lg p-3 shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--status-amber)] text-xs">Needs Label</p>
+          <p className="text-xl font-bold text-[var(--ink)]">{needsLabel.length}</p>
         </div>
-        <div className="bg-gray-900 border border-green-800/50 rounded-lg p-3">
-          <p className="text-green-400 text-xs">Ready to Ship</p>
-          <p className="text-xl font-bold text-white">{readyToShip.length}</p>
+        <div className="bg-[var(--paper)] border border-[var(--status-green-tint)] rounded-lg p-3 shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--status-green)] text-xs">Ready to Ship</p>
+          <p className="text-xl font-bold text-[var(--ink)]">{readyToShip.length}</p>
         </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-lg p-3">
-          <p className="text-gray-500 text-xs">Shipped Today</p>
-          <p className="text-xl font-bold text-white">{shippedToday.length}</p>
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg p-3 shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--ink-4)] text-xs">Shipped Today</p>
+          <p className="text-xl font-bold text-[var(--ink)]">{shippedToday.length}</p>
         </div>
       </div>
 
       {/* Error */}
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+        <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3 text-[var(--status-red)] text-sm">
           {error}
         </div>
       )}
 
       {/* Deep-link banner: orderId param present but order not in ready-to-ship set */}
       {!loading && orderIdParam && !orders.find((o) => o.id === parseInt(orderIdParam)) && (
-        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg px-4 py-3 flex items-start gap-3">
-          <svg className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg px-4 py-3 flex items-start gap-3">
+          <svg className="w-5 h-5 text-[var(--status-amber)] mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
           </svg>
-          <p className="text-yellow-300 text-sm">
-            Order isn&apos;t ready to ship yet — production must complete.
+          <p className="text-[var(--status-amber)] text-sm">
+            Order isn&apos;t in an active shipping stage — it may already be shipped, cancelled, or not yet confirmed.
           </p>
         </div>
       )}
@@ -632,14 +661,13 @@ export default function AdminShipping() {
       {/* purger and will be stripped from the production bundle. */}
       {(() => {
         const TAB_STYLES = {
-          blue:   { border: "border-blue-500 text-blue-400",     badge: "bg-blue-500/20"   },
-          yellow: { border: "border-yellow-500 text-yellow-400", badge: "bg-yellow-500/20" },
-          green:  { border: "border-green-500 text-green-400",   badge: "bg-green-500/20"  },
+          amber: { border: "border-[var(--status-amber)] text-[var(--status-amber)]", badge: "bg-[var(--status-amber-tint)]" },
+          green: { border: "border-[var(--status-green)] text-[var(--status-green)]", badge: "bg-[var(--status-green-tint)]" },
         };
         return (
-          <div className="flex gap-1 border-b border-gray-800">
+          <div className="flex gap-1 border-b border-[var(--rule-hair)]">
             {tabs.map((tab) => {
-              const styles = TAB_STYLES[tab.color] ?? TAB_STYLES.blue;
+              const styles = TAB_STYLES[tab.color] ?? TAB_STYLES.amber;
               return (
                 <button
                   key={tab.key}
@@ -647,12 +675,12 @@ export default function AdminShipping() {
                   className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
                     activeTab === tab.key
                       ? styles.border
-                      : "border-transparent text-gray-500 hover:text-gray-300"
+                      : "border-transparent text-[var(--ink-4)] hover:text-[var(--ink-2)]"
                   }`}
                 >
                   {tab.label}
-                  <span className={`ml-2 px-1.5 py-0.5 rounded text-xs ${
-                    activeTab === tab.key ? styles.badge : "bg-gray-800"
+                  <span className={`ml-2 px-1.5 py-0.5 rounded text-xs font-mono-data ${
+                    activeTab === tab.key ? styles.badge : "bg-[var(--paper-sunk)]"
                   }`}>
                     {tab.count}
                   </span>
@@ -666,17 +694,17 @@ export default function AdminShipping() {
       {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center h-32">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
         </div>
       )}
 
       {/* Orders Table */}
       {!loading && (
-        <div className="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg overflow-hidden shadow-[var(--shadow-pop)]">
           <div className="overflow-x-auto">
           <table className="w-full min-w-[640px] text-sm">
-            <thead className="bg-gray-800/50">
-              <tr className="text-left text-gray-400 text-xs uppercase">
+            <thead className="bg-[var(--paper-sunk)]">
+              <tr className="text-left text-[var(--ink-3)] text-xs uppercase">
                 <th className="px-4 py-3 font-medium">Order</th>
                 <th className="px-4 py-3 font-medium">Product</th>
                 <th className="px-4 py-3 font-medium">Ship To</th>
@@ -687,65 +715,74 @@ export default function AdminShipping() {
                 <th className="px-4 py-3 font-medium text-right">Actions</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-800">
+            <tbody className="divide-y divide-[var(--rule-hair)]">
               {getCurrentOrders().map((order) => {
                 const ps = productionStatus[order.id];
                 const isExpanded = expandedOrder === order.id;
                 const dueDateInfo = getDueDateInfo(order);
+                const preflight = canShip[order.id] ?? canShip[String(order.id)];
+                const blocked = activeTab === "ready_to_ship" && preflight && !preflight.can_ship;
 
                 // Color classes for due date urgency
                 const dueDateColorClass = {
-                  overdue: "text-red-400 font-medium",
-                  today: "text-yellow-400 font-medium",
-                  soon: "text-orange-400",
-                  normal: "text-gray-400",
-                  none: "text-gray-600",
+                  overdue: "text-[var(--status-red)] font-medium",
+                  today: "text-[var(--status-amber)] font-medium",
+                  soon: "text-[var(--status-amber)]",
+                  normal: "text-[var(--ink-3)]",
+                  none: "text-[var(--ink-4)]",
                 }[dueDateInfo.status];
 
                 return (
-                  <tr key={order.id} className="hover:bg-gray-800/50">
+                  <tr key={order.id} className="hover:bg-[var(--paper-sunk)]">
                     <td className="px-4 py-3">
                       <button
                         onClick={() => navigate(`/admin/orders/${order.id}`)}
-                        className="text-blue-400 hover:text-blue-300 font-medium"
+                        className="text-[var(--ink)] hover:text-[var(--orange)] font-medium font-mono-data"
                       >
                         {order.order_number}
                       </button>
                     </td>
-                    <td className="px-4 py-3 text-white">
+                    <td className="px-4 py-3 text-[var(--ink)]">
                       <div className="max-w-[200px] truncate" title={order.product_name}>
                         {order.product_name}
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-gray-400">
+                    <td className="px-4 py-3 text-[var(--ink-3)]">
                       {hasShippingAddress(order) ? (
                         formatAddressShort(order)
                       ) : (
-                        <span className="text-red-400">No address</span>
+                        <span className="text-[var(--status-red)]">No address</span>
                       )}
                     </td>
                     <td className={`px-4 py-3 ${dueDateColorClass}`}>
                       {dueDateInfo.text}
                     </td>
-                    <td className="px-4 py-3 text-right text-white">{order.quantity}</td>
-                    <td className="px-4 py-3 text-right text-green-400">
+                    <td className="px-4 py-3 text-right text-[var(--ink)] font-mono-data">{order.quantity}</td>
+                    <td className="px-4 py-3 text-right text-[var(--status-green)] font-mono-data">
                       {formatCurrency(order.grand_total)}
                     </td>
                     <td className="px-4 py-3">
                       {activeTab === "packaging" && ps && (
-                        <span className="text-yellow-400 text-xs">
+                        <span className="text-[var(--status-amber)] text-xs">
                           {ps.anyInProgress
                             ? `${Math.round(ps.completionPercent)}% done`
                             : "Not started"}
                         </span>
                       )}
                       {activeTab === "needs_label" && (
-                        <span className="text-blue-400 text-xs">Ready to label</span>
+                        <span className="text-[var(--status-amber)] text-xs">Ready to label</span>
                       )}
                       {activeTab === "ready_to_ship" && order.tracking_number && (
-                        <span className="font-mono text-xs text-gray-400" title={order.tracking_number}>
-                          {order.carrier}: {order.tracking_number.slice(0, 12)}...
-                        </span>
+                        <div>
+                          <span className="font-mono-data text-xs text-[var(--ink-3)]" title={order.tracking_number}>
+                            {order.carrier}: {order.tracking_number.slice(0, 12)}...
+                          </span>
+                          {blocked && (
+                            <div className="text-[var(--status-red)] text-xs mt-0.5" title={preflight.reasons?.join("; ")}>
+                              {preflight.reasons?.[0] || "Cannot ship yet"}
+                            </div>
+                          )}
+                        </div>
                       )}
                     </td>
                     <td className="px-4 py-3 text-right">
@@ -754,26 +791,26 @@ export default function AdminShipping() {
                           <>
                             <button
                               onClick={() => handlePackingSlip(order.id)}
-                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              className="px-3 py-1 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-xs hover:bg-[var(--rule-hair)]"
                               title="Print packing slip"
                             >
                               Packing Slip
                             </button>
-                            <span className="text-gray-500 text-xs italic">Awaiting production</span>
+                            <span className="text-[var(--ink-4)] text-xs italic">Awaiting production</span>
                           </>
                         )}
                         {activeTab === "needs_label" && (
                           <>
                             <button
                               onClick={() => handlePackingSlip(order.id)}
-                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              className="px-3 py-1 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-xs hover:bg-[var(--rule-hair)]"
                               title="Print packing slip"
                             >
                               Packing Slip
                             </button>
                             <button
                               onClick={() => setExpandedOrder(isExpanded ? null : order.id)}
-                              className="px-3 py-1 bg-yellow-600 text-white rounded text-xs hover:bg-yellow-700"
+                              className="px-3 py-1 bg-[var(--orange)] text-white rounded text-xs hover:bg-[var(--orange-press)]"
                             >
                               {isExpanded ? "Cancel" : "Add Label"}
                             </button>
@@ -783,15 +820,16 @@ export default function AdminShipping() {
                           <>
                             <button
                               onClick={() => handlePackingSlip(order.id)}
-                              className="px-3 py-1 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                              className="px-3 py-1 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-xs hover:bg-[var(--rule-hair)]"
                               title="Print packing slip"
                             >
                               Packing Slip
                             </button>
                             <button
                               onClick={() => handleMarkShipped(order.id)}
-                              disabled={saving}
-                              className="px-3 py-1 bg-green-600 text-white rounded text-xs hover:bg-green-700 disabled:opacity-50"
+                              disabled={saving || blocked}
+                              title={blocked ? preflight.reasons?.join("; ") : undefined}
+                              className="px-3 py-1 bg-[var(--orange)] text-white rounded text-xs hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                               {saving ? "..." : "Ship"}
                             </button>
@@ -805,15 +843,15 @@ export default function AdminShipping() {
 
               {/* Inline Label Entry Row */}
               {expandedOrder && activeTab === "needs_label" && (
-                <tr className="bg-yellow-900/10">
+                <tr className="bg-[var(--status-amber-tint)]">
                   <td colSpan={8} className="px-4 py-4">
                     <div className="flex items-center gap-4">
                       <div className="flex-1 flex items-center gap-3">
-                        <span className="text-gray-400 text-sm">Carrier:</span>
+                        <span className="text-[var(--ink-3)] text-sm">Carrier:</span>
                         <select
                           value={trackingForm.carrier}
                           onChange={(e) => setTrackingForm({ ...trackingForm, carrier: e.target.value })}
-                          className="bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-white text-sm"
+                          className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded px-2 py-1.5 text-[var(--ink)] text-sm"
                         >
                           <option value="USPS">USPS</option>
                           <option value="FedEx">FedEx</option>
@@ -821,13 +859,13 @@ export default function AdminShipping() {
                           <option value="DHL">DHL</option>
                           <option value="Other">Other</option>
                         </select>
-                        <span className="text-gray-400 text-sm">Tracking:</span>
+                        <span className="text-[var(--ink-3)] text-sm">Tracking:</span>
                         <input
                           type="text"
                           value={trackingForm.tracking_number}
                           onChange={(e) => setTrackingForm({ ...trackingForm, tracking_number: e.target.value })}
                           placeholder="Enter tracking number..."
-                          className="flex-1 bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-white text-sm placeholder-gray-500"
+                          className="flex-1 bg-[var(--paper)] border border-[var(--rule-hair)] rounded px-3 py-1.5 text-[var(--ink)] text-sm placeholder-[var(--ink-4)]"
                           autoFocus
                         />
                       </div>
@@ -836,7 +874,7 @@ export default function AdminShipping() {
                           href="https://www.usps.com/ship/"
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="px-2 py-1.5 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                          className="px-2 py-1.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-xs hover:bg-[var(--rule-hair)]"
                         >
                           USPS ↗
                         </a>
@@ -844,14 +882,14 @@ export default function AdminShipping() {
                           href="https://www.pirateship.com/"
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="px-2 py-1.5 bg-gray-700 text-gray-300 rounded text-xs hover:bg-gray-600"
+                          className="px-2 py-1.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-xs hover:bg-[var(--rule-hair)]"
                         >
                           PirateShip ↗
                         </a>
                         <button
                           onClick={() => handleSaveTracking(expandedOrder)}
                           disabled={saving || !trackingForm.tracking_number.trim()}
-                          className="px-4 py-1.5 bg-green-600 text-white rounded text-sm hover:bg-green-700 disabled:opacity-50"
+                          className="px-4 py-1.5 bg-[var(--orange)] text-white rounded text-sm hover:bg-[var(--orange-press)] disabled:opacity-50"
                         >
                           {saving ? "Saving..." : "Save & Ship"}
                         </button>
@@ -860,7 +898,7 @@ export default function AdminShipping() {
                             setExpandedOrder(null);
                             setTrackingForm({ carrier: "USPS", tracking_number: "" });
                           }}
-                          className="px-3 py-1.5 bg-gray-700 text-gray-300 rounded text-sm hover:bg-gray-600"
+                          className="px-3 py-1.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded text-sm hover:bg-[var(--rule-hair)]"
                         >
                           Cancel
                         </button>
@@ -872,7 +910,7 @@ export default function AdminShipping() {
 
               {getCurrentOrders().length === 0 && (
                 <tr>
-                  <td colSpan={8} className="px-4 py-8 text-center text-gray-500">
+                  <td colSpan={8} className="px-4 py-8 text-center text-[var(--ink-4)]">
                     {activeTab === "packaging" && "No orders awaiting packaging"}
                     {activeTab === "needs_label" && "No orders need labels"}
                     {activeTab === "ready_to_ship" && "No orders ready to ship"}

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -322,6 +322,7 @@ export default function AdminShipping() {
   const [error, setError] = useState(null);
   const [productionStatus, setProductionStatus] = useState({});
   const [canShip, setCanShip] = useState({}); // #845: order_id -> {can_ship, reasons[]}
+  const [canShipUnavailable, setCanShipUnavailable] = useState(false); // preflight fetch failed — fail CLOSED, not open
   const [activeTab, setActiveTab] = useState("packaging"); // packaging, needs_label, ready_to_ship
   const [expandedOrder, setExpandedOrder] = useState(null);
   const [trackingForm, setTrackingForm] = useState({ carrier: "USPS", tracking_number: "" });
@@ -404,8 +405,14 @@ export default function AdminShipping() {
     try {
       const data = await api.get(`/api/v1/sales-orders/can-ship`);
       setCanShip(data || {});
+      setCanShipUnavailable(false);
     } catch {
-      // Non-critical — Ship action still falls back to a reactive error toast.
+      // Fail CLOSED, not open: if the preflight can't be fetched, treat every
+      // order as unverified rather than silently re-enabling Ship with zero
+      // protection. ship_order() still enforces correctness server-side, but
+      // the whole point of this preflight is to warn BEFORE the click.
+      setCanShip({});
+      setCanShipUnavailable(true);
     }
   };
 
@@ -690,6 +697,16 @@ export default function AdminShipping() {
           </div>
         );
       })()}
+
+      {/* Preflight degraded-state warning — make a can-ship fetch failure
+          VISIBLE rather than silently re-enabling Ship with no protection.
+          ship_order() still fully validates server-side either way; this is
+          advisory so the operator isn't caught off guard by a 409. */}
+      {canShipUnavailable && activeTab === "ready_to_ship" && (
+        <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg px-4 py-2.5 text-[var(--status-amber)] text-sm">
+          Couldn&apos;t verify which orders are ready to ship — the eligibility check didn&apos;t load. Shipping will still be validated when you click Ship.
+        </div>
+      )}
 
       {/* Loading */}
       {loading && (

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -398,7 +398,7 @@ export default function AdminShipping() {
       setOrders(orderList);
 
       // Fetch production status for all orders in one batch call
-      fetchAllProductionStatuses(orderList);
+      fetchAllProductionStatuses(orderList, requestId);
 
       // Await the can-ship preflight so loading stays true until eligibility is
       // known — Ship rows must not be interactive before the preflight resolves
@@ -406,7 +406,7 @@ export default function AdminShipping() {
       await fetchCanShip();
 
       // Fetch shipped today for metrics
-      fetchShippedToday();
+      fetchShippedToday(requestId);
     } catch (err) {
       if (requestId === ordersReqRef.current) setError(err.message);
     } finally {
@@ -434,12 +434,14 @@ export default function AdminShipping() {
     }
   };
 
-  const fetchShippedToday = async () => {
+  const fetchShippedToday = async (requestId) => {
     try {
       const today = new Date().toISOString().split("T")[0];
       const data = await api.get(
         `/api/v1/sales-orders/?status=shipped&shipped_after=${today}&limit=100`
       );
+      // Drop the write if a newer fetchOrders() sequence has started.
+      if (requestId !== undefined && requestId !== ordersReqRef.current) return;
       setShippedToday(data.items || data || []);
     } catch {
       // Non-critical
@@ -462,7 +464,7 @@ export default function AdminShipping() {
   };
 
   // Batch fetch: one API call for all production orders, group by sales_order_id
-  const fetchAllProductionStatuses = async (orderList) => {
+  const fetchAllProductionStatuses = async (orderList, requestId) => {
     if (orderList.length === 0) return;
     try {
       const data = await api.get(`/api/v1/production-orders?limit=500`);
@@ -480,6 +482,8 @@ export default function AdminShipping() {
       for (const order of orderList) {
         statusMap[order.id] = computeProductionStatus(grouped[order.id] || []);
       }
+      // Drop the write if a newer fetchOrders() sequence has started.
+      if (requestId !== undefined && requestId !== ordersReqRef.current) return;
       setProductionStatus(statusMap);
     } catch {
       // Non-critical - production status just won't show

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -322,7 +322,8 @@ export default function AdminShipping() {
   const [error, setError] = useState(null);
   const [productionStatus, setProductionStatus] = useState({});
   const [canShip, setCanShip] = useState({}); // #845: order_id -> {can_ship, reasons[]}
-  const [canShipUnavailable, setCanShipUnavailable] = useState(false); // preflight fetch failed — fail CLOSED, not open
+  const [canShipUnavailable, setCanShipUnavailable] = useState(false); // preflight fetch failed — surfaced via a banner (fail-visible)
+  const canShipReqRef = useRef(0); // monotonic guard: only the latest fetch writes state
   const [activeTab, setActiveTab] = useState("packaging"); // packaging, needs_label, ready_to_ship
   const [expandedOrder, setExpandedOrder] = useState(null);
   const [trackingForm, setTrackingForm] = useState({ carrier: "USPS", tracking_number: "" });
@@ -402,15 +403,20 @@ export default function AdminShipping() {
   };
 
   const fetchCanShip = async () => {
+    // Guard against stale overlapping refreshes (initial load / manual refresh /
+    // post-ship reload can race): only the newest request may write state.
+    const requestId = ++canShipReqRef.current;
     try {
       const data = await api.get(`/api/v1/sales-orders/can-ship`);
+      if (requestId !== canShipReqRef.current) return;
       setCanShip(data || {});
       setCanShipUnavailable(false);
     } catch {
-      // Fail CLOSED, not open: if the preflight can't be fetched, treat every
-      // order as unverified rather than silently re-enabling Ship with zero
-      // protection. ship_order() still enforces correctness server-side, but
-      // the whole point of this preflight is to warn BEFORE the click.
+      if (requestId !== canShipReqRef.current) return;
+      // Fail VISIBLE, not closed: show a banner but keep Ship enabled.
+      // ship_order() is the authoritative gate, so a preflight outage must not
+      // block shipping of orders that are actually shippable — it only costs
+      // the pre-click warning, which the banner explains.
       setCanShip({});
       setCanShipUnavailable(true);
     }

--- a/frontend/src/pages/admin/AdminShipping.jsx
+++ b/frontend/src/pages/admin/AdminShipping.jsx
@@ -395,15 +395,18 @@ export default function AdminShipping() {
 
       const orderList = data.items || data || [];
       if (requestId !== ordersReqRef.current) return;
+      setError(null); // clear any stale error from a prior failed refresh
       setOrders(orderList);
 
-      // Fetch production status for all orders in one batch call
-      fetchAllProductionStatuses(orderList, requestId);
-
-      // Await the can-ship preflight so loading stays true until eligibility is
-      // known — Ship rows must not be interactive before the preflight resolves
-      // (#845). This is the same gate ship_order() enforces.
-      await fetchCanShip();
+      // Await BOTH the production-status batch and the can-ship preflight before
+      // clearing loading. Production status drives tab classification
+      // (categorizeOrders); if loading cleared first, the initial render would
+      // mis-bucket orders whose WOs hadn't loaded yet. can-ship is awaited for
+      // the same reason ship_order() enforces it (#845). Run them in parallel.
+      await Promise.all([
+        fetchCanShip(),
+        fetchAllProductionStatuses(orderList, requestId),
+      ]);
 
       // Fetch shipped today for metrics
       fetchShippedToday(requestId);

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -213,6 +213,11 @@ export default function OrderDetail() {
   // one state var previously held both shapes, so clicking Check overwrote the
   // summary object with an array and silently flipped the shortage footer.
   const [availabilityChecks, setAvailabilityChecks] = useState([]);
+  // #845/#846: single-order can-ship preflight — the authoritative ship gate
+  // (status + address + inventory), shared with ship_order(). Drives the
+  // FulfillmentProgress Ship button so it can't advertise a ship the backend
+  // would reject.
+  const [canShip, setCanShip] = useState(null);
 
   // Fulfillment status hook (UI-302)
   const {
@@ -438,6 +443,17 @@ export default function OrderDetail() {
     }
   };
 
+  const fetchCanShip = async ({ shouldApply = () => true } = {}) => {
+    if (!orderId) return;
+    try {
+      const data = await api.get(`/api/v1/sales-orders/${orderId}/can-ship`);
+      if (shouldApply()) setCanShip(data);
+    } catch {
+      // Advisory only — ship_order() still enforces the gate server-side.
+      if (shouldApply()) setCanShip(null);
+    }
+  };
+
   useEffect(() => {
     if (!orderId) return undefined;
     let cancelled = false;
@@ -450,6 +466,7 @@ export default function OrderDetail() {
           fetchProductionOrders(),
           fetchPaymentData(),
           fetchOrderInvoice({ shouldApply }),
+          fetchCanShip({ shouldApply }),
         ]);
       } catch {
         // Individual fetchers own user-visible error state.
@@ -497,6 +514,7 @@ export default function OrderDetail() {
         fetchProductionOrders(),
         fetchPaymentData(),
         fetchOrderInvoice(),
+        fetchCanShip(),
       ]);
       toast.success("Data refreshed");
     } catch {
@@ -961,7 +979,8 @@ export default function OrderDetail() {
         loading={fulfillmentLoading}
         error={fulfillmentError}
         onRefresh={refetchFulfillment}
-        onShip={(type) => navigate(`/admin/shipping?orderId=${order.id}&mode=${type}`)}
+        canShip={canShip}
+        onShip={() => navigate(`/admin/shipping?orderId=${order.id}`)}
         closedShort={order?.closed_short === true}
       />
 

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -760,7 +760,7 @@ export default function OrderDetail() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <div className="text-white">Loading order...</div>
+        <div className="text-[var(--ink)]">Loading order...</div>
       </div>
     );
   }
@@ -768,7 +768,7 @@ export default function OrderDetail() {
   if (error || !order) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <div className="text-red-400">Error: {error || "Order not found"}</div>
+        <div className="text-[var(--status-red)]">Error: {error || "Order not found"}</div>
       </div>
     );
   }
@@ -818,14 +818,14 @@ export default function OrderDetail() {
         <div>
           <button
             onClick={() => navigate("/admin/orders")}
-            className="text-gray-400 hover:text-white mb-2"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] mb-2"
           >
             &larr; Back to Orders
           </button>
-          <h1 className="text-2xl font-bold text-white">
+          <h1 className="text-2xl font-bold text-[var(--ink)]">
             Order: {order.order_number}
           </h1>
-          <p className="text-gray-400 mt-1">Order Command Center</p>
+          <p className="text-[var(--ink-3)] mt-1">Order Command Center</p>
         </div>
         <OrderHeaderActions
           orderId={order.id}
@@ -878,33 +878,33 @@ export default function OrderDetail() {
       />
 
       {/* Quick Actions \u2014 idempotent tools only (links + checks) */}
-      <div className="bg-gradient-to-r from-blue-900/20 to-cyan-900/20 border border-blue-500/30 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+        <h2 className="text-lg font-semibold text-[var(--ink)] mb-4 flex items-center gap-2">
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
           </svg>
           Quick Actions
         </h2>
         {invoiceLoading && !orderInvoice && (
-          <div className="mb-4 rounded-lg border border-gray-700 bg-gray-900/70 px-4 py-3 text-sm text-gray-400">
+          <div className="mb-4 rounded-lg border border-[var(--rule-hair)] bg-[var(--paper-sunk)] px-4 py-3 text-sm text-[var(--ink-3)]">
             Checking invoice status...
           </div>
         )}
         {orderInvoice && (
-          <div className="mb-4 rounded-lg border border-emerald-500/30 bg-emerald-950/20 px-4 py-3">
+          <div className="mb-4 rounded-lg border border-[var(--status-green)]/30 bg-[var(--status-green-tint)] px-4 py-3">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div>
-                <div className="text-xs uppercase tracking-wide text-emerald-300">
+                <div className="text-xs uppercase tracking-wide text-[var(--status-green)]">
                   Invoice on this order
                 </div>
                 <div className="mt-1 flex flex-wrap items-center gap-3">
-                  <span className="font-mono text-sm font-semibold text-white">
+                  <span className="font-mono text-sm font-semibold text-[var(--ink)]">
                     {orderInvoice.invoice_number}
                   </span>
-                  <span className="rounded-full bg-gray-900 px-2 py-1 text-xs text-gray-300">
+                  <span className="rounded-full bg-[var(--paper-sunk)] px-2 py-1 text-xs text-[var(--ink-2)]">
                     {orderInvoice.status?.replace(/_/g, " ") || "draft"}
                   </span>
-                  <span className="text-sm text-gray-300">
+                  <span className="text-sm text-[var(--ink-2)]">
                     Balance {formatMoney(getInvoiceBalanceDue(orderInvoice))}
                   </span>
                 </div>
@@ -912,13 +912,13 @@ export default function OrderDetail() {
               <div className="flex flex-wrap gap-2">
                 <button
                   onClick={() => navigate(`/admin/invoices?invoice=${orderInvoice.id}`)}
-                  className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600"
+                  className="rounded-lg bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] px-3 py-2 text-sm hover:bg-[var(--rule-hair)]"
                 >
                   Open Invoice
                 </button>
                 <button
                   onClick={handleDownloadOrderInvoice}
-                  className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white hover:bg-gray-600"
+                  className="rounded-lg bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] px-3 py-2 text-sm hover:bg-[var(--rule-hair)]"
                 >
                   Download PDF
                 </button>
@@ -930,7 +930,7 @@ export default function OrderDetail() {
           <button
             onClick={handleCheckAvailability}
             disabled={checkingAvailability || productionOrders.length === 0}
-            className="px-4 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
+            className="px-4 py-3 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-colors"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -940,7 +940,7 @@ export default function OrderDetail() {
           {productionOrders.length > 0 && (
             <button
               onClick={() => navigate(`/admin/production/${productionOrders[0].id}`)}
-              className="px-4 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 flex items-center justify-center gap-2 transition-colors"
+              className="px-4 py-3 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)] flex items-center justify-center gap-2 transition-colors"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -957,13 +957,13 @@ export default function OrderDetail() {
                 key={idx}
                 className={`p-3 rounded-lg ${
                   avail.can_release
-                    ? "bg-green-900/20 border border-green-500/30"
-                    : "bg-red-900/20 border border-red-500/30"
+                    ? "bg-[var(--status-green-tint)] border border-[var(--status-green)]/30"
+                    : "bg-[var(--status-red-tint)] border border-[var(--status-red)]/30"
                 }`}
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-white font-medium">{avail.order_code}</span>
-                  <span className={`text-sm ${avail.can_release ? "text-green-400" : "text-red-400"}`}>
+                  <span className="text-[var(--ink)] font-medium">{avail.order_code}</span>
+                  <span className={`text-sm ${avail.can_release ? "text-[var(--status-green)]" : "text-[var(--status-red)]"}`}>
                     {avail.can_release ? "\u2713 Materials Available" : `\u26A0 ${avail.shortage_count} Shortage${avail.shortage_count !== 1 ? "s" : ""}`}
                   </span>
                 </div>
@@ -1009,36 +1009,36 @@ export default function OrderDetail() {
       />
 
       {/* Order Summary */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Order Summary</h2>
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+        <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Order Summary</h2>
         <div className="grid grid-cols-4 gap-4">
           <div>
-            <div className="text-sm text-gray-400">Product</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Product</div>
+            <div className="text-[var(--ink)] font-medium">
               {order.lines?.length > 1
                 ? `${order.lines.length} line items`
                 : order.product_name || order.lines?.[0]?.product_name || "N/A"}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">
+            <div className="text-sm text-[var(--ink-3)]">
               {order.lines?.length > 1 ? "Lines" : "Quantity"}
             </div>
-            <div className="text-white font-medium">
+            <div className="text-[var(--ink)] font-medium">
               {order.lines?.length > 1 ? order.lines.length : order.quantity}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Status</div>
-            <div className="text-white font-medium flex items-center gap-2 capitalize">
+            <div className="text-sm text-[var(--ink-3)]">Status</div>
+            <div className="text-[var(--ink)] font-medium flex items-center gap-2 capitalize">
               {order.status?.replace(/_/g, " ") || "unknown"}
               {order.closed_short && (
                 getProductionComplete() ? (
-                  <span className="px-2 py-0.5 text-xs rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
+                  <span className="px-2 py-0.5 text-xs rounded-full bg-[var(--status-green-tint)] text-[var(--status-green)] border border-[var(--status-green)]/30">
                     Previously Closed Short — Fulfilled
                   </span>
                 ) : (
-                  <span className="px-2 py-0.5 text-xs rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                  <span className="px-2 py-0.5 text-xs rounded-full bg-[var(--status-amber-tint)] text-[var(--status-amber)] border border-[var(--status-amber)]/30">
                     Closed Short
                   </span>
                 )
@@ -1046,8 +1046,8 @@ export default function OrderDetail() {
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Total</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Total</div>
+            <div className="text-[var(--ink)] font-medium">
               ${parseFloat(order.grand_total ?? order.total_price ?? 0).toFixed(2)}
             </div>
           </div>
@@ -1064,39 +1064,39 @@ export default function OrderDetail() {
       )}
 
       {/* Customer Information */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Customer</h2>
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+        <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Customer</h2>
         {order.customer_name || order.customer_email ? (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div>
-              <div className="text-sm text-gray-400">Name</div>
-              <div className="text-white font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Name</div>
+              <div className="text-[var(--ink)] font-medium">
                 {order.customer_name || "\u2014"}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-400">Email</div>
-              <div className="text-white font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Email</div>
+              <div className="text-[var(--ink)] font-medium">
                 {order.customer_email ? (
-                  <a href={`mailto:${order.customer_email}`} className="text-blue-400 hover:underline">
+                  <a href={`mailto:${order.customer_email}`} className="text-[var(--orange)] hover:underline">
                     {order.customer_email}
                   </a>
                 ) : "\u2014"}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-400">Phone</div>
-              <div className="text-white font-medium">
+              <div className="text-sm text-[var(--ink-3)]">Phone</div>
+              <div className="text-[var(--ink)] font-medium">
                 {order.customer_phone || "\u2014"}
               </div>
             </div>
             {order.customer_id && (
               <div>
-                <div className="text-sm text-gray-400">Customer ID</div>
-                <div className="text-white font-medium">
+                <div className="text-sm text-[var(--ink-3)]">Customer ID</div>
+                <div className="text-[var(--ink)] font-medium">
                   <button
                     onClick={() => navigate(`/admin/customers/${order.customer_id}`)}
-                    className="text-blue-400 hover:underline"
+                    className="text-[var(--orange)] hover:underline"
                   >
                     #{order.customer_id}
                   </button>
@@ -1105,17 +1105,17 @@ export default function OrderDetail() {
             )}
           </div>
         ) : order.quote_id ? (
-          <div className="text-gray-400">
+          <div className="text-[var(--ink-3)]">
             Customer info available in linked quote.
             <button
               onClick={() => navigate(`/admin/quotes`)}
-              className="text-blue-400 hover:underline ml-2"
+              className="text-[var(--orange)] hover:underline ml-2"
             >
               View Quote
             </button>
           </div>
         ) : (
-          <div className="text-gray-400">No customer information on file.</div>
+          <div className="text-[var(--ink-3)]">No customer information on file.</div>
         )}
       </div>
 
@@ -1144,10 +1144,10 @@ export default function OrderDetail() {
 
       {/* Production Orders - Status Display */}
       {productionOrders.length > 0 && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
           <button
             onClick={() => toggleSection("productionOrders")}
-            className="flex items-center gap-2 text-lg font-semibold text-white hover:text-gray-300 mb-4"
+            className="flex items-center gap-2 text-lg font-semibold text-[var(--ink)] hover:text-[var(--ink-2)] mb-4"
           >
             <svg
               className={`w-5 h-5 transition-transform ${expandedSections.productionOrders ? "rotate-90" : ""}`}
@@ -1192,19 +1192,19 @@ export default function OrderDetail() {
       />
 
       {/* Activity Timeline */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Activity</h2>
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+        <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Activity</h2>
         <ActivityTimeline orderId={parseInt(orderId)} />
       </div>
 
       {/* Shipping Timeline - Show if order has been shipped */}
       {order?.tracking_number && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
           <div className="flex items-center gap-2 mb-4">
-            <svg className="w-5 h-5 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 text-[var(--ink-3)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0" />
             </svg>
-            <h2 className="text-lg font-semibold text-white">Shipping Tracking</h2>
+            <h2 className="text-lg font-semibold text-[var(--ink)]">Shipping Tracking</h2>
           </div>
           <ShippingTimeline orderId={parseInt(orderId)} />
         </div>
@@ -1263,19 +1263,19 @@ export default function OrderDetail() {
       {/* Close Short Modal */}
       {showCloseShortModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={() => { setShowCloseShortModal(false); setCloseShortPreview(null); setCloseShortReason(""); }}>
-          <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-lg font-semibold text-white mb-2">
+          <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto shadow-[var(--shadow-pop)]" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold text-[var(--ink)] mb-2">
               Close Order Short
             </h3>
-            <p className="text-gray-400 text-sm mb-4">
+            <p className="text-[var(--ink-3)] text-sm mb-4">
               This will adjust line quantities to match actual produced amounts and set the order to Ready to Ship.
             </p>
 
             {/* Unresolved PO warning */}
             {closeShortPreview && !closeShortPreview.all_pos_resolved && (
-              <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mb-4">
-                <p className="text-red-400 text-sm font-medium mb-1">Production orders still unresolved</p>
-                <p className="text-red-400/80 text-xs">
+              <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3 mb-4">
+                <p className="text-[var(--status-red)] text-sm font-medium mb-1">Production orders still unresolved</p>
+                <p className="text-[var(--status-red)]/80 text-xs">
                   Accept short on these POs first: {closeShortPreview.unresolved_pos.join(", ")}
                 </p>
               </div>
@@ -1283,27 +1283,27 @@ export default function OrderDetail() {
 
             {/* Preview table from backend */}
             {loadingPreview ? (
-              <div className="bg-gray-800 rounded-lg p-4 mb-4 text-center text-gray-400 text-sm">Loading preview...</div>
+              <div className="bg-[var(--paper-sunk)] rounded-lg p-4 mb-4 text-center text-[var(--ink-3)] text-sm">Loading preview...</div>
             ) : closeShortPreview?.lines ? (
-              <div className="bg-gray-800 rounded-lg p-3 mb-4">
+              <div className="bg-[var(--paper-sunk)] rounded-lg p-3 mb-4">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="text-gray-400 text-xs">
+                    <tr className="text-[var(--ink-3)] text-xs">
                       <th className="text-left py-1">Product</th>
                       <th className="text-right py-1">Ordered</th>
                       <th className="text-right py-1">Adjusted</th>
                       <th className="text-left py-1 pl-3">Reason</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-700">
+                  <tbody className="divide-y divide-[var(--rule-hair)]">
                     {closeShortPreview.lines.map((line) => (
                       <tr key={line.line_id}>
-                        <td className="py-1.5 text-white text-xs">{line.product_name || line.product_sku || "N/A"}</td>
-                        <td className="py-1.5 text-right text-white">{line.ordered_qty}</td>
-                        <td className={`py-1.5 text-right font-medium ${line.will_adjust ? "text-amber-400" : "text-green-400"}`}>
+                        <td className="py-1.5 text-[var(--ink)] text-xs">{line.product_name || line.product_sku || "N/A"}</td>
+                        <td className="py-1.5 text-right text-[var(--ink)]">{line.ordered_qty}</td>
+                        <td className={`py-1.5 text-right font-medium ${line.will_adjust ? "text-[var(--status-amber)]" : "text-[var(--status-green)]"}`}>
                           {line.achievable_qty}
                         </td>
-                        <td className="py-1.5 text-left pl-3 text-gray-400 text-xs max-w-[200px] truncate">{line.reason}</td>
+                        <td className="py-1.5 text-left pl-3 text-[var(--ink-3)] text-xs max-w-[200px] truncate">{line.reason}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -1311,11 +1311,11 @@ export default function OrderDetail() {
 
                 {/* PO summary */}
                 {closeShortPreview.lines.some(l => l.linked_po_summary?.length > 0) && (
-                  <div className="mt-3 pt-3 border-t border-gray-700">
-                    <p className="text-xs text-gray-500 mb-1">Linked Production Orders:</p>
+                  <div className="mt-3 pt-3 border-t border-[var(--rule-hair)]">
+                    <p className="text-xs text-[var(--ink-4)] mb-1">Linked Production Orders:</p>
                     <div className="flex flex-wrap gap-2">
                       {[...new Map(closeShortPreview.lines.flatMap(l => l.linked_po_summary || []).map(po => [po.po_number, po])).values()].map(po => (
-                        <span key={po.po_number} className={`px-2 py-0.5 rounded text-xs ${["complete", "completed", "closed", "cancelled"].includes(po.status) ? "bg-green-500/20 text-green-400" : "bg-amber-500/20 text-amber-400"}`}>
+                        <span key={po.po_number} className={`px-2 py-0.5 rounded text-xs ${["complete", "completed", "closed", "cancelled"].includes(po.status) ? "bg-[var(--status-green-tint)] text-[var(--status-green)]" : "bg-[var(--status-amber-tint)] text-[var(--status-amber)]"}`}>
                           {po.po_number}: {po.completed}/{po.ordered} ({po.status})
                         </span>
                       ))}
@@ -1325,8 +1325,8 @@ export default function OrderDetail() {
               </div>
             ) : null}
 
-            <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-3 mb-4">
-              <p className="text-amber-400 text-sm">
+            <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-3 mb-4">
+              <p className="text-[var(--status-amber)] text-sm">
                 This will adjust quantities and set the order to Ready to Ship. Ship through the normal flow after.
               </p>
             </div>
@@ -1335,20 +1335,20 @@ export default function OrderDetail() {
               value={closeShortReason}
               onChange={(e) => setCloseShortReason(e.target.value)}
               placeholder="Reason for closing short (required)..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg p-3 text-white placeholder-gray-500 focus:border-amber-500 focus:ring-1 focus:ring-amber-500 mb-4"
+              className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3 text-[var(--ink)] placeholder-[var(--ink-4)] focus:border-[var(--orange)] focus:ring-1 focus:ring-[var(--orange)] mb-4"
               rows={2}
             />
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => { setShowCloseShortModal(false); setCloseShortReason(""); setCloseShortPreview(null); }}
-                className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+                className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)]"
               >
                 Cancel
               </button>
               <button
                 onClick={handleCloseShort}
                 disabled={!closeShortReason.trim() || closingShort || (closeShortPreview && !closeShortPreview.all_pos_resolved)}
-                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {closingShort ? "Closing..." : "Close Order Short"}
               </button>
@@ -1360,18 +1360,18 @@ export default function OrderDetail() {
       {/* Reject Order Modal */}
       {showRejectModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-          <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold text-white mb-4">
+          <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 max-w-md w-full mx-4 shadow-[var(--shadow-pop)]">
+            <h3 className="text-lg font-semibold text-[var(--ink)] mb-4">
               Reject Order {order.order_number}
             </h3>
-            <p className="text-gray-400 text-sm mb-4">
+            <p className="text-[var(--ink-3)] text-sm mb-4">
               This will cancel the order and notify the source system.
             </p>
             <textarea
               value={rejectReason}
               onChange={(e) => setRejectReason(e.target.value)}
               placeholder="Reason for rejection..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg p-3 text-white placeholder-gray-500 focus:border-red-500 focus:ring-1 focus:ring-red-500 mb-4"
+              className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3 text-[var(--ink)] placeholder-[var(--ink-4)] focus:border-[var(--status-red)] focus:ring-1 focus:ring-[var(--status-red)] mb-4"
               rows={3}
             />
             <div className="flex justify-end gap-3">
@@ -1380,14 +1380,14 @@ export default function OrderDetail() {
                   setShowRejectModal(false);
                   setRejectReason("");
                 }}
-                className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+                className="px-4 py-2 bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:bg-[var(--rule-hair)]"
               >
                 Cancel
               </button>
               <button
                 onClick={handleRejectOrder}
                 disabled={!rejectReason.trim() || rejectingOrder}
-                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-[var(--status-red)] text-white rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {rejectingOrder ? "Rejecting..." : "Reject Order"}
               </button>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -1048,7 +1048,7 @@ export default function OrderDetail() {
           <div>
             <div className="text-sm text-gray-400">Total</div>
             <div className="text-white font-medium">
-              ${parseFloat(order.total_price || 0).toFixed(2)}
+              ${parseFloat(order.grand_total ?? order.total_price ?? 0).toFixed(2)}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -205,7 +205,14 @@ export default function OrderDetail() {
 
   // Material availability check state
   const [checkingAvailability, setCheckingAvailability] = useState(false);
-  const [materialAvailability, setMaterialAvailability] = useState(null);
+  // Material requirements SUMMARY (object: has_shortages/materials_short/…) —
+  // drives the requirements section's shortage footer + historical badge.
+  const [materialSummary, setMaterialSummary] = useState(null);
+  // Per-production-order availability CHECKS (array) — drives the "Check
+  // Material Availability" result list. Kept separate from the summary above:
+  // one state var previously held both shapes, so clicking Check overwrote the
+  // summary object with an array and silently flipped the shortage footer.
+  const [availabilityChecks, setAvailabilityChecks] = useState([]);
 
   // Fulfillment status hook (UI-302)
   const {
@@ -240,7 +247,7 @@ export default function OrderDetail() {
           incoming_supply_details: req.incoming_supply_details || null,
         }));
         setMaterialRequirements(requirements);
-        setMaterialAvailability(matReqData.summary);
+        setMaterialSummary(matReqData.summary);
       } catch {
         // FALLBACK: Use the MRP requirements endpoint
         try {
@@ -526,8 +533,13 @@ export default function OrderDetail() {
   };
 
   const handleCreatePurchaseOrder = async (materialReq) => {
+    // AdminPurchasing opens the pre-filled PO modal only for the
+    // create_po=true + product_id + quantity contract. The old material_id/qty
+    // keys were never read, so the modal never opened and nothing pre-filled.
+    const qty = materialReq.net_shortage;
     navigate(
-      `/admin/purchasing?material_id=${materialReq.product_id}&qty=${materialReq.net_shortage}`
+      `/admin/purchasing?create_po=true&product_id=${materialReq.product_id}` +
+        (qty ? `&quantity=${qty}` : "")
     );
   };
 
@@ -752,7 +764,7 @@ export default function OrderDetail() {
     setCheckingAvailability(true);
     try {
       if (productionOrders.length > 0) {
-        const availabilityChecks = await Promise.all(
+        const checks = await Promise.all(
           productionOrders.map(async (po) => {
             try {
               return await api.get(
@@ -763,7 +775,7 @@ export default function OrderDetail() {
             }
           })
         );
-        setMaterialAvailability(availabilityChecks.filter(Boolean));
+        setAvailabilityChecks(checks.filter(Boolean));
       } else {
         toast.info("Create a production order first to check material availability");
       }
@@ -920,9 +932,9 @@ export default function OrderDetail() {
             </button>
           )}
         </div>
-        {materialAvailability && materialAvailability.length > 0 && (
+        {availabilityChecks.length > 0 && (
           <div className="mt-4 space-y-2">
-            {materialAvailability.map((avail, idx) => (
+            {availabilityChecks.map((avail, idx) => (
               <div
                 key={idx}
                 className={`p-3 rounded-lg ${
@@ -1094,7 +1106,7 @@ export default function OrderDetail() {
       {/* Material Requirements */}
       <MaterialRequirementsSection
         materialRequirements={materialRequirements}
-        materialAvailability={materialAvailability}
+        materialAvailability={materialSummary}
         expandedSections={expandedSections}
         onToggle={toggleSection}
         exploding={exploding}

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -288,6 +288,9 @@ export default function OrderDetail() {
             };
           });
           setMaterialRequirements(scaled);
+          // Fallback path has no summary object — clear it so the shortage
+          // footer/badge can't show the previous order's stale summary.
+          setMaterialSummary(null);
         } catch {
           // If MRP endpoint fails, try BOM explosion directly
           try {
@@ -309,6 +312,7 @@ export default function OrderDetail() {
               material_source: "bom",
             }));
             setMaterialRequirements(requirements);
+            setMaterialSummary(null);
           } catch {
             // All BOM endpoints failed - material requirements section will be empty
           }
@@ -452,6 +456,12 @@ export default function OrderDetail() {
       // Advisory only — ship_order() still enforces the gate server-side.
       if (shouldApply()) setCanShip(null);
     }
+  };
+
+  // The FulfillmentProgress panel now renders its Ship CTA/reasons from canShip,
+  // so a panel refresh must refresh the ship gate too — not just line readiness.
+  const refreshFulfillmentPanel = async () => {
+    await Promise.all([refetchFulfillment(), fetchCanShip()]);
   };
 
   useEffect(() => {
@@ -979,7 +989,7 @@ export default function OrderDetail() {
         fulfillmentStatus={fulfillmentStatus}
         loading={fulfillmentLoading}
         error={fulfillmentError}
-        onRefresh={refetchFulfillment}
+        onRefresh={refreshFulfillmentPanel}
         canShip={canShip}
         onShip={() => navigate(`/admin/shipping?orderId=${order.id}`)}
         closedShort={order?.closed_short === true}

--- a/frontend/src/pages/admin/OrderDetail.jsx
+++ b/frontend/src/pages/admin/OrderDetail.jsx
@@ -813,8 +813,9 @@ export default function OrderDetail() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex justify-between items-center">
+      {/* Header — wrapped in a paper card so the dark ink title/subtitle read
+          against the (still-dark) app shell until the shell slice lands. */}
+      <div className="flex justify-between items-center bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
         <div>
           <button
             onClick={() => navigate("/admin/orders")}

--- a/frontend/src/pages/admin/__tests__/AdminShipping.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminShipping.test.jsx
@@ -60,7 +60,7 @@ describe('AdminShipping — deep-link banner', () => {
     renderWithParam()
     await waitFor(() => expect(mocks.get).toHaveBeenCalled())
     expect(
-      screen.queryByText(/isn't ready to ship yet/),
+      screen.queryByText(/isn't in an active shipping stage/),
     ).not.toBeInTheDocument()
   })
 
@@ -68,7 +68,7 @@ describe('AdminShipping — deep-link banner', () => {
     renderWithParam('?orderId=999')
     await waitFor(() =>
       expect(
-        screen.getByText(/isn't ready to ship yet — production must complete/),
+        screen.getByText(/isn't in an active shipping stage/),
       ).toBeInTheDocument(),
     )
   })


### PR DESCRIPTION
First vertical slice of the #846 Industrial Workbench GTM epic, run as a **functional audit + re-skin** of the Shipping → OrderDetail flow. Each finding was verified against real code; the visual was verified against the **rendered page**, not just the diff.

## Backend — can-ship single source of truth (#845)
- `GET /sales-orders/can-ship` (batch, ready_to_ship) and `GET /{order_id}/can-ship` (single, any status), both routing through the same `can_ship_reasons()` helper that `ship_order()` enforces — the UI can't advertise a ship the backend would reject.
- Fail-**visible** (not fail-open) when the preflight fetch fails.

## AdminShipping
- Re-skinned to Workbench tokens; Ship actions wired to the can-ship gate with backend reasons surfaced.

## OrderDetail — functional fixes (from the audit)
- **Create-PO dead link** → correct `create_po=true&product_id=&quantity=` contract (modal actually opens).
- **Dual-shape `materialAvailability` state** split into `materialSummary` + `availabilityChecks` (the array no longer clobbers the summary and flips the shortage footer).
- **Ship button** gated on the authoritative can-ship (not the per-line inventory flag); **dead "Ship Partial"** removed (partial shipment is unimplemented — tracked as #726).
- **grand_total** with a Subtotal/Tax/Shipping/Total breakdown instead of the pre-tax subtotal mislabeled "Total"; footer colspan aligned.
- Billing-before-production is now enforced server-side (shipped separately as #853, merged) — payment **or** an issued invoice satisfies it (net-terms friendly).

## OrderDetail — Workbench re-skin
- OrderDetail + its ~14 child components (OrderWorkflowPanel, BlockingIssuesPanel, MaterialRequirementsSection, PaymentsSection, ProductionStatusCards, modals, timelines, …) converted to Workbench tokens. Orange reserved for the one primary CTA per section; `--status-{green,amber,red}` for state; destructive stays red.

## Verification
- Backend: new can-ship tests; full sales/production/legacy suites green.
- Frontend: 42 unit tests pass; no new lint; **0 residual dark classes** (every remaining `text-white` is on a colored button).
- **Browser-verified the rendered page** via `preview_inspect`: cards resolve to `--paper`, and a page-wide contrast sweep found **0 low-contrast elements across 237 text nodes** (after wrapping the header in a paper card — a bug the browser pass caught that static checks couldn't).

Part of epic #846. Related: #845 (divergent gates), #726 (partial shipment, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staff-only “can-ship” preflight endpoints for single orders and batches, returning shipping eligibility plus actionable reason messages.
  * Wired admin shipping and order detail pages (including ship actions and “ready-to-ship” blocking) to enforce and display preflight results.
  * Updated fulfillment UI to gate shipping actions using preflight eligibility.
* **Bug Fixes**
  * Order total now prefers `grand_total` when available.
* **Tests**
  * Added coverage for “can-ship” batch/single endpoints and `can_ship_reasons()` logic, including bounded query volume checks.
* **Style**
  * Migrated many order/shipping/admin/timeline components to CSS-variable-driven theme colors for consistent visual states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->