### PR TITLE
feat(licensing): live require_feature gate for PRO backend features (PR-D1)

### DIFF
--- a/backend/app/api/v1/endpoints/accounting.py
+++ b/backend/app/api/v1/endpoints/accounting.py
@@ -23,7 +23,16 @@ from app.services import accounting_service
 
 # PRO gate (PR-D1): GL reporting + fiscal period close/reopen require the
 # "accounting" feature entitlement. Community installs have no features → 403.
-router = APIRouter(dependencies=[Depends(require_feature("accounting"))])
+# Auth runs FIRST so an anonymous request gets 401 (not authenticated) — it
+# must not learn that this is a PRO-gated feature. FastAPI caches identical
+# sub-dependencies per request, so also declaring get_current_admin_user on a
+# route does not re-execute it.
+router = APIRouter(
+    dependencies=[
+        Depends(get_current_admin_user),
+        Depends(require_feature("accounting")),
+    ]
+)
 
 
 # =============================================================================

--- a/backend/app/api/v1/endpoints/accounting.py
+++ b/backend/app/api/v1/endpoints/accounting.py
@@ -15,12 +15,15 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
+from app.core.licensing_gate import require_feature
 from app.db.session import get_db
 from app.api.v1.endpoints.auth import get_current_admin_user
 from app.models.user import User
 from app.services import accounting_service
 
-router = APIRouter()
+# PRO gate (PR-D1): GL reporting + fiscal period close/reopen require the
+# "accounting" feature entitlement. Community installs have no features → 403.
+router = APIRouter(dependencies=[Depends(require_feature("accounting"))])
 
 
 # =============================================================================

--- a/backend/app/api/v1/endpoints/admin/analytics.py
+++ b/backend/app/api/v1/endpoints/admin/analytics.py
@@ -18,10 +18,17 @@ from app.services import analytics_service
 # PRO gate (PR-D1): advanced analytics require the "reports_advanced" feature
 # entitlement. Replaces the dormant @require_tier decorator (a no-op while
 # LICENSING_ENABLED was False). Community installs have no features → 403.
+# Auth runs FIRST so an anonymous request gets 401 (not authenticated) — it
+# must not learn that this is a PRO-gated feature. FastAPI caches identical
+# sub-dependencies per request, so also declaring get_current_admin_user on a
+# route does not re-execute it.
 router = APIRouter(
     prefix="/analytics",
     tags=["analytics"],
-    dependencies=[Depends(require_feature("reports_advanced"))],
+    dependencies=[
+        Depends(get_current_admin_user),
+        Depends(require_feature("reports_advanced")),
+    ],
 )
 
 

--- a/backend/app/api/v1/endpoints/admin/analytics.py
+++ b/backend/app/api/v1/endpoints/admin/analytics.py
@@ -10,12 +10,19 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.v1.endpoints.auth import get_current_admin_user
-from app.core.features import Tier, require_tier
+from app.core.licensing_gate import require_feature
 from app.db.session import get_db
 from app.models.user import User
 from app.services import analytics_service
 
-router = APIRouter(prefix="/analytics", tags=["analytics"])
+# PRO gate (PR-D1): advanced analytics require the "reports_advanced" feature
+# entitlement. Replaces the dormant @require_tier decorator (a no-op while
+# LICENSING_ENABLED was False). Community installs have no features → 403.
+router = APIRouter(
+    prefix="/analytics",
+    tags=["analytics"],
+    dependencies=[Depends(require_feature("reports_advanced"))],
+)
 
 
 class RevenueMetrics(BaseModel):
@@ -61,7 +68,6 @@ class AnalyticsDashboard(BaseModel):
 
 
 @router.get("/dashboard", response_model=AnalyticsDashboard)
-@require_tier(Tier.PRO)
 async def get_analytics_dashboard(
     days: int = 30,
     current_user: User = Depends(get_current_admin_user),

--- a/backend/app/api/v1/endpoints/mqtt.py
+++ b/backend/app/api/v1/endpoints/mqtt.py
@@ -2,9 +2,11 @@
 MQTT Telemetry API Endpoints
 
 Provides REST access to live printer telemetry for:
-- AI workers (Otto, Sam, Ada) via API key auth
+- AI workers (Otto, Sam, Ada)
 - Admin UI for monitoring
 - Frontend command center
+
+All endpoints authenticate via the standard JWT dependency (get_current_user).
 """
 
 from datetime import datetime, timezone

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -24,7 +24,7 @@ from app.schemas.scheduling import (
     MachineAvailabilityResponse,
 )
 from app.api.v1.deps import get_current_user
-from app.core.features import require_tier, Tier
+from app.core.licensing_gate import require_feature
 from app.models.user import User
 from app.services.resource_compatibility_service import (
     is_machine_compatible,
@@ -504,8 +504,10 @@ async def get_machine_availability(
     return result
 
 
-@router.post("/auto-schedule")
-@require_tier(Tier.PRO)
+@router.post(
+    "/auto-schedule",
+    dependencies=[Depends(require_feature("production_advanced"))],
+)
 async def auto_schedule_order(
     order_id: int = Query(..., description="Production order ID"),
     preferred_start: Optional[datetime] = Query(None, description="Preferred start time"),

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -506,7 +506,14 @@ async def get_machine_availability(
 
 @router.post(
     "/auto-schedule",
-    dependencies=[Depends(require_feature("production_advanced"))],
+    # Auth runs FIRST so an anonymous request gets 401 (not authenticated) — it
+    # must not learn that this is a PRO-gated feature. FastAPI caches identical
+    # sub-dependencies per request, so the current_user param below does not
+    # re-execute get_current_user.
+    dependencies=[
+        Depends(get_current_user),
+        Depends(require_feature("production_advanced")),
+    ],
 )
 async def auto_schedule_order(
     order_id: int = Query(..., description="Production order ID"),

--- a/backend/app/core/features.py
+++ b/backend/app/core/features.py
@@ -1,13 +1,15 @@
 """
 Feature Flag System for FilaOps
 
-Controls access to features based on subscription tier.
-Set LICENSING_ENABLED = False to give everyone all features (current mode).
-Set LICENSING_ENABLED = True to enforce license checking.
+Historically this module also housed a ``require_tier`` decorator used as an
+API gate. That gate was a no-op (it short-circuited whenever
+``LICENSING_ENABLED`` was False) and has been RETIRED — live PRO feature
+gating now lives in ``app.core.licensing_gate.require_feature``, which reads
+the plugin registry and fails closed. This module retains only the resource
+LIMIT helpers (seats/printers/sites), still guarded by ``LICENSING_ENABLED``.
 """
 from enum import Enum
-from typing import Dict, List, Callable
-from functools import wraps
+from typing import Dict, List
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
@@ -261,56 +263,9 @@ def get_available_features(tier: FeatureTier) -> List[str]:
     """
     return get_features_for_tier(tier.value)
 
-def require_tier(minimum_tier: FeatureTier) -> Callable:
-    """
-    Decorator to require a minimum subscription tier.
-    
-    Usage:
-        @router.get("/advanced-analytics")
-        @require_tier(Tier.PROFESSIONAL)
-        async def advanced_analytics(...):
-            ...
-    
-    Args:
-        minimum_tier: Minimum tier required
-    
-    Returns:
-        Decorator function
-    """
-    def decorator(func: Callable) -> Callable:
-        @wraps(func)
-        async def wrapper(*args, **kwargs):
-            # If licensing is disabled, allow everything
-            if not LICENSING_ENABLED:
-                return await func(*args, **kwargs)
-            
-            # Extract user and db from kwargs (injected by FastAPI)
-            user = kwargs.get("current_user")
-            db = kwargs.get("db")
-            
-            if not user or not db:
-                raise HTTPException(
-                    status_code=500,
-                    detail="Missing authentication dependencies"
-                )
-            
-            # Check user's tier
-            user_tier = get_current_tier(db, user)
-            tier_order = ["community", "professional", "enterprise"]
-            
-            required_index = tier_order.index(minimum_tier.value)
-            user_index = tier_order.index(user_tier.value)
-            
-            if user_index < required_index:
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"This feature requires {minimum_tier.value.title()} tier or higher"
-                )
-            
-            return await func(*args, **kwargs)
-
-        return wrapper
-    return decorator
+# NOTE: ``require_tier`` (a decorator-based API gate) was removed in PR-D1.
+# It short-circuited whenever LICENSING_ENABLED was False, so every use was a
+# silent no-op. Live PRO gating is now ``app.core.licensing_gate.require_feature``.
 
 
 # ============================================================================

--- a/backend/app/core/licensing_gate.py
+++ b/backend/app/core/licensing_gate.py
@@ -1,0 +1,73 @@
+"""
+Live licensing gate for FilaOps Core.
+
+This is the ONE server-side entitlement check for PRO features. It reads the
+current enabled-feature set from ``plugin_registry`` (which the installed PRO
+plugin populates at startup via ``set_features``) and denies any request for a
+feature that is not licensed.
+
+Design:
+- Source of truth is ``plugin_registry.get_features()`` — a plugin calls
+  ``set_features([...])`` during ``register(app)``. Core alone ships with an
+  empty feature list (community tier).
+- ``require_feature(key)`` is a FastAPI dependency factory. Apply it either at
+  the router level (``dependencies=[Depends(require_feature("accounting"))]``)
+  or per-route.
+- FAIL CLOSED: if the feature key is absent from the licensed set — including
+  the common case of an empty list on an unlicensed/community install — the
+  request is denied with HTTP 403. There is no "licensing disabled" escape
+  hatch here; absence of an entitlement is a denial.
+
+Usage:
+    from app.core.licensing_gate import require_feature
+
+    router = APIRouter(
+        prefix="/accounting",
+        dependencies=[Depends(require_feature("accounting"))],
+    )
+"""
+from typing import Callable
+
+from fastapi import HTTPException
+
+from app.core import plugin_registry
+
+# Standard denial message. Kept generic so it maps to any PRO feature key.
+UPGRADE_MESSAGE = "This feature requires a FilaOps PRO license."
+
+
+def feature_enabled(key: str) -> bool:
+    """Return True iff ``key`` is in the currently licensed feature set.
+
+    Fails closed: an empty or absent feature list yields False. This is the
+    plain-Python predicate behind ``require_feature`` and is convenient for
+    direct unit testing and for imperative checks inside a handler.
+    """
+    if not key:
+        return False
+    return key in plugin_registry.get_features()
+
+
+def require_feature(key: str) -> Callable[[], None]:
+    """FastAPI dependency factory that enforces a PRO feature entitlement.
+
+    Reads the licensed feature set from ``plugin_registry`` on every request
+    (so a plugin loaded at startup is honored, and community installs — which
+    have an empty set — are denied). Raises HTTP 403 when ``key`` is not
+    licensed.
+
+    Args:
+        key: The feature key to require (matches the PRO plugin's
+             ``set_features`` keys, e.g. "accounting", "reports_advanced",
+             "production_advanced").
+
+    Returns:
+        A dependency callable suitable for ``Depends(...)`` /
+        ``dependencies=[...]``.
+    """
+
+    def _dependency() -> None:
+        if not feature_enabled(key):
+            raise HTTPException(status_code=403, detail=UPGRADE_MESSAGE)
+
+    return _dependency

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -108,7 +108,6 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(
         default=30, description="JWT token expiration in minutes"
     )
-    API_KEY: Optional[str] = Field(default=None, description="API key for integrations")
     COOKIE_SECURE: bool = Field(
         default=False,
         description="Set Secure flag on auth cookies (requires HTTPS). Must be true in production.",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -299,7 +299,7 @@ app.add_middleware(
     allow_origins=_all_cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With", "X-API-Key"],
+    allow_headers=["Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"],
 )
 
 

--- a/backend/tests/api/v1/test_licensing_gate.py
+++ b/backend/tests/api/v1/test_licensing_gate.py
@@ -90,6 +90,16 @@ class TestAccountingGate:
         resp = client.get(self.URL)
         assert resp.status_code != 403
 
+    def test_anonymous_returns_401_not_403(self, unauthed_client):
+        """Auth precedes the feature gate: an unauthenticated request must get
+        401 (not authenticated), never a PRO-specific 403 — anon callers must
+        not learn that this is a PRO-gated feature. The registry is empty here,
+        so if the gate ran before auth this would incorrectly be a 403.
+        """
+        assert plugin_registry.get_features() == []
+        resp = unauthed_client.get(self.URL)
+        assert resp.status_code == 401
+
 
 # ── Admin analytics router: require_feature("reports_advanced") ──────
 

--- a/backend/tests/api/v1/test_licensing_gate.py
+++ b/backend/tests/api/v1/test_licensing_gate.py
@@ -1,0 +1,125 @@
+"""Tests for the live PRO feature gate (app.core.licensing_gate.require_feature).
+
+Covers (PR-D1 — the PRO-leak keystone):
+- Direct unit tests of require_feature / feature_enabled (fail-closed).
+- Per-router HTTP tests for the three gated features:
+    * accounting          -> require_feature("accounting")
+    * reports_advanced    -> require_feature("reports_advanced")  (admin analytics)
+    * production_advanced -> require_feature("production_advanced") (scheduling auto-schedule)
+
+For each router: unlicensed/community (no feature in plugin_registry) => 403;
+licensed (feature present) => NOT 403 (the gate no longer blocks; the request
+reaches the handler).
+
+The unlicensed=>403 path is exercised by the gate dependency *before* the
+DB-backed handler runs, so those assertions hold even without seeded data.
+The licensed path reaches the handler and therefore relies on the seeded
+Postgres fixture (as the rest of the suite does).
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import plugin_registry
+from app.core.licensing_gate import feature_enabled, require_feature, UPGRADE_MESSAGE
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Each test starts and ends with clean community defaults (no features)."""
+    plugin_registry.reset()
+    yield
+    plugin_registry.reset()
+
+
+# ── Direct unit tests: require_feature / feature_enabled ─────────────
+
+class TestRequireFeatureUnit:
+    """The gate must FAIL CLOSED: absent entitlement => deny."""
+
+    def test_feature_enabled_false_on_empty(self):
+        # Community default is an empty feature list.
+        assert plugin_registry.get_features() == []
+        assert feature_enabled("accounting") is False
+
+    def test_feature_enabled_false_on_missing_key(self):
+        plugin_registry.set_features(["reports_advanced"])
+        assert feature_enabled("accounting") is False
+
+    def test_feature_enabled_false_on_empty_key(self):
+        plugin_registry.set_features(["accounting"])
+        assert feature_enabled("") is False
+
+    def test_feature_enabled_true_when_licensed(self):
+        plugin_registry.set_features(["accounting"])
+        assert feature_enabled("accounting") is True
+
+    def test_require_feature_raises_403_when_unlicensed(self):
+        dep = require_feature("accounting")
+        with pytest.raises(HTTPException) as exc:
+            dep()
+        assert exc.value.status_code == 403
+        assert exc.value.detail == UPGRADE_MESSAGE
+
+    def test_require_feature_raises_403_on_wrong_key(self):
+        plugin_registry.set_features(["reports_advanced"])
+        dep = require_feature("accounting")
+        with pytest.raises(HTTPException) as exc:
+            dep()
+        assert exc.value.status_code == 403
+
+    def test_require_feature_allows_when_licensed(self):
+        plugin_registry.set_features(["accounting"])
+        dep = require_feature("accounting")
+        # No exception => allowed.
+        assert dep() is None
+
+
+# ── Accounting router: require_feature("accounting") ─────────────────
+
+class TestAccountingGate:
+    URL = "/api/v1/accounting/trial-balance"
+
+    def test_unlicensed_returns_403(self, client):
+        resp = client.get(self.URL)
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == UPGRADE_MESSAGE
+
+    def test_licensed_not_403(self, client):
+        plugin_registry.set_features(["accounting"])
+        resp = client.get(self.URL)
+        assert resp.status_code != 403
+
+
+# ── Admin analytics router: require_feature("reports_advanced") ──────
+
+class TestAnalyticsGate:
+    URL = "/api/v1/admin/analytics/dashboard"
+
+    def test_unlicensed_returns_403(self, client):
+        resp = client.get(self.URL)
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == UPGRADE_MESSAGE
+
+    def test_licensed_not_403(self, client):
+        plugin_registry.set_features(["reports_advanced"])
+        resp = client.get(self.URL)
+        assert resp.status_code != 403
+
+
+# ── Scheduling auto-schedule: require_feature("production_advanced") ─
+
+class TestSchedulingGate:
+    URL = "/api/v1/scheduling/auto-schedule"
+
+    def test_unlicensed_returns_403(self, client):
+        # order_id is required (Query) — but the feature gate runs first, so an
+        # unlicensed caller is denied regardless of query params.
+        resp = client.post(f"{self.URL}?order_id=1")
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == UPGRADE_MESSAGE
+
+    def test_licensed_not_403(self, client):
+        plugin_registry.set_features(["production_advanced"])
+        resp = client.post(f"{self.URL}?order_id=1")
+        assert resp.status_code != 403


### PR DESCRIPTION
## Summary — the keystone fix for the 2026-07-01 PRO-leak audit

Core had **no live server-side tier check**. The legacy gate in
`app/core/features.py` was dormant (`LICENSING_ENABLED = False`), so its
`require_tier` decorator short-circuited to a **no-op** — several PRO features
ran FREE on unlicensed/community installs (audit's 6-critical finding).

This PR adds a **live, fail-closed** gate and applies it to the leaking real
features.

### `require_feature(key)` — `app/core/licensing_gate.py`
- FastAPI dependency factory. Reads the enabled-feature set from
  `plugin_registry.get_features()` (the source of truth — the installed PRO
  plugin calls `set_features([...])` at startup; Core alone ships an empty list).
- **FAILS CLOSED**: if `key` is not in the licensed set — including the common
  empty-list community case — it raises `HTTPException(403, "This feature
  requires a FilaOps PRO license.")`. No `LICENSING_ENABLED` escape hatch.
- Also exposes `feature_enabled(key)` as a plain predicate for unit tests /
  imperative checks.

### Routers gated (feature key)
| Router | Feature key | How |
|---|---|---|
| `accounting.py` (GL trial-balance/ledger/valuation + fiscal period close/reopen) | `accounting` | router-level `dependencies=[Depends(require_feature("accounting"))]` |
| `admin/analytics.py` (advanced analytics dashboard) | `reports_advanced` | router-level dependency; **replaces dead `@require_tier(Tier.PRO)`** |
| `scheduling.py` `POST /auto-schedule` | `production_advanced` | route-level dependency; **replaces dead `@require_tier(Tier.PRO)`** |

### Retired the dormant gate
- Removed `require_tier` from `features.py` (zero remaining callers after the
  analytics/scheduling migration) — no more silent no-op gates.
- Left `get_current_tier` / `enforce_resource_limit` and the resource-LIMIT
  helpers intact: those feed **seat/printer limits**, owned by **PR-D2**
  (multi_user). This PR does not touch `admin/users.py` or seat logic.

### Dead `api_access` cleanup (verified truly unused first)
- Deleted the generic `settings.API_KEY` field (no `settings.API_KEY`
  consumers; `LICENSE_API_KEY`/`BAMBU_SUITE_API_KEY`/`EASYPOST_API_KEY` are
  distinct, active fields and are untouched).
- Removed the `X-API-Key` CORS `allow_headers` entry (`main.py`) — no inbound
  Core endpoint reads that request header; the license-server calls send it
  outbound, unaffected.
- Fixed the false "via API key auth" docstring in `mqtt.py` (all MQTT
  endpoints authenticate via the JWT `get_current_user` dependency).

## Scheduling note (audit hint)
`scheduling.py`'s `POST /auto-schedule` is a **real, existing Core handler**
(material-compatibility-aware slot finder), not a missing wheel endpoint — it
had a dead `@require_tier` that this PR replaces with the live
`require_feature("production_advanced")` dependency. Its other endpoints
(`/board`, `/capacity/*`, `/resource-conflicts`) were never gated and are left
open to community to avoid changing existing behavior. If the FE separately
404s on an auto-schedule wheel endpoint, that is a distinct missing-feature bug
outside this leak-closure PR.

The top-level `accounting.py` router (named by the audit) is gated here. The
separate `admin/accounting.py` "accounting views into business data" router was
not named by the audit and is intentionally left out of scope.

## Tests — `tests/api/v1/test_licensing_gate.py`
- Direct unit tests: `require_feature`/`feature_enabled` fail closed on empty
  and wrong-key feature sets; allow when licensed.
- Per-router HTTP tests for all three gated features:
  community/no-feature => **403**; feature present => **not 403** (reaches
  handler). Mirrors the `plugin_registry.reset()/set_features` fixture pattern
  from `test_system.py`.
- **13 tests collect cleanly** and `ruff check` is clean on all changed files.
  A fresh worktree lacks the seeded session Postgres (same constraint as
  PR-D0), so the suite executes in CI; the gate's fail-closed logic was also
  verified out-of-band via a standalone import.

## Follow-ups (not this PR)
- `multi_user` seat caps → **PR-D2**.
- The 4 empty `tier_features` keys → license-server cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live entitlement-based access control for advanced areas (accounting, advanced analytics, and auto-scheduling), returning clear access-denied responses when not licensed.
* **Bug Fixes**
  * Ensured unauthenticated requests fail with the correct authentication error (401) rather than a licensing-specific denial.
* **Changes**
  * Removed legacy tier checks and API-key configuration; updated request auth guidance for MQTT endpoints.
  * Tightened CORS allowed headers by removing the API-key header.
* **Tests**
  * Added automated coverage for both licensed and unlicensed access to protected endpoints and the licensing gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->