### PR TITLE
fix(production): QC + completion flow (#846 slice 2)

### DIFF
--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -60,6 +60,10 @@ class QCStatus(str, Enum):
     PASSED = "passed"
     FAILED = "failed"
     WAIVED = "waived"
+    # Accepted-with-conditions result. The service (_QC_RESULTS) and DB CHECK
+    # already accept it; the modal offers it — this member lets the API bind it
+    # instead of 422-ing a valid inspection result.
+    CONDITIONAL = "conditional"
 
 
 # ============================================================================

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -641,7 +641,7 @@ class QCInspectionRequest(BaseModel):
     """Request to perform QC inspection on a production order"""
     result: QCStatus = Field(
         ...,
-        description="QC result: 'passed' or 'failed'"
+        description="QC result: 'passed', 'failed', 'waived', or 'conditional'"
     )
     quantity_passed: Optional[int] = Field(
         None,

--- a/backend/app/services/production_order_execution_service.py
+++ b/backend/app/services/production_order_execution_service.py
@@ -153,6 +153,18 @@ def complete_production_order(
         except Exception as e:
             logger.warning("Actual cost recalculation failed for %s: %s", order.code, e)
 
+        # Advance the parent sales order (allocated qty + ready_to_ship once all
+        # its WOs are done). The per-operation completion path syncs this; the
+        # bulk-complete path (e.g. "Complete Production" on ProductionOrderDetail,
+        # and the only path for routing-less WOs) must too, or the SO is stranded
+        # in in_production and never becomes shippable. sync_on_production_complete
+        # is a no-op unless every sibling WO is complete, so it is safe here.
+        try:
+            from app.services.status_sync_service import sync_on_production_complete
+            sync_on_production_complete(db, order)
+        except Exception as e:
+            logger.error("Failed to sync sales order for %s: %s", order.code, e)
+
     if notes:
         if order.notes:
             order.notes = f"{order.notes}\n[{datetime.now(timezone.utc).isoformat()}] {notes}"

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -808,6 +808,11 @@ def record_qc_inspection(
     # would double-count the failed units.
     if qc_status == "failed":
         order.status = "qc_hold"
+    elif order.status == "qc_hold":
+        # A passing/waived/conditional re-inspection releases a previously held
+        # order back to 'complete' so it can proceed to fulfillment. Without this
+        # the WO stays stuck in qc_hold forever even after the defect is cleared.
+        order.status = "complete"
 
     # #783: append an immutable inspection record so re-inspections keep a
     # history and true first-pass yield is derivable. The order.qc_* fields

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -813,6 +813,15 @@ def record_qc_inspection(
         # order back to 'complete' so it can proceed to fulfillment. Without this
         # the WO stays stuck in qc_hold forever even after the defect is cleared.
         order.status = "complete"
+        # Re-sync the parent sales order: a sibling WO may have completed while
+        # this one was held, so the earlier completion sync saw this WO as
+        # qc_hold and left the SO in in_production. Releasing it can be what
+        # makes the SO fully complete. Idempotent — a no-op unless all WOs done.
+        try:
+            from app.services.status_sync_service import sync_on_production_complete
+            sync_on_production_complete(db, order)
+        except Exception as e:
+            logger.error("Failed to sync sales order for %s: %s", order.code, e)
 
     # #783: append an immutable inspection record so re-inspections keep a
     # history and true first-pass yield is derivable. The order.qc_* fields

--- a/backend/tests/api/v1/test_production_orders.py
+++ b/backend/tests/api/v1/test_production_orders.py
@@ -657,6 +657,29 @@ class TestCompleteProductionOrder:
         assert response.json()["status"] == "complete"
 
 
+class TestQCInspectionEndpoint:
+    """Test POST /api/v1/production-orders/{id}/qc"""
+
+    def test_qc_conditional_result_accepted(self, client, db, make_product, make_bom):
+        """'conditional' is a valid QC result — the endpoint must bind it (A6).
+        It previously 422'd because QCStatus lacked the member, even though the
+        service and DB CHECK already accept it."""
+        fg, _, _ = _create_product_with_bom(make_product, make_bom, db)
+        order_data = _create_draft_order(client, fg.id)
+        client.post(f"{BASE_URL}/{order_data['id']}/release")
+        client.post(f"{BASE_URL}/{order_data['id']}/start")
+        client.post(
+            f"{BASE_URL}/{order_data['id']}/complete",
+            json={"quantity_completed": "10"},
+        )
+
+        response = client.post(
+            f"{BASE_URL}/{order_data['id']}/qc",
+            json={"result": "conditional", "notes": "Accepted with minor cosmetic deviation"},
+        )
+        assert response.status_code == 200, response.text
+
+
 # =============================================================================
 # Cancel -- POST /api/v1/production-orders/{id}/cancel
 # =============================================================================

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2837,23 +2837,34 @@ class TestRecordQCInspection:
         assert reloaded.qc_notes == "All checks passed"
         assert reloaded.qc_inspected_at is not None
 
-    def test_passing_reinspection_releases_qc_hold(self, db, finished_good):
-        """A qc_hold order that later passes re-inspection returns to 'complete'
-        so it can proceed to fulfillment instead of staying stuck on hold (A4)."""
-        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+    @pytest.mark.parametrize("release_result", ["passed", "waived", "conditional"])
+    def test_reinspection_releases_qc_hold_and_syncs_so(
+        self, db, finished_good, make_sales_order, release_result
+    ):
+        """A non-failed re-inspection releases a qc_hold WO back to 'complete' AND
+        re-syncs the parent SO — a sibling may have completed while this WO was
+        held, so releasing it is what makes the SO shippable (A4)."""
+        so = make_sales_order(
+            product_id=finished_good.id, quantity=10, status="in_production",
+        )
+        order = _make_production_order(
+            db, finished_good, status="in_progress", quantity=10, sales_order_id=so.id,
+        )
         order.quantity_completed = 10
         db.flush()
-        # First inspection fails -> qc_hold
+        # Fail QC -> qc_hold; the parent SO is not advanced.
         svc.record_qc_inspection(
             db, order.id, inspector="Insp", qc_status="failed", quantity_failed=10,
         )
         assert order.status == "qc_hold"
-        # Re-inspection passes -> released back to complete
+        assert so.status == "in_production"
+        # A non-failed re-inspection releases the WO and advances the SO.
         svc.record_qc_inspection(
-            db, order.id, inspector="Insp", qc_status="passed", quantity_passed=10,
+            db, order.id, inspector="Insp", qc_status=release_result, quantity_passed=10,
         )
         assert order.status == "complete"
-        assert order.qc_status == "passed"
+        assert order.qc_status == release_result
+        assert so.status == "ready_to_ship"
 
     def test_record_failed_inspection_holds_order_without_autoscrap(self, db, finished_good):
         """A failed inspection holds the order for disposition but does NOT

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -1079,6 +1079,26 @@ class TestStartProductionOrder:
 class TestCompleteProductionOrder:
     """Test production order completion."""
 
+    def test_complete_syncs_parent_sales_order_to_ready_to_ship(
+        self, db, finished_good, make_sales_order
+    ):
+        """Bulk complete must advance the parent SalesOrder to ready_to_ship once
+        all its WOs are done — the per-operation path synced this, the bulk path
+        didn't, stranding routing-less orders in in_production (A5)."""
+        so = make_sales_order(
+            product_id=finished_good.id, quantity=5, status="in_production",
+        )
+        order = _make_production_order(
+            db, finished_good, status="in_progress", quantity=5, sales_order_id=so.id,
+        )
+        svc.complete_production_order(
+            db, order.id, "test@filaops.dev", quantity_good=5,
+        )
+        assert order.status == "complete"
+        # sync_on_production_complete mutates this same session instance; don't
+        # refresh (that would revert the un-flushed change to the stored value).
+        assert so.status == "ready_to_ship"
+
     def test_complete_in_progress_order(self, db, finished_good):
         """Should complete an in_progress order with full quantity."""
         order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
@@ -2816,6 +2836,24 @@ class TestRecordQCInspection:
         assert reloaded.qc_inspected_by == "Inspector Persist"
         assert reloaded.qc_notes == "All checks passed"
         assert reloaded.qc_inspected_at is not None
+
+    def test_passing_reinspection_releases_qc_hold(self, db, finished_good):
+        """A qc_hold order that later passes re-inspection returns to 'complete'
+        so it can proceed to fulfillment instead of staying stuck on hold (A4)."""
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        order.quantity_completed = 10
+        db.flush()
+        # First inspection fails -> qc_hold
+        svc.record_qc_inspection(
+            db, order.id, inspector="Insp", qc_status="failed", quantity_failed=10,
+        )
+        assert order.status == "qc_hold"
+        # Re-inspection passes -> released back to complete
+        svc.record_qc_inspection(
+            db, order.id, inspector="Insp", qc_status="passed", quantity_passed=10,
+        )
+        assert order.status == "complete"
+        assert order.qc_status == "passed"
 
     def test_record_failed_inspection_holds_order_without_autoscrap(self, db, finished_good):
         """A failed inspection holds the order for disposition but does NOT


### PR DESCRIPTION
## Epic #846 — Production stage, slice 2

Second Production slice: three **reachable, functional** bugs in the QC + completion flow, verified against `main` (all from the audit tracker #858, adversarially refuted before inclusion).

### A4 [critical] — QC re-inspection couldn't release a held order
`record_qc_inspection` only wrote `status` on a `failed` result. A WO that failed QC (`status=qc_hold`) then **stayed stuck in `qc_hold` forever**, even after passing a re-inspection — it could never proceed to fulfillment. Now a `passed`/`waived`/`conditional` re-inspection of a `qc_hold` order restores it to `complete`.

### A5 [major] — Bulk complete never advanced the parent SalesOrder
`complete_production_order` set the WO to `complete` but, unlike the per-operation completion path, never called `sync_on_production_complete`. So an SO whose WO was finished via **"Complete Production"** on `ProductionOrderDetail` (the only completion path for routing-less WOs) was stranded in `in_production` and never became shippable. Now mirrors the per-op sync — which is a no-op unless every sibling WO is done, so it's safe and won't double-advance.

### A6 [major] — QC "Conditional" 422'd
The QC modal offers a `Conditional` result, and the service (`_QC_RESULTS`) + DB CHECK already accept it — but the `QCStatus` enum bound by `QCInspectionRequest` lacked the member, so FastAPI rejected a valid inspection with a 422. Added `CONDITIONAL` to the enum.

### Tests (+3, all backend)
- `test_passing_reinspection_releases_qc_hold` (A4)
- `test_complete_syncs_parent_sales_order_to_ready_to_ship` (A5)
- `test_qc_conditional_result_accepted` (A6, endpoint)
- Full production service + endpoint suites **300/300**; completion/QC/sync/fulfillment blast-radius **848/848**; `ruff` clean. No frontend changes.

Tracker: #858. Next in the backward march: the scheduling subsystem (#857).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QC inspections now accept a new **“conditional”** result.
  * Re-inspecting an order after a failed QC can return it from **QC hold** to **complete** for non-failed outcomes.
* **Bug Fixes**
  * Completing a production order now also updates the related sales order to the next shipping-ready state.
  * QC state transitions are handled more consistently during completion and re-inspection.
* **Tests**
  * Added coverage for the **conditional** QC result and for sales-order synchronization during QC/reinspection and completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->