### PR TITLE
feat(ui): consistent PRO gating across menu/route/page (audit PR-C)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -304,7 +304,9 @@ export default function App() {
                       path="analytics"
                       element={
                         <Suspense fallback={<PageLoader />}>
-                          <AdminAnalytics />
+                          <ProGate>
+                            <AdminAnalytics />
+                          </ProGate>
                         </Suspense>
                       }
                     />

--- a/frontend/src/components/AdminLayout.jsx
+++ b/frontend/src/components/AdminLayout.jsx
@@ -430,6 +430,18 @@ const navGroups = [
         label: "Analytics",
         icon: AnalyticsIcon,
       },
+      {
+        // Advanced Analytics (revenue/customer/product/profit dashboard) is a
+        // wholly-PRO page behind reports_advanced. It had a route + page but no
+        // nav entry — reachable only by typing the URL. Surface it badged so
+        // non-PRO sees the upgrade prompt instead of a hidden dead-end.
+        path: "/admin/analytics",
+        label: "Advanced Analytics",
+        icon: AnalyticsIcon,
+        adminOnly: true,
+        proOnly: true,
+        feature: "reports_advanced",
+      },
     ],
   },
   {
@@ -500,12 +512,20 @@ const navGroups = [
         label: "Intake Studio",
         icon: ProductionIcon,
         adminOnly: true,
+        // Intake Studio gates access on isPro at the page level (the
+        // intake_unified_flow flag only switches the UI variant, it is not
+        // the access gate), so this is proOnly with no feature filter —
+        // available to every PRO tier. This is the original PRO-leak audit
+        // finding (2026-07-01): the item was previously adminOnly-only.
+        proOnly: true,
       },
       {
         path: "/admin/intake-batch",
         label: "Intake Batch",
         icon: ProductionIcon,
         adminOnly: true,
+        // Same access model as Intake Studio — isPro page gate, no feature.
+        proOnly: true,
       },
     ],
   },

--- a/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
+++ b/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
@@ -94,7 +94,7 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
       <button
         type="button"
         onClick={handleClick}
-        disabled={disabled || running || !operationId || flagsLoading}
+        disabled={disabled || running || !productionOrderId || flagsLoading}
         className="text-xs text-purple-400 hover:text-purple-300 border border-purple-500/30 hover:border-purple-400/50 rounded px-2 py-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         title="Use the PRO auto-scheduler to find the optimal slot"
       >

--- a/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
+++ b/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
@@ -12,8 +12,10 @@
  */
 import { useState, useEffect } from "react";
 import { API_URL } from "../../../config/api";
+import { useFeatureFlags } from "../../../hooks/useFeatureFlags";
 
 export default function AutoPickSlotButton({ operationId, productionOrderId, onSlotPicked, disabled }) {
+  const { isPro } = useFeatureFlags();
   const [running, setRunning] = useState(false);
   const [proUnavailable, setProUnavailable] = useState(false);
   const [pickError, setPickError] = useState(null);
@@ -21,6 +23,7 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
   // PRO availability is per-install, but reset on operation change so a
   // transient 403 (e.g. session blip) doesn't stick for the whole session.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional reset of local availability/error state when the target operation changes.
     setProUnavailable(false);
     setPickError(null);
   }, [operationId]);
@@ -62,7 +65,12 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
     }
   };
 
-  if (proUnavailable) {
+  // Proactively gate on tier: the /auto-schedule endpoint is PRO-only
+  // (require_feature("production_advanced")), so on community show the upsell
+  // note up front instead of firing a request that would only 403. The
+  // proUnavailable branch below still covers a PRO tier whose install lacks
+  // the endpoint (older wheel / feature not loaded).
+  if (!isPro || proUnavailable) {
     return (
       <span className="text-xs text-gray-500 italic">
         Auto-pick requires FilaOps PRO

--- a/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
+++ b/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
@@ -1,12 +1,14 @@
 /**
  * AutoPickSlotButton — PRO-gated auto-scheduler affordance.
  *
- * Extracted verbatim from OperationSchedulerModal.jsx (DEBT-1 D2-B). Markup,
- * classes, fetch logic, and props are unchanged.
+ * Extracted from OperationSchedulerModal.jsx (DEBT-1 D2-B).
  *
- * Calls POST /api/v1/pro/auto-schedule with the operation + production order
- * context.  If the endpoint returns 404/403 (Core install without PRO), shows
- * a polite "PRO feature" note instead of an error.
+ * Calls POST /api/v1/scheduling/auto-schedule?order_id=<productionOrderId> —
+ * the Core scheduling route gated by require_feature("production_advanced")
+ * (PR #861). The endpoint takes the production order id as a query param (not
+ * a JSON body) and does not use the operation id. If it returns 404/403 (a PRO
+ * install whose wheel lacks the endpoint, or the feature not loaded), shows a
+ * polite "PRO feature" note instead of an error.
  *
  * On success the returned slot is applied to startTime / endTime.
  */
@@ -15,7 +17,7 @@ import { API_URL } from "../../../config/api";
 import { useFeatureFlags } from "../../../hooks/useFeatureFlags";
 
 export default function AutoPickSlotButton({ operationId, productionOrderId, onSlotPicked, disabled }) {
-  const { isPro } = useFeatureFlags();
+  const { isPro, loading: flagsLoading } = useFeatureFlags();
   const [running, setRunning] = useState(false);
   const [proUnavailable, setProUnavailable] = useState(false);
   const [pickError, setPickError] = useState(null);
@@ -33,12 +35,15 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
     setProUnavailable(false);
     setPickError(null);
     try {
-      const res = await fetch(`${API_URL}/api/v1/pro/auto-schedule`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ operation_id: operationId, production_order_id: productionOrderId }),
-      });
+      // order_id is a query param on the Core scheduling route (not a JSON
+      // body). productionOrderId maps to the endpoint's order_id.
+      const res = await fetch(
+        `${API_URL}/api/v1/scheduling/auto-schedule?order_id=${encodeURIComponent(productionOrderId)}`,
+        {
+          method: "POST",
+          credentials: "include",
+        },
+      );
       if (res.status === 404 || res.status === 403) {
         setProUnavailable(true);
         return;
@@ -68,9 +73,15 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
   // Proactively gate on tier: the /auto-schedule endpoint is PRO-only
   // (require_feature("production_advanced")), so on community show the upsell
   // note up front instead of firing a request that would only 403. The
-  // proUnavailable branch below still covers a PRO tier whose install lacks
-  // the endpoint (older wheel / feature not loaded).
-  if (!isPro || proUnavailable) {
+  // proUnavailable branch also covers a PRO tier whose install lacks the
+  // endpoint (older wheel / feature not loaded).
+  //
+  // Wait for feature flags to hydrate before showing the locked note: isPro
+  // derives from tier, which is undefined while flagsLoading is true, so
+  // branching on !isPro too early would flash "requires FilaOps PRO" at PRO
+  // users. While loading, render the neutral (disabled) button and only
+  // resolve the locked vs. active state once flags are known.
+  if (!flagsLoading && (!isPro || proUnavailable)) {
     return (
       <span className="text-xs text-gray-500 italic">
         Auto-pick requires FilaOps PRO
@@ -83,7 +94,7 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
       <button
         type="button"
         onClick={handleClick}
-        disabled={disabled || running || !operationId}
+        disabled={disabled || running || !operationId || flagsLoading}
         className="text-xs text-purple-400 hover:text-purple-300 border border-purple-500/30 hover:border-purple-400/50 rounded px-2 py-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         title="Use the PRO auto-scheduler to find the optimal slot"
       >

--- a/frontend/src/pages/admin/AdminAccounting.jsx
+++ b/frontend/src/pages/admin/AdminAccounting.jsx
@@ -10,7 +10,7 @@ import PeriodsTab from "../../components/accounting/PeriodsTab";
 
 export default function AdminAccounting() {
   const [activeTab, setActiveTab] = useState("dashboard");
-  const { isPro, isEnterprise } = useFeatureFlags();
+  const { hasFeature, isEnterprise } = useFeatureFlags();
 
   const tabs = [
     { id: "dashboard", label: "Dashboard", icon: "chart-bar", tier: "community" },
@@ -22,10 +22,13 @@ export default function AdminAccounting() {
     { id: "periods", label: "Periods", icon: "calendar", tier: "pro" },
   ];
 
-  // Check if user can access a tab based on their tier
+  // Check if user can access a tab based on their tier. The GL/period tabs
+  // back the PRO-gated accounting endpoints (require_feature("accounting")
+  // keystone #861), so route the pro check through hasFeature("accounting")
+  // rather than the raw tier — matches the backend gate exactly.
   const canAccessTab = (tier) => {
     if (tier === "community") return true;
-    if (tier === "pro") return isPro || isEnterprise;
+    if (tier === "pro") return hasFeature("accounting");
     if (tier === "enterprise") return isEnterprise;
     return false;
   };
@@ -195,8 +198,57 @@ export default function AdminAccounting() {
       {activeTab === "payments" && <PaymentsTab />}
       {activeTab === "cogs" && <COGSTab />}
       {activeTab === "tax" && <TaxCenterTab />}
-      {activeTab === "glreports" && <GLReportsTab />}
-      {activeTab === "periods" && <PeriodsTab />}
+      {/* GL Reports / Periods back the PRO-gated accounting endpoints. Render
+          a locked panel (not the tab component) when the accounting feature is
+          absent, so a non-PRO user who reaches the tab sees the upsell rather
+          than a 402-driven error state. Disabled tab buttons already block the
+          click path; this guards direct/state edge cases too. */}
+      {activeTab === "glreports" &&
+        (canAccessTab("pro") ? (
+          <GLReportsTab />
+        ) : (
+          <LockedAccountingPanel label="GL Reports" />
+        ))}
+      {activeTab === "periods" &&
+        (canAccessTab("pro") ? (
+          <PeriodsTab />
+        ) : (
+          <LockedAccountingPanel label="Accounting Periods" />
+        ))}
+    </div>
+  );
+}
+
+// Locked panel for PRO-gated accounting tabs (GL Reports / Periods). Mirrors
+// the AdminIntakeStudio PRO upsell shape.
+function LockedAccountingPanel({ label }) {
+  return (
+    <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6 text-center">
+      <svg
+        className="w-12 h-12 text-blue-400 mx-auto mb-3"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+        />
+      </svg>
+      <h3 className="text-lg font-semibold text-white mb-2">PRO Feature</h3>
+      <p className="text-gray-400 mb-4">
+        {label} is part of FilaOps PRO accounting — general-ledger reporting and
+        period close on top of your community sales journal, payments, and tax
+        center.
+      </p>
+      <a
+        href="/pricing"
+        className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors"
+      >
+        Upgrade to PRO
+      </a>
     </div>
   );
 }

--- a/frontend/src/pages/admin/AdminAnalytics.jsx
+++ b/frontend/src/pages/admin/AdminAnalytics.jsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useApi } from "../../hooks/useApi";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 
 const AdminAnalytics = () => {
   const api = useApi();
+  const { hasFeature } = useFeatureFlags();
+  const hasAnalytics = hasFeature("reports_advanced");
   const [analytics, setAnalytics] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [days, setDays] = useState(30);
 
-  useEffect(() => {
-    fetchAnalytics();
-  }, [days]);
-
-  const fetchAnalytics = async () => {
+  const fetchAnalytics = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -21,17 +20,68 @@ const AdminAnalytics = () => {
       );
       setAnalytics(data);
     } catch (err) {
-      if (err.status === 402) {
-        // Tier required - user will see the Pro announcement
-        setLoading(false);
-        return;
-      }
       console.error("Analytics fetch error:", err);
       setError(err.message || "Failed to connect to analytics service");
     } finally {
       setLoading(false);
     }
-  };
+  }, [api, days]);
+
+  useEffect(() => {
+    // Don't call the (now gated) endpoint without the feature — the locked
+    // panel renders below regardless of loading state, so the request would
+    // only 402. Skipping the fetch leaves loading truthy, but !hasAnalytics
+    // is checked first so the locked panel wins.
+    if (!hasAnalytics) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Fetch-on-mount updates state after the async API response.
+    fetchAnalytics();
+  }, [hasAnalytics, fetchAnalytics]);
+
+  // PRO gate — Advanced Analytics (reports_advanced) is a wholly-PRO page.
+  // The /admin/analytics route is already wrapped in <ProGate> (redirects a
+  // non-PRO direct-URL visit to the License page), but we also lock the page
+  // itself on the feature so a PRO tier without reports_advanced sees the
+  // upsell rather than a 402-driven error. Locked-state shape mirrors
+  // AdminIntakeStudio.
+  if (!hasAnalytics) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Advanced Analytics</h1>
+          <p className="text-gray-400 mt-1">
+            Revenue, customer, product, and profit insights for your business
+          </p>
+        </div>
+        <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-6 text-center">
+          <svg
+            className="w-12 h-12 text-blue-400 mx-auto mb-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+          <h3 className="text-lg font-semibold text-white mb-2">PRO Feature</h3>
+          <p className="text-gray-400 mb-4">
+            Advanced Analytics gives you revenue metrics with growth tracking,
+            top-customer and top-product analysis, profit margin calculations,
+            and customizable date ranges — all in one dashboard.
+          </p>
+          <a
+            href="/pricing"
+            className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors"
+          >
+            Upgrade to PRO
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   if (loading) {
     return <div className="p-6 text-white">Loading analytics...</div>;
@@ -54,51 +104,6 @@ const AdminAnalytics = () => {
           >
             Retry
           </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (error?.includes("402") || error?.includes("tier")) {
-    return (
-      <div className="p-6 space-y-6">
-        <div className="bg-gradient-to-r from-blue-600/20 to-purple-600/20 border border-blue-500/30 rounded-lg p-8 text-center">
-          <h1 className="text-3xl font-bold text-white mb-2">
-            Advanced Analytics
-          </h1>
-          <p className="text-gray-300 mb-6">
-            Get comprehensive insights into your business with revenue,
-            customer, product, and profit analytics.
-          </p>
-          <div className="bg-gray-800/50 rounded-lg p-6 mb-6">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              Available in FilaOps Pro
-            </h2>
-            <ul className="text-left text-gray-300 space-y-2 max-w-md mx-auto">
-              <li className="flex items-start">
-                <span className="text-green-400 mr-2">+</span>
-                <span>Revenue metrics with growth tracking</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-green-400 mr-2">+</span>
-                <span>Top customers and products analysis</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-green-400 mr-2">+</span>
-                <span>Profit margin calculations</span>
-              </li>
-              <li className="flex items-start">
-                <span className="text-green-400 mr-2">+</span>
-                <span>Customizable date ranges</span>
-              </li>
-            </ul>
-          </div>
-          <p className="text-sm text-gray-400">
-            Learn more at{" "}
-            <a href="/pricing" className="text-blue-400 hover:text-blue-300 underline">
-              filaops.com/pricing
-            </a>
-          </p>
         </div>
       </div>
     );

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -208,7 +208,7 @@ export default function AdminUsers() {
           disabled={atSeatCap}
           title={
             atSeatCap
-              ? "Your plan allows 1 user. Upgrade to PRO to add team members."
+              ? `Your plan allows ${COMMUNITY_SEAT_CAP} user${COMMUNITY_SEAT_CAP === 1 ? "" : "s"}. Upgrade to PRO to add team members.`
               : undefined
           }
           className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:from-blue-600 disabled:hover:to-purple-600"

--- a/frontend/src/pages/admin/AdminUsers.jsx
+++ b/frontend/src/pages/admin/AdminUsers.jsx
@@ -2,7 +2,14 @@ import { useState, useEffect } from "react";
 import { useApi } from "../../hooks/useApi";
 import { useCRUD } from "../../hooks/useCRUD";
 import { useToast } from "../../components/Toast";
+import { useFeatureFlags } from "../../hooks/useFeatureFlags";
 import Modal from "../../components/Modal";
+
+// Community installs allow a single active staff seat; PRO/enterprise are
+// unlimited. Mirrors backend app/core/seat_limits.py (community cap = 1). The
+// backend is the real gate (enforce_seat_cap, PR-D2 #862) — this constant only
+// drives the FE seat banner / Add-User affordance.
+const COMMUNITY_SEAT_CAP = 1;
 
 // Role options
 const ROLE_OPTIONS = [
@@ -30,6 +37,7 @@ const STATUS_OPTIONS = [
 export default function AdminUsers() {
   const toast = useToast();
   const api = useApi();
+  const { isPro } = useFeatureFlags();
   const {
     items: users,
     loading,
@@ -84,6 +92,13 @@ export default function AdminUsers() {
     ).length,
     inactive: users.filter((u) => u.status !== "active").length,
   };
+
+  // Seat usage — active staff seats (admin + operator). On a capped community
+  // tier we surface the 1-seat limit and disable "Add User" at cap; PRO is
+  // unlimited so no banner. The backend still enforces the cap regardless
+  // (enforce_seat_cap #862) — this is upsell/awareness only.
+  const activeSeats = stats.admins + stats.operators;
+  const atSeatCap = !isPro && activeSeats >= COMMUNITY_SEAT_CAP;
 
   const getRoleStyle = (role) => {
     const found = ROLE_OPTIONS.find((r) => r.value === role);
@@ -190,11 +205,53 @@ export default function AdminUsers() {
             setEditingUser(null);
             setShowUserModal(true);
           }}
-          className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500"
+          disabled={atSeatCap}
+          title={
+            atSeatCap
+              ? "Your plan allows 1 user. Upgrade to PRO to add team members."
+              : undefined
+          }
+          className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:from-blue-600 disabled:hover:to-purple-600"
         >
           + Add User
         </button>
       </div>
+
+      {/* Seat-cap banner — community allows 1 staff seat; PRO is unlimited. */}
+      {!isPro && (
+        <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <svg
+              className="w-5 h-5 text-blue-400 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+              />
+            </svg>
+            <p className="text-sm text-gray-300">
+              <span className="font-semibold text-white">
+                {activeSeats} of {COMMUNITY_SEAT_CAP} staff seat
+                {COMMUNITY_SEAT_CAP === 1 ? "" : "s"} used
+              </span>{" "}
+              — your plan allows {COMMUNITY_SEAT_CAP} user
+              {COMMUNITY_SEAT_CAP === 1 ? "" : "s"}. Upgrade to PRO for unlimited
+              team members.
+            </p>
+          </div>
+          <a
+            href="/pricing"
+            className="shrink-0 inline-block bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm transition-colors text-center"
+          >
+            Upgrade to PRO
+          </a>
+        </div>
+      )}
 
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">


### PR DESCRIPTION
The client-side finishing batch of the 2026-07-01 PRO-leak audit, applying the adopted **Bambuddy pattern** (menu visible-but-badged with `proOnly`+`feature`; `<ProGate>` route wrapper for wholly-PRO pages; page-level `hasFeature`/`isPro` locked state). Scope narrowed by the product decisions: the **dropped keys** (`mrp` / `api_access` / `inventory_advanced` / `bom_advanced`) are now **free**, so there is **NO** client gating for those.

Backend gates already merged — `require_feature` keystone (#861) and multi_user seat caps (#862) — are the real security boundary. **This PR is UX consistency + upsell, not the boundary.**

### Menu — `frontend/src/components/AdminLayout.jsx`
- **Intake Studio** + **Intake Batch**: added `proOnly: true` (they were `adminOnly`-only — the original finding that kicked off the audit). **No `feature:` filter** — Intake Studio/Batch gate access on `isPro` at the page level; the `intake_unified_flow` flag only switches the UI variant, it is not the access gate. So the menu is `proOnly` only, available to every PRO tier.
- **Advanced Analytics**: **added a new nav item** (`/admin/analytics`, `proOnly: true`, `feature: 'reports_advanced'`). No analytics nav item existed before — the page had a route + component but was reachable only by typing the URL. Now it is surfaced and lock-badged for non-PRO.
- **Accounting**: nav left untouched. Accounting is a **mixed** community/PRO page (community: Dashboard/Sales/Payments/COGS/Tax; PRO: GL Reports/Periods), so it is gated at the tab level inside the page, not wholesale at the nav.

### Route — `frontend/src/App.jsx`
- Wrapped `/admin/analytics` in `<ProGate>` (mirrors the existing price-levels route). Did **not** ProGate `/admin/bom`, `/admin/accounting`, `/admin/users`, or `/admin/intake-studio` — those are mixed pages or already gate at the page level (Intake Studio has its own `!isPro` gate; adding ProGate too would be redundant).

### Page-level locks
- **`AdminAnalytics.jsx`** (`reports_advanced`): added a `hasFeature('reports_advanced')` early-return locked state (copies the AdminIntakeStudio upsell shape) and **removed the dead 402-handling branch** (it was unreachable — the generic `error` return fired first). Skips the now-gated fetch when the feature is absent.
- **`AdminAccounting.jsx`** (`accounting`): `canAccessTab`'s pro check now routes through `hasFeature('accounting')` (matches the backend keystone), and the GL Reports / Periods tabs render a **locked upsell panel** when the feature is absent rather than only visually disabling the tab buttons. Community tabs unchanged.
- **`AutoPickSlotButton.jsx`** (`production_advanced`): gated on `isPro` up front — community sees the "requires FilaOps PRO" note instead of firing an `/auto-schedule` request that would only 403. The existing `proUnavailable` fallback still covers a PRO install whose wheel lacks the endpoint.
- **`AdminUsers.jsx`** (multi_user seats): added a seat-usage banner + cap-aware Add User. On community (1-seat cap, per `app/core/seat_limits.py`) it shows "N of 1 staff seats used" with an upgrade prompt and disables Add User at cap; PRO/enterprise (unlimited) see no banner. Uses `useFeatureFlags` (`isPro`) — no hardcoded tier logic. Backend `enforce_seat_cap` (#862) remains the real gate.

### Validation
- `npm ci` + `npm run build` pass.
- Lint: no **new** errors in changed files (repo has ~212 pre-existing lint issues elsewhere, unchanged). Two pre-existing `set-state-in-effect` cases in touched files were silenced with the repo's established `eslint-disable-next-line react-hooks/set-state-in-effect` convention.
- Existing OperationSchedulerModal + ProductionOrderDetail unit tests (24) still pass.

**Do not merge** — for product-owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Advanced Analytics** admin sidebar entry and route, with PRO-only access and an upsell panel when unavailable.
  * Updated admin accounting and analytics pages to show locked/upgrade messaging based on required feature access.
  * Updated team-member **Add User** to display a community seat-cap banner for non-PRO users.
* **Bug Fixes**
  * PRO-only auto-scheduling now waits for feature access to load and shows the locked notice appropriately; the auto-schedule request behavior was updated for reliable scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->