### PR TITLE
feat(users): multi_user seat caps (community 1 / PRO unlimited, grandfathered) — PR-D2

### DIFF
--- a/backend/app/api/v1/endpoints/admin/users.py
+++ b/backend/app/api/v1/endpoints/admin/users.py
@@ -67,7 +67,7 @@ async def list_admin_users(
     Admin only.
     """
     query = db.query(User).filter(
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     )
     
     # Filter by account type
@@ -125,7 +125,7 @@ async def get_user_stats(
     ).count()
 
     total_inactive = db.query(User).filter(
-        User.account_type.in_(["admin", "operator"]),
+        User.account_type.in_(STAFF_ACCOUNT_TYPES),
         User.status != "active"
     ).count()
 
@@ -154,7 +154,7 @@ async def get_admin_user(
     """
     user = db.query(User).filter(
         User.id == user_id,
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     ).first()
     
     if not user:
@@ -202,7 +202,7 @@ async def create_admin_user(
     # Legacy tier-limit hook (dormant unless features.LICENSING_ENABLED is on;
     # owned by a separate change). Kept for continuity — real enforcement above.
     current_user_count = db.query(User).filter(
-        User.account_type.in_(list(STAFF_ACCOUNT_TYPES)),
+        User.account_type.in_(STAFF_ACCOUNT_TYPES),
         User.status == "active"
     ).count()
 
@@ -282,7 +282,7 @@ async def update_admin_user(
     """
     user = db.query(User).filter(
         User.id == user_id,
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     ).first()
     
     if not user:
@@ -389,7 +389,7 @@ async def reset_user_password(
     """
     user = db.query(User).filter(
         User.id == user_id,
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     ).first()
     
     if not user:
@@ -445,7 +445,7 @@ async def deactivate_admin_user(
     """
     user = db.query(User).filter(
         User.id == user_id,
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     ).first()
     
     if not user:
@@ -520,7 +520,7 @@ async def reactivate_admin_user(
     """
     user = db.query(User).filter(
         User.id == user_id,
-        User.account_type.in_(["admin", "operator"])
+        User.account_type.in_(STAFF_ACCOUNT_TYPES)
     ).first()
     
     if not user:

--- a/backend/app/api/v1/endpoints/admin/users.py
+++ b/backend/app/api/v1/endpoints/admin/users.py
@@ -194,13 +194,9 @@ async def create_admin_user(
 
     Note: Subject to tier limits. Community tier allows 1 user (the initial admin).
     """
-    # Multi-user seat cap: community allows 1 active staff seat, PRO/enterprise
-    # unlimited. Reads the live tier from plugin_registry. Blocks only the NEW
-    # seat over the cap — never affects existing users (grandfathered).
-    enforce_seat_cap(db)
-
     # Legacy tier-limit hook (dormant unless features.LICENSING_ENABLED is on;
-    # owned by a separate change). Kept for continuity — real enforcement above.
+    # owned by a separate change). Kept for continuity — real enforcement is
+    # enforce_seat_cap() just before db.add() below.
     current_user_count = db.query(User).filter(
         User.account_type.in_(STAFF_ACCOUNT_TYPES),
         User.status == "active"
@@ -216,12 +212,23 @@ async def create_admin_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email already registered"
         )
-    
+
     # Hash password
     password_hashed = hash_password(request.password)
-    
+
     now = datetime.now(timezone.utc)
-    
+
+    # Multi-user seat cap: community allows 1 active staff seat, PRO/enterprise
+    # unlimited. Reads the live tier from plugin_registry. Blocks only the NEW
+    # seat over the cap — never affects existing users (grandfathered).
+    # Placed LAST before db.add() (CodeRabbit #862): on capped tiers this takes
+    # a transaction-scoped advisory lock held until commit, so it must not sit
+    # above the email lookup / bcrypt hashing — that would serialize concurrent
+    # creates through the slowest part of the handler. It must still run BEFORE
+    # db.add(): the session would autoflush the pending user into the seat
+    # count and off-by-one every create.
+    enforce_seat_cap(db)
+
     user = User(
         email=request.email,
         password_hash=password_hashed,

--- a/backend/app/api/v1/endpoints/admin/users.py
+++ b/backend/app/api/v1/endpoints/admin/users.py
@@ -21,6 +21,7 @@ from app.models.user import User, RefreshToken
 from app.api.v1.deps import get_current_admin_user
 from app.core.security import hash_password
 from app.core.features import enforce_resource_limit, get_current_tier
+from app.core.seat_limits import enforce_seat_cap, STAFF_ACCOUNT_TYPES
 from app.logging_config import get_logger
 from app.schemas.user_admin import (
     AdminUserCreate,
@@ -193,9 +194,15 @@ async def create_admin_user(
 
     Note: Subject to tier limits. Community tier allows 1 user (the initial admin).
     """
-    # Check tier limits before creating
+    # Multi-user seat cap: community allows 1 active staff seat, PRO/enterprise
+    # unlimited. Reads the live tier from plugin_registry. Blocks only the NEW
+    # seat over the cap — never affects existing users (grandfathered).
+    enforce_seat_cap(db)
+
+    # Legacy tier-limit hook (dormant unless features.LICENSING_ENABLED is on;
+    # owned by a separate change). Kept for continuity — real enforcement above.
     current_user_count = db.query(User).filter(
-        User.account_type.in_(["admin", "operator"]),
+        User.account_type.in_(list(STAFF_ACCOUNT_TYPES)),
         User.status == "active"
     ).count()
 
@@ -319,7 +326,14 @@ async def update_admin_user(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Email already in use"
             )
-    
+
+    # Multi-user seat cap: block activating a currently-inactive staff user via
+    # PATCH status='active' if it would exceed the tier's active-staff cap.
+    # Only fires on an inactive->active transition, so editing an already-active
+    # user is unaffected (grandfathered). Exclude this user from the count.
+    if request.status == "active" and user.status != "active":
+        enforce_seat_cap(db, exclude_user_id=user.id)
+
     # Update fields
     update_data = request.model_dump(exclude_unset=True)
     for field, value in update_data.items():
@@ -520,7 +534,12 @@ async def reactivate_admin_user(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="User is already active"
         )
-    
+
+    # Multi-user seat cap: reactivating adds one active staff seat. Block if it
+    # would exceed the tier cap (community=1, PRO/enterprise unlimited). Exclude
+    # this user from the count. Grandfathered — never touches other users.
+    enforce_seat_cap(db, exclude_user_id=user.id)
+
     user.status = "active"
     user.updated_by = current_admin.id
     user.updated_at = datetime.now(timezone.utc)

--- a/backend/app/core/seat_limits.py
+++ b/backend/app/core/seat_limits.py
@@ -1,0 +1,110 @@
+"""
+Multi-user seat caps for FilaOps Core.
+
+The ``multi_user`` capability is a PRO feature: unlicensed (community) installs
+get a single staff seat, while licensed installs (professional / enterprise) get
+unlimited staff seats.
+
+A *seat* is a STAFF/team user account — ``account_type`` in ``admin`` or
+``operator``. Customer / portal accounts (``account_type == "customer"``) are NOT
+team members and never consume or count against a seat.
+
+Tier is read directly from ``app.core.plugin_registry`` (set by the filaops-pro
+plugin at startup). This module is deliberately independent of
+``app.core.features.LICENSING_ENABLED`` — that legacy master switch is dormant
+(everything free) and owned by a separate change; seat enforcement must work
+regardless of its value so the leak is actually closed.
+
+GRANDFATHERING: the cap only blocks *adding* or *activating* a NEW staff seat
+beyond the cap. It never deactivates or locks out existing users. An install that
+is already over the cap (e.g. a pre-existing multi-user community deployment)
+keeps every current user working; it simply cannot add or reactivate another
+staff member until it upgrades. There is no startup- or login-time enforcement.
+"""
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.plugin_registry import get_tier
+from app.models.user import User
+
+# Account types that count as a staff/team "seat". Customers/portal accounts
+# (account_type == "customer") are intentionally excluded.
+STAFF_ACCOUNT_TYPES = ("admin", "operator")
+
+# Tier -> maximum concurrent active staff seats.
+# ``None`` means unlimited. Any tier not listed here falls back to the community
+# cap (fail-safe: an unknown/unlicensed tier is treated as community).
+_SEAT_CAPS: dict[str, Optional[int]] = {
+    "community": 1,
+    "professional": None,  # unlimited
+    "enterprise": None,    # unlimited
+}
+
+# Shown to the user when they hit the community seat cap.
+SEAT_LIMIT_MESSAGE = (
+    "Your plan allows 1 user. Upgrade to PRO to add team members."
+)
+
+
+def seat_cap_for_tier(tier: str) -> Optional[int]:
+    """Return the max active staff seats for a tier (``None`` = unlimited).
+
+    Unknown tiers fall back to the community cap so a missing/garbled tier can
+    never silently grant unlimited seats.
+    """
+    return _SEAT_CAPS.get((tier or "").lower(), _SEAT_CAPS["community"])
+
+
+def count_active_staff(db: Session, exclude_user_id: Optional[int] = None) -> int:
+    """Count currently-active staff (admin/operator) users.
+
+    Args:
+        db: Database session.
+        exclude_user_id: Optional user id to exclude from the count — used when
+            re-activating an existing user so we count the seats that would
+            remain *besides* the one being activated.
+    """
+    query = db.query(User).filter(
+        User.account_type.in_(STAFF_ACCOUNT_TYPES),
+        User.status == "active",
+    )
+    if exclude_user_id is not None:
+        query = query.filter(User.id != exclude_user_id)
+    return query.count()
+
+
+def enforce_seat_cap(db: Session, exclude_user_id: Optional[int] = None) -> None:
+    """Raise 403 if adding/activating one more staff seat would exceed the cap.
+
+    Reads the current tier from ``plugin_registry``. On a capped tier
+    (community), blocks the action when the resulting active-staff count would
+    exceed the cap. On an uncapped tier (professional/enterprise) this is a
+    no-op.
+
+    GRANDFATHER: this only guards the *incremental* seat. It never touches or
+    deactivates existing users; installs already over the cap keep working and
+    are simply prevented from adding more.
+
+    Args:
+        db: Database session.
+        exclude_user_id: When activating/reactivating an existing user, pass its
+            id so it is not double-counted against the cap.
+
+    Raises:
+        HTTPException: 403 when the community seat cap would be exceeded.
+    """
+    cap = seat_cap_for_tier(get_tier())
+    if cap is None:
+        return  # unlimited — nothing to enforce
+
+    current_active_staff = count_active_staff(db, exclude_user_id=exclude_user_id)
+
+    # The action would add one more active staff seat. Block only if that pushes
+    # the count above the cap (i.e. current already >= cap).
+    if current_active_staff >= cap:
+        raise HTTPException(
+            status_code=403,
+            detail=SEAT_LIMIT_MESSAGE,
+        )

--- a/backend/app/core/seat_limits.py
+++ b/backend/app/core/seat_limits.py
@@ -24,6 +24,7 @@ staff member until it upgrades. There is no startup- or login-time enforcement.
 from typing import Optional
 
 from fastapi import HTTPException
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.core.plugin_registry import get_tier
@@ -32,6 +33,12 @@ from app.models.user import User
 # Account types that count as a staff/team "seat". Customers/portal accounts
 # (account_type == "customer") are intentionally excluded.
 STAFF_ACCOUNT_TYPES = ("admin", "operator")
+
+# Fixed, arbitrary key for the transaction-scoped Postgres advisory lock that
+# serializes seat-cap enforcement across concurrent requests (see
+# enforce_seat_cap). Any stable int works; this private constant means only
+# seat enforcement contends on it.
+_SEAT_LOCK_KEY = 848_293_001
 
 # Tier -> maximum concurrent active staff seats.
 # ``None`` means unlimited. Any tier not listed here falls back to the community
@@ -87,6 +94,17 @@ def enforce_seat_cap(db: Session, exclude_user_id: Optional[int] = None) -> None
     deactivates existing users; installs already over the cap keep working and
     are simply prevented from adding more.
 
+    CONCURRENCY (TOCTOU): the count-then-insert/activate performed by the caller
+    is check-then-act. Two concurrent create/activate requests could each read
+    a below-cap count and both proceed, overshooting the cap. To close that gap
+    we take a transaction-scoped Postgres advisory lock at the top of the check.
+    ``enforce_seat_cap`` runs inside the request's DB session/transaction and the
+    caller commits the insert/activation on that SAME session with no
+    intermediate commit, so the xact lock is held until that commit. A second
+    concurrent request therefore blocks here until the first commits, then its
+    count reflects the newly-added seat and it correctly 403s. The lock
+    auto-releases at commit/rollback — no explicit unlock needed.
+
     Args:
         db: Database session.
         exclude_user_id: When activating/reactivating an existing user, pass its
@@ -98,6 +116,16 @@ def enforce_seat_cap(db: Session, exclude_user_id: Optional[int] = None) -> None
     cap = seat_cap_for_tier(get_tier())
     if cap is None:
         return  # unlimited — nothing to enforce
+
+    # Serialize concurrent seat checks+writes. pg_advisory_xact_lock is
+    # Postgres-only; guard by dialect so sqlite / other backends no-op (the
+    # lock is a safety net, not a correctness requirement for single-writer
+    # test backends).
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        db.execute(
+            text("SELECT pg_advisory_xact_lock(:key)"),
+            {"key": _SEAT_LOCK_KEY},
+        )
 
     current_active_staff = count_active_staff(db, exclude_user_id=exclude_user_id)
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,6 +4,9 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 
+markers =
+    seat_caps: multi-user seat-cap tests that drive the license tier themselves
+
 # Filter known warnings that are not actionable
 filterwarnings =
     ignore::DeprecationWarning:datetime.*:

--- a/backend/tests/api/v1/test_admin_users.py
+++ b/backend/tests/api/v1/test_admin_users.py
@@ -828,6 +828,100 @@ class TestMultiUserSeatCaps:
 
 
 # =============================================================================
+# 10b. TestSeatCapAdvisoryLock — TOCTOU serialization (no DB required)
+# =============================================================================
+
+class _FakeDialect:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeBind:
+    def __init__(self, dialect_name):
+        self.dialect = _FakeDialect(dialect_name)
+
+
+class _FakeQuery:
+    def __init__(self, count):
+        self._count = count
+
+    def filter(self, *a, **k):
+        return self
+
+    def count(self):
+        return self._count
+
+
+class _SpyDB:
+    """Minimal stand-in for a Session that records execute() calls and reports a
+    chosen SQL dialect, so we can assert the advisory-lock SQL is issued on the
+    seat-check path without needing a live database."""
+
+    def __init__(self, dialect_name="postgresql", active_staff=0):
+        self.bind = _FakeBind(dialect_name)
+        self._active_staff = active_staff
+        self.executed = []  # list of (sql_text, params)
+
+    def execute(self, statement, params=None):
+        self.executed.append((str(statement), params))
+        return None
+
+    def query(self, *a, **k):
+        return _FakeQuery(self._active_staff)
+
+
+@pytest.mark.seat_caps
+class TestSeatCapAdvisoryLock:
+    """The seat check must serialize itself with a transaction-scoped advisory
+    lock on Postgres to close the check-then-write TOCTOU window."""
+
+    def test_advisory_lock_issued_on_postgres(self, set_tier):
+        from app.core import seat_limits
+
+        set_tier("community")
+        spy = _SpyDB(dialect_name="postgresql", active_staff=0)
+        # active_staff=0 under community cap of 1 -> allowed, no raise.
+        seat_limits.enforce_seat_cap(spy)
+
+        lock_calls = [sql for sql, _ in spy.executed if "pg_advisory_xact_lock" in sql]
+        assert lock_calls, "expected a pg_advisory_xact_lock on the seat-check path"
+
+    def test_advisory_lock_uses_module_key(self, set_tier):
+        from app.core import seat_limits
+
+        set_tier("community")
+        spy = _SpyDB(dialect_name="postgresql", active_staff=0)
+        seat_limits.enforce_seat_cap(spy)
+
+        lock_params = [
+            params for sql, params in spy.executed
+            if "pg_advisory_xact_lock" in sql
+        ]
+        assert lock_params and lock_params[0]["key"] == seat_limits._SEAT_LOCK_KEY
+
+    def test_no_advisory_lock_on_non_postgres(self, set_tier):
+        """The lock is Postgres-only; other dialects must no-op (not error)."""
+        from app.core import seat_limits
+
+        set_tier("community")
+        spy = _SpyDB(dialect_name="sqlite", active_staff=0)
+        seat_limits.enforce_seat_cap(spy)
+
+        lock_calls = [sql for sql, _ in spy.executed if "pg_advisory_xact_lock" in sql]
+        assert not lock_calls, "advisory lock must not be issued on non-Postgres"
+
+    def test_no_lock_when_tier_unlimited(self, set_tier):
+        """Uncapped tiers short-circuit before any DB work — no lock taken."""
+        from app.core import seat_limits
+
+        set_tier("professional")
+        spy = _SpyDB(dialect_name="postgresql", active_staff=99)
+        seat_limits.enforce_seat_cap(spy)
+
+        assert spy.executed == [], "unlimited tier must not touch the DB"
+
+
+# =============================================================================
 # 9. TestAdminUserAuth — 401 tests
 # =============================================================================
 

--- a/backend/tests/api/v1/test_admin_users.py
+++ b/backend/tests/api/v1/test_admin_users.py
@@ -15,7 +15,48 @@ import uuid
 
 import pytest
 
+from app.core import plugin_registry
+
 BASE_URL = "/api/v1/admin/users"
+
+
+# =============================================================================
+# Tier control for seat caps
+# =============================================================================
+
+@pytest.fixture
+def set_tier():
+    """Set the plugin_registry tier for a test, restoring the default after.
+
+    Seat-cap enforcement (app.core.seat_limits) reads the live tier from
+    plugin_registry. Tests that want to exercise a specific tier call this;
+    the registry is reset to community defaults on teardown so tests stay
+    isolated.
+    """
+    def _apply(tier: str) -> None:
+        plugin_registry.set_tier(tier)
+
+    yield _apply
+    plugin_registry.reset()
+
+
+@pytest.fixture(autouse=True)
+def _unlimited_seats_for_crud_tests(request):
+    """Give the general CRUD suite an unlimited (professional) seat tier.
+
+    The default community tier caps active staff at 1 seat, which would block
+    the many operators/admins these CRUD tests create. The dedicated seat-cap
+    suite (TestMultiUserSeatCaps) opts out via the ``seat_caps`` marker so it
+    can drive the tier itself.
+    """
+    if request.node.get_closest_marker("seat_caps"):
+        yield
+        return
+    plugin_registry.set_tier("professional")
+    try:
+        yield
+    finally:
+        plugin_registry.reset()
 
 
 # =============================================================================
@@ -556,6 +597,234 @@ class TestAdminUserReactivate:
     def test_reactivate_nonexistent_user_returns_404(self, client):
         resp = client.post(f"{BASE_URL}/999999/reactivate")
         assert resp.status_code == 404
+
+
+# =============================================================================
+# 10. TestMultiUserSeatCaps — PR-D2: multi_user seat enforcement
+# =============================================================================
+
+def _seat_error(resp) -> str:
+    """Extract the detail string from a seat-cap 403 response."""
+    detail = resp.json().get("detail")
+    return detail if isinstance(detail, str) else str(detail)
+
+
+@pytest.mark.seat_caps
+class TestMultiUserSeatCaps:
+    """Seat-cap enforcement: community = 1 staff seat, PRO/enterprise unlimited.
+
+    These tests drive the license tier directly via the ``set_tier`` fixture
+    (the seeded admin id=1 is the single existing active staff seat). The
+    ``seat_caps`` marker opts out of the module's default unlimited tier.
+    """
+
+    # ---- (a) community + 1 active staff -> 2nd staff blocked ----------------
+
+    def test_community_second_staff_create_returns_403(self, client, set_tier):
+        set_tier("community")
+        # Seeded admin (id=1) already occupies the single community seat.
+        payload = {
+            "email": _unique_email(),
+            "password": "SecurePass1!",
+            "account_type": "operator",
+        }
+        resp = client.post(f"{BASE_URL}/", json=payload)
+        assert resp.status_code == 403, resp.text
+        assert "upgrade to pro" in _seat_error(resp).lower()
+
+    def test_community_second_admin_create_returns_403(self, client, set_tier):
+        set_tier("community")
+        payload = {
+            "email": _unique_email(),
+            "password": "SecurePass1!",
+            "account_type": "admin",
+        }
+        resp = client.post(f"{BASE_URL}/", json=payload)
+        assert resp.status_code == 403, resp.text
+
+    def test_community_reactivate_second_staff_returns_403(self, client, set_tier, db):
+        """An inactive staff user cannot be reactivated when the single seat is
+        already taken by the active seeded admin."""
+        from app.models.user import User
+        inactive = User(
+            email=_unique_email(),
+            password_hash="fake-hash",
+            account_type="operator",
+            status="inactive",
+        )
+        db.add(inactive)
+        db.flush()
+
+        set_tier("community")
+        resp = client.post(f"{BASE_URL}/{inactive.id}/reactivate")
+        assert resp.status_code == 403, resp.text
+        assert "upgrade to pro" in _seat_error(resp).lower()
+
+    def test_community_activate_via_patch_returns_403(self, client, set_tier, db):
+        """PATCH status='active' on an inactive staff user is blocked at the cap."""
+        from app.models.user import User
+        inactive = User(
+            email=_unique_email(),
+            password_hash="fake-hash",
+            account_type="operator",
+            status="inactive",
+        )
+        db.add(inactive)
+        db.flush()
+
+        set_tier("community")
+        resp = client.patch(f"{BASE_URL}/{inactive.id}", json={"status": "active"})
+        assert resp.status_code == 403, resp.text
+
+    # ---- (b) professional -> Nth staff allowed ------------------------------
+
+    def test_professional_second_staff_create_allowed(self, client, set_tier):
+        set_tier("professional")
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "email": _unique_email(),
+                "password": "SecurePass1!",
+                "account_type": "operator",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_professional_many_staff_allowed(self, client, set_tier):
+        set_tier("professional")
+        for _ in range(3):
+            resp = client.post(
+                f"{BASE_URL}/",
+                json={
+                    "email": _unique_email(),
+                    "password": "SecurePass1!",
+                    "account_type": "operator",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+
+    def test_enterprise_second_staff_create_allowed(self, client, set_tier):
+        set_tier("enterprise")
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "email": _unique_email(),
+                "password": "SecurePass1!",
+                "account_type": "admin",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    # ---- (c) grandfather: community over cap keeps all users, blocks new ----
+
+    def test_community_grandfathered_users_stay_usable(self, client, set_tier, db):
+        """A community install already holding N (>1) active staff keeps every
+        user active/usable; only ADDING the N+1th seat is blocked."""
+        from app.models.user import User
+        # Seed two extra active staff (id=1 seeded admin => 3 active total),
+        # simulating a pre-existing multi-user community install.
+        extra_ids = []
+        for _ in range(2):
+            u = User(
+                email=_unique_email(),
+                password_hash="fake-hash",
+                account_type="operator",
+                status="active",
+            )
+            db.add(u)
+            db.flush()
+            extra_ids.append(u.id)
+
+        set_tier("community")
+
+        # Grandfathered users remain fully usable: they are listed active,
+        # readable, and editable — enforcement never deactivates them.
+        listed = client.get(f"{BASE_URL}/", params={"account_type": "operator"}).json()
+        listed_ids = {u["id"] for u in listed if u["status"] == "active"}
+        assert set(extra_ids).issubset(listed_ids)
+
+        for uid in extra_ids:
+            got = client.get(f"{BASE_URL}/{uid}")
+            assert got.status_code == 200
+            assert got.json()["status"] == "active"
+            # A non-status edit on an existing active user is not blocked.
+            edit = client.patch(f"{BASE_URL}/{uid}", json={"first_name": "Kept"})
+            assert edit.status_code == 200, edit.text
+
+        # But adding the N+1th staff seat is blocked.
+        resp = client.post(
+            f"{BASE_URL}/",
+            json={
+                "email": _unique_email(),
+                "password": "SecurePass1!",
+                "account_type": "operator",
+            },
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_community_reactivate_over_cap_blocked_but_existing_untouched(
+        self, client, set_tier, db
+    ):
+        """Over-cap community install: reactivating an inactive user is blocked,
+        and the existing active users are left untouched."""
+        from app.models.user import User
+        active_extra = User(
+            email=_unique_email(),
+            password_hash="fake-hash",
+            account_type="operator",
+            status="active",
+        )
+        inactive_extra = User(
+            email=_unique_email(),
+            password_hash="fake-hash",
+            account_type="operator",
+            status="inactive",
+        )
+        db.add_all([active_extra, inactive_extra])
+        db.flush()
+
+        set_tier("community")
+        resp = client.post(f"{BASE_URL}/{inactive_extra.id}/reactivate")
+        assert resp.status_code == 403, resp.text
+
+        # Existing active user is untouched (still active).
+        got = client.get(f"{BASE_URL}/{active_extra.id}")
+        assert got.status_code == 200
+        assert got.json()["status"] == "active"
+
+    # ---- (d) customer/portal accounts never consume a seat ------------------
+
+    def test_community_customer_creation_not_blocked_by_seat_cap(
+        self, client, set_tier, db
+    ):
+        """Creating a customer/portal account is NOT a staff seat and must not
+        be blocked by the community cap, even when the staff seat is full.
+
+        This endpoint only manages admin/operator, so we assert directly that a
+        customer row can be created at community tier without seat enforcement
+        touching it (customers are created via /admin/customers in production).
+        """
+        from app.models.user import User
+        set_tier("community")
+
+        # The staff seat is already full (seeded admin). Creating a customer
+        # must still succeed — customers are not seats.
+        customer = User(
+            email=_unique_email(),
+            password_hash="fake-hash",
+            account_type="customer",
+            status="active",
+        )
+        db.add(customer)
+        db.flush()
+        assert customer.id is not None
+
+        # And a customer does not count against the staff seat cap: an admin
+        # user create is still blocked purely by staff count, unaffected by the
+        # newly added customer.
+        from app.core.seat_limits import count_active_staff
+        # Only the seeded admin counts as staff; the customer does not.
+        assert count_active_staff(db) == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## What & why

Per the 2026-07-01 PRO-leak audit, **multi_user was the real leak** — unlimited users free. With the legacy `features.py` gate dormant (`LICENSING_ENABLED=False`), `enforce_resource_limit` is a no-op, so every unlicensed (community) install got UNLIMITED staff users, giving away a real PRO feature.

**Product decision:** community = 1 staff seat, PRO/enterprise = unlimited.

## How

- New `backend/app/core/seat_limits.py` reads the **live tier from `plugin_registry`** (deliberately independent of `features.LICENSING_ENABLED`, which is owned by PR-D1). `seat_cap_for_tier()` maps `community -> 1`, `professional/enterprise -> unlimited (None)`; unknown tiers fail safe to the community cap.
- A **seat = a STAFF account** (`account_type in {admin, operator}`). Customer/portal accounts (`account_type == "customer"`) never count against or are blocked by the cap — this endpoint only manages admin/operator anyway.
- Enforced at **user create**, **PATCH `status='active'`** (inactive→active only), and **reactivate**, reading the plugin_registry tier at each call.

## Grandfathered (safe for existing multi-user installs: 129, local VM)

The check blocks only **adding/activating a NEW seat** over the cap. It **never deactivates or locks out existing users**, and there is **no startup/login-time enforcement** — read-only login of existing users is unaffected. An install already over the cap keeps every current user active and usable; it simply cannot add or reactivate another staff member until it upgrades.

## Tests

`TestMultiUserSeatCaps` (marker `seat_caps`) covers:
- (a) community + 1 active staff → 2nd staff **403** (create, PATCH-activate, reactivate)
- (b) professional/enterprise → 2nd/Nth staff **allowed**
- (c) grandfather → community with N (>1) active staff: all stay active/usable/editable, N+1th create & reactivate **403**
- (d) community customer/portal account creation **not** seat-blocked

The existing admin-user CRUD suite runs under an unlimited (professional) tier fixture so its multi-user setup is unaffected.

> Note: the fresh worktree has no reachable seeded Postgres (`filaops_test` auth rejected the ambient local PG), so the DB-backed tests were verified to **collect cleanly** (70 collected, 0 collection errors) and CI runs the DB. The pure seat-cap logic (`seat_cap_for_tier`, `enforce_seat_cap` raise/no-op, grandfather semantics, fail-safe) was validated directly. `ruff check` clean on changed files.

`require_feature` gating for other features is a separate change (PR-D1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plan-based “staff seat” enforcement for admin and operator accounts, limiting concurrent active staff by tier (community is capped; higher tiers allow more).
  * Staff activation and reactivation now respect the seat cap, while customer accounts don’t consume seats.

* **Bug Fixes**
  * Prevented seat-cap checks from double-counting the user being activated.
  * Improved concurrency handling so simultaneous seat checks are safely coordinated on supported databases.

* **Tests**
  * Added tier-specific multi-user seat-cap and concurrency test coverage, including advisory-lock behavior verification and grandfathered over-cap handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->