### PR TITLE
feat(production): route operation-level scrap + cascade preview (#858 B1)

### DIFF
--- a/backend/app/api/v1/endpoints/operation_status.py
+++ b/backend/app/api/v1/endpoints/operation_status.py
@@ -2,7 +2,7 @@
 API endpoints for operation status transitions.
 """
 from typing import List
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.api.v1.deps import get_db, get_current_user
@@ -16,6 +16,7 @@ from app.schemas.operation_status import (
     ProductionOrderSummary,
     NextOperationInfo,
 )
+from app.schemas.production_order import OperationScrapRequest
 from app.schemas.operation_blocking import (
     CanStartResponse,
     OperationBlockingResponse,
@@ -224,6 +225,71 @@ def get_operations(
             materials=op_materials,
         ))
 
+    return result
+
+
+@router.get(
+    "/{po_id}/operations/{op_id}/scrap-cascade",
+    summary="Preview cascading scrap cost for an operation",
+)
+def get_scrap_cascade_preview(
+    po_id: int,
+    op_id: int,
+    quantity: int = Query(..., ge=1, description="Units being scrapped"),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Read-only preview of the material + labor cost cascade of scrapping
+    ``quantity`` units at this operation (materials from this AND all prior
+    operations were consumed to reach it). Backs the live cost preview in
+    ScrapEntryModal and OperationCompletionModal, which previously 404'd —
+    the service existed but was never routed (#858 B1).
+    """
+    from app.services.scrap_service import ScrapError, calculate_scrap_cascade
+
+    try:
+        return calculate_scrap_cascade(db, po_id, op_id, quantity)
+    except ScrapError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+
+@router.post(
+    "/{po_id}/operations/{op_id}/scrap",
+    summary="Record scrap at an operation",
+)
+def record_operation_scrap(
+    po_id: int,
+    op_id: int,
+    request: OperationScrapRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Record operation-level scrap with cascading material accounting:
+    ScrapRecords for materials consumed at this + prior operations, a balanced
+    GL entry (DR Scrap Expense / CR WIP), quantity updates, downstream
+    auto-skip when no good pieces remain, and an optional replacement order.
+
+    Same engine complete_operation uses for its bad-quantity path
+    (process_operation_scrap); this route serves the standalone Scrap button
+    on a running/complete operation, which previously 404'd (#858 B1).
+    """
+    from app.services.scrap_service import ScrapError, process_operation_scrap
+
+    try:
+        result = process_operation_scrap(
+            db,
+            po_id,
+            op_id,
+            quantity_scrapped=request.quantity_scrapped,
+            scrap_reason_code=request.scrap_reason_code,
+            notes=request.notes,
+            create_replacement=request.create_replacement,
+            user_id=current_user.id,
+        )
+    except ScrapError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+    db.commit()
     return result
 
 

--- a/backend/tests/api/v1/test_production_orders.py
+++ b/backend/tests/api/v1/test_production_orders.py
@@ -747,6 +747,149 @@ class TestSplitProductionOrder:
         assert response.status_code == 422
 
 
+class TestOperationScrapEndpoints:
+    """Test the operation-level scrap routes (#858 B1).
+
+    ScrapEntryModal and OperationCompletionModal called
+    /{po}/operations/{op}/scrap and .../scrap-cascade, but neither route
+    existed — the scrap_service functions were built (and covered by
+    tests/services/test_scrap_service.py, incl. GL balance) yet never routed.
+    """
+
+    def _setup(self, db, make_product, make_production_order, make_work_center):
+        """PO in progress with one complete operation (10 good units) that
+        consumed a material, plus an active scrap reason."""
+        from app.models.production_order import (
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial,
+        )
+        from app.models.scrap_reason import ScrapReason
+
+        fg = make_product(item_type="finished_good", standard_cost=Decimal("10.00"))
+        material = make_product(item_type="supply", is_raw_material=True,
+                                standard_cost=Decimal("2.50"))
+        wc = make_work_center()
+        po = make_production_order(
+            product_id=fg.id, status="in_progress", quantity=10,
+        )
+        op = ProductionOrderOperation(
+            production_order_id=po.id,
+            work_center_id=wc.id,
+            sequence=10,
+            operation_code="PRINT",
+            operation_name="Print",
+            status="complete",
+            quantity_completed=Decimal("10"),
+            quantity_scrapped=Decimal("0"),
+            planned_setup_minutes=Decimal("0"),
+            planned_run_minutes=Decimal("30"),
+        )
+        db.add(op)
+        db.flush()
+        db.add(ProductionOrderOperationMaterial(
+            production_order_operation_id=op.id,
+            component_id=material.id,
+            quantity_required=Decimal("10"),
+            quantity_allocated=Decimal("0"),
+            quantity_consumed=Decimal("0"),
+            unit="EA",
+            status="pending",
+        ))
+        reason = db.query(ScrapReason).filter(ScrapReason.code == "op-scrap-test").first()
+        if not reason:
+            db.add(ScrapReason(code="op-scrap-test", name="Op Scrap Test", active=True))
+        db.flush()
+        return po, op
+
+    def test_cascade_preview_returns_costs(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        po, op = self._setup(db, make_product, make_production_order, make_work_center)
+
+        response = client.get(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/scrap-cascade",
+            params={"quantity": 2},
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["production_order_id"] == po.id
+        assert data["operation_id"] == op.id
+        assert data["quantity_scrapped"] == 2
+        # 2 units × (10 EA / 10 ordered) × $2.50 material + labor share
+        assert data["total_cost"] > 0
+        assert len(data["materials_consumed"]) == 1
+
+    def test_scrap_records_and_updates_quantities(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        po, op = self._setup(db, make_product, make_production_order, make_work_center)
+
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/scrap",
+            json={
+                "quantity_scrapped": 2,
+                "scrap_reason_code": "op-scrap-test",
+                "create_replacement": False,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["success"] is True
+        assert data["scrap_records_created"] >= 1
+        assert data["replacement_order"] is None
+
+        db.refresh(po)
+        db.refresh(op)
+        assert int(po.quantity_scrapped) == 2
+        assert int(op.quantity_scrapped) == 2
+
+    def test_scrap_invalid_reason_returns_400(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        po, op = self._setup(db, make_product, make_production_order, make_work_center)
+
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/scrap",
+            json={
+                "quantity_scrapped": 1,
+                "scrap_reason_code": "no-such-reason",
+                "create_replacement": False,
+            },
+        )
+        assert response.status_code == 400
+        assert "scrap reason" in response.json()["detail"].lower()
+
+    def test_scrap_over_available_returns_400(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        po, op = self._setup(db, make_product, make_production_order, make_work_center)
+
+        response = client.post(
+            f"{BASE_URL}/{po.id}/operations/{op.id}/scrap",
+            json={
+                "quantity_scrapped": 11,  # only 10 completed
+                "scrap_reason_code": "op-scrap-test",
+                "create_replacement": False,
+            },
+        )
+        assert response.status_code == 400
+
+    def test_cascade_op_not_in_po_returns_400(
+        self, client, db, make_product, make_production_order, make_work_center
+    ):
+        po, op = self._setup(db, make_product, make_production_order, make_work_center)
+        other_po = make_production_order(
+            product_id=make_product().id, status="in_progress", quantity=5,
+        )
+        db.flush()
+
+        response = client.get(
+            f"{BASE_URL}/{other_po.id}/operations/{op.id}/scrap-cascade",
+            params={"quantity": 1},
+        )
+        assert response.status_code == 400
+
+
 # =============================================================================
 # Cancel -- POST /api/v1/production-orders/{id}/cancel
 # =============================================================================


### PR DESCRIPTION
## Production audit — B1: the last user-reachable broken action

`ScrapEntryModal` (the red **Scrap** button on a running/complete operation in the Operations panel) and `OperationCompletionModal`'s live cost preview call `POST /{po}/operations/{op}/scrap` and `GET .../scrap-cascade` — **neither route existed**. Every operation-level scrap 404'd; the cascade preview silently never loaded.

### Why this is wiring, not new machinery
The engine was already built and battle-tested:
- `scrap_service.process_operation_scrap` — ScrapRecords for materials at this **and all prior** operations, a **balanced GL entry** (DR Scrap Expense 5020 / CR WIP 1210), quantity updates, downstream auto-skip when no good pieces remain, optional replacement PO.
- It's the **same function `complete_operation` already calls** for its bad-quantity path, and it carries 21 service tests including GL-balance verification (`test_scrap_service.py`).
- The modal's POST body is the exact shape of the existing `OperationScrapRequest` schema, and the service's return dict already matches what the modal reads (`total_scrap_cost`, `replacement_order.code`). Everything agreed — the routes were just never added.

### The change
Two routes in `endpoints/operation_status.py` (where the other op-level routes live): the read-only cascade preview (`calculate_scrap_cascade`) and the scrap recorder (`process_operation_scrap`), with `ScrapError.status_code` mapped to `HTTPException`. Commit after success, no service changes, no schema changes, no frontend changes.

### Transactional safety
This intentionally *reuses* the accounting path that's already live via `complete_operation` — no new GL/inventory logic. The endpoint test exercises the real transactional path end-to-end (ScrapRecords created, quantities updated on op + PO).

### Tests (+5)
Cascade preview returns costs · scrap records + updates quantities through the real path · invalid reason 400 · over-available 400 · op/PO mismatch 400. Blast radius (production endpoints + service + scrap service + scheduling) **336/336**; ruff clean.

Tracker: #858 (remaining: status-vocab consolidation B7, QC-ship-gate decision B4, spools_used A11, production re-skin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)