### PR TITLE
fix(scheduling): show the machine for printer-scheduled operations (#857 PR-1)

### DIFF
--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -69,8 +69,13 @@ router = APIRouter()
 
 def build_operation_response(op, po, next_op=None) -> OperationResponse:
     """Build response from operation model."""
+    # Machine lane first: schedule_operation stores printers in printer_id
+    # (resource_id=None), so resolving only op.resource left printer-scheduled
+    # ops with no machine in start/complete/skip responses.
     resource_code = None
-    if op.resource:
+    if op.printer_id and op.printer:
+        resource_code = op.printer.code
+    elif op.resource:
         resource_code = op.resource.code
 
     # Get current operation sequence for PO
@@ -181,12 +186,17 @@ def get_operations(
                 status=mat.status,
             ))
 
-        # Resolve resource name - handle negative IDs (printers) vs positive (resources)
+        # Resolve the machine display. Modern writers (schedule_operation)
+        # store printers in printer_id with resource_id=None and resources in
+        # resource_id; legacy rows encoded printers as a negative resource_id.
         resource_code = None
         resource_name = None
-        if op.resource_id:
+        if op.printer_id and op.printer:
+            resource_code = op.printer.code
+            resource_name = op.printer.name
+        elif op.resource_id:
             if op.resource_id < 0:
-                # Negative ID = printer ID (stored as -printer_id)
+                # Legacy encoding: printer stored as -printer_id
                 printer = db.get(Printer, abs(op.resource_id))
                 if printer:
                     resource_code = printer.code
@@ -207,6 +217,7 @@ def get_operations(
             work_center_code=op.work_center.code if op.work_center else None,
             work_center_name=op.work_center.name if op.work_center else None,
             resource_id=op.resource_id,
+            printer_id=op.printer_id,
             resource_code=resource_code,
             resource_name=resource_name,
             planned_setup_minutes=op.planned_setup_minutes,

--- a/backend/app/schemas/operation_status.py
+++ b/backend/app/schemas/operation_status.py
@@ -146,6 +146,10 @@ class OperationListItem(BaseModel):
     work_center_name: Optional[str] = None
 
     resource_id: Optional[int] = None
+    # Printer assignment (mutually exclusive with resource_id — see
+    # resource_scheduling.schedule_operation). resource_code/resource_name are
+    # populated from whichever machine lane is set.
+    printer_id: Optional[int] = None
     resource_code: Optional[str] = None
     resource_name: Optional[str] = None
 

--- a/backend/tests/api/v1/test_operation_status_scheduling.py
+++ b/backend/tests/api/v1/test_operation_status_scheduling.py
@@ -93,6 +93,87 @@ class TestNextAvailableSlotEndpoint:
         assert response.status_code == 401
 
 
+class TestOperationsListMachineResolution:
+    """GET /{po}/operations must show the machine for BOTH scheduling lanes.
+
+    schedule_operation stores printers in printer_id (resource_id=None) and
+    resources in resource_id — the list previously resolved only resource_id,
+    so printer-scheduled ops rendered a blank machine column (#857 G2).
+    """
+
+    def test_printer_scheduled_op_resolves_machine(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        _make_operation(
+            db, po.id, work_center.id,
+            status="queued",
+            printer_id=printer.id,  # modern printer lane: resource_id stays None
+        )
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{po.id}/operations")
+        assert response.status_code == 200
+        op = response.json()[0]
+        assert op["printer_id"] == printer.id
+        assert op["resource_code"] == printer.code
+        assert op["resource_name"] == printer.name
+
+    def test_resource_scheduled_op_still_resolves(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Regression guard: the resource lane keeps working unchanged."""
+        from app.models.manufacturing import Resource
+
+        work_center = make_work_center()
+        resource = Resource(
+            work_center_id=work_center.id,
+            code=f"RES-{_uid()}",
+            name="Test Resource",
+        )
+        db.add(resource)
+        db.flush()
+        product = make_product()
+        po = make_production_order(product_id=product.id)
+        _make_operation(
+            db, po.id, work_center.id,
+            status="queued",
+            resource_id=resource.id,
+        )
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{po.id}/operations")
+        assert response.status_code == 200
+        op = response.json()[0]
+        assert op["resource_code"] == resource.code
+        assert op["resource_name"] == resource.name
+
+    def test_start_response_resolves_printer_machine(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """build_operation_response (start/complete/skip) must also resolve the
+        printer lane — it previously had no printer handling at all."""
+        work_center = make_work_center()
+        printer = _make_printer(db, work_center.id)
+        product = make_product()
+        po = make_production_order(product_id=product.id, status="released")
+        op = _make_operation(
+            db, po.id, work_center.id,
+            status="queued",
+            printer_id=printer.id,
+        )
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/start", json={}
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["resource_code"] == printer.code
+
+
 class TestScheduleOperationPredecessorResponse:
     """Verify predecessor violation returns earliest_valid_start >= predecessor end.
 


### PR DESCRIPTION
## #857 scheduling — PR 1 of 2: "Show the machine"

First slice of #857, executed **verify-first**: all G-findings were adversarially re-verified against `main` by a 10-agent workflow (verify → refute → coupling map → plan) before any code was written. This PR is the confirmed **demo-killer** — the one users see every day.

### The bug (G2, CONFIRMED high-confidence)
`schedule_operation` stores printers in `printer_id` with `resource_id=None` (`resource_scheduling.py:520-526`) — but:
- `get_operations` (`operation_status.py:184-198`) decoded only `resource_id`, including a **legacy negative-id convention no current writer produces** — so every printer-scheduled op rendered a **blank machine column** in the operations list.
- `build_operation_response` (`:70-74`) resolved only `op.resource` — no printer handling at all — so start/complete/skip responses blanked the machine too.

### The fix (read-side only, ~30 lines)
- Resolve the **printer lane first** (`op.printer` relationship) in both readers, falling back to the resource lane.
- Keep the legacy negative-id decode as a defensive fallback. Note: it can't match any FK-valid row (`resource_id` has an FK to `resources.id`), so it's vestigial — kept because it's harmless.
- Additive `printer_id` on `OperationListItem`. **No fields renamed/retyped** — the frontend reads `resource_name` (`OperationRow.jsx:206`, `OperationCard.jsx`, `ProductionQueueList.jsx:48`) and starts rendering machines with zero frontend changes.

### Cross-module / accounting safety (per verification workflow `w21mnidcu`)
- **Transactionally inert, verified:** scheduling code paths write no `InventoryTransaction`, GL, reservations, or costs anywhere; this PR is pure response serialization on top of that. The coupling audit grep-verified `scheduled_*`/`printer_id`/`resource_id` appear in no accounting/inventory-transaction module.
- **Write paths untouched:** `schedule_operation` semantics, dispatch, reschedule/unschedule, the scheduler board, and conflict queries all key on the same columns they did before.

### Tests
+3: printer lane resolves in the list; resource lane regression guard; start-response printer resolution. Operations + schema blast radius **536/536**, `ruff` clean.

### Next (PR 2, after this merges)
"Capacity plane tells the truth" — re-point `check_capacity`/`available-slots`/`machine-availability`/`auto-schedule` from the never-populated order-level columns (G1) to operation-level bookings, tz normalization (G4-partial), overlap/maintenance/monotonic-cursor fixes in auto-schedule (G5), duration fallback from op planned minutes (G3), and no-slot 404→409 (G8 rider). All confined to `endpoints/scheduling.py`; zero frontend callers exist for those endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now consistently show the correct machine details, whether they were scheduled through the printer lane or the legacy resource path.
  * Start responses now return the proper machine information for printer-scheduled operations.
* **New Features**
  * Operation list responses now include printer-related machine identifiers when available.
* **Tests**
  * Added coverage for printer-scheduled operations, resource-scheduled operations, and operation start responses to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->