### PR TITLE
fix(production): wire dead order actions — Complete/Split/QC (#858 slice 3)

### DIFF
--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -1432,23 +1432,49 @@ async def split_production_order(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> ProductionOrderSplitResponse:
-    """Split a production order into two."""
-    original, new_order = production_order_service.split_production_order(
-        db,
-        order_id,
-        split_quantity=request.split_quantity,
-        user_email=current_user.email,
-        reason=request.reason,
-    )
+    """Split a production order into multiple orders.
+
+    The first split quantity stays on the parent; each remaining quantity
+    becomes a new child order (source="split"). The quantities must total
+    the parent's current ordered quantity (the UI enforces the same rule).
+    """
+    order = production_order_service.get_production_order(db, order_id)
+
+    total = sum(s.quantity for s in request.splits)
+    if total != order.quantity_ordered:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Split quantities must total the ordered quantity "
+                f"({total} != {order.quantity_ordered})"
+            ),
+        )
+
+    # The service splits ONE child off the parent per call, reducing the
+    # parent's quantity each time. The first split is what remains on the
+    # parent, so loop over the rest.
+    children = []
+    original = order
+    for split in request.splits[1:]:
+        original, child = production_order_service.split_production_order(
+            db,
+            order_id,
+            split_quantity=split.quantity,
+            user_email=current_user.email,
+        )
+        children.append(child)
 
     db.commit()
     db.refresh(original)
-    db.refresh(new_order)
+    for child in children:
+        db.refresh(child)
 
     return ProductionOrderSplitResponse(
-        original_order=build_production_order_response(original, db),
-        new_order=build_production_order_response(new_order, db),
-        message=f"Split {request.split_quantity} units to {new_order.code}",
+        parent_order_id=original.id,
+        parent_order_code=original.code,
+        parent_status=original.status,
+        child_orders=[build_list_response(c, db) for c in children],
+        message=f"Split {original.code} into {len(request.splits)} orders",
     )
 
 

--- a/backend/tests/api/v1/test_production_orders.py
+++ b/backend/tests/api/v1/test_production_orders.py
@@ -680,6 +680,73 @@ class TestQCInspectionEndpoint:
         assert response.status_code == 200, response.text
 
 
+class TestSplitProductionOrder:
+    """Test POST /api/v1/production-orders/{id}/split (#858 A3).
+
+    The endpoint previously read request.split_quantity/request.reason —
+    fields that don't exist on ProductionOrderSplitRequest (which carries
+    splits: List[SplitQuantity]) — and built the response with kwargs that
+    don't match ProductionOrderSplitResponse, so every split 500'd twice.
+    """
+
+    def test_split_two_ways(self, client, db, make_product, make_bom):
+        fg, _, _ = _create_product_with_bom(make_product, make_bom, db)
+        order_data = _create_draft_order(client, fg.id)  # qty 10
+
+        response = client.post(
+            f"{BASE_URL}/{order_data['id']}/split",
+            json={"splits": [{"quantity": 6}, {"quantity": 4}]},
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["parent_order_id"] == order_data["id"]
+        assert data["parent_order_code"] == order_data["code"]
+        assert len(data["child_orders"]) == 1
+        child = data["child_orders"][0]
+        assert Decimal(str(child["quantity_ordered"])) == Decimal("4")
+        assert child["code"] != order_data["code"]
+
+        # Parent keeps the first split quantity.
+        parent = client.get(f"{BASE_URL}/{order_data['id']}").json()
+        assert Decimal(str(parent["quantity_ordered"])) == Decimal("6")
+
+    def test_split_three_ways(self, client, db, make_product, make_bom):
+        fg, _, _ = _create_product_with_bom(make_product, make_bom, db)
+        order_data = _create_draft_order(client, fg.id)  # qty 10
+
+        response = client.post(
+            f"{BASE_URL}/{order_data['id']}/split",
+            json={"splits": [{"quantity": 4}, {"quantity": 3}, {"quantity": 3}]},
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data["child_orders"]) == 2
+        parent = client.get(f"{BASE_URL}/{order_data['id']}").json()
+        assert Decimal(str(parent["quantity_ordered"])) == Decimal("4")
+
+    def test_split_sum_mismatch_returns_400(self, client, db, make_product, make_bom):
+        fg, _, _ = _create_product_with_bom(make_product, make_bom, db)
+        order_data = _create_draft_order(client, fg.id)  # qty 10
+
+        response = client.post(
+            f"{BASE_URL}/{order_data['id']}/split",
+            json={"splits": [{"quantity": 5}, {"quantity": 4}]},
+        )
+        assert response.status_code == 400
+        assert "total" in response.json()["detail"].lower()
+
+    def test_split_single_entry_rejected(self, client, db, make_product, make_bom):
+        """The schema requires at least 2 splits."""
+        fg, _, _ = _create_product_with_bom(make_product, make_bom, db)
+        order_data = _create_draft_order(client, fg.id)
+
+        response = client.post(
+            f"{BASE_URL}/{order_data['id']}/split",
+            json={"splits": [{"quantity": 10}]},
+        )
+        assert response.status_code == 422
+
+
 # =============================================================================
 # Cancel -- POST /api/v1/production-orders/{id}/cancel
 # =============================================================================

--- a/frontend/src/components/CompleteOrderModal.jsx
+++ b/frontend/src/components/CompleteOrderModal.jsx
@@ -107,17 +107,17 @@ export default function CompleteOrderModal({
 
     setSubmitting(true);
     try {
-      const params = new URLSearchParams({
-        quantity_completed: quantityCompleted.toString(),
-      });
-
-      // If closing short and user acknowledged, add force flag
+      // The endpoint binds ProductionOrderCompleteRequest from the JSON body.
+      // quantity_completed/force_close_short were previously sent as query
+      // params, which FastAPI silently dropped — the backend then recorded a
+      // FULL-quantity completion regardless of the entered value, and closing
+      // short was impossible (the force flag never arrived).
+      const requestBody = {
+        quantity_completed: quantityCompleted,
+      };
       if (isClosingShort && acknowledgeShort) {
-        params.append("force_close_short", "true");
+        requestBody.force_close_short = true;
       }
-
-      // Prepare request body with optional notes and spool selections
-      const requestBody = {};
       if (notes.trim()) {
         requestBody.notes = notes.trim();
       }
@@ -129,7 +129,7 @@ export default function CompleteOrderModal({
       }
 
       const res = await fetch(
-        `${API_URL}/api/v1/production-orders/${productionOrder.id}/complete?${params}`,
+        `${API_URL}/api/v1/production-orders/${productionOrder.id}/complete`,
         {
           method: "POST",
           credentials: "include",

--- a/frontend/src/components/production/ProductionQueueList.jsx
+++ b/frontend/src/components/production/ProductionQueueList.jsx
@@ -108,7 +108,7 @@ function calculateTotalTime(operations) {
  * held for QC) show a "Scrap" affordance that calls onScrap(order) so the parent
  * can open the ScrapOrderModal — previously the modal was mounted but unreachable.
  */
-function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap }) {
+function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap, onSplit, onComplete, onQC }) {
   const totalMinutes = calculateTotalTime(operations);
 
   // Gather all materials from all operations
@@ -124,6 +124,16 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
   // progress, finished goods received at completion, or goods held after a QC
   // failure.  draft/released have nothing made yet; scrapped/cancelled are done.
   const canScrap = ['in_progress', 'complete', 'qc_hold', 'short'].includes(order.status);
+
+  // #858: Split/Complete/QC modals were mounted on the page but nothing ever
+  // opened them. Split follows the service guard (draft/scheduled/released,
+  // >1 unit); Complete is the bulk order-level action for WIP; QC uses the
+  // backend-computed guard (is_ready_for_qc) plus held orders awaiting
+  // re-inspection.
+  const canSplit = ['draft', 'scheduled', 'released'].includes(order.status)
+    && (order.quantity_ordered || 0) > 1;
+  const canComplete = order.status === 'in_progress';
+  const canQC = order.status === 'qc_hold' || order.is_ready_for_qc === true;
 
   return (
     <tr
@@ -191,33 +201,76 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
         )}
       </td>
 
-      {/* SCHED-3: dispatch affordance on released orders; #781: scrap affordance once units exist */}
+      {/* Row actions: Dispatch (SCHED-3), Split/Complete/QC (#858), Scrap (#781).
+          Status-gating keeps this to at most two buttons per row. */}
       <td className="px-4 py-3 text-right">
-        {order.status === 'released' && firstPendingOp && onDispatch ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDispatch(order, firstPendingOp);
-            }}
-            className="text-xs text-blue-400 hover:text-blue-300 border border-blue-500/30 hover:border-blue-400/50 rounded px-2 py-1 transition-colors"
-            title="Open scheduler for this order's next pending operation"
-          >
-            Dispatch →
-          </button>
-        ) : canScrap && onScrap ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onScrap(order);
-            }}
-            className="text-xs text-red-400 hover:text-red-300 border border-red-500/30 hover:border-red-400/50 rounded px-2 py-1 transition-colors"
-            title="Record scrap for this order"
-          >
-            Scrap
-          </button>
-        ) : null}
+        <div className="flex items-center justify-end gap-1">
+          {order.status === 'released' && firstPendingOp && onDispatch && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDispatch(order, firstPendingOp);
+              }}
+              className="text-xs text-blue-400 hover:text-blue-300 border border-blue-500/30 hover:border-blue-400/50 rounded px-2 py-1 transition-colors"
+              title="Open scheduler for this order's next pending operation"
+            >
+              Dispatch →
+            </button>
+          )}
+          {canSplit && onSplit && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSplit(order);
+              }}
+              className="text-xs text-cyan-400 hover:text-cyan-300 border border-cyan-500/30 hover:border-cyan-400/50 rounded px-2 py-1 transition-colors"
+              title="Split this order into multiple orders"
+            >
+              Split
+            </button>
+          )}
+          {canComplete && onComplete && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onComplete(order);
+              }}
+              className="text-xs text-green-400 hover:text-green-300 border border-green-500/30 hover:border-green-400/50 rounded px-2 py-1 transition-colors"
+              title="Complete this order"
+            >
+              Complete
+            </button>
+          )}
+          {canQC && onQC && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onQC(order);
+              }}
+              className="text-xs text-amber-400 hover:text-amber-300 border border-amber-500/30 hover:border-amber-400/50 rounded px-2 py-1 transition-colors"
+              title="Record a QC inspection for this order"
+            >
+              QC
+            </button>
+          )}
+          {canScrap && onScrap && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onScrap(order);
+              }}
+              className="text-xs text-red-400 hover:text-red-300 border border-red-500/30 hover:border-red-400/50 rounded px-2 py-1 transition-colors"
+              title="Record scrap for this order"
+            >
+              Scrap
+            </button>
+          )}
+        </div>
       </td>
     </tr>
   );
@@ -235,6 +288,9 @@ export default function ProductionQueueList({
   onCreateOrder,
   onDispatch,
   onScrap,
+  onSplit,
+  onComplete,
+  onQC,
 }) {
   const [operationsMap, setOperationsMap] = useState({});
   const [loadingOps, setLoadingOps] = useState(false);
@@ -449,6 +505,9 @@ export default function ProductionQueueList({
                   onRowClick={onOrderClick}
                   onDispatch={onDispatch}
                   onScrap={onScrap}
+                  onSplit={onSplit}
+                  onComplete={onComplete}
+                  onQC={onQC}
                 />
               ))
             )}

--- a/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
+++ b/frontend/src/components/production/__tests__/ProductionQueueList.test.jsx
@@ -42,7 +42,7 @@ function makeOrder(overrides) {
   };
 }
 
-function renderList(orders, onScrap) {
+function renderList(orders, onScrap, extraHandlers = {}) {
   return render(
     <ProductionQueueList
       orders={orders}
@@ -52,6 +52,7 @@ function renderList(orders, onScrap) {
       onFiltersChange={() => {}}
       onCreateOrder={() => {}}
       onScrap={onScrap}
+      {...extraHandlers}
     />,
   );
 }
@@ -91,5 +92,73 @@ describe("ProductionQueueList — Scrap affordance (#781)", () => {
     // Let the mount effects settle so we are asserting on the final render.
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect(screen.queryByRole("button", { name: /scrap/i })).toBeNull();
+  });
+});
+
+describe("ProductionQueueList — Split/Complete/QC affordances (#858)", () => {
+  // These modals were mounted on AdminProduction but nothing ever opened
+  // them; the row affordances are the openers.
+
+  it.each(["draft", "scheduled", "released"])(
+    "renders a Split button for a %s order with quantity > 1 and calls onSplit",
+    async (status) => {
+      const onSplit = vi.fn();
+      const order = makeOrder({ status, quantity_ordered: 10 });
+      renderList([order], vi.fn(), { onSplit });
+
+      const btn = await screen.findByRole("button", { name: /split/i });
+      fireEvent.click(btn);
+      expect(onSplit).toHaveBeenCalledWith(order);
+    },
+  );
+
+  it("does NOT render Split for a single-unit order", async () => {
+    renderList(
+      [makeOrder({ status: "draft", quantity_ordered: 1 })],
+      vi.fn(),
+      { onSplit: vi.fn() },
+    );
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /split/i })).toBeNull();
+  });
+
+  it("renders a Complete button for an in_progress order and calls onComplete", async () => {
+    const onComplete = vi.fn();
+    const order = makeOrder({ status: "in_progress" });
+    renderList([order], vi.fn(), { onComplete });
+
+    const btn = await screen.findByRole("button", { name: /^complete$/i });
+    fireEvent.click(btn);
+    expect(onComplete).toHaveBeenCalledWith(order);
+  });
+
+  it("renders a QC button for a qc_hold order and calls onQC", async () => {
+    const onQC = vi.fn();
+    const order = makeOrder({ status: "qc_hold" });
+    renderList([order], vi.fn(), { onQC });
+
+    const btn = await screen.findByRole("button", { name: /^qc$/i });
+    fireEvent.click(btn);
+    expect(onQC).toHaveBeenCalledWith(order);
+  });
+
+  it("renders a QC button when the backend guard is_ready_for_qc is true", async () => {
+    const onQC = vi.fn();
+    const order = makeOrder({ status: "complete", is_ready_for_qc: true });
+    renderList([order], vi.fn(), { onQC });
+
+    expect(
+      await screen.findByRole("button", { name: /^qc$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render QC for a completed order without the guard", async () => {
+    renderList(
+      [makeOrder({ status: "complete", is_ready_for_qc: false })],
+      vi.fn(),
+      { onQC: vi.fn() },
+    );
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: /^qc$/i })).toBeNull();
   });
 });

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -581,6 +581,18 @@ export default function AdminProduction() {
           setSelectedOrderForScrap(order);
           setShowScrapModal(true);
         }}
+        onSplit={(order) => {
+          setSelectedOrderForSplit(order);
+          setShowSplitModal(true);
+        }}
+        onComplete={(order) => {
+          setSelectedOrderForComplete(order);
+          setShowCompleteModal(true);
+        }}
+        onQC={(order) => {
+          setSelectedOrderForQC(order);
+          setShowQCModal(true);
+        }}
       />
         </>
       )}


### PR DESCRIPTION
## Production audit — slice 3: dead-wired order actions

Third Production slice from the #858 tracker (after #856 scrap flow and #860 QC/completion). All findings adversarially verified against `main` before implementation.

### A2 [critical] — Complete modal recorded the WRONG quantity
`CompleteOrderModal` sent `quantity_completed`/`force_close_short` as **query params** while the endpoint binds `ProductionOrderCompleteRequest` from the **JSON body**. FastAPI silently dropped both, so:
- entering 8 of 10 recorded a **full 10-unit completion** (wrong inventory receipt), and
- close-short was **impossible** — the force flag never arrived, the backend 400'd.

Both fields now travel in the body (same bug class as #856's scrap fix; the endpoint side was already correct and tested).

### A3 [critical] — Split 500'd twice
`POST /{id}/split` read `request.split_quantity`/`request.reason` — fields that **don't exist** on `ProductionOrderSplitRequest` (which carries `splits: List[SplitQuantity]`) — and built the response with kwargs that don't match `ProductionOrderSplitResponse`. Rewritten to the schema contract the UI already sends: first split stays on the parent, each remaining quantity becomes a child order (loops the single-split service), quantities must total the ordered quantity (400 otherwise).

### B2/B5/B6 — the modals nothing could open
`SplitOrderModal`, `CompleteOrderModal`, and `QCInspectionModal` were mounted on AdminProduction with refresh handlers ready — but no control ever set their state. Added status-gated row affordances in `ProductionQueueList`, mirroring the existing #781 Scrap pattern:
- **Split** — `draft`/`scheduled`/`released` with qty > 1 (matches the service guard)
- **Complete** — `in_progress`
- **QC** — `qc_hold` (re-inspection) or the backend-computed `is_ready_for_qc` guard

Gating keeps it to **at most two buttons per row**.

### Safety
Backend change is confined to the split endpoint (schema-contract fix; the service — including its material reservation for the child — is unchanged and was already exercised). The A2 fix is frontend-only; the body path it now uses is the one already covered by `test_complete_with_quantity`/`test_complete_short_with_force_succeeds`.

### Tests
- Backend +4: two-way split (parent keeps first qty, child created), three-way, sum-mismatch 400, single-entry 422. Production suites **331/331**.
- Frontend +8: affordance render + callback per status, plus negative cases (no Split on single-unit, no QC without the guard). Build ✓, **581/581** unit.

Tracker: #858 (remaining: operation-level scrap endpoint, status-vocab consolidation, QC-ship-gate decision, A11 spools_used, production re-skin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)