### PR TITLE
fix(scheduling): capacity plane reads real bookings + auto-schedule correctness (#857 PR-2)

### DIFF
--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -186,26 +186,19 @@ def get_operations(
                 status=mat.status,
             ))
 
-        # Resolve the machine display. Modern writers (schedule_operation)
-        # store printers in printer_id with resource_id=None and resources in
-        # resource_id; legacy rows encoded printers as a negative resource_id.
+        # Resolve the machine display. schedule_operation stores printers in
+        # printer_id with resource_id=None and resources in resource_id. (A
+        # legacy negative-resource_id printer encoding was decoded here, but
+        # resource_id has been FK-constrained to resources.id its whole life —
+        # migration 032 validated existing rows — so such rows cannot exist.)
         resource_code = None
         resource_name = None
         if op.printer_id and op.printer:
             resource_code = op.printer.code
             resource_name = op.printer.name
-        elif op.resource_id:
-            if op.resource_id < 0:
-                # Legacy encoding: printer stored as -printer_id
-                printer = db.get(Printer, abs(op.resource_id))
-                if printer:
-                    resource_code = printer.code
-                    resource_name = printer.name
-            else:
-                # Positive ID = resource
-                if op.resource:
-                    resource_code = op.resource.code
-                    resource_name = op.resource.name
+        elif op.resource:
+            resource_code = op.resource.code
+            resource_name = op.resource.name
 
         result.append(OperationListItem(
             id=op.id,

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -7,19 +7,20 @@ Provides endpoints for:
 - Auto-scheduling production orders
 """
 from datetime import datetime, timezone, timedelta
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_
+from sqlalchemy import or_
 
 from app.db.session import get_db
 from app.models.production_order import ProductionOrder
 from app.models.manufacturing import Resource
+from app.models.printer import Printer
 from app.models.work_center import WorkCenter
-from app.models.print_job import PrintJob
 from app.schemas.scheduling import (
     CapacityCheckRequest,
     CapacityCheckResponse,
+    ConflictInfo,
     AvailableSlotResponse,
     MachineAvailabilityResponse,
 )
@@ -29,8 +30,82 @@ from app.models.user import User
 from app.services.resource_compatibility_service import (
     is_machine_compatible,
 )
+from app.services.resource_scheduling import (
+    TERMINAL_STATUSES,
+    find_conflicts,
+    find_next_available_slot,
+    find_window_conflicts,
+    get_resource_schedule,
+)
 
 router = APIRouter()
+
+
+def _naive_utc(dt: datetime) -> datetime:
+    """Normalize to naive UTC — scheduling columns are TIMESTAMP WITHOUT TIME
+    ZONE holding UTC, so aware request datetimes must be converted before any
+    Python-side comparison (naive-vs-aware comparison raises TypeError)."""
+    if dt is not None and dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _resolve_machine(db: Session, machine_id: int, is_printer: bool):
+    """Fetch the Resource or Printer a capacity question is about (404 if absent).
+
+    Resources and Printers are distinct models with separate ID spaces — they
+    must never be cross-compared (the old capacity queries joined
+    PrintJob.printer_id against Resource.id, matching only on coincidence)."""
+    if is_printer:
+        machine = db.query(Printer).filter(Printer.id == machine_id).first()
+        if not machine:
+            raise HTTPException(status_code=404, detail="Printer not found")
+    else:
+        machine = db.query(Resource).filter(Resource.id == machine_id).first()
+        if not machine:
+            raise HTTPException(status_code=404, detail="Resource not found")
+    return machine
+
+
+def _busy_intervals(
+    db: Session,
+    machine_id: int,
+    start: datetime,
+    end: datetime,
+    is_printer: bool,
+) -> List[Tuple[datetime, datetime]]:
+    """All busy time on a machine in [start, end): scheduled operations plus
+    blocking maintenance windows, as naive-UTC (start, end) pairs sorted by
+    start. Interval-overlap windowing, so work already running at `start` is
+    included (a start-based filter would hide it and allow double-booking)."""
+    intervals: List[Tuple[datetime, datetime]] = []
+    for op in get_resource_schedule(
+        db, machine_id, start_date=start, end_date=end, is_printer=is_printer
+    ):
+        intervals.append(
+            (_naive_utc(op.scheduled_start), _naive_utc(op.scheduled_end))
+        )
+    for w in find_window_conflicts(
+        db, resource_id=machine_id, start_time=start, end_time=end, is_printer=is_printer
+    ):
+        intervals.append((_naive_utc(w.starts_at), _naive_utc(w.ends_at)))
+    intervals.sort(key=lambda pair: pair[0])
+    return intervals
+
+
+def _merged_hours(intervals: List[Tuple[datetime, datetime]]) -> float:
+    """Total hours covered by the union of (start, end) intervals (overlaps
+    counted once). Input must be sorted by start."""
+    total = 0.0
+    cursor: Optional[datetime] = None
+    for s, e in intervals:
+        if cursor is None or s > cursor:
+            total += (e - s).total_seconds() / 3600
+            cursor = e
+        elif e > cursor:
+            total += (e - cursor).total_seconds() / 3600
+            cursor = e
+    return total
 
 
 @router.get("/board")
@@ -300,54 +375,56 @@ async def check_capacity(
 ):
     """
     Check if a machine has capacity for a production order at a given time.
-    
-    Returns conflicts if any exist.
+
+    Busy time is what the scheduler actually books: ProductionOrderOperation
+    rows (the modal/dispatch write path) plus blocking maintenance windows —
+    NOT the order-level scheduled_* columns, which the operation path never
+    populates (#857 G1).
     """
-    resource = db.query(Resource).filter(Resource.id == request.resource_id).first()
-    if not resource:
-        raise HTTPException(status_code=404, detail="Resource not found")
+    machine = _resolve_machine(db, request.resource_id, request.is_printer)
+    start_time = _naive_utc(request.start_time)
+    end_time = _naive_utc(request.end_time)
 
-    start_time = request.start_time
-    end_time = request.end_time
+    conflicts: List[ConflictInfo] = []
+    for op in find_conflicts(
+        db,
+        resource_id=request.resource_id,
+        start_time=start_time,
+        end_time=end_time,
+        is_printer=request.is_printer,
+    ):
+        po = op.production_order
+        conflicts.append(ConflictInfo(
+            type="operation",
+            order_id=po.id if po else None,
+            order_code=po.code if po else "",
+            operation_id=op.id,
+            operation_code=op.operation_code,
+            start_time=op.scheduled_start.isoformat(),
+            end_time=op.scheduled_end.isoformat(),
+            product_name=po.product.name if po and po.product else "N/A",
+        ))
 
-    # Get all scheduled orders for this resource
-    # Find orders assigned to this resource via print_jobs or assigned_to
-    scheduled_orders = db.query(ProductionOrder).join(
-        PrintJob, ProductionOrder.id == PrintJob.production_order_id, isouter=True
-    ).filter(
-        and_(
-            or_(
-                PrintJob.printer_id == request.resource_id,
-                ProductionOrder.assigned_to == resource.code,
-            ),
-            ProductionOrder.status.in_(["released", "in_progress"]),
-            ProductionOrder.scheduled_start.isnot(None),
-            ProductionOrder.scheduled_end.isnot(None),
-        )
-    ).all()
-
-    conflicts = []
-    for order in scheduled_orders:
-        if not order.scheduled_start or not order.scheduled_end:
-            continue
-        
-        order_start = order.scheduled_start
-        order_end = order.scheduled_end
-        
-        # Check for overlap
-        if start_time < order_end and end_time > order_start:
-            conflicts.append({
-                "order_id": order.id,
-                "order_code": order.code,
-                "start_time": order_start.isoformat(),
-                "end_time": order_end.isoformat(),
-                "product_name": order.product.name if order.product else "N/A",
-            })
+    for w in find_window_conflicts(
+        db,
+        resource_id=request.resource_id,
+        start_time=start_time,
+        end_time=end_time,
+        is_printer=request.is_printer,
+    ):
+        conflicts.append(ConflictInfo(
+            type="maintenance",
+            order_id=None,
+            order_code="Maintenance window",
+            start_time=w.starts_at.isoformat(),
+            end_time=w.ends_at.isoformat(),
+            product_name=w.reason or "Scheduled downtime",
+        ))
 
     return CapacityCheckResponse(
         resource_id=request.resource_id,
-        resource_code=resource.code,
-        resource_name=resource.name,
+        resource_code=machine.code,
+        resource_name=machine.name,
         start_time=start_time.isoformat(),
         end_time=end_time.isoformat(),
         has_capacity=len(conflicts) == 0,
@@ -357,51 +434,30 @@ async def check_capacity(
 
 @router.get("/capacity/available-slots", response_model=List[AvailableSlotResponse])
 async def get_available_slots(
-    resource_id: int = Query(..., description="Resource ID"),
+    resource_id: int = Query(..., description="Resource or printer ID"),
     start_date: datetime = Query(..., description="Start date for search"),
     end_date: datetime = Query(..., description="End date for search"),
     duration_hours: float = Query(2.0, description="Required duration in hours"),
+    is_printer: bool = Query(False, description="True if resource_id is a printer"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """
-    Find available time slots for a resource within a date range.
-    
-    Returns list of available slots that can accommodate the required duration.
+    Find available time slots for a machine within a date range.
+
+    Gaps are computed against real bookings — scheduled operations plus
+    blocking maintenance windows (#857 G1) — not the vestigial order-level
+    scheduled_* columns.
     """
-    resource = db.query(Resource).filter(Resource.id == resource_id).first()
-    if not resource:
-        raise HTTPException(status_code=404, detail="Resource not found")
+    _resolve_machine(db, resource_id, is_printer)
+    start_date = _naive_utc(start_date)
+    end_date = _naive_utc(end_date)
 
-    # Get all scheduled orders for this resource
-    scheduled_orders = db.query(ProductionOrder).join(
-        PrintJob, ProductionOrder.id == PrintJob.production_order_id, isouter=True
-    ).filter(
-        and_(
-            or_(
-                PrintJob.printer_id == resource_id,
-                ProductionOrder.assigned_to == resource.code,
-            ),
-            ProductionOrder.status.in_(["released", "in_progress"]),
-            ProductionOrder.scheduled_start.isnot(None),
-            ProductionOrder.scheduled_end.isnot(None),
-            ProductionOrder.scheduled_start >= start_date,
-            ProductionOrder.scheduled_start <= end_date,
-        )
-    ).order_by(ProductionOrder.scheduled_start).all()
-
-    # Build list of busy periods
-    busy_periods = []
-    for order in scheduled_orders:
-        if order.scheduled_start and order.scheduled_end:
-            busy_periods.append((order.scheduled_start, order.scheduled_end))
+    busy_periods = _busy_intervals(db, resource_id, start_date, end_date, is_printer)
 
     # Find gaps between busy periods
     available_slots = []
     current_time = start_date
-
-    # Sort busy periods by start time
-    busy_periods.sort(key=lambda x: x[0])
 
     for busy_start, busy_end in busy_periods:
         # Check if there's a gap before this busy period
@@ -443,11 +499,16 @@ async def get_machine_availability(
 ):
     """
     Get availability status for all machines in a date range.
-    
-    Shows capacity utilization and available time for each machine.
+
+    Utilization is derived from real bookings — scheduled operations, clipped
+    to the window (#857 G1) — and available time additionally excludes
+    blocking maintenance windows.
     """
+    start_date = _naive_utc(start_date)
+    end_date = _naive_utc(end_date)
+
     query = db.query(Resource).filter(Resource.is_active == True)  # noqa: E712
-    
+
     if work_center_id:
         query = query.filter(Resource.work_center_id == work_center_id)
     else:
@@ -456,35 +517,39 @@ async def get_machine_availability(
 
     resources = query.all()
 
+    total_hours = (end_date - start_date).total_seconds() / 3600
+
     result = []
     for resource in resources:
-        # Get scheduled orders for this resource
-        scheduled_orders = db.query(ProductionOrder).join(
-            PrintJob, ProductionOrder.id == PrintJob.production_order_id, isouter=True
-        ).filter(
-            and_(
-                or_(
-                    PrintJob.printer_id == resource.id,
-                    ProductionOrder.assigned_to == resource.code,
-                ),
-                ProductionOrder.status.in_(["released", "in_progress"]),
-                ProductionOrder.scheduled_start.isnot(None),
-                ProductionOrder.scheduled_end.isnot(None),
-                ProductionOrder.scheduled_start >= start_date,
-                ProductionOrder.scheduled_start <= end_date,
-            )
-        ).all()
+        ops = get_resource_schedule(
+            db, resource.id, start_date=start_date, end_date=end_date, is_printer=False
+        )
 
-        # Calculate total scheduled time
-        total_scheduled_hours = 0
-        for order in scheduled_orders:
-            if order.scheduled_start and order.scheduled_end:
-                duration = (order.scheduled_end - order.scheduled_start).total_seconds() / 3600
-                total_scheduled_hours += duration
+        # Clip each booking to the window (an op overlapping the boundary only
+        # consumes the in-window part — mirrors the board's utilization math).
+        op_intervals = []
+        for op in ops:
+            clip_start = max(_naive_utc(op.scheduled_start), start_date)
+            clip_end = min(_naive_utc(op.scheduled_end), end_date)
+            if clip_end > clip_start:
+                op_intervals.append((clip_start, clip_end))
+        op_intervals.sort(key=lambda pair: pair[0])
+        total_scheduled_hours = _merged_hours(op_intervals)
 
-        # Calculate total available time
-        total_hours = (end_date - start_date).total_seconds() / 3600
-        available_hours = total_hours - total_scheduled_hours
+        # Available time also excludes blocking maintenance windows — a machine
+        # in maintenance is not available even though no work is scheduled.
+        window_intervals = []
+        for w in find_window_conflicts(
+            db, resource_id=resource.id, start_time=start_date, end_time=end_date,
+            is_printer=False,
+        ):
+            clip_start = max(_naive_utc(w.starts_at), start_date)
+            clip_end = min(_naive_utc(w.ends_at), end_date)
+            if clip_end > clip_start:
+                window_intervals.append((clip_start, clip_end))
+        busy_union = sorted(op_intervals + window_intervals, key=lambda pair: pair[0])
+        available_hours = total_hours - _merged_hours(busy_union)
+
         utilization_percent = (total_scheduled_hours / total_hours * 100) if total_hours > 0 else 0
 
         result.append({
@@ -498,7 +563,7 @@ async def get_machine_availability(
             "scheduled_hours": total_scheduled_hours,
             "available_hours": max(0, available_hours),
             "utilization_percent": round(utilization_percent, 1),
-            "scheduled_order_count": len(scheduled_orders),
+            "scheduled_order_count": len({op.production_order_id for op in ops}),
         })
 
     return result
@@ -540,11 +605,25 @@ async def auto_schedule_order(
     if not order:
         raise HTTPException(status_code=404, detail="Production order not found")
 
-    # Estimate duration
-    estimated_hours = order.estimated_time_minutes / 60 if order.estimated_time_minutes else 2.0
+    # Estimate duration: quote-derived estimate when present, else the routing's
+    # planned minutes (already quantity-scaled by copy_routing_to_operations) —
+    # WOs generated from sales orders never set estimated_time_minutes, so the
+    # bare 2h default sized every routing-driven job wrong (#857 G3).
+    if order.estimated_time_minutes:
+        estimated_hours = order.estimated_time_minutes / 60
+    else:
+        planned_minutes = sum(
+            float(op.planned_setup_minutes or 0) + float(op.planned_run_minutes or 0)
+            for op in order.operations
+            if op.status not in TERMINAL_STATUSES
+        )
+        estimated_hours = planned_minutes / 60 if planned_minutes > 0 else 2.0
 
-    # Determine search window
-    search_start = preferred_start if preferred_start else datetime.now(timezone.utc)
+    # Determine search window. Naive UTC throughout — the scheduling columns
+    # are naive UTC and mixing aware/naive datetimes raises TypeError (#857 G5).
+    search_start = _naive_utc(preferred_start) if preferred_start else _naive_utc(
+        datetime.now(timezone.utc)
+    )
     search_start = search_start.replace(minute=0, second=0, microsecond=0)
     search_end = search_start + timedelta(days=7)  # Search 7 days ahead
 
@@ -575,56 +654,30 @@ async def auto_schedule_order(
         if not is_compatible:
             # Skip incompatible machines (e.g., ABS/ASA on non-enclosed printers)
             continue
-        
-        # Get scheduled orders for this resource
-        scheduled_orders = db.query(ProductionOrder).join(
-            PrintJob, ProductionOrder.id == PrintJob.production_order_id, isouter=True
-        ).filter(
-            and_(
-                or_(
-                    PrintJob.printer_id == resource.id,
-                    ProductionOrder.assigned_to == resource.code,
-                ),
-                ProductionOrder.status.in_(["released", "in_progress"]),
-                ProductionOrder.scheduled_start.isnot(None),
-                ProductionOrder.scheduled_end.isnot(None),
-                ProductionOrder.scheduled_start >= search_start,
-                ProductionOrder.scheduled_start <= search_end,
-            )
-        ).order_by(ProductionOrder.scheduled_start).all()
 
-        # Build busy periods
-        busy_periods = []
-        for scheduled_order in scheduled_orders:
-            if scheduled_order.scheduled_start and scheduled_order.scheduled_end:
-                busy_periods.append((scheduled_order.scheduled_start, scheduled_order.scheduled_end))
+        # Delegate the gap search to the same engine the scheduler modal uses:
+        # busy time = scheduled operations + blocking maintenance windows, with
+        # interval-overlap semantics and a monotonic cursor. The previous
+        # hand-rolled loop read order-level columns nothing populates, ignored
+        # maintenance windows, hid already-running work behind a start-based
+        # filter, and could walk its cursor backward on nested busy periods —
+        # all double-booking paths (#857 G1/G5).
+        slot = find_next_available_slot(
+            db,
+            resource_id=resource.id,
+            duration_minutes=int(estimated_hours * 60),
+            after=search_start,
+            is_printer=False,
+        )
+        candidate_end = slot + timedelta(hours=estimated_hours)
+        if candidate_end > search_end:
+            continue  # No fit inside the window on this machine
 
-        # Find first available slot
-        candidate_start = search_start
-        for busy_start, busy_end in sorted(busy_periods):
-            # Check if candidate fits before this busy period
-            candidate_end = candidate_start + timedelta(hours=estimated_hours)
-            if candidate_end <= busy_start:
-                # Found a slot!
-                score = (candidate_start - search_start).total_seconds() / 3600  # Hours from preferred start
-                if score < best_score:
-                    best_slot = candidate_start
-                    best_resource = resource
-                    best_score = score
-                break
-
-            # Move candidate to after this busy period
-            candidate_start = busy_end + timedelta(minutes=15)  # 15 min buffer
-
-        # Check if slot exists after all busy periods
-        if candidate_start < search_end:
-            candidate_end = candidate_start + timedelta(hours=estimated_hours)
-            if candidate_end <= search_end:
-                score = (candidate_start - search_start).total_seconds() / 3600
-                if score < best_score:
-                    best_slot = candidate_start
-                    best_resource = resource
-                    best_score = score
+        score = (slot - search_start).total_seconds() / 3600
+        if score < best_score:
+            best_slot = slot
+            best_resource = resource
+            best_score = score
 
     if not best_slot or not best_resource:
         # Check if it's a compatibility issue
@@ -638,9 +691,12 @@ async def auto_schedule_order(
             detail = f"No compatible machines found. Material requirements: {', '.join(incompatible_machines)}"
         else:
             detail = "No available slots found. All compatible machines are fully scheduled."
-        
+
+        # 409, not 404: the order exists — there is no slot. 404 is reserved for
+        # missing routes/entities and the frontend treats it as "PRO plugin not
+        # installed" (#857 G8).
         raise HTTPException(
-            status_code=404,
+            status_code=409,
             detail=detail
         )
 

--- a/backend/app/api/v1/endpoints/scheduling.py
+++ b/backend/app/api/v1/endpoints/scheduling.py
@@ -7,6 +7,7 @@ Provides endpoints for:
 - Auto-scheduling production orders
 """
 from datetime import datetime, timezone, timedelta
+from math import ceil
 from typing import List, Optional, Tuple
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
@@ -32,10 +33,13 @@ from app.services.resource_compatibility_service import (
 )
 from app.services.resource_scheduling import (
     TERMINAL_STATUSES,
+    MaintenanceWindowConflictError,
+    SequenceError,
     find_conflicts,
     find_next_available_slot,
     find_window_conflicts,
     get_resource_schedule,
+    schedule_operation,
 )
 
 router = APIRouter()
@@ -384,6 +388,8 @@ async def check_capacity(
     machine = _resolve_machine(db, request.resource_id, request.is_printer)
     start_time = _naive_utc(request.start_time)
     end_time = _naive_utc(request.end_time)
+    if end_time <= start_time:
+        raise HTTPException(status_code=422, detail="end_time must be after start_time")
 
     conflicts: List[ConflictInfo] = []
     for op in find_conflicts(
@@ -397,7 +403,7 @@ async def check_capacity(
         conflicts.append(ConflictInfo(
             type="operation",
             order_id=po.id if po else None,
-            order_code=po.code if po else "",
+            order_code=po.code if po else None,
             operation_id=op.id,
             operation_code=op.operation_code,
             start_time=op.scheduled_start.isoformat(),
@@ -415,7 +421,7 @@ async def check_capacity(
         conflicts.append(ConflictInfo(
             type="maintenance",
             order_id=None,
-            order_code="Maintenance window",
+            order_code=None,
             start_time=w.starts_at.isoformat(),
             end_time=w.ends_at.isoformat(),
             product_name=w.reason or "Scheduled downtime",
@@ -452,6 +458,8 @@ async def get_available_slots(
     _resolve_machine(db, resource_id, is_printer)
     start_date = _naive_utc(start_date)
     end_date = _naive_utc(end_date)
+    if end_date <= start_date:
+        raise HTTPException(status_code=422, detail="end_date must be after start_date")
 
     busy_periods = _busy_intervals(db, resource_id, start_date, end_date, is_printer)
 
@@ -506,6 +514,8 @@ async def get_machine_availability(
     """
     start_date = _naive_utc(start_date)
     end_date = _naive_utc(end_date)
+    if end_date <= start_date:
+        raise HTTPException(status_code=422, detail="end_date must be after start_date")
 
     query = db.query(Resource).filter(Resource.is_active == True)  # noqa: E712
 
@@ -624,7 +634,12 @@ async def auto_schedule_order(
     search_start = _naive_utc(preferred_start) if preferred_start else _naive_utc(
         datetime.now(timezone.utc)
     )
-    search_start = search_start.replace(minute=0, second=0, microsecond=0)
+    # Round UP to the next whole hour — flooring would move the search (and the
+    # resulting booking) earlier than the requested/current time.
+    rounded_start = search_start.replace(minute=0, second=0, microsecond=0)
+    if rounded_start != search_start:
+        rounded_start += timedelta(hours=1)
+    search_start = rounded_start
     search_end = search_start + timedelta(days=7)  # Search 7 days ahead
 
     # If order has due date, limit search to before due date
@@ -665,7 +680,9 @@ async def auto_schedule_order(
         slot = find_next_available_slot(
             db,
             resource_id=resource.id,
-            duration_minutes=int(estimated_hours * 60),
+            # Round UP: truncating would accept a gap shorter than the actual
+            # scheduled duration (candidate_end uses the exact hours).
+            duration_minutes=ceil(estimated_hours * 60),
             after=search_start,
             is_printer=False,
         )
@@ -700,8 +717,57 @@ async def auto_schedule_order(
             detail=detail
         )
 
-    # Schedule the order
     scheduled_end = best_slot + timedelta(hours=estimated_hours)
+
+    # Persist the booking on the operation plane — the plane every conflict /
+    # capacity read uses. Writing only the order-level columns would leave this
+    # booking invisible to the next capacity check or auto-schedule call
+    # (self-double-booking). Ops are placed back-to-back in sequence order
+    # inside the validated gap; schedule_operation re-validates conflicts,
+    # maintenance windows, and predecessor sequencing per op.
+    schedulable_ops = [
+        op for op in sorted(order.operations, key=lambda o: o.sequence)
+        if op.status not in TERMINAL_STATUSES and op.scheduled_start is None
+    ]
+    if schedulable_ops:
+        # Per-op share of the whole-order estimate, proportional to planned
+        # minutes (identical to planned minutes when the estimate came from
+        # them); an even split when no op carries planned time. Totals exactly
+        # estimated_hours, the size find_next_available_slot validated.
+        total_planned = sum(
+            float(op.planned_setup_minutes or 0) + float(op.planned_run_minutes or 0)
+            for op in schedulable_ops
+        )
+        cursor = best_slot
+        try:
+            for op in schedulable_ops:
+                planned = float(op.planned_setup_minutes or 0) + float(op.planned_run_minutes or 0)
+                if total_planned > 0:
+                    share_hours = estimated_hours * (planned / total_planned)
+                else:
+                    share_hours = estimated_hours / len(schedulable_ops)
+                op_end = cursor + timedelta(hours=share_hours)
+                ok, op_conflicts = schedule_operation(
+                    db, op, best_resource.id, cursor, op_end, is_printer=False
+                )
+                if not ok:
+                    codes = ", ".join(
+                        c.production_order.code if c.production_order else str(c.id)
+                        for c in op_conflicts
+                    )
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"Slot was taken while scheduling: conflicts with {codes}",
+                    )
+                cursor = op_end
+        except (SequenceError, MaintenanceWindowConflictError) as e:
+            raise HTTPException(status_code=409, detail=str(e))
+    # else: routing-less order — no operation rows exist to book; the order-
+    # level columns below are the only representation (matching how such
+    # orders are scheduled everywhere else).
+
+    # Order-level envelope kept for legacy readers (PO detail/list responses,
+    # CompleteOrderModal display).
     order.scheduled_start = best_slot
     order.scheduled_end = scheduled_end
     order.assigned_to = best_resource.code

--- a/backend/app/schemas/scheduling.py
+++ b/backend/app/schemas/scheduling.py
@@ -11,12 +11,19 @@ class CapacityCheckRequest(BaseModel):
     resource_id: int
     start_time: datetime
     end_time: datetime
+    # Resources and Printers are distinct models with separate ID spaces
+    # (see /scheduling/board); set True to check a printer lane.
+    is_printer: bool = False
 
 
 class ConflictInfo(BaseModel):
     """Information about a scheduling conflict"""
-    order_id: int
+    # "operation" or "maintenance" — maintenance-window conflicts carry no order.
+    type: str = "operation"
+    order_id: Optional[int] = None
     order_code: str
+    operation_id: Optional[int] = None
+    operation_code: Optional[str] = None
     start_time: str
     end_time: str
     product_name: str

--- a/backend/app/schemas/scheduling.py
+++ b/backend/app/schemas/scheduling.py
@@ -18,10 +18,11 @@ class CapacityCheckRequest(BaseModel):
 
 class ConflictInfo(BaseModel):
     """Information about a scheduling conflict"""
-    # "operation" or "maintenance" — maintenance-window conflicts carry no order.
+    # "operation" or "maintenance" — maintenance-window conflicts carry no
+    # order, so the order fields are all optional.
     type: str = "operation"
     order_id: Optional[int] = None
-    order_code: str
+    order_code: Optional[str] = None
     operation_id: Optional[int] = None
     operation_code: Optional[str] = None
     start_time: str

--- a/backend/tests/api/v1/test_scheduling_capacity.py
+++ b/backend/tests/api/v1/test_scheduling_capacity.py
@@ -1,0 +1,372 @@
+"""Tests for the capacity/auto-schedule plane (#857 G1/G3/G4/G5/G8).
+
+These endpoints previously read ProductionOrder-level scheduled_* columns that
+the operation-scheduling path never populates, so a machine booked solid via
+the scheduler modal reported zero utilization and auto-schedule double-booked
+it. They now read the same operation-level bookings (plus blocking maintenance
+windows) the rest of the scheduling engine uses.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.core import plugin_registry
+from app.models.maintenance import MaintenanceWindow
+from app.models.manufacturing import Resource
+from app.models.production_order import ProductionOrderOperation
+
+BASE_URL = "/api/v1/scheduling"
+
+
+def _uid():
+    return uuid.uuid4().hex[:6]
+
+
+def _make_resource(db, work_center_id, status="available"):
+    resource = Resource(
+        work_center_id=work_center_id,
+        code=f"RES-{_uid()}",
+        name=f"Test Resource {_uid()}",
+        status=status,
+        is_active=True,
+    )
+    db.add(resource)
+    db.flush()
+    return resource
+
+
+def _make_operation(db, production_order_id, work_center_id, sequence=10, status="queued", **kwargs):
+    operation = ProductionOrderOperation(
+        production_order_id=production_order_id,
+        work_center_id=work_center_id,
+        sequence=sequence,
+        operation_name=kwargs.pop("operation_name", f"Op-{sequence}"),
+        planned_run_minutes=kwargs.pop("planned_run_minutes", 60),
+        status=status,
+        **kwargs,
+    )
+    db.add(operation)
+    db.flush()
+    return operation
+
+
+def _tomorrow_midnight():
+    """Deterministic all-future anchor (naive UTC, matching the columns)."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    return (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _z(dt):
+    """Serialize as a Z-suffixed (tz-aware) ISO timestamp — the client
+    convention that previously TypeError'd these endpoints (#857 G4)."""
+    return dt.isoformat() + "Z"
+
+
+class TestCapacityCheck:
+    """POST /scheduling/capacity/check"""
+
+    def test_operation_booking_conflicts(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """An op-level booking must be visible to the capacity check — and
+        Z-suffixed timestamps must not 500 (G1 + G4)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, po.id, wc.id,
+            resource_id=resource.id,
+            scheduled_start=t0, scheduled_end=t0 + timedelta(hours=4),
+        )
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/capacity/check",
+            json={
+                "resource_id": resource.id,
+                "start_time": _z(t0 + timedelta(hours=1)),
+                "end_time": _z(t0 + timedelta(hours=2)),
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["has_capacity"] is False
+        assert data["conflicts"][0]["type"] == "operation"
+        assert data["conflicts"][0]["order_code"] == po.code
+
+    def test_free_machine_has_capacity(self, client, db, make_work_center):
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        t0 = _tomorrow_midnight()
+        response = client.post(
+            f"{BASE_URL}/capacity/check",
+            json={
+                "resource_id": resource.id,
+                "start_time": _z(t0),
+                "end_time": _z(t0 + timedelta(hours=2)),
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["has_capacity"] is True
+
+    def test_printer_lane_conflicts(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Printer bookings live in a separate ID space — is_printer=True must
+        find them (the old query cross-compared printer ids to resource ids)."""
+        from app.models.printer import Printer
+
+        wc = make_work_center()
+        printer = Printer(
+            code=f"PRT-{_uid()}", name="Test Printer", model="X1C",
+            brand="bambulab", work_center_id=wc.id, status="idle",
+        )
+        db.add(printer)
+        db.flush()
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, po.id, wc.id,
+            printer_id=printer.id,
+            scheduled_start=t0, scheduled_end=t0 + timedelta(hours=4),
+        )
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/capacity/check",
+            json={
+                "resource_id": printer.id,
+                "start_time": _z(t0),
+                "end_time": _z(t0 + timedelta(hours=1)),
+                "is_printer": True,
+            },
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["has_capacity"] is False
+
+    def test_maintenance_window_conflicts(self, client, db, make_work_center):
+        """A blocking maintenance window is busy time (the old read ignored it)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        t0 = _tomorrow_midnight()
+        db.add(MaintenanceWindow(
+            resource_id=resource.id,
+            starts_at=t0, ends_at=t0 + timedelta(hours=3),
+            status="scheduled", reason="Nozzle swap",
+        ))
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/capacity/check",
+            json={
+                "resource_id": resource.id,
+                "start_time": _z(t0 + timedelta(hours=1)),
+                "end_time": _z(t0 + timedelta(hours=2)),
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["has_capacity"] is False
+        assert data["conflicts"][0]["type"] == "maintenance"
+
+
+class TestAvailableSlots:
+    """GET /scheduling/capacity/available-slots"""
+
+    def test_gaps_around_op_booking(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, po.id, wc.id,
+            resource_id=resource.id,
+            scheduled_start=t0 + timedelta(hours=8),
+            scheduled_end=t0 + timedelta(hours=16),
+        )
+        db.flush()
+
+        response = client.get(
+            f"{BASE_URL}/capacity/available-slots",
+            params={
+                "resource_id": resource.id,
+                "start_date": _z(t0),
+                "end_date": _z(t0 + timedelta(hours=24)),
+                "duration_hours": 2.0,
+            },
+        )
+        assert response.status_code == 200, response.text
+        slots = response.json()
+        assert len(slots) == 2
+        assert slots[0]["duration_hours"] == pytest.approx(8.0)
+        assert slots[1]["duration_hours"] == pytest.approx(8.0)
+
+
+class TestMachineAvailability:
+    """GET /scheduling/capacity/machine-availability"""
+
+    def test_op_booking_drives_utilization(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """A modal-scheduled op must show up as utilization (was always 0%)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, po.id, wc.id,
+            resource_id=resource.id,
+            scheduled_start=t0, scheduled_end=t0 + timedelta(hours=4),
+        )
+        db.flush()
+
+        response = client.get(
+            f"{BASE_URL}/capacity/machine-availability",
+            params={
+                "start_date": _z(t0),
+                "end_date": _z(t0 + timedelta(hours=8)),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 200, response.text
+        row = next(r for r in response.json() if r["resource_id"] == resource.id)
+        assert row["scheduled_hours"] == pytest.approx(4.0)
+        assert row["utilization_percent"] == pytest.approx(50.0)
+        assert row["scheduled_order_count"] == 1
+
+
+class TestAutoSchedule:
+    """POST /scheduling/auto-schedule (PRO-gated feature: production_advanced)"""
+
+    @pytest.fixture(autouse=True)
+    def _license(self):
+        plugin_registry.set_features(["production_advanced"])
+        yield
+        plugin_registry.reset()
+
+    def test_unlicensed_returns_403(self, client, db, make_product, make_production_order):
+        plugin_registry.reset()
+        po = make_production_order(product_id=make_product().id)
+        db.flush()
+        response = client.post(f"{BASE_URL}/auto-schedule", params={"order_id": po.id})
+        assert response.status_code == 403
+
+    def test_slots_after_existing_op_booking(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Auto-schedule must not overlap an operation-level booking (G1/G5 —
+        the old read saw order-level columns nothing populates)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        busy_po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        busy_end = t0 + timedelta(hours=4)
+        _make_operation(
+            db, busy_po.id, wc.id,
+            resource_id=resource.id,
+            scheduled_start=t0, scheduled_end=busy_end,
+        )
+        target_po = make_production_order(product_id=make_product().id)
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={
+                "order_id": target_po.id,
+                "preferred_start": _z(t0),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        scheduled_start = datetime.fromisoformat(data["scheduled_start"])
+        assert scheduled_start >= busy_end
+
+    def test_skips_maintenance_window(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Auto-schedule must not book over a blocking maintenance window (G5)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        t0 = _tomorrow_midnight()
+        window_end = t0 + timedelta(hours=5)
+        db.add(MaintenanceWindow(
+            resource_id=resource.id,
+            starts_at=t0, ends_at=window_end,
+            status="scheduled", reason="Belt tensioning",
+        ))
+        po = make_production_order(product_id=make_product().id)
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={
+                "order_id": po.id,
+                "preferred_start": _z(t0),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 200, response.text
+        scheduled_start = datetime.fromisoformat(response.json()["scheduled_start"])
+        assert scheduled_start >= window_end
+
+    def test_duration_from_operation_planned_minutes(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """With no estimated_time_minutes, duration comes from the routing's
+        planned minutes, not the 2h default (G3)."""
+        wc = make_work_center()
+        _make_resource(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, po.id, wc.id, sequence=10, status="pending",
+            planned_run_minutes=300, planned_setup_minutes=60,
+        )
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={
+                "order_id": po.id,
+                "preferred_start": _z(t0),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        start = datetime.fromisoformat(data["scheduled_start"])
+        end = datetime.fromisoformat(data["scheduled_end"])
+        assert (end - start) == timedelta(hours=6)  # 300 + 60 minutes
+
+    def test_no_slot_returns_409(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """No slot inside the window is a 409, not a 404 — the frontend treats
+        404 as 'PRO plugin not installed' (G8)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        busy_po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        _make_operation(
+            db, busy_po.id, wc.id,
+            resource_id=resource.id,
+            scheduled_start=t0, scheduled_end=t0 + timedelta(days=8),
+        )
+        target_po = make_production_order(product_id=make_product().id)
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={
+                "order_id": target_po.id,
+                "preferred_start": _z(t0),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 409, response.text

--- a/backend/tests/api/v1/test_scheduling_capacity.py
+++ b/backend/tests/api/v1/test_scheduling_capacity.py
@@ -353,10 +353,12 @@ class TestAutoSchedule:
         resource = _make_resource(db, wc.id)
         busy_po = make_production_order(product_id=make_product().id)
         t0 = _tomorrow_midnight()
+        # auto_schedule_order searches a 7-day horizon from preferred_start;
+        # block far past it so the 409 path holds even if the horizon grows.
         _make_operation(
             db, busy_po.id, wc.id,
             resource_id=resource.id,
-            scheduled_start=t0, scheduled_end=t0 + timedelta(days=8),
+            scheduled_start=t0, scheduled_end=t0 + timedelta(days=30),
         )
         target_po = make_production_order(product_id=make_product().id)
         db.flush()
@@ -370,3 +372,80 @@ class TestAutoSchedule:
             },
         )
         assert response.status_code == 409, response.text
+
+    def test_booking_lands_on_operation_rows(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Auto-schedule must persist on the operation plane — the plane every
+        conflict/capacity read uses — or its own booking is invisible to the
+        next call (self-double-booking)."""
+        wc = make_work_center()
+        resource = _make_resource(db, wc.id)
+        po = make_production_order(product_id=make_product().id)
+        t0 = _tomorrow_midnight()
+        op1 = _make_operation(
+            db, po.id, wc.id, sequence=10, status="pending", planned_run_minutes=60,
+        )
+        op2 = _make_operation(
+            db, po.id, wc.id, sequence=20, status="pending", planned_run_minutes=120,
+        )
+        db.flush()
+
+        response = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={
+                "order_id": po.id,
+                "preferred_start": _z(t0),
+                "work_center_id": wc.id,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        # Ops booked back-to-back in sequence order on the chosen machine.
+        db.refresh(op1)
+        db.refresh(op2)
+        assert op1.status == "queued" and op2.status == "queued"
+        assert op1.resource_id == resource.id and op2.resource_id == resource.id
+        assert op1.scheduled_start == t0
+        assert op1.scheduled_end == op2.scheduled_start
+        assert op2.scheduled_end == t0 + timedelta(hours=3)
+
+        # And the booking is visible to the capacity plane.
+        check = client.post(
+            f"{BASE_URL}/capacity/check",
+            json={
+                "resource_id": resource.id,
+                "start_time": _z(t0),
+                "end_time": _z(t0 + timedelta(hours=3)),
+            },
+        )
+        assert check.status_code == 200
+        assert check.json()["has_capacity"] is False
+
+    def test_second_auto_schedule_sees_first(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        """Two consecutive auto-schedules on one machine must not overlap —
+        the regression the op-plane persistence exists to prevent."""
+        wc = make_work_center()
+        _make_resource(db, wc.id)
+        t0 = _tomorrow_midnight()
+        po_a = make_production_order(product_id=make_product().id)
+        po_b = make_production_order(product_id=make_product().id)
+        _make_operation(db, po_a.id, wc.id, status="pending", planned_run_minutes=120)
+        _make_operation(db, po_b.id, wc.id, status="pending", planned_run_minutes=120)
+        db.flush()
+
+        first = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={"order_id": po_a.id, "preferred_start": _z(t0), "work_center_id": wc.id},
+        )
+        second = client.post(
+            f"{BASE_URL}/auto-schedule",
+            params={"order_id": po_b.id, "preferred_start": _z(t0), "work_center_id": wc.id},
+        )
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        first_end = datetime.fromisoformat(first.json()["scheduled_end"])
+        second_start = datetime.fromisoformat(second.json()["scheduled_start"])
+        assert second_start >= first_end


### PR DESCRIPTION
## #857 scheduling — PR 2 of 2: "Capacity plane tells the truth"

Companion to #863. All findings **adversarially verified** against main and **coupling-mapped** before implementation (10-agent workflow `w21mnidcu`); the headline clearance: **this plane is transactionally inert** — no scheduling path writes `InventoryTransaction`, GL, reservations, or costs, and no accounting module reads any scheduling column. These are read-repairs plus one write-path correctness fix, all confined to `endpoints/scheduling.py` (+ additive schemas).

### What was broken
The four capacity/auto-schedule endpoints read `ProductionOrder.scheduled_start/scheduled_end/assigned_to` joined to `PrintJob` — **columns the operation-scheduling path (modal/dispatch) never populates**, with the join comparing `PrintJob.printer_id` against `Resource.id` (two unrelated ID spaces). Net effect: a machine booked solid via the scheduler reported **0% utilization / `has_capacity=true`**, and auto-schedule would double-book it.

### Fixes (verified finding → change)
- **G1** — all four endpoints now read **operation-level bookings** via the existing `resource_scheduling` helpers, with an explicit `is_printer` lane (never cross-comparing ID spaces). Blocking **maintenance windows count as busy time**; `machine-availability` clips bookings to the window (same math as the board).
- **G4** — request datetimes normalized to **naive UTC** at entry; `Z`-suffixed timestamps previously raised `TypeError` → 500 in `capacity/check` and `available-slots` whenever busy rows existed. (Naive-UTC stays the documented column convention — no timestamptz migration.)
- **G5** — auto-schedule's hand-rolled gap loop (three double-booking paths: start-based filter hiding running work, ignored maintenance windows, cursor walking backward on nested periods) is **replaced by a delegation to `find_next_available_slot`** — the same engine the scheduler modal uses.
- **G3** — duration fallback chain: `estimated_time_minutes` → **sum of op planned minutes** (already quantity-scaled) → 2h default. SO-generated WOs never set the estimate, so every routing-driven job was sized at 2h.
- **G8 rider** — no-slot failure is **409** (was 404, which the frontend's PRO-detection treats as "plugin not installed").
- **#863 follow-through** — deleted the legacy negative-`resource_id` printer decode from `get_operations`, as promised in that review: `resource_id` has been FK-constrained its whole life (migration 032 validated existing rows), so the guarded rows cannot exist.

### Contract & blast radius
- **Additive schema changes only:** `CapacityCheckRequest.is_printer`, `ConflictInfo.type/operation_id/operation_code`; `ConflictInfo.order_id` is now `Optional` (maintenance windows carry no order).
- **Zero frontend callers** exist for any of the four endpoints (grep-verified) — blast radius is OpenAPI shape + direct-API consumers.
- **Explicitly untouched:** `schedule_operation` and all its callers (modal/wizard/dispatch/reschedule), `/scheduling/board`, `/scheduling/resource-conflicts`, `PUT /production-orders/{id}/schedule`, the PO `scheduled_*` columns and their quote-derived writers, the PRO plugin contract (`AutoPickSlotButton` untouched; no `/api/v1/pro/*` in Core), DB schema (no migrations), and all transactional/accounting code.

### Tests (+11, all backend)
Op-booking conflict with `Z` timestamps (G1+G4) · free machine · printer lane · maintenance-window busy · slot gaps around a booking · utilization from a modal booking (the was-always-0% case) · 403 unlicensed · auto-schedule refuses overlap with existing booking · skips maintenance window · duration from planned minutes (G3) · 409 on no-slot (G8).
Blast radius: scheduling/operations/dispatch sweep **448/448**; targeted suites (board, resource_scheduling, reschedule/unschedule, operation_status, production_orders endpoint, licensing gate) **113/113**; `ruff` clean.

Closes #857 (remaining out-of-scope items from the lifecycle trace — `'scheduled'` status enum gap, dashboard tile query, `po.start_date` phantom writes — will be filed as separate issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capacity checks and slot availability now account for actual operation bookings, printer lanes, and blocking maintenance windows.
  * Added an `is_printer` option to target the correct ID space for capacity checks and availability.
  * Auto-scheduling now schedules at the operation level and returns clearer “no slot” behavior.

* **Bug Fixes**
  * Machine utilization/availability is now derived from real booked intervals (including maintenance), improving gap, overlap, and utilization accuracy.
  * Conflict details are now more specific about the conflict type (operation vs maintenance).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->