### PR TITLE
feat(intake): assembly intake mode — components + FG BOM in one flow (PR2 of 2)

### DIFF
--- a/frontend/src/components/OperationMaterialModal.jsx
+++ b/frontend/src/components/OperationMaterialModal.jsx
@@ -15,6 +15,13 @@ export default function OperationMaterialModal({
   operation: _operation = null, // Operation context (for title/label)
   defaultTypeFilter = 'all', // Smart default computed by parent from operation name
   material = null,           // If provided, editing existing material
+  // Hide the op-material-only fields (Per, Scrap Factor, flags, Notes) for
+  // consumers whose downstream contract carries only component + quantity +
+  // unit — e.g. Intake's assembly packaging lines (PackagingIn mirrors the
+  // /sku packaging shape, which has no quantity_per/scrap_factor). Keeping
+  // those inputs visible would let the operator set values that get silently
+  // dropped at submit. Default false → existing usages render unchanged.
+  simpleFields = false,
   onSave,
 }) {
   const [loading, setLoading] = useState(false);
@@ -331,6 +338,7 @@ export default function OperationMaterialModal({
                   className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
                 />
               </div>
+              {!simpleFields && (
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">
                   Per
@@ -345,6 +353,7 @@ export default function OperationMaterialModal({
                   <option value="order">Per Order</option>
                 </select>
               </div>
+              )}
             </div>
 
             {/* Unit and Scrap Factor */}
@@ -360,6 +369,7 @@ export default function OperationMaterialModal({
                   className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
                 />
               </div>
+              {!simpleFields && (
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">
                   Scrap Factor %
@@ -374,9 +384,11 @@ export default function OperationMaterialModal({
                   className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
                 />
               </div>
+              )}
             </div>
 
             {/* Options */}
+            {!simpleFields && (
             <div className="flex flex-wrap gap-6">
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
@@ -407,8 +419,10 @@ export default function OperationMaterialModal({
                 <span className="text-xs text-gray-500">(swap this material per variant)</span>
               </label>
             </div>
+            )}
 
             {/* Notes */}
+            {!simpleFields && (
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">
                 Notes
@@ -420,6 +434,7 @@ export default function OperationMaterialModal({
                 placeholder="Optional notes about this material..."
               />
             </div>
+            )}
           </div>
 
           {/* Actions */}

--- a/frontend/src/components/OperationMaterialModal.jsx
+++ b/frontend/src/components/OperationMaterialModal.jsx
@@ -323,8 +323,9 @@ export default function OperationMaterialModal({
               )}
             </div>
 
-            {/* Quantity */}
-            <div className="grid grid-cols-2 gap-4">
+            {/* Quantity — collapses to one column in simple mode so the
+                hidden "Per" field doesn't leave a blank half-row. */}
+            <div className={simpleFields ? "grid grid-cols-1 gap-4" : "grid grid-cols-2 gap-4"}>
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">
                   Quantity *
@@ -356,8 +357,9 @@ export default function OperationMaterialModal({
               )}
             </div>
 
-            {/* Unit and Scrap Factor */}
-            <div className="grid grid-cols-2 gap-4">
+            {/* Unit and Scrap Factor — same single-column collapse in
+                simple mode (Scrap Factor is hidden there). */}
+            <div className={simpleFields ? "grid grid-cols-1 gap-4" : "grid grid-cols-2 gap-4"}>
               <div>
                 <label className="block text-sm font-medium text-gray-300 mb-2">
                   Unit

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -1621,9 +1621,21 @@ export default function AdminIntakeStudio() {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
       }
       // The panel is unusable without plates[] (nothing to build components
-      // from) — treat it like a failed slice and keep the picker for retry.
-      if (!Array.isArray(data.plates) || data.plates.length === 0) {
-        toast.error("Slicing returned no plate data — please retry.");
+      // from), and everything downstream — component rows, {SKU}-Pnn suffixes,
+      // the /assembly payload — keys off plates[].plate_index round-tripped
+      // verbatim. Reject the result unless EVERY plate carries a usable
+      // numeric plate_index; treat it like a failed slice (early return keeps
+      // the mode chooser + held file intact for retry).
+      const platesUsable =
+        Array.isArray(data.plates) &&
+        data.plates.length > 0 &&
+        data.plates.every(
+          (p) =>
+            typeof p?.plate_index === "number" &&
+            Number.isFinite(p.plate_index)
+        );
+      if (!platesUsable) {
+        toast.error("Slicing returned no usable plate data — please retry.");
         return;
       }
       // Work centers for the panel's pickers. Awaited here (not fire-and-

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -9,6 +9,7 @@ import {
 } from "../../config/intakeFlags";
 import SearchableSelect from "../../components/SearchableSelect";
 import OperationMaterialModal from "../../components/OperationMaterialModal";
+import AssemblyIntakePanel from "./intake/AssemblyIntakePanel";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -727,6 +728,20 @@ export default function AdminIntakeStudio() {
   // when no plate is selected yet / the file is single-plate. Sent to /parse as
   // the `plate_index` form field. Inert when the gate is off or plate_count<=1.
   const [selectedPlateIndex, setSelectedPlateIndex] = useState(null);
+  // Assembly intake (unified flow, raw multi-plate only). `intakeMode` is the
+  // operator's choice at the PlatePicker: "plate" (today's single-plate flow,
+  // default) or "assembly" (slice ALL plates in one async job → one component
+  // per plate + a parent assembly BOM via POST /assembly). `assemblyParse`
+  // holds the slice-all parse contract (its plates[] carries every plate's
+  // grams/time/slots); non-null switches Step 1 to the AssemblyIntakePanel.
+  // `assemblyContext` is the /context payload (work centers) fetched for the
+  // panel once the slice-all completes — the parent fetches it (no effects in
+  // this file's components) and the panel offers a retry on failure. All inert
+  // when the gate is off or the file isn't a raw multi-plate .3mf.
+  const [intakeMode, setIntakeMode] = useState("plate");
+  const [assemblyParse, setAssemblyParse] = useState(null);
+  const [assemblyContext, setAssemblyContext] = useState(null);
+  const [assemblyContextBusy, setAssemblyContextBusy] = useState(false);
   const [bomMaterials, setBomMaterials] = useState([]); // /materials/for-bom items
   // Drop-time catalog fetch state for the bare-mesh staging picker. Distinguishes
   // in-flight ("loading") from a resolved-but-unusable catalog ("empty"/"failed")
@@ -803,6 +818,11 @@ export default function AdminIntakeStudio() {
   // so the PlatePicker can drive the /parse once the operator chooses a plate.
   // Cleared by reset and once the parse is dispatched.
   const pendingPlateFileRef = useRef(null);
+  // Monotonic token for the active /context fetch feeding the assembly panel.
+  // A new file or a reset bumps it; a response whose token no longer matches
+  // is stale (it belongs to a prior assembly run) and is dropped so a slow
+  // fetch can't clobber a newer run's work-center list. Mirrors previewRequestIdRef.
+  const assemblyContextRequestIdRef = useRef(0);
 
   // Step 5 — Result
   const [skuResult, setSkuResult] = useState(null);
@@ -916,6 +936,14 @@ export default function AdminIntakeStudio() {
     // so a stale pre-parse/plate-pick can't dispatch a parse for the old file.
     setSelectedPlateIndex(null);
     pendingPlateFileRef.current = null;
+    // Assembly intake: back to the default per-plate mode and drop any prior
+    // run's slice-all result + context so the panel can't render stale plates.
+    setIntakeMode("plate");
+    setAssemblyParse(null);
+    setAssemblyContext(null);
+    setAssemblyContextBusy(false);
+    // Invalidate any /context fetch still in flight for a prior assembly run.
+    assemblyContextRequestIdRef.current += 1;
     // Invalidate any pre-parse still in flight so its response is ignored.
     preparseRequestIdRef.current += 1;
     // Invalidate any catalog fetch still in flight so a stale /for-bom response
@@ -1440,6 +1468,199 @@ export default function AdminIntakeStudio() {
     uploadIntakeFile(pending, null, null, selectedPlateIndex);
   };
 
+  // ---------------------------------------------------------------------------
+  // Assembly intake (unified flow, raw multi-plate only)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * GET /context for the assembly panel's work-center pickers. Fetched by the
+   * parent right after the slice-all completes (this file's components use no
+   * effects, so the panel can't self-fetch on mount) and re-invoked by the
+   * panel's retry button. Non-fatal: a failure leaves assemblyContext null and
+   * the panel renders a retry banner — it must NOT discard a multi-minute
+   * slice-all result. Stale-guarded so a slow response from a prior run can't
+   * clobber a newer run's work-center list.
+   * @returns {Promise<void>}
+   */
+  const loadAssemblyContext = async () => {
+    const requestId = ++assemblyContextRequestIdRef.current;
+    setAssemblyContextBusy(true);
+    try {
+      const data = await api.get("/api/v1/pro/intake/context");
+      if (requestId !== assemblyContextRequestIdRef.current) return;
+      setAssemblyContext(data);
+    } catch {
+      if (requestId !== assemblyContextRequestIdRef.current) return;
+      // Leave null — the panel shows an explicit retry instead of dead pickers.
+      setAssemblyContext(null);
+    } finally {
+      if (requestId === assemblyContextRequestIdRef.current) {
+        setAssemblyContextBusy(false);
+      }
+    }
+  };
+
+  /**
+   * Assembly path upload: slice EVERY plate of a raw multi-plate .3mf in one
+   * async job, then hand the result to the AssemblyIntakePanel. Mirrors
+   * uploadIntakeFile's async submit+poll machinery (same stale-guard token,
+   * same 3.5s interval / 22min cap / #844 timeout guidance / 429 + 404-expired
+   * handling) with two deliberate differences:
+   *   - NO plate_index form field → the worker's --slice 0 default slices ALL
+   *     plates in the one job, and the done contract's plates[] carries every
+   *     plate's grams/time/slots for the component table.
+   *   - NO sync-/parse fallback on submit 404: an old wheel without
+   *     /parse-async also lacks POST /assembly (both ship in the async/assembly
+   *     wheels), so falling back would slice for minutes only to dead-end at
+   *     the create step. Surface the deploy hint instead.
+   * @param {File} f - the held raw multi-plate .3mf.
+   * @returns {Promise<void>}
+   */
+  const uploadAssemblyFile = async (f) => {
+    // Same token as uploadIntakeFile: a new file or a reset bumps
+    // uploadRequestIdRef, marking this slice-all stale so a slow response can't
+    // re-open the assembly panel (or toast) after the operator moved on.
+    const requestId = ++uploadRequestIdRef.current;
+    const isStaleUpload = () => requestId !== uploadRequestIdRef.current;
+    setBusyMode("slicing-all");
+    setUploadBusy(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", f);
+      // Intentionally NO plate_index: omitted → worker default 0 = slice ALL.
+      // Same #844 guidance as the single-plate path — shared by the poll's 504
+      // status and the client-side polling cap below.
+      const sliceTimeoutToast = () =>
+        toast.error(
+          "This file is too large or complex to slice on the server — it timed " +
+            "out. Slice it in Bambu Studio and drop the exported .gcode.3mf (it " +
+            "imports instantly), or intake plates individually.",
+          14000,
+        );
+      const submitRes = await fetch(
+        `${API_URL}/api/v1/pro/intake/parse-async`,
+        {
+          method: "POST",
+          credentials: "include",
+          body: formData,
+        },
+      );
+      let submitBody;
+      try {
+        submitBody = await submitRes.json();
+      } catch {
+        submitBody = {};
+      }
+      if (isStaleUpload()) return;
+      if (submitRes.status === 404) {
+        // Old wheel without the async routes → it lacks POST /assembly too.
+        // Don't fall back to a multi-minute sync slice-all that would dead-end
+        // at the create step; the picker stays intact (early return) so the
+        // operator can intake per plate or retry after the deploy.
+        toast.error(
+          "Assembly intake needs the updated backend — deploy the latest wheel.",
+          10000,
+        );
+        return;
+      }
+      if (submitRes.status === 429) {
+        // Worker busy — the slice queue is full. Retryable: picker state stays
+        // intact so the operator can simply try again.
+        toast.error(
+          "Slice queue is full — the server is busy. Try again in a minute.",
+          8000,
+        );
+        return;
+      }
+      if (submitRes.status !== 202 || !submitBody.job_id) {
+        toast.error(submitBody.detail || `Slice failed (${submitRes.status})`);
+        return;
+      }
+      // Poll GET /slice-status/{job_id} to done — identical loop shape to
+      // uploadIntakeFile's pollSliceJob, minus plate_index (slice-all job).
+      const params = new URLSearchParams({ filename: f.name });
+      const statusUrl =
+        `${API_URL}/api/v1/pro/intake/slice-status/` +
+        `${encodeURIComponent(submitBody.job_id)}?${params.toString()}`;
+      const POLL_INTERVAL_MS = 3500;
+      const MAX_POLL_MS = 22 * 60 * 1000;
+      const startedAt = Date.now();
+      let data = null;
+      for (;;) {
+        if (isStaleUpload()) return;
+        const res = await fetch(statusUrl, { credentials: "include" });
+        let body;
+        try {
+          body = await res.json();
+        } catch {
+          body = {};
+        }
+        // Re-check after the await: a new file / reset that landed during the
+        // request must not toast or write state from this dead poll.
+        if (isStaleUpload()) return;
+        if (!res.ok) {
+          if (res.status === 504) {
+            sliceTimeoutToast();
+          } else if (res.status === 404) {
+            toast.error("Slice job expired — please retry.");
+          } else {
+            toast.error(body.detail || `Slice failed (${res.status})`);
+          }
+          return;
+        }
+        if (body.state === "done") {
+          // The done body IS the parse contract plus an extra `state` key.
+          data = { ...body };
+          delete data.state;
+          break;
+        }
+        if (Date.now() - startedAt >= MAX_POLL_MS) {
+          sliceTimeoutToast();
+          return;
+        }
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+      // The panel is unusable without plates[] (nothing to build components
+      // from) — treat it like a failed slice and keep the picker for retry.
+      if (!Array.isArray(data.plates) || data.plates.length === 0) {
+        toast.error("Slicing returned no plate data — please retry.");
+        return;
+      }
+      // Work centers for the panel's pickers. Awaited here (not fire-and-
+      // forget) so the panel opens with them in hand; a failure is non-fatal —
+      // the panel renders a retry banner instead.
+      await loadAssemblyContext();
+      if (isStaleUpload()) return;
+      setAssemblyParse(data);
+      // Slice-all succeeded — now it's safe to clear the held file and picker
+      // state (mirrors uploadIntakeFile's plateIndex success path; a failure
+      // above returned early, leaving the picker intact for retry).
+      pendingPlateFileRef.current = null;
+      setPreparseResult(null);
+      preparseResultRef.current = null;
+      setSelectedPlateIndex(null);
+    } catch (err) {
+      // Suppress a stale upload's error toast (already superseded).
+      if (isStaleUpload()) return;
+      toast.error(err.message || "Upload failed");
+    } finally {
+      // Only the live upload owns the busy spinner (same rule as uploadIntakeFile).
+      if (!isStaleUpload()) {
+        setUploadBusy(false);
+      }
+    }
+  };
+
+  // The operator chose "intake as an assembly" and clicked slice-all. No-op
+  // without a held file (the button only renders while one is held).
+  const continueWithAssembly = () => {
+    const pending = pendingPlateFileRef.current;
+    if (!pending) return;
+    // Keep pendingPlateFileRef held so a slice failure leaves the mode chooser
+    // intact for retry — cleared in uploadAssemblyFile's success path.
+    uploadAssemblyFile(pending);
+  };
+
   const sliceAndContinue = () => {
     if (!pendingMesh) return;
     if (unifiedFlow) {
@@ -1912,6 +2133,14 @@ export default function AdminIntakeStudio() {
     // Multi-plate: clear the chosen plate and any file held for the picker.
     setSelectedPlateIndex(null);
     pendingPlateFileRef.current = null;
+    // Assembly intake: default mode + drop any slice-all result/context, and
+    // invalidate an in-flight /context fetch (same pattern as
+    // resetDerivedStateForNewFile).
+    setIntakeMode("plate");
+    setAssemblyParse(null);
+    setAssemblyContext(null);
+    setAssemblyContextBusy(false);
+    assemblyContextRequestIdRef.current += 1;
     setMaterialsError(null);
     setBomMaterialsLoading(false);
     setBomMaterialsError(null);
@@ -2025,12 +2254,35 @@ export default function AdminIntakeStudio() {
       {/* ------------------------------------------------------------------ */}
       {step === 1 && (
         <div className="bg-gray-900 border border-gray-800 rounded-lg p-6">
-          <StepHeader step={1} total={5} label="Upload file" />
+          {/* Assembly intake is a 2-step branch (slice all → create), not the
+              5-step single-plate wizard — reflect that in the header so the
+              progress bar doesn't promise steps that never come. */}
+          {unifiedFlow && assemblyParse ? (
+            <StepHeader step={2} total={2} label="Create assembly" />
+          ) : unifiedFlow &&
+            intakeMode === "assembly" &&
+            isMultiPlatePending ? (
+            <StepHeader step={1} total={2} label="Slice all plates" />
+          ) : (
+            <StepHeader step={1} total={5} label="Upload file" />
+          )}
 
           {uploadBusy ? (
             <div className="flex flex-col items-center justify-center py-16 gap-4">
               <Spinner />
-              {busyMode === "slicing" ? (
+              {busyMode === "slicing-all" ? (
+                <>
+                  <p className="text-gray-400">
+                    {preparseResult?.plate_count
+                      ? `Slicing all ${preparseResult.plate_count} plates — this can take several minutes.`
+                      : "Slicing all plates — this can take several minutes."}
+                  </p>
+                  <p className="text-gray-600 text-sm">
+                    Every plate is sliced in one server job; the assembly form
+                    opens when it finishes.
+                  </p>
+                </>
+              ) : busyMode === "slicing" ? (
                 <>
                   <p className="text-gray-400">Slicing your model…</p>
                   <p className="text-gray-600 text-sm">
@@ -2285,6 +2537,30 @@ export default function AdminIntakeStudio() {
                 </button>
               </div>
             </div>
+          ) : unifiedFlow && assemblyParse ? (
+            /* Assembly intake: the slice-all job finished — the panel builds
+               one component per sliced plate + the parent assembly form and
+               POSTs /assembly. Fresh-mounted per run (assemblyParse is nulled
+               by every reset/new-file path), so its useState initializers can
+               safely seed from the parse contract. */
+            <AssemblyIntakePanel
+              parse={assemblyParse}
+              context={assemblyContext}
+              contextLoading={assemblyContextBusy}
+              onRetryContext={loadAssemblyContext}
+              materials={bomMaterials}
+              materialsLoading={bomMaterialsLoading}
+              materialsError={bomMaterialsError}
+              onRetryMaterials={() => {
+                // Same retry mechanics as the bare-mesh staging banner: bump
+                // the token so a stale in-flight response is ignored once the
+                // retry's response arrives.
+                bomMaterialsRequestIdRef.current += 1;
+                setBomMaterials([]);
+                loadBomMaterials();
+              }}
+              onStartOver={handleReset}
+            />
           ) : isMultiPlatePending ? (
             /* Multi-plate file: pick a single plate before parsing/slicing.
                No PreParsePanel here — its top-level slot_count/multi-material
@@ -2293,32 +2569,111 @@ export default function AdminIntakeStudio() {
                above the chooser would misrepresent the default plate's slots as
                file-wide. The PlatePicker shows the correct per-plate detail. */
             <div className="space-y-5">
-              <PlatePicker
-                plates={preparseResult?.plates || []}
-                isRaw={isRawPreparse}
-                selectedPlateIndex={selectedPlateIndex}
-                onSelect={setSelectedPlateIndex}
-              />
-              <div className="flex items-center gap-3 pt-1">
-                <button
-                  onClick={continueWithSelectedPlate}
-                  disabled={selectedPlateIndex == null}
-                  className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-6 py-2 rounded-lg font-medium transition-colors"
-                >
-                  {isRawPreparse ? "Slice & continue" : "Continue"}
-                </button>
-                {selectedPlateIndex == null && (
-                  <span className="text-gray-500 text-sm">
-                    Pick a plate to continue
-                  </span>
-                )}
-                <button
-                  onClick={handleReset}
-                  className="border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
-                >
-                  Choose a different file
-                </button>
-              </div>
+              {/* Assembly mode choice — RAW multi-plate only. A sliced
+                  .gcode.3mf stays on the untouched single-plate path (assembly
+                  needs the async slice-all pipeline, which only raw files
+                  take), and single-plate files never reach this branch. */}
+              {isRawPreparse && (
+                <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+                  <h2 className="text-base font-semibold text-white mb-3">
+                    How do you want to intake this file?
+                  </h2>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setIntakeMode("plate")}
+                      aria-pressed={intakeMode === "plate"}
+                      className={`text-left rounded-lg border px-4 py-3 transition-colors ${
+                        intakeMode === "plate"
+                          ? "border-blue-500 bg-blue-500/10"
+                          : "border-gray-700 bg-gray-800 hover:border-gray-600"
+                      }`}
+                    >
+                      <span className="block text-white font-medium">
+                        Intake one plate
+                      </span>
+                      <span className="block text-gray-500 text-sm mt-1">
+                        Pick a single plate below — it&apos;s sliced and becomes
+                        one SKU.
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setIntakeMode("assembly")}
+                      aria-pressed={intakeMode === "assembly"}
+                      className={`text-left rounded-lg border px-4 py-3 transition-colors ${
+                        intakeMode === "assembly"
+                          ? "border-blue-500 bg-blue-500/10"
+                          : "border-gray-700 bg-gray-800 hover:border-gray-600"
+                      }`}
+                    >
+                      <span className="block text-white font-medium">
+                        Intake whole model as an assembly (
+                        {preparseResult?.plate_count} plates)
+                      </span>
+                      <span className="block text-gray-500 text-sm mt-1">
+                        Slice every plate, create one component per plate plus
+                        an assembly BOM — all in one flow.
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              )}
+              {isRawPreparse && intakeMode === "assembly" ? (
+                /* Assembly path: no per-plate picker — every plate is sliced
+                   in ONE async job (no plate_index → worker --slice 0). */
+                <>
+                  <p className="text-gray-400 text-sm">
+                    All {preparseResult?.plate_count} plates will be sliced in
+                    one job using the file&apos;s embedded settings. You&apos;ll
+                    then pick a material and work center, review the per-plate
+                    components, and create everything in one step.
+                  </p>
+                  <div className="flex items-center gap-3 pt-1">
+                    <button
+                      onClick={continueWithAssembly}
+                      className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg font-medium transition-colors"
+                    >
+                      Slice all {preparseResult?.plate_count} plates
+                    </button>
+                    <button
+                      onClick={handleReset}
+                      className="border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+                    >
+                      Choose a different file
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <PlatePicker
+                    plates={preparseResult?.plates || []}
+                    isRaw={isRawPreparse}
+                    selectedPlateIndex={selectedPlateIndex}
+                    onSelect={setSelectedPlateIndex}
+                  />
+                  <div className="flex items-center gap-3 pt-1">
+                    <button
+                      onClick={continueWithSelectedPlate}
+                      disabled={selectedPlateIndex == null}
+                      className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-6 py-2 rounded-lg font-medium transition-colors"
+                    >
+                      {isRawPreparse ? "Slice & continue" : "Continue"}
+                    </button>
+                    {selectedPlateIndex == null && (
+                      <span className="text-gray-500 text-sm">
+                        Pick a plate to continue
+                      </span>
+                    )}
+                    <button
+                      onClick={handleReset}
+                      className="border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+                    >
+                      Choose a different file
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           ) : (
             <div

--- a/frontend/src/pages/admin/intake/AssemblyIntakePanel.jsx
+++ b/frontend/src/pages/admin/intake/AssemblyIntakePanel.jsx
@@ -235,6 +235,19 @@ export default function AssemblyIntakePanel({
     componentRows.every(
       (r) => r.name.trim() && Number(r.quantity) >= 0.001
     );
+  // Labor minutes: empty means 0 (fine), but a typed/pasted negative or
+  // non-numeric value must not reach handleCreate — the inputs' min="0" only
+  // constrains the spinner, not keyboard input. Only gated when an assembly
+  // work center is chosen (without one the inputs are disabled and the
+  // payload omits the labor fields entirely).
+  const minutesValid = (v) => {
+    if (v === "") return true;
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 0;
+  };
+  const assemblyLaborValid =
+    !assemblyWorkCenterId ||
+    (minutesValid(assemblyRunMinutes) && minutesValid(assemblySetupMinutes));
   const canCreate =
     !createBusy &&
     context != null &&
@@ -242,6 +255,7 @@ export default function AssemblyIntakePanel({
     printWorkCenterId !== "" &&
     assemblyName.trim() !== "" &&
     Number(actualPrice) > 0 &&
+    assemblyLaborValid &&
     rowsValid;
 
   // ---------------------------------------------------------------------------
@@ -286,7 +300,7 @@ export default function AssemblyIntakePanel({
   const handleCreate = async () => {
     if (!canCreate) {
       toast.error(
-        "Pick a material, a print work center, a selling price, and give every component a name and a quantity of at least 0.001."
+        "Pick a material, a print work center, a selling price, and give every component a name and a quantity of at least 0.001. Assembly minutes must be zero or more."
       );
       return;
     }
@@ -306,6 +320,12 @@ export default function AssemblyIntakePanel({
             quantity_per: m.quantity_per || "unit",
             scrap_factor: Number(m.scrap_factor) || 0,
           })),
+          // PackagingIn intentionally mirrors the existing /sku packaging
+          // shape: component + quantity + unit ONLY (no quantity_per /
+          // scrap_factor — packaging is a plain BOM line, not an op material).
+          // The modal is opened with simpleFields for packaging, so those
+          // inputs are hidden and the operator can never set values this
+          // mapper would drop.
           packaging: packagingLines.map((m) => ({
             component_product_id: m.component_id,
             quantity: Number(m.quantity) || 0,
@@ -884,7 +904,11 @@ export default function AssemblyIntakePanel({
       <div className="flex justify-between">
         <button
           onClick={onStartOver}
-          className="border border-gray-700 text-gray-500 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+          // Disabled while the (non-idempotent) create POST is pending — a
+          // reset mid-flight would blank the panel while the backend may still
+          // create the products, leaving the operator unsure what happened.
+          disabled={createBusy}
+          className="border border-gray-700 text-gray-500 hover:bg-gray-800 hover:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-lg transition-colors"
         >
           Start over
         </button>
@@ -901,12 +925,17 @@ export default function AssemblyIntakePanel({
         </button>
       </div>
 
-      {/* Shared add-material modal (same component Step 4's finishing ops use) */}
+      {/* Shared add-material modal (same component Step 4's finishing ops use).
+          Packaging lines only carry component + quantity + unit (PackagingIn
+          mirrors /sku's packaging shape), so simpleFields hides the Per/Scrap/
+          flags/Notes inputs for them — glue lines are OpMaterialIn and keep
+          the full form. */}
       <OperationMaterialModal
         isOpen={modalTarget !== null}
         operationId={null}
         material={null}
         defaultTypeFilter={modalTarget === "packaging" ? "packaging" : "all"}
+        simpleFields={modalTarget === "packaging"}
         onClose={() => setModalTarget(null)}
         onSave={(mat) => {
           if (mat) {

--- a/frontend/src/pages/admin/intake/AssemblyIntakePanel.jsx
+++ b/frontend/src/pages/admin/intake/AssemblyIntakePanel.jsx
@@ -1,0 +1,924 @@
+import { useState } from "react";
+import { useApi } from "../../../hooks/useApi";
+import { useToast } from "../../../components/Toast";
+import SearchableSelect from "../../../components/SearchableSelect";
+import OperationMaterialModal from "../../../components/OperationMaterialModal";
+
+// ---------------------------------------------------------------------------
+// Assembly Intake panel (unified flow, raw multi-plate .3mf only).
+//
+// Rendered by AdminIntakeStudio AFTER a slice-ALL-plates async job completes
+// (POST /parse-async with NO plate_index → worker --slice 0 → every plate
+// sliced in one job). The parse contract's plates[] — one entry per sliced
+// plate with plate_index (1-based), total_weight_g, print_time_seconds and a
+// full per-plate slots[] breakdown — drives the component table below.
+//
+// One submit → POST /api/v1/pro/intake/assembly creates N component products
+// (one per plate, each with its own material BOM + print routing op) plus the
+// parent finished-good assembly BOM (components + optional glue/packaging
+// lines + optional assembly routing op) in a single transaction. The endpoint
+// ships in the PR1 wheel; a 404 here means the backend wheel predates it, so
+// we surface a deploy hint instead of a generic failure.
+// ---------------------------------------------------------------------------
+
+/** Mirror of AdminIntakeStudio's secondsToHms (not exported there — a page
+ * module; importing it here would create a page↔panel import cycle). */
+function secondsToHms(s) {
+  if (!s) return "0m";
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0 && m > 0) return `${h}h ${m}m`;
+  if (h > 0) return `${h}h`;
+  return `${m}m`;
+}
+
+/** Mirror of AdminIntakeStudio's buildSuggestedSku — same INTAKE- convention
+ * so assembly SKUs sort next to single-plate intake SKUs. */
+const buildSuggestedSku = (name) =>
+  `INTAKE-${(name || "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+
+/**
+ * Component SKU preview: {PARENT-SKU}-P{nn} (nn = 1-based plate_index, zero
+ * padded to 2). Derived live from the assembly SKU field so the table always
+ * previews exactly what will be POSTed.
+ * @param {string} parentSku - the assembly SKU (may be empty while typing).
+ * @param {number} plateIndex - the plate's 1-based plate_index.
+ * @returns {string} the derived component SKU ("" when no parent SKU yet).
+ */
+const componentSkuFor = (parentSku, plateIndex) => {
+  const base = (parentSku || "").trim().toUpperCase();
+  if (!base) return "";
+  return `${base}-P${String(plateIndex).padStart(2, "0")}`;
+};
+
+/**
+ * One catalog material pick for the WHOLE assembly (type → color, sourced
+ * from /materials/for-bom). Mirrors AdminIntakeStudio's BareMeshMaterialPicker
+ * (not exported there — page module, and importing the page here would be a
+ * cycle). A raw .3mf slices with its EMBEDDED settings, so this pick does not
+ * drive the slice — it only prices the filament: the chosen purchasable item
+ * becomes spool_product_id on every slot of every plate component.
+ * @param {object} props
+ * @param {Array<object>} props.items - the purchasable catalog (/materials/for-bom).
+ * @param {object|null} props.chosen - the currently-chosen catalog item, or null.
+ * @param {(item: object) => void} props.onPick - called with the picked catalog item.
+ * @returns {JSX.Element}
+ */
+function AssemblyMaterialPicker({ items, chosen, onPick }) {
+  // Distinct material types present in the catalog.
+  const typeOptions = [];
+  const seenTypes = new Set();
+  for (const it of items) {
+    if (it.material_code && !seenTypes.has(it.material_code)) {
+      seenTypes.add(it.material_code);
+      typeOptions.push({ id: it.material_code, name: it.material_code });
+    }
+  }
+
+  const selectedType = chosen?.material_code || "";
+
+  // Colors available for the selected type.
+  const colorOptions = items
+    .filter((it) => it.material_code === selectedType)
+    .map((it) => ({
+      id: it.id,
+      name: `${it.color_code || it.name} — $${Number(it.standard_cost || 0).toFixed(2)}/kg`,
+      sku: it.sku,
+      color_hex: it.color_hex,
+    }));
+
+  const pickFirstColorForType = (typeCode) => {
+    const first = items.find((it) => it.material_code === typeCode);
+    if (first) onPick(first);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-1">
+          Material
+        </label>
+        <SearchableSelect
+          options={typeOptions}
+          value={selectedType}
+          onChange={(val) => pickFirstColorForType(val)}
+          placeholder="Select material…"
+          displayKey="name"
+          valueKey="id"
+          formatOption={(opt) => opt.name}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-300 mb-1">
+          Color
+        </label>
+        <SearchableSelect
+          options={colorOptions}
+          value={chosen?.id != null ? String(chosen.id) : ""}
+          onChange={(val) => {
+            const it = items.find((x) => String(x.id) === val);
+            if (it) onPick(it);
+          }}
+          placeholder={selectedType ? "Select color…" : "Pick a material first"}
+          displayKey="name"
+          valueKey="id"
+          formatOption={(opt) => (
+            <span className="flex items-center gap-2">
+              <span
+                className="inline-block w-3 h-3 rounded border border-gray-600 flex-shrink-0"
+                style={{ backgroundColor: opt.color_hex || "#888" }}
+              />
+              {opt.name}
+            </span>
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Assembly intake panel: component table (one row per sliced plate) +
+ * assembly form → POST /api/v1/pro/intake/assembly.
+ *
+ * The parent guarantees a fresh mount per slice-all run (assemblyParse is
+ * nulled by every reset/new-file path before it can be set again), so all
+ * plate-derived state is safely seeded in useState initializers — no effects.
+ *
+ * @param {object} props
+ * @param {object} props.parse - the slice-all parse contract (model_name,
+ *   plate_count, plates[] with per-plate slots/grams/time).
+ * @param {object|null} props.context - the /context payload (work_centers…),
+ *   or null when its fetch failed — the panel then offers a retry.
+ * @param {boolean} props.contextLoading - true while /context is being fetched.
+ * @param {() => void} props.onRetryContext - re-fetch /context.
+ * @param {Array<object>} props.materials - the purchasable catalog
+ *   (/materials/for-bom items) backing the single material pick.
+ * @param {boolean} props.materialsLoading - true while the catalog fetch is in flight.
+ * @param {string|null} props.materialsError - "empty" | "failed" | null.
+ * @param {() => void} props.onRetryMaterials - re-fetch the catalog.
+ * @param {() => void} props.onStartOver - full wizard reset (back to the drop zone).
+ * @returns {JSX.Element}
+ */
+export default function AssemblyIntakePanel({
+  parse,
+  context,
+  contextLoading,
+  onRetryContext,
+  materials,
+  materialsLoading,
+  materialsError,
+  onRetryMaterials,
+  onStartOver,
+}) {
+  const api = useApi();
+  const toast = useToast();
+
+  const plates = Array.isArray(parse?.plates) ? parse.plates : [];
+  const modelName = parse?.model_name || "model";
+
+  // One editable row per sliced plate. plate_index is read VERBATIM from the
+  // contract (1-based, value-matched server-side — never synthesized from
+  // array position, mirroring the PlatePicker's round-trip rule).
+  const [componentRows, setComponentRows] = useState(() =>
+    plates.map((p) => ({
+      plate_index: p.plate_index,
+      name: `${modelName} — Plate ${p.plate_index}`,
+      quantity: "1",
+    }))
+  );
+
+  // Assembly form state.
+  const [assemblyName, setAssemblyName] = useState(modelName);
+  const [assemblySku, setAssemblySku] = useState(buildSuggestedSku(modelName));
+  // Once the operator edits the SKU by hand it stops tracking the name
+  // (same skuEdited pattern as Step 4's SKU field).
+  const [skuEdited, setSkuEdited] = useState(false);
+  const [actualPrice, setActualPrice] = useState("");
+  const [pickedMaterial, setPickedMaterial] = useState(null);
+  const [printWorkCenterId, setPrintWorkCenterId] = useState("");
+  const [assemblyWorkCenterId, setAssemblyWorkCenterId] = useState("");
+  const [assemblyRunMinutes, setAssemblyRunMinutes] = useState("");
+  const [assemblySetupMinutes, setAssemblySetupMinutes] = useState("");
+  // Optional BOM extras, collected via the same OperationMaterialModal used by
+  // Step 4's finishing-op materials. Each entry is the modal's onSave payload
+  // ({ component_id, quantity, unit, quantity_per, scrap_factor,
+  //    component_sku, component_name }).
+  const [glueMaterials, setGlueMaterials] = useState([]);
+  const [packagingLines, setPackagingLines] = useState([]);
+  // Which list the (single, shared) material modal is adding to.
+  const [modalTarget, setModalTarget] = useState(null); // "glue" | "packaging" | null
+  const [createBusy, setCreateBusy] = useState(false);
+  // The 201 response — set switches the panel to the success view.
+  const [result, setResult] = useState(null);
+
+  const plateByIndex = (plateIndex) =>
+    plates.find((p) => p.plate_index === plateIndex);
+
+  const updateRow = (plateIndex, field, value) => {
+    setComponentRows((prev) =>
+      prev.map((r) =>
+        r.plate_index === plateIndex ? { ...r, [field]: value } : r
+      )
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  // Validation (drives both the disabled state and the pre-submit toasts)
+  // ---------------------------------------------------------------------------
+
+  const rowsValid =
+    componentRows.length > 0 &&
+    componentRows.every(
+      (r) => r.name.trim() && Number(r.quantity) >= 0.001
+    );
+  const canCreate =
+    !createBusy &&
+    context != null &&
+    pickedMaterial != null &&
+    printWorkCenterId !== "" &&
+    assemblyName.trim() !== "" &&
+    Number(actualPrice) > 0 &&
+    rowsValid;
+
+  // ---------------------------------------------------------------------------
+  // Client-side cost estimate — cheap and purely informational. Sums per-plate
+  // material (grams × picked material $/kg) + machine time (hours × print WC
+  // rate), each × the row quantity, plus optional assembly labor. Glue and
+  // packaging are NOT included (no client-side unit costs); the BOM rollup
+  // after creation is authoritative.
+  // ---------------------------------------------------------------------------
+
+  const estimatedCost = (() => {
+    if (!pickedMaterial || !printWorkCenterId || !context) return null;
+    const wcById = new Map(
+      (context.work_centers || []).map((wc) => [String(wc.id), wc])
+    );
+    const printRate =
+      Number(wcById.get(String(printWorkCenterId))?.total_rate_per_hour) || 0;
+    const costPerKg = Number(pickedMaterial.standard_cost) || 0;
+    let total = 0;
+    for (const row of componentRows) {
+      const plate = plateByIndex(row.plate_index);
+      const qty = Number(row.quantity) || 0;
+      const grams = Number(plate?.total_weight_g) || 0;
+      const hours = (Number(plate?.print_time_seconds) || 0) / 3600;
+      total += qty * ((grams * costPerKg) / 1000 + hours * printRate);
+    }
+    if (assemblyWorkCenterId) {
+      const aRate =
+        Number(wcById.get(String(assemblyWorkCenterId))?.total_rate_per_hour) ||
+        0;
+      const minutes =
+        (Number(assemblyRunMinutes) || 0) + (Number(assemblySetupMinutes) || 0);
+      total += (minutes / 60) * aRate;
+    }
+    return total;
+  })();
+
+  // ---------------------------------------------------------------------------
+  // Create → POST /assembly
+  // ---------------------------------------------------------------------------
+
+  const handleCreate = async () => {
+    if (!canCreate) {
+      toast.error(
+        "Pick a material, a print work center, a selling price, and give every component a name and a quantity of at least 0.001."
+      );
+      return;
+    }
+    setCreateBusy(true);
+    try {
+      const parentSku = assemblySku.trim();
+      const body = {
+        assembly: {
+          name: assemblyName.trim(),
+          sku: parentSku || undefined,
+          actual_price: Number(actualPrice),
+          unit: "EA",
+          glue_materials: glueMaterials.map((m) => ({
+            component_product_id: m.component_id,
+            quantity: Number(m.quantity) || 0,
+            unit: m.unit || "EA",
+            quantity_per: m.quantity_per || "unit",
+            scrap_factor: Number(m.scrap_factor) || 0,
+          })),
+          packaging: packagingLines.map((m) => ({
+            component_product_id: m.component_id,
+            quantity: Number(m.quantity) || 0,
+            unit: m.unit || "EA",
+          })),
+          // Assembly routing op is optional and only meaningful with a work
+          // center — minutes without one are ignored at build time (the inputs
+          // are disabled in the UI until a work center is chosen).
+          ...(assemblyWorkCenterId
+            ? {
+                assembly_work_center_id: Number(assemblyWorkCenterId),
+                assembly_run_time_minutes: Number(assemblyRunMinutes) || 0,
+                assembly_setup_minutes: Number(assemblySetupMinutes) || 0,
+              }
+            : {}),
+        },
+        components: componentRows.map((row) => {
+          const plate = plateByIndex(row.plate_index);
+          // Full per-plate slot fan-out: the contract's plates[] carries each
+          // plate's real slot breakdown (slot_id/filament_type/color_hex/
+          // used_g), so every component gets its true multi-material grams —
+          // the ONE picked purchasable material is applied as spool_product_id
+          // on every slot (single material pick for the whole assembly).
+          // Defensive fallback: a plate whose slots[] is somehow empty fans its
+          // total grams into one synthetic slot so its material cost isn't
+          // silently dropped.
+          const plateSlots =
+            Array.isArray(plate?.slots) && plate.slots.length > 0
+              ? plate.slots
+              : [
+                  {
+                    slot_id: 0,
+                    filament_type: null,
+                    color_hex: null,
+                    used_g: plate?.total_weight_g ?? 0,
+                  },
+                ];
+          return {
+            plate_index: row.plate_index,
+            name: row.name.trim(),
+            sku: componentSkuFor(parentSku, row.plate_index) || undefined,
+            quantity: Number(row.quantity),
+            print_work_center_id: Number(printWorkCenterId),
+            print_time_seconds: plate?.print_time_seconds ?? 0,
+            parts_on_plate: 1,
+            // Same SkuSlotMap shape the single-plate /sku payload builds
+            // (AdminIntakeStudio buildSlotsPayload).
+            slots: plateSlots.map((s) => ({
+              slot_id: s.slot_id,
+              filament_type: s.filament_type,
+              color_hex: s.color_hex,
+              used_g: s.used_g,
+              spool_product_id: pickedMaterial.id,
+            })),
+          };
+        }),
+      };
+      const data = await api.post("/api/v1/pro/intake/assembly", body);
+      setResult(data);
+      toast.success(`Assembly ${data.assembly?.sku || ""} created`);
+    } catch (err) {
+      // Deploy-ordering: /assembly ships in the PR1 wheel. A 404 means this
+      // backend predates it — tell the operator what to deploy, not "failed".
+      if (err?.status === 404) {
+        toast.error(
+          "Assembly intake needs the updated backend — deploy the latest wheel.",
+          10000
+        );
+      } else {
+        toast.error(err.message || "Assembly creation failed");
+      }
+    } finally {
+      setCreateBusy(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Success view
+  // ---------------------------------------------------------------------------
+
+  if (result) {
+    return (
+      <div className="space-y-6">
+        <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-4 flex items-center gap-3">
+          <svg
+            className="w-6 h-6 text-green-400 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div>
+            <p className="text-green-400 font-semibold">Assembly created</p>
+            <p className="text-gray-300 text-sm">
+              {result.components?.length ?? 0} component
+              {(result.components?.length ?? 0) === 1 ? "" : "s"} + 1 assembly
+              BOM
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-gray-800/50 rounded-lg p-4 space-y-2">
+          <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+            Assembly
+          </h3>
+          <p className="text-white font-mono text-lg">
+            {result.assembly?.sku}
+          </p>
+          <p className="text-gray-400 text-sm">
+            BOM #{result.assembly?.bom_id} — open the BOM editor to review the
+            cost rollup or adjust component lines.
+          </p>
+        </div>
+
+        <div className="bg-gray-800/50 rounded-lg p-4">
+          <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            Components
+          </h3>
+          <div className="space-y-1">
+            {(result.components || []).map((c) => (
+              <div
+                key={c.plate_index}
+                className="flex items-center justify-between text-sm bg-gray-800 rounded px-3 py-1.5"
+              >
+                <span className="text-gray-400">Plate {c.plate_index}</span>
+                <span className="text-white font-mono">{c.sku}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <button
+            onClick={onStartOver}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            Intake another file
+          </button>
+          <a
+            href="/admin/bom"
+            className="border border-gray-700 text-gray-300 hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors"
+          >
+            Open BOM editor
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Form view
+  // ---------------------------------------------------------------------------
+
+  const totalGrams = plates.reduce(
+    (sum, p) => sum + (Number(p.total_weight_g) || 0),
+    0
+  );
+  const totalSeconds = plates.reduce(
+    (sum, p) => sum + (Number(p.print_time_seconds) || 0),
+    0
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Slice-all summary chips */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="px-3 py-1 rounded-full bg-blue-500/20 border border-blue-500/40 text-sm text-blue-300">
+          Assembly intake
+        </span>
+        <span className="px-3 py-1 rounded-full bg-gray-800 border border-gray-700 text-sm text-gray-300">
+          {plates.length} plate{plates.length === 1 ? "" : "s"} sliced
+        </span>
+        <span className="px-3 py-1 rounded-full bg-gray-800 border border-gray-700 text-sm text-gray-300">
+          {totalGrams.toFixed(1)} g total
+        </span>
+        <span className="px-3 py-1 rounded-full bg-gray-800 border border-gray-700 text-sm text-gray-300">
+          {secondsToHms(totalSeconds)} total
+        </span>
+        <span className="text-gray-400 text-sm ml-1 truncate">{modelName}</span>
+      </div>
+
+      {/* Material pick — ONE purchasable material for the whole assembly */}
+      <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+        <h2 className="text-base font-semibold text-white mb-1">Material</h2>
+        <p className="text-gray-500 text-sm mb-4">
+          The plates were sliced with the file&apos;s embedded settings — this
+          one pick prices the filament and becomes the material BOM line on
+          every component.
+        </p>
+        {materials.length === 0 ? (
+          materialsLoading ? (
+            <div className="text-gray-400 text-sm bg-gray-800/50 border border-gray-700 rounded-lg p-3 flex items-center gap-3">
+              <span className="inline-block w-3 h-3 rounded-full border-2 border-gray-500 border-t-transparent animate-spin" />
+              <span>Loading your purchasable materials…</span>
+            </div>
+          ) : (
+            <div className="text-yellow-400/90 text-sm bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3 flex items-center gap-3">
+              <span>
+                {materialsError === "failed"
+                  ? "Couldn't load your purchasable materials catalog. Check your connection and retry."
+                  : "No purchasable materials in your catalog. Add materials, then retry."}
+              </span>
+              <button
+                onClick={onRetryMaterials}
+                className="ml-auto border border-yellow-500/40 text-yellow-300 hover:bg-yellow-500/10 px-3 py-1 rounded-lg text-xs transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          )
+        ) : (
+          <AssemblyMaterialPicker
+            items={materials}
+            chosen={pickedMaterial}
+            onPick={setPickedMaterial}
+          />
+        )}
+      </div>
+
+      {/* Component table — one row per sliced plate */}
+      <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+        <h2 className="text-base font-semibold text-white mb-1">
+          Components ({componentRows.length})
+        </h2>
+        <p className="text-gray-500 text-sm mb-4">
+          One printed component per plate. Grams and print time come from the
+          slice; quantity is how many of that plate go into one assembly.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-800/50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 uppercase">
+                  Plate
+                </th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 uppercase">
+                  Name
+                </th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 uppercase">
+                  SKU
+                </th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-400 uppercase">
+                  Qty
+                </th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-400 uppercase">
+                  Grams
+                </th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-gray-400 uppercase">
+                  Print time
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {componentRows.map((row) => {
+                const plate = plateByIndex(row.plate_index);
+                const skuPreview = componentSkuFor(
+                  assemblySku,
+                  row.plate_index
+                );
+                return (
+                  <tr key={row.plate_index} className="hover:bg-gray-800/30">
+                    <td className="px-3 py-2 text-gray-300 whitespace-nowrap">
+                      Plate {row.plate_index}
+                    </td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="text"
+                        value={row.name}
+                        onChange={(e) =>
+                          updateRow(row.plate_index, "name", e.target.value)
+                        }
+                        className="w-full min-w-48 bg-gray-800 border border-gray-700 rounded-lg px-2 py-1 text-white text-sm focus:outline-none focus:border-blue-500"
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-gray-400 font-mono text-xs whitespace-nowrap">
+                      {skuPreview || "(set assembly SKU)"}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <input
+                        type="number"
+                        min="0.001"
+                        step="any"
+                        value={row.quantity}
+                        onChange={(e) =>
+                          updateRow(row.plate_index, "quantity", e.target.value)
+                        }
+                        className="w-20 bg-gray-800 border border-gray-700 rounded-lg px-2 py-1 text-white text-sm text-right focus:outline-none focus:border-blue-500"
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-300 whitespace-nowrap">
+                      {plate?.total_weight_g != null
+                        ? Number(plate.total_weight_g).toFixed(1)
+                        : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-300 whitespace-nowrap">
+                      {plate?.print_time_seconds != null
+                        ? secondsToHms(plate.print_time_seconds)
+                        : "—"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Assembly form */}
+      <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 space-y-4">
+        <h2 className="text-base font-semibold text-white">Assembly</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">Name</label>
+            <input
+              type="text"
+              value={assemblyName}
+              onChange={(e) => {
+                setAssemblyName(e.target.value);
+                // SKU tracks the name until the operator edits it directly
+                // (same behavior as Step 4's suggested SKU).
+                if (!skuEdited) {
+                  setAssemblySku(buildSuggestedSku(e.target.value));
+                }
+              }}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">
+              SKU code
+            </label>
+            <input
+              type="text"
+              value={assemblySku}
+              onChange={(e) => {
+                setAssemblySku(e.target.value);
+                setSkuEdited(true);
+              }}
+              placeholder="INTAKE-MY-ASSEMBLY"
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+            />
+            <p className="text-gray-600 text-xs mt-1">
+              Component SKUs derive from this: {"{SKU}"}-P01, {"{SKU}"}-P02, …
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">
+              Selling price ($)
+            </label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={actualPrice}
+              onChange={(e) => setActualPrice(e.target.value)}
+              placeholder="0.00"
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+            />
+          </div>
+        </div>
+
+        {/* Work centers — one print work center applied to ALL components */}
+        {context == null ? (
+          <div className="text-yellow-400/90 text-sm bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3 flex items-center gap-3">
+            <span>
+              {contextLoading
+                ? "Loading work centers…"
+                : "Couldn't load work centers. Check your connection and retry."}
+            </span>
+            {!contextLoading && (
+              <button
+                onClick={onRetryContext}
+                className="ml-auto border border-yellow-500/40 text-yellow-300 hover:bg-yellow-500/10 px-3 py-1 rounded-lg text-xs transition-colors"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">
+                Print work center
+                <span className="text-gray-600 font-normal ml-1">
+                  (applied to every component)
+                </span>
+              </label>
+              <SearchableSelect
+                options={(context.work_centers || [])
+                  .filter((wc) => wc.is_active)
+                  .map((wc) => ({
+                    id: wc.id,
+                    name: `${wc.name} (${wc.code}) — $${wc.total_rate_per_hour}/hr`,
+                    sku: wc.code,
+                  }))}
+                value={printWorkCenterId}
+                onChange={setPrintWorkCenterId}
+                placeholder="Select work center…"
+                displayKey="name"
+                valueKey="id"
+                formatOption={(opt) => opt.name}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">
+                Assembly work center
+                <span className="text-gray-600 font-normal ml-1">
+                  (optional)
+                </span>
+                {assemblyWorkCenterId && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAssemblyWorkCenterId("");
+                      setAssemblyRunMinutes("");
+                      setAssemblySetupMinutes("");
+                    }}
+                    className="ml-2 text-xs text-blue-400 hover:text-blue-300"
+                  >
+                    Clear
+                  </button>
+                )}
+              </label>
+              <SearchableSelect
+                options={(context.work_centers || [])
+                  .filter((wc) => wc.is_active)
+                  .map((wc) => ({
+                    id: wc.id,
+                    name: `${wc.name} (${wc.code}) — $${wc.total_rate_per_hour}/hr`,
+                    sku: wc.code,
+                  }))}
+                value={assemblyWorkCenterId}
+                onChange={setAssemblyWorkCenterId}
+                placeholder="No assembly operation…"
+                displayKey="name"
+                valueKey="id"
+                formatOption={(opt) => opt.name}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">
+                Assembly run time (min)
+              </label>
+              <input
+                type="number"
+                min="0"
+                value={assemblyRunMinutes}
+                onChange={(e) => setAssemblyRunMinutes(e.target.value)}
+                disabled={!assemblyWorkCenterId}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">
+                Assembly setup (min)
+              </label>
+              <input
+                type="number"
+                min="0"
+                value={assemblySetupMinutes}
+                onChange={(e) => setAssemblySetupMinutes(e.target.value)}
+                disabled={!assemblyWorkCenterId}
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500 disabled:opacity-50"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Glue / consumables + packaging — optional BOM lines on the assembly */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {[
+            {
+              key: "glue",
+              label: "Glue / consumables",
+              lines: glueMaterials,
+              setLines: setGlueMaterials,
+            },
+            {
+              key: "packaging",
+              label: "Packaging",
+              lines: packagingLines,
+              setLines: setPackagingLines,
+            },
+          ].map(({ key, label, lines, setLines }) => (
+            <div key={key} className="border border-gray-700 rounded-lg p-3">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs text-gray-500">
+                  {label}{" "}
+                  <span className="text-gray-600 font-normal">(optional)</span>
+                </span>
+                <button
+                  onClick={() => setModalTarget(key)}
+                  className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 transition-colors"
+                >
+                  <svg
+                    className="w-3 h-3"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 4v16m8-8H4"
+                    />
+                  </svg>
+                  + Add
+                </button>
+              </div>
+              {lines.length === 0 ? (
+                <p className="text-gray-600 text-xs">None</p>
+              ) : (
+                <div className="space-y-1">
+                  {lines.map((m, mIdx) => (
+                    <div
+                      key={mIdx}
+                      className="flex items-center justify-between text-xs text-gray-300 bg-gray-800 rounded px-2 py-1"
+                    >
+                      <span>
+                        {m.component_sku} — {m.component_name} · {m.quantity}{" "}
+                        {m.unit}
+                      </span>
+                      <button
+                        onClick={() =>
+                          setLines(lines.filter((_, i) => i !== mIdx))
+                        }
+                        className="text-gray-500 hover:text-red-400 ml-2 transition-colors"
+                        title="Remove"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Estimated cost — client-side, informational only */}
+      <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+        {estimatedCost == null ? (
+          <p className="text-gray-500 text-sm">
+            Pick a material and a print work center to estimate cost.
+          </p>
+        ) : (
+          <>
+            <div className="flex items-baseline gap-3">
+              <span className="text-2xl font-bold text-white">
+                ${estimatedCost.toFixed(2)}
+              </span>
+              <span className="text-gray-400 text-sm">
+                estimated assembly cost
+              </span>
+            </div>
+            <p className="text-gray-600 text-xs mt-1">
+              Client-side estimate (print material + machine time
+              {assemblyWorkCenterId ? " + assembly labor" : ""}); glue and
+              packaging excluded. The BOM cost rollup after creation is
+              authoritative.
+            </p>
+          </>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <button
+          onClick={onStartOver}
+          className="border border-gray-700 text-gray-500 hover:bg-gray-800 hover:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+        >
+          Start over
+        </button>
+        <button
+          onClick={handleCreate}
+          disabled={!canCreate}
+          className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 py-2 rounded-lg transition-colors flex items-center gap-2"
+        >
+          {createBusy && (
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+          )}
+          Create {componentRows.length} component
+          {componentRows.length === 1 ? "" : "s"} + assembly
+        </button>
+      </div>
+
+      {/* Shared add-material modal (same component Step 4's finishing ops use) */}
+      <OperationMaterialModal
+        isOpen={modalTarget !== null}
+        operationId={null}
+        material={null}
+        defaultTypeFilter={modalTarget === "packaging" ? "packaging" : "all"}
+        onClose={() => setModalTarget(null)}
+        onSave={(mat) => {
+          if (mat) {
+            if (modalTarget === "glue") {
+              setGlueMaterials((prev) => [...prev, mat]);
+            } else if (modalTarget === "packaging") {
+              setPackagingLines((prev) => [...prev, mat]);
+            }
+          }
+          setModalTarget(null);
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
PR2 of the Assembly Intake feature: the Intake Studio UI mode that intakes a raw multi-plate model as ONE assembly — slice ALL plates in one async job, one material pick, a per-plate component table + assembly form, one `POST /assembly`. Built against the frozen contract; the wheel endpoint (PR1, `feat/intake-assembly` in filaops-ecosystem) is being built in parallel and **must be deployed (150.x license-server rebuild + 129 backend recreate) before this flow can complete** — until then the FE degrades gracefully (see 404 fallback below).

## UX flow

1. **Mode choice at the plate picker (raw multi-plate `.3mf` only).** When the pre-parse reports `plate_count > 1` on a raw file, a chooser renders above the existing PlatePicker: *"Intake one plate"* (default — today's flow, unchanged) vs *"Intake whole model as an assembly (N plates)"*. Choosing assembly hides the per-plate picker. Sliced `.gcode.3mf` multi-plate files never see the chooser — they stay on the untouched single-plate path (assembly rides the async slice-all pipeline, which only raw files take).
2. **Slice all plates in ONE async job.** The assembly path submits the same `POST /parse-async` FormData as the single-plate path but **without `plate_index`** — the worker's `--slice 0` default slices every plate in one job (13-plate drawer proved ~225s against the 1200s async budget). Progress copy: "Slicing all N plates — this can take several minutes." Polling reuses the exact single-plate machinery: 3.5s interval, 22-min client cap, stale-guard token re-checked every cycle (`uploadRequestIdRef`), 504 → the #844 slice-timeout guidance, 429 → queue-busy toast, poll-404 → job-expired.
3. **Assembly panel** (new component `frontend/src/pages/admin/intake/AssemblyIntakePanel.jsx`, following the `admin/bambuddy/`–`admin/quality/` subdir convention) renders on done:
   - **Component table** — one row per sliced plate from the done contract's `plates[]`: editable name (default `{model} — Plate {n}`), auto SKU preview `{PARENT-SKU}-P{nn}`, editable qty (default 1, min 0.001), read-only grams + print time.
   - **One material pick** — the plates sliced with the file's embedded settings, so (matching the single-plate raw path, which picks material AFTER the slice at Step 3) one catalog type→color pick prices the filament for the whole assembly.
   - **Assembly form** — name, SKU (auto from name until edited), selling price, ONE print work center applied to every component, optional assembly work center + run/setup minutes, optional glue/consumable + packaging lines via the same `OperationMaterialModal` Step 4's finishing ops use.
   - **Client-side cost estimate** — Σ per plate qty × (grams × material $/kg + hours × print WC rate) + optional assembly labor; explicitly labeled an estimate (glue/packaging excluded, BOM rollup authoritative).
4. **Create** → `POST /api/v1/pro/intake/assembly` → success view listing the created component SKUs (per plate) + assembly SKU/BOM id with an "Open BOM editor" link.

## Frozen contract (what this POSTs)

```
POST /api/v1/pro/intake/assembly           → 201
{
  "assembly": { name, sku?, actual_price, unit: "EA",
                glue_materials: [{component_product_id, quantity, unit, quantity_per, scrap_factor}],
                packaging: [{component_product_id, quantity, unit}],
                assembly_work_center_id?, assembly_run_time_minutes?, assembly_setup_minutes? },
  "components": [ { plate_index, name, sku?, quantity, print_work_center_id,
                    print_time_seconds, parts_on_plate: 1, slots: [SkuSlotMap…] } ]
}
→ { assembly: {product_id, sku, bom_id}, components: [{plate_index, product_id, sku}] }
```

**Component slots are FULL per-plate fan-outs, not a single-slot simplification.** Verified against merged eco main: `_slice_result_to_parse_contract`'s `plates[]` carries each plate's real slot breakdown (`slot_id`/`filament_type`/`color_hex`/`used_g` from `filament_usage_per_slot`, 1-based `plate_index`). Each component's `slots` mirrors the existing single-plate `/sku` `buildSlotsPayload` shape exactly, with the ONE picked material applied as `spool_product_id` on every slot. Defensive fallback: a plate whose `slots[]` is somehow empty fans its `total_weight_g` into one synthetic slot so its material cost isn't dropped.

## 404 fallback (deploy ordering)

- `POST /parse-async` → 404 (old wheel): toast **"Assembly intake needs the updated backend — deploy the latest wheel."** — deliberately NO sync-`/parse` fallback here (unlike the single-plate path): an old wheel lacking `/parse-async` also lacks `/assembly`, so falling back would slice for minutes only to dead-end at the create step.
- `POST /assembly` → 404 (async wheel deployed, assembly wheel not yet): same toast.

## Reused vs new

Reused: pre-parse/PlatePicker plumbing + `pendingPlateFileRef` hold-for-retry semantics, the async submit+poll pattern with identical stale-guarding, the catalog material picker UX (type→color from `/materials/for-bom`, incl. the loading/empty/failed retry banner), Step-4's work-center `SearchableSelect` options shape, `OperationMaterialModal` (wizard mode) for glue + packaging, `/context` for work centers, toast + timeout guidance copy.

New: `AssemblyIntakePanel` component file, `uploadAssemblyFile` (slice-all twin of `uploadIntakeFile`), `loadAssemblyContext` (parent-fetched — this file's components use no effects — with panel-side retry), the mode chooser, a `slicing-all` busy mode, 2-step header for the assembly branch.

## Deviations from the task spec (and why)

- No auto-prefill of the material pick from the sliced slots' embedded type/color: the `nearestCatalogMatch` helpers are module-private to `AdminIntakeStudio` and exporting them would invite a page↔panel import cycle; the operator makes one explicit pick. Candidate follow-up.
- Component `sku` is sent explicitly as the previewed `{PARENT-SKU}-P{nn}` (omitted only if the assembly SKU is blank) so the preview is exactly what's created.
- No per-component slice-file persistence — the frozen contract carries no artifact attachment; noted as a follow-up for the wheel.

## Guardrails

- Behind the same `unifiedFlow` runtime gate; gate-off render is byte-identical.
- Single-plate, `.gcode.3mf`, and bare-mesh flows untouched (assembly is a strictly additive branch; the 5-step wizard state machine is never entered by it).
- All new async paths stale-guarded exactly like `uploadIntakeFile` (`uploadRequestIdRef` for the slice-all poll, a new `assemblyContextRequestIdRef` for the context fetch); both reset paths clear/invalidate the new state.
- Slice failure/timeout/429 leaves the mode chooser + held file intact for retry; only success clears them (mirrors the plate-pick path).

## Validation

- `npm ci` + `npm run build` ✅ (vite build green)
- `npm run lint` → **0 findings in AdminIntakeStudio/AssemblyIntakePanel**; project total unchanged at the pre-existing 212 errors / 49 warnings.
- Not E2E-verifiable until the PR1 wheel deploys (parse-async slice-all + /assembly); manual test plan: drawer 13-plate raw .3mf on 129 → assembly mode → slice-all → create → verify 13 components + FG BOM in the BOM editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified “assembly intake” flow for raw multi-plate `.3mf` files, including an intake-mode chooser (single plate vs whole-model assembly).
  * Introduced an assembly setup panel with per-plate editing, unified material selection, work-center inputs, pricing, and optional glue/packaging BOM lines.
  * Displays live grams/print-time per plate and an estimated cost, then creates the assembly with associated component plates.
  * Updated the materials modal with a simplified layout option.
* **Bug Fixes**
  * Improved reset and context loading to avoid stale intake results; added validation to ensure expected parse data before switching into assembly mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->