### PR TITLE
fix(production): scrap flow end-to-end + status badges (#846 slice 1)

### DIFF
--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -1075,8 +1075,36 @@ def record_scrap(
     if not reason:
         raise HTTPException(status_code=400, detail=f"Invalid scrap reason: {reason_code}")
 
+    # Cap scrap at the quantity still unaccounted (ordered - completed -
+    # already-scrapped). The ScrapOrderModal enforces this client-side; enforce
+    # it server-side too so a direct API call can't drive quantity_scrapped past
+    # quantity_ordered.
+    already_scrapped = order.quantity_scrapped or 0
+    completed = order.quantity_completed or 0
+    remaining = order.quantity_ordered - completed - already_scrapped
+    if quantity_scrapped > remaining:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot scrap {quantity_scrapped} units: only {remaining} "
+                f"remain unaccounted on {order.code}."
+            ),
+        )
+
     # Update order scrap quantity
     order.quantity_scrapped = (order.quantity_scrapped or 0) + quantity_scrapped
+
+    # If the whole order is now scrapped (nothing completed, everything accounted
+    # as scrap) move it to the terminal 'scrapped' state so it leaves the active
+    # queue. Orders with completed units are left untouched — partial completion
+    # plus scrap is a short-close decision handled elsewhere.
+    _active_statuses = ("draft", "released", "scheduled", "in_progress", "short", "on_hold")
+    if (
+        completed == 0
+        and order.quantity_scrapped >= order.quantity_ordered
+        and order.status in _active_statuses
+    ):
+        order.status = "scrapped"
 
     from app.models.user import User
     scrap_user = db.query(User).filter(User.email == user_email).first()

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2510,7 +2510,9 @@ class TestRecordScrap:
             try:
                 real_flush(*a, **kw)
             except Exception:
-                pass
+                # ScrapRecord is mocked (not ORM-persistent), so real_flush can
+                # raise here; swallowing it is intentional for this patched path.
+                return None
 
         with patch(
             "app.services.production_order_service.ScrapRecord",
@@ -2549,7 +2551,9 @@ class TestRecordScrap:
             try:
                 real_flush(*a, **kw)
             except Exception:
-                pass
+                # ScrapRecord is mocked (not ORM-persistent), so real_flush can
+                # raise here; swallowing it is intentional for this patched path.
+                return None
 
         with patch(
             "app.services.production_order_service.ScrapRecord",
@@ -2611,7 +2615,9 @@ class TestRecordScrap:
             try:
                 real_flush(*a, **kw)
             except Exception:
-                pass
+                # ScrapRecord is mocked (not ORM-persistent), so real_flush can
+                # raise here; swallowing it is intentional for this patched path.
+                return None
 
         with patch(
             "app.services.production_order_service.ScrapRecord",
@@ -2652,7 +2658,9 @@ class TestRecordScrap:
             try:
                 real_flush(*a, **kw)
             except Exception:
-                pass
+                # ScrapRecord is mocked (not ORM-persistent), so real_flush can
+                # raise here; swallowing it is intentional for this patched path.
+                return None
 
         with patch(
             "app.services.production_order_service.ScrapRecord",
@@ -2742,7 +2750,9 @@ class TestRecordScrap:
             try:
                 real_flush(*a, **kw)
             except Exception:
-                pass
+                # ScrapRecord is mocked (not ORM-persistent), so real_flush can
+                # raise here; swallowing it is intentional for this patched path.
+                return None
 
         with patch(
             "app.services.production_order_service.ScrapRecord",

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2474,6 +2474,98 @@ class TestRecordScrap:
         assert exc_info.value.status_code == 400
         assert "Invalid scrap reason" in str(exc_info.value.detail)
 
+    def test_record_scrap_over_remaining_rejected(self, db, finished_good):
+        """Should reject scrapping more units than remain unaccounted (cap guard)."""
+        _make_scrap_reason(db, code="scrap-cap-test", name="Cap Test")
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=5)
+        with pytest.raises(HTTPException) as exc_info:
+            svc.record_scrap(
+                db, order.id,
+                quantity_scrapped=6,  # only 5 remain
+                reason_code="scrap-cap-test",
+                user_email="test@filaops.dev",
+            )
+        assert exc_info.value.status_code == 400
+        assert "remain unaccounted" in str(exc_info.value.detail)
+
+    def test_record_scrap_full_scrap_marks_order_scrapped(self, db, finished_good):
+        """Scrapping the entire outstanding qty (nothing completed) should move
+        the order to the terminal 'scrapped' state so it leaves the active queue."""
+        reason = _make_scrap_reason(db, code="scrap-full-test", name="Full Scrap")
+        reason.requires_remake = False  # service expects this attribute
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=4)
+
+        mock_record = MagicMock()
+        mock_record.id = 2001
+
+        real_add = db.add
+        real_flush = db.flush
+
+        def _safe_add(obj):
+            if isinstance(obj, MagicMock):
+                return
+            real_add(obj)
+
+        def _safe_flush(*a, **kw):
+            try:
+                real_flush(*a, **kw)
+            except Exception:
+                pass
+
+        with patch(
+            "app.services.production_order_service.ScrapRecord",
+            return_value=mock_record,
+        ), patch.object(db, "add", side_effect=_safe_add), \
+             patch.object(db, "flush", side_effect=_safe_flush):
+            svc.record_scrap(
+                db, order.id,
+                quantity_scrapped=4,  # all remaining
+                reason_code="scrap-full-test",
+                user_email="test@filaops.dev",
+                create_remake=False,
+            )
+
+        assert order.status == "scrapped"
+        assert int(order.quantity_scrapped) == 4
+
+    def test_record_scrap_partial_leaves_status_active(self, db, finished_good):
+        """A partial scrap must NOT terminate the order — it stays in progress."""
+        reason = _make_scrap_reason(db, code="scrap-partial-test", name="Partial Scrap")
+        reason.requires_remake = False
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+
+        mock_record = MagicMock()
+        mock_record.id = 2002
+
+        real_add = db.add
+        real_flush = db.flush
+
+        def _safe_add(obj):
+            if isinstance(obj, MagicMock):
+                return
+            real_add(obj)
+
+        def _safe_flush(*a, **kw):
+            try:
+                real_flush(*a, **kw)
+            except Exception:
+                pass
+
+        with patch(
+            "app.services.production_order_service.ScrapRecord",
+            return_value=mock_record,
+        ), patch.object(db, "add", side_effect=_safe_add), \
+             patch.object(db, "flush", side_effect=_safe_flush):
+            svc.record_scrap(
+                db, order.id,
+                quantity_scrapped=3,  # 7 remain
+                reason_code="scrap-partial-test",
+                user_email="test@filaops.dev",
+                create_remake=False,
+            )
+
+        assert order.status == "in_progress"
+
     def test_record_scrap_nonexistent_order(self, db):
         """Should raise 404 for nonexistent order."""
         with pytest.raises(HTTPException) as exc_info:

--- a/frontend/src/components/ScrapOrderModal.jsx
+++ b/frontend/src/components/ScrapOrderModal.jsx
@@ -66,23 +66,28 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
 
     setSubmitting(true);
     try {
-      const params = new URLSearchParams({
-        scrap_reason: scrapReason,
-        quantity_scrapped: quantityScrapped.toString(),
-        create_remake: createRemake.toString(),
-      });
+      // The endpoint binds an OperationScrapRequest from the JSON body. Sent as
+      // query params these were silently dropped, so every scrap 422'd on the
+      // missing required fields. Match the schema field names exactly
+      // (scrap_reason_code, create_replacement).
+      const body = {
+        quantity_scrapped: quantityScrapped,
+        scrap_reason_code: scrapReason,
+        create_replacement: createRemake,
+      };
       if (notes.trim()) {
-        params.append("notes", notes.trim());
+        body.notes = notes.trim();
       }
 
       const res = await fetch(
-        `${API_URL}/api/v1/production-orders/${productionOrder.id}/scrap?${params}`,
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/scrap`,
         {
           method: "POST",
           credentials: "include",
           headers: {
             "Content-Type": "application/json",
           },
+          body: JSON.stringify(body),
         }
       );
 

--- a/frontend/src/components/orders/ProductionStatusCards.jsx
+++ b/frontend/src/components/orders/ProductionStatusCards.jsx
@@ -46,10 +46,15 @@ export function ProductionProgressSummary({ orders }) {
 const STATUS_CONFIG = {
   draft: { color: "bg-[var(--ink-3)]", text: "Draft" },
   released: { color: "bg-[var(--status-amber)]", text: "Released" },
+  scheduled: { color: "bg-[var(--status-amber)]", text: "Scheduled" },
   in_progress: { color: "bg-[var(--status-amber)]", text: "In Progress" },
   short: { color: "bg-[var(--status-amber)]", text: "Short" },
+  qc_hold: { color: "bg-[var(--status-amber)]", text: "QC Hold" },
+  on_hold: { color: "bg-[var(--status-amber)]", text: "On Hold" },
   complete: { color: "bg-[var(--status-green)]", text: "Complete" },
+  completed: { color: "bg-[var(--status-green)]", text: "Complete" },
   scrapped: { color: "bg-[var(--status-red)]", text: "Scrapped" },
+  cancelled: { color: "bg-[var(--ink-4)]", text: "Cancelled" },
   closed: { color: "bg-[var(--ink-4)]", text: "Closed" },
 };
 

--- a/frontend/src/lib/statusColors.js
+++ b/frontend/src/lib/statusColors.js
@@ -88,9 +88,15 @@ export const PRINTER_COLORS = {
 export const PRODUCTION_ORDER_BADGE_CONFIGS = {
   draft: { bg: "bg-gray-500/20", text: "text-gray-400", label: "Draft" },
   released: { bg: "bg-blue-500/20", text: "text-blue-400", label: "Released" },
+  scheduled: { bg: "bg-cyan-500/20", text: "text-cyan-400", label: "Scheduled" },
   in_progress: { bg: "bg-purple-500/20", text: "text-purple-400", label: "In Progress" },
   complete: { bg: "bg-green-500/20", text: "text-green-400", label: "Complete" },
+  completed: { bg: "bg-green-500/20", text: "text-green-400", label: "Complete" },
+  closed: { bg: "bg-green-700/20", text: "text-green-300", label: "Closed" },
   short: { bg: "bg-orange-500/20", text: "text-orange-400", label: "Short" },
+  qc_hold: { bg: "bg-amber-500/20", text: "text-amber-400", label: "QC Hold" },
+  on_hold: { bg: "bg-yellow-500/20", text: "text-yellow-400", label: "On Hold" },
+  scrapped: { bg: "bg-red-500/20", text: "text-red-400", label: "Scrapped" },
   cancelled: { bg: "bg-red-500/20", text: "text-red-400", label: "Cancelled" },
 };
 

--- a/frontend/src/lib/statusDescriptors.js
+++ b/frontend/src/lib/statusDescriptors.js
@@ -67,12 +67,15 @@ export const STATUS_DESCRIPTORS = {
     status: {
       draft: { label: "Draft", tone: "neutral" },
       released: { label: "Released", tone: "info" },
+      scheduled: { label: "Scheduled", tone: "info" },
       in_progress: { label: "In Progress", tone: "purple" },
       on_hold: { label: "On Hold", tone: "warning" },
       short: { label: "Short", tone: "warning" },
       complete: { label: "Complete", tone: "success", terminal: true },
       // alias of `complete` (legacy / sales-order spelling) — see PR-0.
       completed: { label: "Complete", tone: "success", terminal: true },
+      // `closed` is written by the WO disposition machine (order_status.py).
+      closed: { label: "Closed", tone: "success", terminal: true },
       qc_hold: { label: "QC Hold", tone: "warning" },
       scrapped: { label: "Scrapped", tone: "danger", terminal: true },
       cancelled: { label: "Cancelled", tone: "danger", terminal: true },


### PR DESCRIPTION
## Epic #846 — Production stage, slice 1

First slice of the **Production** stage in the backward functional audit of the order-to-cash spine (shipping ✅ merged → **production** → orders → quoting). This slice fixes the genuinely **user-reachable, high-value** breakages in the scrap flow + status display. The rest of the audit's 40 verified findings are being filed as durable, epic-linked issues (dead-wired Split/Complete/QC openers, operation-level scrap endpoint, the scheduling subsystem, PO status-vocabulary unification, and the Workbench re-skin) rather than piled into one megamerge.

### What's fixed (all verified against `main`, adversarially refuted before inclusion)

**1. Order Scrap always 422'd (critical, user-reachable)**
`ScrapOrderModal` sent scrap fields as query params (`scrap_reason`, `create_remake`) to an endpoint that binds `OperationScrapRequest` from the **JSON body** — FastAPI dropped them and returned 422 on the missing required fields. Now POSTs a body with the exact schema names (`quantity_scrapped`, `scrap_reason_code`, `notes`, `create_replacement`).

**2. Scrap had no cap and never dispositioned the order (major, data-integrity)**
`record_scrap` is now bounded server-side (can't scrap more than remains unaccounted → 400) and a fully-scrapped order (nothing completed) transitions to the terminal `scrapped` state so it leaves the active queue. Partial scraps stay active (unchanged).

**3. Live statuses rendered as a gray "Draft" pill (major, UX)**
`PRODUCTION_ORDER_BADGE_CONFIGS` and OrderDetail's `STATUS_CONFIG` were missing `scheduled`/`qc_hold`/`on_hold`/`scrapped`/`completed`/`closed`, so a QC-held or scrapped order showed as **Draft** in the queue and order detail. Added the keys; registered `scheduled`+`closed` in the `statusDescriptors` source-of-truth to preserve the coverage invariant.

### Tests
- Backend: +3 `record_scrap` tests (over-cap rejection, full-scrap → `scrapped`, partial-scrap stays active). `TestRecordScrap` 12/12, `ruff` clean.
- Frontend: `vite build` ✓, `573/573` unit (incl. the descriptor-coverage invariant that caught the missing registry entries).

### Note
The audit also **refuted** a previously-filed gap (task #22, "no-routing WOs can't be completed") — `ProductionOrderDetail` has a live "Complete Production" button. Verify-before-file earning its keep again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrap quantities are now server-validated against remaining unaccounted amount, rejecting over-scrapping with a clear 400 error.
  * Production orders now auto-transition to the terminal **Scrapped** status when fully scrapped; partially scrapped orders remain active.

* **New Features**
  * Enhanced production status badge rendering and descriptors for additional statuses (scheduled, qc hold, on hold, closed, cancelled, and scrapped), including improved “completed” display behavior.
  * Updated scrap submission to send fields in the JSON request body instead of URL query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->