### PR TITLE
fix(inventory): require staff auth on inventory mutation endpoints (security)

### DIFF
--- a/backend/app/api/v1/endpoints/inventory.py
+++ b/backend/app/api/v1/endpoints/inventory.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, desc, or_
 
 from app.db.session import get_db
-from app.api.v1.endpoints.auth import get_current_user
 from app.api.v1.deps import get_current_staff_user
 from app.models import User, InventoryTransaction, Inventory, Product
 from app.services import inventory_ledger
@@ -30,7 +29,7 @@ async def approve_negative_inventory(
     transaction_id: int,
     approval_reason: str = Query(..., description="Reason for approving negative inventory"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Approve a negative inventory transaction that requires approval.
@@ -158,7 +157,7 @@ async def get_negative_inventory_report(
     include_approved: bool = Query(True, description="Include approved transactions"),
     include_pending: bool = Query(True, description="Include pending approvals"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Generate negative inventory report showing all negative inventory occurrences.
@@ -277,7 +276,7 @@ async def validate_inventory_consistency_endpoint(
     location_id: Optional[int] = Query(None, description="Filter by location ID"),
     auto_fix: bool = Query(False, description="Automatically fix inconsistencies"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Validate inventory consistency: check that allocated doesn't exceed on_hand.
@@ -311,7 +310,7 @@ async def adjust_inventory_quantity(
     cost_per_unit: Optional[float] = Query(None, description="Cost per unit for accounting (optional, defaults to product's effective cost)"),
     notes: Optional[str] = Query(None, description="Additional notes"),
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_staff_user),
 ):
     """
     Adjust inventory on-hand quantity and create an adjustment transaction.

--- a/backend/tests/endpoints/test_inventory_auth.py
+++ b/backend/tests/endpoints/test_inventory_auth.py
@@ -1,0 +1,88 @@
+"""
+Auth tests for inventory mutation endpoints (/api/v1/inventory/).
+
+Regression coverage for the PR-D0 security fix. Four endpoints previously
+depended on ``get_current_user`` (ANY authenticated user, including
+``account_type='customer'`` portal/buyer accounts) instead of
+``get_current_staff_user``. That let a non-staff account rewrite on-hand
+inventory and approve/void negative-inventory transactions.
+
+These tests lock in that:
+  * an unauthenticated request is rejected with 401, and
+  * an authenticated NON-STAFF (customer) user is rejected with 403,
+matching the rest of the admin/inventory surface (e.g. reject-held).
+"""
+import pytest
+
+# The four endpoints hardened by PR-D0, keyed by (method, path).
+MUTATION_ENDPOINTS = [
+    ("post", "/api/v1/inventory/transactions/1/approve-negative?approval_reason=x"),
+    ("get", "/api/v1/inventory/negative-inventory-report"),
+    ("post", "/api/v1/inventory/validate-consistency"),
+    (
+        "post",
+        "/api/v1/inventory/adjust-quantity"
+        "?product_id=1&new_on_hand_quantity=5&adjustment_reason=count",
+    ),
+]
+
+
+@pytest.fixture
+def customer_client(db):
+    """TestClient authenticated as a NON-STAFF (account_type='customer') user.
+
+    Mirrors the conftest ``client`` fixture (DB override + Bearer token) but
+    the token is minted for a freshly created customer account so the
+    ``get_current_staff_user`` role check is exercised, not just auth.
+    """
+    from fastapi.testclient import TestClient
+    from app.main import app
+    from app.db.session import get_db
+    from app.models.user import User
+    from app.core.security import create_access_token
+
+    customer = User(
+        email=f"buyer-{id(db)}@example.com",
+        password_hash="not-a-real-hash",
+        account_type="customer",
+        status="active",
+    )
+    db.add(customer)
+    db.flush()
+    token = create_access_token(user_id=customer.id)
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass  # db fixture handles rollback
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+class TestInventoryMutationsUnauthenticated:
+    """Inventory mutation endpoints reject unauthenticated requests with 401."""
+
+    @pytest.mark.parametrize("method,path", MUTATION_ENDPOINTS)
+    def test_requires_auth(self, unauthed_client, method, path):
+        resp = getattr(unauthed_client, method)(path)
+        assert resp.status_code == 401
+
+
+class TestInventoryMutationsNonStaffForbidden:
+    """Authenticated non-staff (customer) users are rejected with 403.
+
+    This is the PR-D0 regression: before the fix these resolved via
+    ``get_current_user`` and a customer account could reach the handler.
+    """
+
+    @pytest.mark.parametrize("method,path", MUTATION_ENDPOINTS)
+    def test_non_staff_forbidden(self, customer_client, method, path):
+        resp = getattr(customer_client, method)(path)
+        assert resp.status_code == 403


### PR DESCRIPTION
## Security fix (PR-D0)

Four inventory endpoints authenticated with `get_current_user`, which resolves to **any authenticated user** — including `account_type='customer'` portal/buyer accounts — instead of a staff role. That let a non-staff account rewrite on-hand inventory and approve/void negative-inventory transactions:

| Method | Path | Handler | Why it matters |
|--------|------|---------|----------------|
| POST | `/inventory/transactions/{id}/approve-negative` | `approve_negative_inventory` | approves negative inventory, writes `approved_by`/`approved_at` |
| GET | `/inventory/negative-inventory-report` | `get_negative_inventory_report` | staff/audit report exposing full inventory transaction + approval history |
| POST | `/inventory/validate-consistency` | `validate_inventory_consistency_endpoint` | `auto_fix=True` mutates `allocated` |
| POST | `/inventory/adjust-quantity` | `adjust_inventory_quantity` | rewrites `on_hand` and creates an adjustment transaction |

All four now depend on `get_current_staff_user`, matching the rest of the admin/inventory surface (e.g. `/inventory/transactions/{id}/reject-held`, which was already staff-gated). The now-unused `get_current_user` import is removed.

This is a **role-gating fix, not a licensing change**. Found by the 2026-07-01 PRO-leak audit as a non-license role hole.

## Changes
- `backend/app/api/v1/endpoints/inventory.py` — swap `get_current_user` → `get_current_staff_user` on the four endpoints above; drop the now-unused import.
- `backend/tests/endpoints/test_inventory_auth.py` (new) — regression tests: unauthenticated → 401, and authenticated non-staff (`account_type='customer'`) → 403 on all four endpoints. Adds a `customer_client` fixture mirroring the conftest `client` fixture. (Existing `*_auth.py` tests only covered 401/staff-200, never a non-staff authenticated 403.)

## Validation
- `python -m ruff check` clean on both files.
- **pytest could not run in this worktree**: the harness requires a seeded `filaops_test` Postgres DB and the fresh worktree has no `.env`/DB credentials, so collection fails with `password authentication failed for user "postgres"` (a DB-connection error, not a test-logic failure — all 8 parametrized cases enumerate correctly). Recommend running `pytest backend/tests/endpoints/test_inventory_auth.py` in an environment with `filaops_test` provisioned before/after merge to confirm green.

## Recommendation
Security fix — recommend prompt merge + deploy to live ERPs (129 brownfield, local BLB3D VM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory approval, reporting, validation, and adjustment actions now require staff access, preventing non-staff users from using these endpoints.
* **Tests**
  * Added regression coverage to verify inventory mutation endpoints return `401` when unauthenticated and `403` for signed-in non-staff users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->