### PR TITLE
feat(ui): re-skin the Production surface to Industrial Workbench (#846)

### DIFF
--- a/frontend/src/components/CompleteOrderModal.jsx
+++ b/frontend/src/components/CompleteOrderModal.jsx
@@ -177,7 +177,7 @@ export default function CompleteOrderModal({
           toast.success(
             <div>
               <p>Order completed (short by {shortfall} units).</p>
-              <p className="mt-1 text-green-300">
+              <p className="mt-1 text-[var(--status-green)]">
                 Remake order <strong>{remakeOrderCode}</strong> created for remaining {shortfall} units.
               </p>
             </div>,
@@ -209,20 +209,20 @@ export default function CompleteOrderModal({
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Complete Production Order" className="w-full max-w-lg p-6" disableClose={submitting}>
+    <Modal isOpen={true} onClose={onClose} title="Complete Production Order" variant="workbench" className="w-full max-w-lg p-6" disableClose={submitting}>
         <div className="flex justify-between items-center mb-6">
           <div>
-            <h2 className="text-xl font-bold text-white">
+            <h2 className="text-xl font-bold text-[var(--ink)]">
               Complete Production Order
             </h2>
-            <p className="text-gray-400 text-sm mt-1">
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               {productionOrder.code} -{" "}
               {productionOrder.product_name || productionOrder.product_sku}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white text-xl"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl"
             disabled={submitting}
           >
             &times;
@@ -230,17 +230,17 @@ export default function CompleteOrderModal({
         </div>
 
         {/* Order Details */}
-        <div className="bg-gray-800/50 rounded-lg p-4 mb-6">
+        <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-6">
           <div className="flex justify-between text-sm mb-2">
-            <span className="text-gray-400">Quantity Ordered:</span>
-            <span className="text-white font-medium">
+            <span className="text-[var(--ink-3)]">Quantity Ordered:</span>
+            <span className="text-[var(--ink)] font-medium">
               {quantityOrdered} units
             </span>
           </div>
           {productionOrder.scheduled_start && (
             <div className="flex justify-between text-sm">
-              <span className="text-gray-400">Scheduled:</span>
-              <span className="text-white">
+              <span className="text-[var(--ink-3)]">Scheduled:</span>
+              <span className="text-[var(--ink)]">
                 {new Date(productionOrder.scheduled_start).toLocaleDateString()}
               </span>
             </div>
@@ -249,7 +249,7 @@ export default function CompleteOrderModal({
 
         {/* Quantity Completed */}
         <div className="mb-4">
-          <label className="block text-sm text-gray-400 mb-2">
+          <label className="block text-sm text-[var(--ink-3)] mb-2">
             Quantity Completed *
           </label>
           <input
@@ -259,9 +259,9 @@ export default function CompleteOrderModal({
               setQuantityCompleted(parseInt(e.target.value) || 0)
             }
             min="1"
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white text-lg"
+            className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] text-lg"
           />
-          <p className="text-gray-500 text-sm mt-1">
+          <p className="text-[var(--ink-4)] text-sm mt-1">
             Enter actual quantity produced (can exceed ordered qty for MTS
             overruns)
           </p>
@@ -270,25 +270,25 @@ export default function CompleteOrderModal({
         {/* Spool Selection */}
         {bomMaterials.length > 0 && (
           <div className="mb-4">
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Material Spools Used (Optional)
             </label>
-            <div className="space-y-3 bg-gray-800/50 rounded-lg p-3">
+            <div className="space-y-3 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
               {loadingMaterials ? (
-                <div className="text-gray-500 text-sm">Loading materials...</div>
+                <div className="text-[var(--ink-4)] text-sm">Loading materials...</div>
               ) : (
                 bomMaterials.map((material) => {
                   const availableSpools = availableSpoolsByMaterial[material.component_id] || [];
                   const requiredWeight = material.quantity * quantityCompleted;
                   
                   return (
-                    <div key={material.component_id} className="border-b border-gray-700 pb-3 last:border-0 last:pb-0">
+                    <div key={material.component_id} className="border-b border-[var(--rule-hair)] pb-3 last:border-0 last:pb-0">
                       <div className="flex justify-between items-start mb-2">
                         <div>
-                          <div className="text-white text-sm font-medium">
+                          <div className="text-[var(--ink)] text-sm font-medium">
                             {material.component_name || material.component_sku}
                           </div>
-                          <div className="text-gray-500 text-xs">
+                          <div className="text-[var(--ink-4)] text-xs">
                             Required: {requiredWeight.toFixed(3)} {material.unit}
                           </div>
                         </div>
@@ -302,7 +302,7 @@ export default function CompleteOrderModal({
                               [material.component_id]: e.target.value ? parseInt(e.target.value) : null,
                             }));
                           }}
-                          className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2 text-white text-sm"
+                          className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-3 py-2 text-[var(--ink)] text-sm"
                         >
                           <option value="">No spool selected</option>
                           {availableSpools.map((spool) => (
@@ -312,14 +312,14 @@ export default function CompleteOrderModal({
                           ))}
                         </select>
                       ) : (
-                        <div className="text-gray-500 text-xs">No active spools available</div>
+                        <div className="text-[var(--ink-4)] text-xs">No active spools available</div>
                       )}
                     </div>
                   );
                 })
               )}
             </div>
-            <p className="text-gray-500 text-xs mt-2">
+            <p className="text-[var(--ink-4)] text-xs mt-2">
               Select spools to track material consumption and weight remaining
             </p>
           </div>
@@ -327,7 +327,7 @@ export default function CompleteOrderModal({
 
         {/* Notes */}
         <div className="mb-4">
-          <label className="block text-sm text-gray-400 mb-2">
+          <label className="block text-sm text-[var(--ink-3)] mb-2">
             Completion Notes (Optional)
           </label>
           <textarea
@@ -335,16 +335,16 @@ export default function CompleteOrderModal({
             onChange={(e) => setNotes(e.target.value)}
             placeholder="Add any notes about the completion (e.g., quality issues, early completion, etc.)"
             rows={3}
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white resize-none"
+            className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] placeholder-[var(--ink-4)] resize-none"
           />
         </div>
 
         {/* Overrun Info Banner */}
         {isOverrun && (
-          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 mb-6">
+          <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-6">
             <div className="flex gap-3">
               <svg
-                className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5"
+                className="w-5 h-5 text-[var(--ink-2)] flex-shrink-0 mt-0.5"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -357,8 +357,8 @@ export default function CompleteOrderModal({
                 />
               </svg>
               <div>
-                <p className="text-blue-400 font-medium">MTS Overrun</p>
-                <p className="text-blue-400/80 text-sm">
+                <p className="text-[var(--ink-2)] font-medium">MTS Overrun</p>
+                <p className="text-[var(--ink-3)] text-sm">
                   {quantityCompleted - quantityOrdered} extra unit
                   {quantityCompleted - quantityOrdered > 1 ? "s" : ""} will be
                   added to inventory as Make-to-Stock.
@@ -370,19 +370,19 @@ export default function CompleteOrderModal({
 
         {/* Closing Short Warning - requires acknowledgment */}
         {isClosingShort && quantityCompleted > 0 && (
-          <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mb-6 space-y-4">
+          <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-4 mb-6 space-y-4">
             <label className="flex items-start gap-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={acknowledgeShort}
                 onChange={(e) => setAcknowledgeShort(e.target.checked)}
-                className="mt-1 w-5 h-5 rounded bg-gray-700 border-gray-600 text-red-500 focus:ring-red-500 focus:ring-offset-0"
+                className="mt-1 w-5 h-5 rounded bg-[var(--paper)] border-[var(--rule-hair)] text-[var(--status-red)] focus:ring-[var(--status-red)] focus:ring-offset-0"
               />
               <div>
-                <p className="text-red-400 font-medium">
+                <p className="text-[var(--status-red)] font-medium">
                   Closing Order Short ({shortfall} units unaccounted)
                 </p>
-                <p className="text-red-400/80 text-sm">
+                <p className="text-[var(--status-red)]/80 text-sm">
                   Ordered: {quantityOrdered}, Completing: {quantityCompleted}, Already Scrapped: {quantityScrapped}.
                   <br />
                   <strong>{shortfall} units</strong> were neither completed nor scrapped.
@@ -393,22 +393,22 @@ export default function CompleteOrderModal({
 
             {/* Create Remake Order Toggle */}
             {acknowledgeShort && (
-              <div className="border-t border-red-500/20 pt-4">
+              <div className="border-t border-[var(--status-red)]/20 pt-4">
                 <label className="flex items-start gap-3 cursor-pointer">
                   <input
                     type="checkbox"
                     checked={createRemakeForShortfall}
                     onChange={(e) => setCreateRemakeForShortfall(e.target.checked)}
-                    className="mt-1 w-5 h-5 rounded bg-gray-700 border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                    className="mt-1 w-5 h-5 rounded bg-[var(--paper)] border-[var(--rule-hair)] text-[var(--orange)] focus:ring-[var(--orange)] focus:ring-offset-0"
                   />
                   <div>
-                    <p className="text-white font-medium">
+                    <p className="text-[var(--ink)] font-medium">
                       Create Remake Order for {shortfall} units
                     </p>
-                    <p className="text-gray-400 text-sm">
+                    <p className="text-[var(--ink-3)] text-sm">
                       Automatically create a new production order for the shortfall
                       {productionOrder.sales_order_id && (
-                        <span className="text-blue-400"> (linked to same Sales Order)</span>
+                        <span className="text-[var(--ink-2)]"> (linked to same Sales Order)</span>
                       )}
                     </p>
                   </div>
@@ -423,14 +423,14 @@ export default function CompleteOrderModal({
           <button
             onClick={onClose}
             disabled={submitting}
-            className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={quantityCompleted < 1 || submitting || (isClosingShort && !acknowledgeShort)}
-            className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 px-4 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting ? "Processing..." : isClosingShort ? "Complete Order (Short)" : "Complete Order"}
           </button>

--- a/frontend/src/components/CompleteOrderModal.jsx
+++ b/frontend/src/components/CompleteOrderModal.jsx
@@ -121,11 +121,17 @@ export default function CompleteOrderModal({
       if (notes.trim()) {
         requestBody.notes = notes.trim();
       }
-      if (Object.keys(selectedSpools).length > 0) {
-        requestBody.spools_used = Object.entries(selectedSpools).map(([productId, spoolId]) => ({
+      // A selection cleared back to "No spool selected" is stored as null;
+      // SpoolUsage.spool_id is a required int, so a null entry would 422 the
+      // whole completion. Send only real selections.
+      const spoolsUsed = Object.entries(selectedSpools)
+        .filter(([, spoolId]) => spoolId != null)
+        .map(([productId, spoolId]) => ({
           product_id: parseInt(productId),
           spool_id: spoolId,
         }));
+      if (spoolsUsed.length > 0) {
+        requestBody.spools_used = spoolsUsed;
       }
 
       const res = await fetch(

--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -146,6 +146,32 @@ const icons = {
   ),
 };
 
+// Color treatment per design system. "dark" is the legacy default; "workbench"
+// is the Industrial Workbench paper treatment (#846) — opt-in per consumer so
+// un-migrated dark pages keep their current look (same pattern as Modal's
+// variant prop).
+const TONES = {
+  dark: {
+    surface: "bg-gray-900 border border-gray-700",
+    surfaceCompact: "bg-gray-900",
+    icon: "text-white",
+    title: "text-white",
+    text: "text-white",
+    cta: "bg-emerald-600 hover:bg-emerald-500 text-white",
+    clear: "bg-gray-700 hover:bg-gray-600 text-white",
+  },
+  workbench: {
+    surface: "bg-[var(--paper-sunk)] border border-[var(--rule-hair)]",
+    surfaceCompact: "bg-[var(--paper-sunk)]",
+    icon: "text-[var(--ink-4)]",
+    title: "text-[var(--ink)]",
+    text: "text-[var(--ink-3)]",
+    cta: "bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white",
+    clear:
+      "bg-[var(--paper)] border border-[var(--rule-hair)] text-[var(--ink-2)] hover:text-[var(--ink)]",
+  },
+};
+
 export default function EmptyState({
   icon = "default",
   title = "No items found",
@@ -155,18 +181,19 @@ export default function EmptyState({
   onAction,
   customIcon,
   variant = "default", // default, compact, inline
+  tone = "dark", // dark (legacy), workbench (#846)
   // "No matches" / filter-clear variant — when provided, replaces the action button
   onClearFilters,
 }) {
   // Use custom icon if provided, otherwise use predefined
   const iconElement = customIcon || icons[icon] || icons.default;
 
-  // Render action button inline (not as component to avoid React fast refresh issues)
-  const buttonClasses =
-    "inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg transition-colors text-sm font-medium";
+  const T = TONES[tone] ?? TONES.dark;
 
-  const clearFiltersClasses =
-    "inline-flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors text-sm font-medium";
+  // Render action button inline (not as component to avoid React fast refresh issues)
+  const buttonClasses = `inline-flex items-center gap-2 px-4 py-2 ${T.cta} rounded-lg transition-colors text-sm font-medium`;
+
+  const clearFiltersClasses = `inline-flex items-center gap-2 px-4 py-2 ${T.clear} rounded-lg transition-colors text-sm font-medium`;
 
   const renderActionButton = () => {
     // "Clear filters" variant takes precedence over create CTA
@@ -233,11 +260,11 @@ export default function EmptyState({
   // Compact variant for smaller spaces
   if (variant === "compact") {
     return (
-      <div className="flex flex-col items-center justify-center py-8 text-center bg-gray-900">
-        <div className="text-white mb-3">{iconElement}</div>
-        <h3 className="text-white font-medium">{title}</h3>
+      <div className={`flex flex-col items-center justify-center py-8 text-center ${T.surfaceCompact}`}>
+        <div className={`${T.icon} mb-3`}>{iconElement}</div>
+        <h3 className={`${T.title} font-medium`}>{title}</h3>
         {description && (
-          <p className="text-white text-sm mt-1 max-w-xs">{description}</p>
+          <p className={`${T.text} text-sm mt-1 max-w-xs`}>{description}</p>
         )}
         {actionLabel && <div className="mt-4">{renderActionButton()}</div>}
       </div>
@@ -247,14 +274,14 @@ export default function EmptyState({
   // Inline variant for table rows or narrow spaces
   if (variant === "inline") {
     return (
-      <div className="flex items-center justify-center gap-4 py-6 bg-gray-900 border border-gray-700">
-        <div className="text-white w-8 h-8 [&>svg]:w-8 [&>svg]:h-8">
+      <div className={`flex items-center justify-center gap-4 py-6 ${T.surface}`}>
+        <div className={`${T.icon} w-8 h-8 [&>svg]:w-8 [&>svg]:h-8`}>
           {iconElement}
         </div>
         <div>
-          <span className="text-white">{title}</span>
+          <span className={T.title}>{title}</span>
           {description && (
-            <span className="text-white ml-2">{description}</span>
+            <span className={`${T.text} ml-2`}>{description}</span>
           )}
         </div>
         {actionLabel && renderActionButton()}
@@ -264,11 +291,11 @@ export default function EmptyState({
 
   // Default variant - full empty state
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center bg-gray-900 border border-gray-700">
-      <div className="text-white mb-4">{iconElement}</div>
-      <h3 className="text-lg font-medium text-white mb-2">{title}</h3>
+    <div className={`flex flex-col items-center justify-center py-16 text-center ${T.surface}`}>
+      <div className={`${T.icon} mb-4`}>{iconElement}</div>
+      <h3 className={`text-lg font-medium ${T.title} mb-2`}>{title}</h3>
       {description && (
-        <p className="text-white text-sm max-w-md mb-6">{description}</p>
+        <p className={`${T.text} text-sm max-w-md mb-6`}>{description}</p>
       )}
       {renderActionButton()}
     </div>

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -11,6 +11,14 @@
  */
 import { useEffect, useRef, useId } from "react";
 
+// Shell styling per design system. "dark" is the legacy default; "workbench"
+// is the Industrial Workbench paper shell (#846) — opt-in per modal so
+// un-migrated consumers keep their current look.
+const VARIANT_SHELL = {
+  dark: "bg-gray-900 border border-gray-700",
+  workbench: "bg-[var(--paper)] border border-[var(--rule-hair)]",
+};
+
 export default function Modal({
   isOpen,
   onClose,
@@ -18,6 +26,7 @@ export default function Modal({
   children,
   className = "w-full max-w-lg",
   disableClose = false,
+  variant = "dark",
 }) {
   const dialogRef = useRef(null);
   const previousFocusRef = useRef(null);
@@ -114,7 +123,7 @@ export default function Modal({
     >
       <div
         ref={dialogRef}
-        className={`bg-gray-900 border border-gray-700 rounded-xl shadow-xl ${className}`}
+        className={`${VARIANT_SHELL[variant] ?? VARIANT_SHELL.dark} rounded-xl shadow-xl ${className}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? titleId : undefined}

--- a/frontend/src/components/QCInspectionModal.jsx
+++ b/frontend/src/components/QCInspectionModal.jsx
@@ -9,13 +9,13 @@ import QCInspectionPhotos from "./QCInspectionPhotos";
 // defect, attributed to the operator) and Conditional are the full-QMS additions.
 const RESULTS = [
   { value: "passed", label: "Pass", hint: "Quality acceptable",
-    sel: "border-green-500 bg-green-500/10", txt: "text-green-400", fade: "text-green-400/70", btn: "bg-green-600 hover:bg-green-500" },
+    sel: "border-[var(--status-green)] bg-[var(--status-green-tint)]", txt: "text-[var(--status-green)]", fade: "text-[var(--status-green)]/70", btn: "bg-[var(--orange)] hover:bg-[var(--orange-press)]" },
   { value: "failed", label: "Fail", hint: "Quality issues found",
-    sel: "border-red-500 bg-red-500/10", txt: "text-red-400", fade: "text-red-400/70", btn: "bg-red-600 hover:bg-red-500" },
+    sel: "border-[var(--status-red)] bg-[var(--status-red-tint)]", txt: "text-[var(--status-red)]", fade: "text-[var(--status-red)]/70", btn: "bg-[var(--orange)] hover:bg-[var(--orange-press)]" },
   { value: "waived", label: "Waive", hint: "Accept despite a defect",
-    sel: "border-amber-500 bg-amber-500/10", txt: "text-amber-400", fade: "text-amber-400/70", btn: "bg-amber-600 hover:bg-amber-500" },
+    sel: "border-[var(--status-amber)] bg-[var(--status-amber-tint)]", txt: "text-[var(--status-amber)]", fade: "text-[var(--status-amber)]/70", btn: "bg-[var(--orange)] hover:bg-[var(--orange-press)]" },
   { value: "conditional", label: "Conditional", hint: "Accept with conditions",
-    sel: "border-blue-500 bg-blue-500/10", txt: "text-blue-400", fade: "text-blue-400/70", btn: "bg-blue-600 hover:bg-blue-500" },
+    sel: "border-[var(--ink-3)] bg-[var(--paper-sunk)]", txt: "text-[var(--ink)]", fade: "text-[var(--ink-3)]", btn: "bg-[var(--orange)] hover:bg-[var(--orange-press)]" },
 ];
 
 const emptyMeasurement = () => ({
@@ -222,7 +222,7 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
   };
 
   const inputCls =
-    "w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm";
+    "w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-3 py-2 text-[var(--ink)] text-sm";
 
   // After recording, switch to an optional photo-attachment step for the new
   // inspection (photos need the inspection_id the POST just returned).
@@ -230,15 +230,15 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
     // The inspection is already saved, so ANY exit here (Done, header ×, backdrop,
     // Escape) must run onComplete so the parent refetches and shows fresh QC state.
     return (
-      <Modal isOpen={true} onClose={onComplete} title="QC Inspection" className="w-full max-w-2xl p-6">
+      <Modal isOpen={true} onClose={onComplete} title="QC Inspection" variant="workbench" className="w-full max-w-2xl p-6">
         <div className="flex justify-between items-center mb-6">
           <div>
-            <h2 className="text-xl font-bold text-white">Inspection recorded</h2>
-            <p className="text-gray-400 text-sm mt-1">
+            <h2 className="text-xl font-bold text-[var(--ink)]">Inspection recorded</h2>
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               {productionOrder.code} — attach photos (optional)
             </p>
           </div>
-          <button onClick={onComplete} className="text-gray-400 hover:text-white text-xl">
+          <button onClick={onComplete} className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl">
             &times;
           </button>
         </div>
@@ -246,7 +246,7 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
         <div className="flex justify-end mt-6">
           <button
             onClick={onComplete}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg"
+            className="px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg"
           >
             Done
           </button>
@@ -256,37 +256,37 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
   }
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="QC Inspection" className="w-full max-w-2xl p-6">
+    <Modal isOpen={true} onClose={onClose} title="QC Inspection" variant="workbench" className="w-full max-w-2xl p-6">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h2 className="text-xl font-bold text-white">QC Inspection</h2>
-          <p className="text-gray-400 text-sm mt-1">
+          <h2 className="text-xl font-bold text-[var(--ink)]">QC Inspection</h2>
+          <p className="text-[var(--ink-3)] text-sm mt-1">
             {productionOrder.code} -{" "}
             {productionOrder.product_name || productionOrder.product_sku}
           </p>
         </div>
-        <button onClick={onClose} className="text-gray-400 hover:text-white text-xl">
+        <button onClick={onClose} className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl">
           &times;
         </button>
       </div>
 
       {/* Order details */}
-      <div className="bg-gray-800/50 rounded-lg p-4 mb-6">
+      <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-6">
         <div className="flex justify-between text-sm mb-2">
-          <span className="text-gray-400">Quantity Completed:</span>
-          <span className="text-white font-medium">
+          <span className="text-[var(--ink-3)]">Quantity Completed:</span>
+          <span className="text-[var(--ink)] font-medium">
             {productionOrder.quantity_completed || productionOrder.quantity_ordered} units
           </span>
         </div>
         <div className="flex justify-between text-sm">
-          <span className="text-gray-400">Status:</span>
-          <span className="text-green-400 font-medium">{productionOrder.status}</span>
+          <span className="text-[var(--ink-3)]">Status:</span>
+          <span className="text-[var(--status-green)] font-medium">{productionOrder.status}</span>
         </div>
       </div>
 
       {/* Result selection */}
       <div className="mb-6">
-        <label className="block text-sm text-gray-400 mb-3">Inspection Result *</label>
+        <label className="block text-sm text-[var(--ink-3)] mb-3">Inspection Result *</label>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {RESULTS.map((r) => (
             <button
@@ -294,13 +294,13 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
               type="button"
               onClick={() => setResult(r.value)}
               className={`p-3 rounded-lg border-2 transition-all text-center ${
-                result === r.value ? r.sel : "border-gray-700 bg-gray-800 hover:border-gray-600"
+                result === r.value ? r.sel : "border-[var(--rule-hair)] bg-[var(--paper-sunk)] hover:border-[var(--ink-4)]"
               }`}
             >
-              <span className={`font-medium ${result === r.value ? r.txt : "text-gray-300"}`}>
+              <span className={`font-medium ${result === r.value ? r.txt : "text-[var(--ink-2)]"}`}>
                 {r.label}
               </span>
-              <p className={`text-xs mt-1 ${result === r.value ? r.fade : "text-gray-500"}`}>
+              <p className={`text-xs mt-1 ${result === r.value ? r.fade : "text-[var(--ink-4)]"}`}>
                 {r.hint}
               </p>
             </button>
@@ -311,18 +311,18 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
       {/* Quantities (optional) */}
       <div className="grid grid-cols-2 gap-4 mb-6">
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Quantity Passed</label>
+          <label className="block text-sm text-[var(--ink-3)] mb-1">Quantity Passed</label>
           <input type="number" min="0" value={quantityPassed}
             onChange={(e) => setQuantityPassed(e.target.value)}
             placeholder="(whole order)" className={inputCls} />
         </div>
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Quantity Failed</label>
+          <label className="block text-sm text-[var(--ink-3)] mb-1">Quantity Failed</label>
           <input type="number" min="0" value={quantityFailed}
             onChange={(e) => setQuantityFailed(e.target.value)}
             placeholder="(whole order)" className={inputCls} />
         </div>
-        <p className="col-span-2 text-xs text-gray-500 -mt-2">
+        <p className="col-span-2 text-xs text-[var(--ink-4)] -mt-2">
           Leave blank for a whole-order result; the unspecified side is derived.
         </p>
       </div>
@@ -330,7 +330,7 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
       {/* Operation (optional) */}
       {operations.length > 0 && (
         <div className="mb-6">
-          <label className="block text-sm text-gray-400 mb-1">Operation inspected</label>
+          <label className="block text-sm text-[var(--ink-3)] mb-1">Operation inspected</label>
           <select value={operationId} onChange={(e) => setOperationId(e.target.value)} className={inputCls}>
             <option value="">Default (the order&apos;s QC step)</option>
             {operations.map((op) => (
@@ -345,7 +345,7 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
       {/* Defect reason (when not a clean pass) */}
       {needsDefect && (
         <div className="mb-6">
-          <label className="block text-sm text-gray-400 mb-1">
+          <label className="block text-sm text-[var(--ink-3)] mb-1">
             Defect Reason {result === "failed" ? "(recommended)" : "(optional)"}
           </label>
           <select value={defectReasonId} onChange={(e) => setDefectReasonId(e.target.value)} className={inputCls}>
@@ -362,21 +362,21 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
       {/* Measurements grid */}
       <div className="mb-6">
         <div className="flex items-center justify-between mb-2">
-          <label className="block text-sm text-gray-400">
+          <label className="block text-sm text-[var(--ink-3)]">
             {seededPlan ? "Characteristics (from plan)" : "Measurements (SPC)"}
           </label>
           <button type="button" onClick={addMeasurement}
-            className="text-sm text-blue-400 hover:text-blue-300">+ Add measurement</button>
+            className="text-sm text-[var(--ink-2)] hover:text-[var(--ink)]">+ Add measurement</button>
         </div>
         {seededPlan && (
-          <p className="text-xs text-gray-400 mb-2">
+          <p className="text-xs text-[var(--ink-3)] mb-2">
             Seeded from plan{" "}
-            <span className="font-mono text-gray-300">{seededPlan.code}</span>
+            <span className="font-mono text-[var(--ink-2)]">{seededPlan.code}</span>
             {seededPlan.name ? ` — ${seededPlan.name}` : ""}. Record a reading for each characteristic.
           </p>
         )}
         {measurements.length === 0 ? (
-          <p className="text-xs text-gray-500">No measurements. Add one to record a dimensional/SPC reading.</p>
+          <p className="text-xs text-[var(--ink-4)]">No measurements. Add one to record a dimensional/SPC reading.</p>
         ) : (
           <div className="space-y-2">
             {measurements.map((m, idx) => {
@@ -385,11 +385,11 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
                 return (
                   <div key={idx} className="grid grid-cols-12 gap-2 items-center">
                     <div className="col-span-5">
-                      <div className="px-3 py-2 text-sm text-white truncate" title={m.characteristic}>
+                      <div className="px-3 py-2 text-sm text-[var(--ink)] truncate" title={m.characteristic}>
                         {m.characteristic}
                       </div>
                       {m.acceptance_criteria && (
-                        <p className="text-xs text-gray-500 px-3 -mt-1">{m.acceptance_criteria}</p>
+                        <p className="text-xs text-[var(--ink-4)] px-3 -mt-1">{m.acceptance_criteria}</p>
                       )}
                     </div>
                     <div className="col-span-6 flex gap-2" role="group"
@@ -398,16 +398,16 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
                         aria-label={`${m.characteristic}: pass`}
                         onClick={() => setMeasurement(idx, "conforms", m.conforms === true ? null : true)}
                         className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                          m.conforms === true ? "border-green-500 bg-green-500/10 text-green-400"
-                            : "border-gray-700 bg-gray-800 text-gray-300 hover:border-gray-600"}`}>
+                          m.conforms === true ? "border-[var(--status-green)] bg-[var(--status-green-tint)] text-[var(--status-green)]"
+                            : "border-[var(--rule-hair)] bg-[var(--paper-sunk)] text-[var(--ink-2)] hover:border-[var(--ink-4)]"}`}>
                         Pass
                       </button>
                       <button type="button" aria-pressed={m.conforms === false}
                         aria-label={`${m.characteristic}: fail`}
                         onClick={() => setMeasurement(idx, "conforms", m.conforms === false ? null : false)}
                         className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                          m.conforms === false ? "border-red-500 bg-red-500/10 text-red-400"
-                            : "border-gray-700 bg-gray-800 text-gray-300 hover:border-gray-600"}`}>
+                          m.conforms === false ? "border-[var(--status-red)] bg-[var(--status-red-tint)] text-[var(--status-red)]"
+                            : "border-[var(--rule-hair)] bg-[var(--paper-sunk)] text-[var(--ink-2)] hover:border-[var(--ink-4)]"}`}>
                         Fail
                       </button>
                     </div>
@@ -418,7 +418,7 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
               // Variable row: locked spec (from plan) is read-only, only the
               // measured value is editable; a manual row is fully editable.
               const ok = withinSpec(m);
-              const ro = m.locked ? "bg-gray-800/40 text-gray-400 cursor-default" : "";
+              const ro = m.locked ? "bg-[var(--paper-sunk)] text-[var(--ink-3)] cursor-default" : "";
               return (
                 <div key={idx} className="grid grid-cols-12 gap-2 items-center">
                   <input className={`${inputCls} col-span-3 ${ro}`} placeholder="Characteristic"
@@ -446,12 +446,12 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
                     onChange={(e) => setMeasurement(idx, "unit", e.target.value)} />
                   <div className="col-span-1 flex items-center justify-end gap-1">
                     {ok === true && <span role="img" aria-label="In spec"
-                      className="w-2.5 h-2.5 rounded-full bg-green-500" title="In spec" />}
+                      className="w-2.5 h-2.5 rounded-full bg-[var(--status-green)]" title="In spec" />}
                     {ok === false && <span role="img" aria-label="Out of spec"
-                      className="w-2.5 h-2.5 rounded-full bg-red-500" title="Out of spec" />}
+                      className="w-2.5 h-2.5 rounded-full bg-[var(--status-red)]" title="Out of spec" />}
                     {!m.locked && (
                       <button type="button" onClick={() => removeMeasurement(idx)}
-                        className="text-gray-500 hover:text-red-400" title="Remove">&times;</button>
+                        className="text-[var(--ink-4)] hover:text-[var(--status-red)]" title="Remove">&times;</button>
                     )}
                   </div>
                 </div>
@@ -463,20 +463,20 @@ export default function QCInspectionModal({ productionOrder, onClose, onComplete
 
       {/* Notes */}
       <div className="mb-6">
-        <label className="block text-sm text-gray-400 mb-2">
+        <label className="block text-sm text-[var(--ink-3)] mb-2">
           Inspection Notes {result === "failed" ? "(recommended)" : "(optional)"}
         </label>
         <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2}
           placeholder={result === "failed"
             ? "Describe the quality issues found"
             : "Add any notes about the inspection"}
-          className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white text-sm resize-none" />
+          className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] placeholder-[var(--ink-4)] text-sm resize-none" />
       </div>
 
       {/* Actions */}
       <div className="flex gap-3">
         <button onClick={onClose}
-          className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600">
+          className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]">
           Cancel
         </button>
         <button onClick={handleSubmit} disabled={submitting}

--- a/frontend/src/components/ScrapOrderModal.jsx
+++ b/frontend/src/components/ScrapOrderModal.jsx
@@ -98,7 +98,7 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
           toast.success(
             <div>
               <p>Scrapped {quantityScrapped} units.</p>
-              <p className="mt-1 text-green-300">
+              <p className="mt-1 text-[var(--status-green)]">
                 Remake order <strong>{data.remake_order_code}</strong> created and ready for scheduling.
               </p>
             </div>,
@@ -122,43 +122,43 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Scrap Production Order" className="w-full max-w-lg p-6">
+    <Modal isOpen={true} onClose={onClose} title="Scrap Production Order" variant="workbench" className="w-full max-w-lg p-6">
         <div className="flex justify-between items-center mb-6">
           <div>
-            <h2 className="text-xl font-bold text-white">Scrap Production Order</h2>
-            <p className="text-gray-400 text-sm mt-1">
+            <h2 className="text-xl font-bold text-[var(--ink)]">Scrap Production Order</h2>
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               {productionOrder.code} - {productionOrder.product_name || productionOrder.product_sku}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white text-xl"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl"
           >
             &times;
           </button>
         </div>
 
         {/* Order Details */}
-        <div className="bg-gray-800/50 rounded-lg p-4 mb-6">
+        <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-6">
           <div className="grid grid-cols-3 gap-4 text-sm">
             <div>
-              <span className="text-gray-400">Ordered:</span>
-              <span className="text-white font-medium ml-2">{productionOrder.quantity_ordered}</span>
+              <span className="text-[var(--ink-3)]">Ordered:</span>
+              <span className="text-[var(--ink)] font-medium ml-2">{productionOrder.quantity_ordered}</span>
             </div>
             <div>
-              <span className="text-gray-400">Completed:</span>
-              <span className="text-green-400 font-medium ml-2">{productionOrder.quantity_completed || 0}</span>
+              <span className="text-[var(--ink-3)]">Completed:</span>
+              <span className="text-[var(--status-green)] font-medium ml-2">{productionOrder.quantity_completed || 0}</span>
             </div>
             <div>
-              <span className="text-gray-400">Remaining:</span>
-              <span className="text-white font-medium ml-2">{remainingQty}</span>
+              <span className="text-[var(--ink-3)]">Remaining:</span>
+              <span className="text-[var(--ink)] font-medium ml-2">{remainingQty}</span>
             </div>
           </div>
         </div>
 
         {/* Quantity to Scrap */}
         <div className="mb-4">
-          <label className="block text-sm text-gray-400 mb-2">
+          <label className="block text-sm text-[var(--ink-3)] mb-2">
             Quantity to Scrap *
           </label>
           <input
@@ -167,23 +167,23 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
             onChange={(e) => setQuantityScrapped(parseInt(e.target.value) || 0)}
             min="1"
             max={remainingQty}
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white text-lg"
+            className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] text-lg"
           />
-          <p className="text-gray-500 text-sm mt-1">
+          <p className="text-[var(--ink-4)] text-sm mt-1">
             How many units failed? (max: {remainingQty})
           </p>
         </div>
 
         {/* Partial Scrap Info */}
         {isPartialScrap && (
-          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 mb-4">
+          <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-4">
             <div className="flex gap-3">
-              <svg className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-[var(--ink-2)] flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div>
-                <p className="text-blue-400 font-medium">Partial Scrap</p>
-                <p className="text-blue-400/80 text-sm">
+                <p className="text-[var(--ink-2)] font-medium">Partial Scrap</p>
+                <p className="text-[var(--ink-3)] text-sm">
                   Scrapping {quantityScrapped} of {remainingQty} remaining units.
                   Order will stay in progress for the remaining {remainingQty - quantityScrapped} units.
                 </p>
@@ -194,18 +194,18 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
 
         {/* Scrap Reason */}
         <div className="mb-4">
-          <label className="block text-sm text-gray-400 mb-2">
+          <label className="block text-sm text-[var(--ink-3)] mb-2">
             Failure Reason *
           </label>
           {loading ? (
-            <div className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-gray-500">
+            <div className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink-4)]">
               Loading reasons...
             </div>
           ) : (
             <select
               value={scrapReason}
               onChange={(e) => setScrapReason(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)]"
               required
             >
               <option value="">Select reason...</option>
@@ -217,7 +217,7 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
             </select>
           )}
           {scrapReason && (
-            <p className="text-gray-500 text-sm mt-1">
+            <p className="text-[var(--ink-4)] text-sm mt-1">
               {scrapReasons.find(r => r.code === scrapReason)?.description}
             </p>
           )}
@@ -225,30 +225,30 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
 
         {/* Notes */}
         <div className="mb-4">
-          <label className="block text-sm text-gray-400 mb-2">
+          <label className="block text-sm text-[var(--ink-3)] mb-2">
             Additional Notes
           </label>
           <textarea
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white h-24 resize-none"
+            className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] placeholder-[var(--ink-4)] h-24 resize-none"
             placeholder="Describe what happened, approximate failure point, etc..."
           />
         </div>
 
         {/* Create Remake Toggle - only show for full scrap */}
         {!isPartialScrap && (
-          <div className="bg-gray-800/50 rounded-lg p-4 mb-6">
+          <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 mb-6">
             <label className="flex items-center gap-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={createRemake}
                 onChange={(e) => setCreateRemake(e.target.checked)}
-                className="w-5 h-5 rounded bg-gray-700 border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                className="w-5 h-5 rounded bg-[var(--paper)] border-[var(--rule-hair)] text-[var(--orange)] focus:ring-[var(--orange)] focus:ring-offset-0"
               />
               <div>
-                <span className="text-white font-medium">Create Remake Order</span>
-                <p className="text-gray-400 text-sm">
+                <span className="text-[var(--ink)] font-medium">Create Remake Order</span>
+                <p className="text-[var(--ink-3)] text-sm">
                   Automatically create a new production order to replace this failed print
                 </p>
               </div>
@@ -257,8 +257,8 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
         )}
 
         {/* Material Cost Warning */}
-        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3 mb-6">
-          <p className="text-yellow-400 text-sm">
+        <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-3 mb-6">
+          <p className="text-[var(--status-amber)] text-sm">
             Material costs for {quantityScrapped} scrapped unit{quantityScrapped > 1 ? "s" : ""} will be added to the order's total COGS.
             {createRemake && !isPartialScrap && " The remake order will use additional material."}
           </p>
@@ -268,14 +268,14 @@ export default function ScrapOrderModal({ productionOrder, onClose, onScrap }) {
         <div className="flex gap-3">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
           >
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={!scrapReason || quantityScrapped <= 0 || quantityScrapped > remainingQty || submitting}
-            className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 px-4 py-2 bg-[var(--status-red)] text-white rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting ? "Processing..." : `Scrap ${quantityScrapped} Unit${quantityScrapped > 1 ? "s" : ""}`}
           </button>

--- a/frontend/src/components/production/OperationActions.jsx
+++ b/frontend/src/components/production/OperationActions.jsx
@@ -69,11 +69,11 @@ function StartButton({ operation, productionOrderId, onSuccess, onError }) {
         handleStart();
       }}
       disabled={loading}
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-blue-600/20 text-blue-400 border border-blue-500/30 rounded-lg hover:bg-blue-600/30 disabled:opacity-50 transition-colors"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-[var(--orange)] text-white border border-transparent rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 transition-colors"
     >
       {loading ? (
         <>
-          <div className="animate-spin rounded-full h-3.5 w-3.5 border-b-2 border-blue-400"></div>
+          <div className="animate-spin rounded-full h-3.5 w-3.5 border-b-2 border-white"></div>
           Checking...
         </>
       ) : (
@@ -100,7 +100,7 @@ function CompleteButton({ operation, onClick }) {
         e.stopPropagation();
         onClick?.();
       }}
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-green-600/20 text-green-400 border border-green-500/30 rounded-lg hover:bg-green-600/30 transition-colors"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-[var(--orange)] text-white border border-transparent rounded-lg hover:bg-[var(--orange-press)] transition-colors"
     >
       <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -120,7 +120,7 @@ function SkipButton({ onClick }) {
         e.stopPropagation();
         onClick?.();
       }}
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 rounded-lg hover:bg-yellow-600/30 transition-colors"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-[var(--paper-sunk)] text-[var(--ink-2)] border border-[var(--rule-hair)] rounded-lg hover:text-[var(--ink)] transition-colors"
     >
       <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
@@ -140,7 +140,7 @@ function ScrapButton({ onClick }) {
         e.stopPropagation();
         onClick?.();
       }}
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-red-600/20 text-red-400 border border-red-500/30 rounded-lg hover:bg-red-600/30 transition-colors"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-[var(--status-red-tint)] text-[var(--status-red)] border border-[var(--status-red)]/30 rounded-lg hover:bg-[var(--status-red)]/20 transition-colors"
     >
       <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/frontend/src/components/production/OperationCard.jsx
+++ b/frontend/src/components/production/OperationCard.jsx
@@ -9,37 +9,37 @@ const statusConfig = {
   pending: {
     icon: '○',
     label: 'Pending',
-    bg: 'bg-gray-800/50',
-    border: 'border-gray-700',
-    iconColor: 'text-gray-400',
+    bg: 'bg-[var(--paper-sunk)]',
+    border: 'border-[var(--rule-hair)]',
+    iconColor: 'text-[var(--ink-3)]',
   },
   queued: {
     icon: '◐',
     label: 'Queued',
-    bg: 'bg-blue-900/30',
-    border: 'border-blue-500/30',
-    iconColor: 'text-blue-400',
+    bg: 'bg-[var(--paper-sunk)]',
+    border: 'border-[var(--rule-hair)]',
+    iconColor: 'text-[var(--ink-3)]',
   },
   running: {
     icon: '●',
     label: 'Running',
-    bg: 'bg-purple-900/30',
-    border: 'border-purple-500/50',
-    iconColor: 'text-purple-400 animate-pulse',
+    bg: 'bg-[var(--status-amber-tint)]',
+    border: 'border-[var(--status-amber)]/50',
+    iconColor: 'text-[var(--status-amber)] animate-pulse',
   },
   complete: {
     icon: '✓',
     label: 'Complete',
-    bg: 'bg-green-900/20',
-    border: 'border-green-500/30',
-    iconColor: 'text-green-400',
+    bg: 'bg-[var(--status-green-tint)]',
+    border: 'border-[var(--status-green)]/30',
+    iconColor: 'text-[var(--status-green)]',
   },
   skipped: {
     icon: '⊘',
     label: 'Skipped',
-    bg: 'bg-yellow-900/20',
-    border: 'border-yellow-500/30',
-    iconColor: 'text-yellow-400',
+    bg: 'bg-[var(--status-amber-tint)]',
+    border: 'border-[var(--status-amber)]/30',
+    iconColor: 'text-[var(--status-amber)]',
   },
 };
 
@@ -134,17 +134,17 @@ export default function OperationCard({
           <span className={`text-lg ${config.iconColor}`}>{config.icon}</span>
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-white font-medium">
+              <span className="text-[var(--ink)] font-medium">
                 {operation.operation_code || `Op ${operation.sequence}`}
               </span>
               {operation.operation_name && (
-                <span className="text-gray-400">— {operation.operation_name}</span>
+                <span className="text-[var(--ink-3)]">— {operation.operation_name}</span>
               )}
             </div>
-            <div className="text-xs text-gray-500">
+            <div className="text-xs text-[var(--ink-4)]">
               {operation.work_center_name || 'No work center'}
               {operation.resource_name && (
-                <span className="text-blue-400"> → {operation.resource_name}</span>
+                <span className="text-[var(--ink-2)]"> → {operation.resource_name}</span>
               )}
             </div>
           </div>
@@ -155,23 +155,23 @@ export default function OperationCard({
           {operation.status === 'running' && operation.actual_start && (
             <ElapsedTimer
               startTime={operation.actual_start}
-              className="text-purple-400 text-sm"
+              className="text-[var(--status-amber)] text-sm"
             />
           )}
 
           {/* Time estimate/actual */}
           {operation.status === 'complete' ? (
-            <span className="text-gray-400 text-sm font-mono">
+            <span className="text-[var(--ink-3)] text-sm font-mono">
               {formatDuration(actualMinutes)}
             </span>
           ) : (
-            <span className="text-gray-500 text-sm font-mono">
+            <span className="text-[var(--ink-4)] text-sm font-mono">
               ~{formatDuration(plannedMinutes)}
             </span>
           )}
 
           {/* Expand indicator */}
-          <span className="text-gray-500 text-xs">
+          <span className="text-[var(--ink-4)] text-xs">
             {isExpanded ? '▼' : '▶'}
           </span>
         </div>
@@ -179,17 +179,17 @@ export default function OperationCard({
 
       {/* Expanded content */}
       {isExpanded && (
-        <div className="border-t border-gray-700/50 p-4 space-y-4">
+        <div className="border-t border-[var(--rule-hair)] p-4 space-y-4">
           {/* Status-specific content */}
 
           {/* PENDING - Show schedule option */}
           {operation.status === 'pending' && (
             <div className="space-y-3">
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[var(--ink-3)]">
                 Not yet scheduled. Assign to a resource to begin.
               </div>
               {operation.materials?.length > 0 && (
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-[var(--ink-4)]">
                   Materials:{' '}
                   {operation.materials
                     .map((m) => `${m.component_name || m.component_sku || 'Unknown'} (${m.quantity_required})`)
@@ -200,14 +200,14 @@ export default function OperationCard({
                 <button
                   onClick={() => onSchedule?.(operation)}
                   disabled={loading}
-                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm transition-colors disabled:opacity-50"
+                  className="px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg text-sm transition-colors disabled:opacity-50"
                 >
                   Schedule
                 </button>
                 <button
                   onClick={() => onSkip?.(operation)}
                   disabled={loading}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg text-sm transition-colors disabled:opacity-50"
+                  className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] hover:text-[var(--ink)] text-[var(--ink-2)] rounded-lg text-sm transition-colors disabled:opacity-50"
                 >
                   Skip
                 </button>
@@ -218,7 +218,7 @@ export default function OperationCard({
           {/* QUEUED - Show start option */}
           {operation.status === 'queued' && (
             <div className="space-y-3">
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[var(--ink-3)]">
                 Scheduled
                 {operation.scheduled_start && (
                   <span>
@@ -226,21 +226,21 @@ export default function OperationCard({
                   </span>
                 )}
                 {operation.resource_name && (
-                  <span className="text-blue-400"> on {operation.resource_name}</span>
+                  <span className="text-[var(--ink-2)]"> on {operation.resource_name}</span>
                 )}
               </div>
               <div className="flex gap-2">
                 <button
                   onClick={() => onStart?.(operation)}
                   disabled={loading}
-                  className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+                  className="px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
                 >
                   ▶ Start Operation
                 </button>
                 <button
                   onClick={() => onSkip?.(operation)}
                   disabled={loading}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg text-sm transition-colors disabled:opacity-50"
+                  className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] hover:text-[var(--ink)] text-[var(--ink-2)] rounded-lg text-sm transition-colors disabled:opacity-50"
                 >
                   Skip
                 </button>
@@ -251,17 +251,17 @@ export default function OperationCard({
           {/* RUNNING - Show complete form */}
           {operation.status === 'running' && (
             <div className="space-y-4">
-              <div className="text-sm text-gray-400">
+              <div className="text-sm text-[var(--ink-3)]">
                 Started {operation.actual_start && formatTime(operation.actual_start)}
                 {operation.resource_name && (
-                  <span className="text-blue-400"> on {operation.resource_name}</span>
+                  <span className="text-[var(--ink-2)]"> on {operation.resource_name}</span>
                 )}
               </div>
 
               {/* Quantity inputs */}
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">
+                  <label className="block text-xs text-[var(--ink-4)] mb-1">
                     Qty Good
                   </label>
                   <input
@@ -270,11 +270,11 @@ export default function OperationCard({
                     max={maxQtyInt}
                     value={qtyGood}
                     onChange={(e) => handleQtyGoodChange(e.target.value)}
-                    className="w-full bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-lg font-mono focus:border-green-500 focus:outline-none"
+                    className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-3 py-2 text-[var(--ink)] text-lg font-mono focus:border-[var(--status-green)] focus:outline-none"
                   />
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">
+                  <label className="block text-xs text-[var(--ink-4)] mb-1">
                     Qty Bad
                   </label>
                   <input
@@ -283,7 +283,7 @@ export default function OperationCard({
                     max={maxQtyInt - qtyGood}
                     value={qtyBad}
                     onChange={(e) => handleQtyBadChange(e.target.value)}
-                    className="w-full bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white text-lg font-mono focus:border-red-500 focus:outline-none"
+                    className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-3 py-2 text-[var(--ink)] text-lg font-mono focus:border-[var(--status-red)] focus:outline-none"
                   />
                 </div>
               </div>
@@ -291,13 +291,13 @@ export default function OperationCard({
               {/* Scrap reason dropdown - only shown when qty bad > 0 */}
               {qtyBad > 0 && (
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">
-                    Scrap Reason <span className="text-red-400">*</span>
+                  <label className="block text-xs text-[var(--ink-4)] mb-1">
+                    Scrap Reason <span className="text-[var(--status-red)]">*</span>
                   </label>
                   <select
                     value={scrapReason}
                     onChange={(e) => setScrapReason(e.target.value)}
-                    className="w-full bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-white focus:border-red-500 focus:outline-none"
+                    className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-3 py-2 text-[var(--ink)] focus:border-[var(--status-red)] focus:outline-none"
                   >
                     {scrapReasons.map((r) => (
                       <option key={r.value} value={r.value}>
@@ -312,14 +312,14 @@ export default function OperationCard({
                 <button
                   onClick={handleComplete}
                   disabled={loading || (qtyGood + qtyBad === 0 && maxQtyInt > 0) || !scrapReasonValid}
-                  className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {loading ? 'Completing...' : maxQtyInt === 0 ? 'Complete (No Input)' : 'Complete Operation'}
                 </button>
                 <button
                   onClick={() => onSkip?.(operation)}
                   disabled={loading}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg text-sm transition-colors disabled:opacity-50"
+                  className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] hover:text-[var(--ink)] text-[var(--ink-2)] rounded-lg text-sm transition-colors disabled:opacity-50"
                 >
                   Skip
                 </button>
@@ -331,23 +331,23 @@ export default function OperationCard({
           {operation.status === 'complete' && (
             <div className="text-sm space-y-1">
               <div className="flex justify-between">
-                <span className="text-gray-500">Qty Completed</span>
-                <span className="text-green-400 font-mono">
+                <span className="text-[var(--ink-4)]">Qty Completed</span>
+                <span className="text-[var(--status-green)] font-mono">
                   {operation.quantity_completed || 0}
                 </span>
               </div>
               {operation.quantity_scrapped > 0 && (
                 <>
                   <div className="flex justify-between">
-                    <span className="text-gray-500">Qty Scrapped</span>
-                    <span className="text-red-400 font-mono">
+                    <span className="text-[var(--ink-4)]">Qty Scrapped</span>
+                    <span className="text-[var(--status-red)] font-mono">
                       {operation.quantity_scrapped}
                     </span>
                   </div>
                   {operation.scrap_reason && (
                     <div className="flex justify-between">
-                      <span className="text-gray-500">Scrap Reason</span>
-                      <span className="text-red-400">
+                      <span className="text-[var(--ink-4)]">Scrap Reason</span>
+                      <span className="text-[var(--status-red)]">
                         {scrapReasons.find(r => r.value === operation.scrap_reason)?.label || operation.scrap_reason}
                       </span>
                     </div>
@@ -355,15 +355,15 @@ export default function OperationCard({
                 </>
               )}
               <div className="flex justify-between">
-                <span className="text-gray-500">Actual Time</span>
-                <span className="text-gray-300 font-mono">
+                <span className="text-[var(--ink-4)]">Actual Time</span>
+                <span className="text-[var(--ink-2)] font-mono">
                   {formatDuration(actualMinutes)}
                 </span>
               </div>
               {operation.actual_start && operation.actual_end && (
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Completed</span>
-                  <span className="text-gray-300">
+                  <span className="text-[var(--ink-4)]">Completed</span>
+                  <span className="text-[var(--ink-2)]">
                     {formatTime(operation.actual_end)}
                   </span>
                 </div>
@@ -374,7 +374,7 @@ export default function OperationCard({
           {/* SKIPPED - Show reason */}
           {operation.status === 'skipped' && (
             <div className="text-sm">
-              <div className="text-yellow-400/80">
+              <div className="text-[var(--status-amber)]/80">
                 {operation.notes?.replace(/^SKIPPED:\s*/i, '') || 'No reason provided'}
               </div>
             </div>

--- a/frontend/src/components/production/OperationCompletionModal.jsx
+++ b/frontend/src/components/production/OperationCompletionModal.jsx
@@ -39,37 +39,37 @@ function CascadeSummary({ materials, totalCost, operationsAffected }) {
   const sortedOps = Object.values(byOperation).sort((a, b) => a.sequence - b.sequence);
 
   return (
-    <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
+    <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3">
       <div
         className="flex items-center justify-between cursor-pointer"
         onClick={() => setExpanded(!expanded)}
       >
         <div className="flex items-center gap-2">
           <svg
-            className={`w-4 h-4 text-red-400 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            className={`w-4 h-4 text-[var(--status-red)] transition-transform ${expanded ? 'rotate-90' : ''}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
-          <span className="text-red-400 text-sm font-medium">
+          <span className="text-[var(--status-red)] text-sm font-medium">
             Scrap Cost: {formatCurrency(totalCost)}
           </span>
         </div>
-        <span className="text-red-400/70 text-xs">
+        <span className="text-[var(--status-red)]/70 text-xs">
           {operationsAffected} operation{operationsAffected !== 1 ? 's' : ''} affected
         </span>
       </div>
 
       {expanded && (
-        <div className="mt-3 pt-3 border-t border-red-500/20 space-y-2">
+        <div className="mt-3 pt-3 border-t border-[var(--status-red)]/20 space-y-2">
           {sortedOps.map((op) => (
             <div key={op.sequence} className="flex items-center justify-between text-xs">
-              <span className="text-gray-400">
+              <span className="text-[var(--ink-3)]">
                 Op {op.sequence}: {op.name}
               </span>
-              <span className="text-red-400">{formatCurrency(op.subtotal)}</span>
+              <span className="text-[var(--status-red)]">{formatCurrency(op.subtotal)}</span>
             </div>
           ))}
         </div>
@@ -252,7 +252,7 @@ export default function OperationCompletionModal({
           toast.success(
             <div>
               <p>{message}</p>
-              <p className="mt-1 text-green-300">
+              <p className="mt-1 text-[var(--status-green)]">
                 Replacement order{' '}
                 <strong>{data.scrap_result.replacement_order.code}</strong> created
               </p>
@@ -281,18 +281,18 @@ export default function OperationCompletionModal({
   const selectedReason = scrapReasons.find((r) => r.code === scrapReason);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Complete Operation" disableClose={submitting} className="w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col">
+    <Modal isOpen={isOpen} onClose={onClose} title="Complete Operation" variant="workbench" disableClose={submitting} className="w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex justify-between items-center p-6 border-b border-gray-800">
+        <div className="flex justify-between items-center p-6 border-b border-[var(--rule-hair)]">
           <div>
-            <h2 className="text-xl font-bold text-white">Complete Operation</h2>
-            <p className="text-gray-400 text-sm mt-1">
+            <h2 className="text-xl font-bold text-[var(--ink)]">Complete Operation</h2>
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               Op {operation.sequence}: {operation.operation_name || operation.operation_code}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white text-xl"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl"
           >
             &times;
           </button>
@@ -301,14 +301,14 @@ export default function OperationCompletionModal({
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6 space-y-5">
           {/* Input quantity summary */}
-          <div className="bg-gray-800/50 rounded-lg p-4">
+          <div className="bg-[var(--paper-sunk)] rounded-lg p-4">
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-400">Input Quantity:</span>
-              <span className="text-white font-medium">{maxQty} units</span>
+              <span className="text-[var(--ink-3)]">Input Quantity:</span>
+              <span className="text-[var(--ink)] font-medium">{maxQty} units</span>
             </div>
             <div className="flex items-center justify-between text-sm mt-1">
-              <span className="text-gray-400">Accounted:</span>
-              <span className={`font-medium ${total === maxQty ? 'text-green-400' : total > maxQty ? 'text-red-400' : 'text-yellow-400'}`}>
+              <span className="text-[var(--ink-3)]">Accounted:</span>
+              <span className={`font-medium ${total === maxQty ? 'text-[var(--status-green)]' : total > maxQty ? 'text-[var(--status-red)]' : 'text-[var(--status-amber)]'}`}>
                 {total} / {maxQty}
               </span>
             </div>
@@ -317,7 +317,7 @@ export default function OperationCompletionModal({
           {/* Quantity inputs */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm text-green-400 mb-2">
+              <label className="block text-sm text-[var(--status-green)] mb-2">
                 Good Units (Pass)
               </label>
               <input
@@ -326,11 +326,11 @@ export default function OperationCompletionModal({
                 onChange={(e) => handleGoodChange(e.target.value)}
                 min="0"
                 max={maxQty}
-                className="w-full bg-gray-800 border border-green-500/50 rounded-lg px-4 py-3 text-white text-lg focus:border-green-500 focus:ring-1 focus:ring-green-500"
+                className="w-full bg-[var(--paper)] border border-[var(--status-green)]/50 rounded-lg px-4 py-3 text-[var(--ink)] text-lg focus:border-[var(--status-green)] focus:ring-1 focus:ring-[var(--status-green)]"
               />
             </div>
             <div>
-              <label className="block text-sm text-red-400 mb-2">
+              <label className="block text-sm text-[var(--status-red)] mb-2">
                 Bad Units (Scrap)
               </label>
               <input
@@ -339,26 +339,26 @@ export default function OperationCompletionModal({
                 onChange={(e) => handleBadChange(e.target.value)}
                 min="0"
                 max={maxQty}
-                className="w-full bg-gray-800 border border-red-500/50 rounded-lg px-4 py-3 text-white text-lg focus:border-red-500 focus:ring-1 focus:ring-red-500"
+                className="w-full bg-[var(--paper)] border border-[var(--status-red)]/50 rounded-lg px-4 py-3 text-[var(--ink)] text-lg focus:border-[var(--status-red)] focus:ring-1 focus:ring-[var(--status-red)]"
               />
             </div>
           </div>
 
           {/* Scrap details - only show if scrapping */}
           {hasScrap && (
-            <div className="space-y-4 pt-4 border-t border-gray-800">
-              <h3 className="text-sm font-medium text-red-400">Scrap Details</h3>
+            <div className="space-y-4 pt-4 border-t border-[var(--rule-hair)]">
+              <h3 className="text-sm font-medium text-[var(--status-red)]">Scrap Details</h3>
 
               {/* Scrap Reason */}
               <div>
-                <label className="block text-sm text-gray-400 mb-2">
+                <label className="block text-sm text-[var(--ink-3)] mb-2">
                   Scrap Reason *
                 </label>
                 <select
                   value={scrapReason}
                   onChange={(e) => setScrapReason(e.target.value)}
-                  className={`w-full bg-gray-800 border rounded-lg px-4 py-2 text-white ${
-                    needsReason ? 'border-red-500' : 'border-gray-700'
+                  className={`w-full bg-[var(--paper)] border rounded-lg px-4 py-2 text-[var(--ink)] ${
+                    needsReason ? 'border-[var(--status-red)]' : 'border-[var(--rule-hair)]'
                   }`}
                 >
                   <option value="">Select reason...</option>
@@ -369,7 +369,7 @@ export default function OperationCompletionModal({
                   ))}
                 </select>
                 {selectedReason?.description && (
-                  <p className="text-gray-500 text-xs mt-1">
+                  <p className="text-[var(--ink-4)] text-xs mt-1">
                     {selectedReason.description}
                   </p>
                 )}
@@ -377,13 +377,13 @@ export default function OperationCompletionModal({
 
               {/* Scrap Notes */}
               <div>
-                <label className="block text-sm text-gray-400 mb-2">
+                <label className="block text-sm text-[var(--ink-3)] mb-2">
                   Scrap Notes
                 </label>
                 <textarea
                   value={scrapNotes}
                   onChange={(e) => setScrapNotes(e.target.value)}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white h-16 resize-none text-sm"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)] placeholder-[var(--ink-4)] h-16 resize-none text-sm"
                   placeholder="What went wrong..."
                 />
               </div>
@@ -391,8 +391,8 @@ export default function OperationCompletionModal({
               {/* Cascade preview */}
               {loading ? (
                 <div className="flex items-center justify-center py-3">
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-red-400"></div>
-                  <span className="ml-2 text-sm text-gray-400">Calculating costs...</span>
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-[var(--orange)]"></div>
+                  <span className="ml-2 text-sm text-[var(--ink-3)]">Calculating costs...</span>
                 </div>
               ) : cascadeData ? (
                 <CascadeSummary
@@ -408,11 +408,11 @@ export default function OperationCompletionModal({
                   type="checkbox"
                   checked={createReplacement}
                   onChange={(e) => setCreateReplacement(e.target.checked)}
-                  className="w-4 h-4 rounded bg-gray-700 border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                  className="w-4 h-4 rounded bg-[var(--paper)] border-[var(--rule-hair)] text-[var(--orange)] focus:ring-[var(--orange)] focus:ring-offset-0"
                 />
                 <div>
-                  <span className="text-white text-sm">Create replacement order</span>
-                  <p className="text-gray-500 text-xs">
+                  <span className="text-[var(--ink)] text-sm">Create replacement order</span>
+                  <p className="text-[var(--ink-4)] text-xs">
                     Auto-create PO for {qtyBad} scrapped unit{qtyBad !== 1 ? 's' : ''}
                   </p>
                 </div>
@@ -422,23 +422,23 @@ export default function OperationCompletionModal({
 
           {/* General notes */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Completion Notes
             </label>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white h-16 resize-none text-sm"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)] placeholder-[var(--ink-4)] h-16 resize-none text-sm"
               placeholder="Any notes about this operation..."
             />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex gap-3 p-6 border-t border-gray-800">
+        <div className="flex gap-3 p-6 border-t border-[var(--rule-hair)]">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
           >
             Cancel
           </button>
@@ -447,8 +447,8 @@ export default function OperationCompletionModal({
             disabled={!isValid || submitting}
             className={`flex-1 px-4 py-2 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
               hasScrap
-                ? 'bg-yellow-600 hover:bg-yellow-500'
-                : 'bg-green-600 hover:bg-green-500'
+                ? 'bg-[var(--status-red)] hover:bg-[var(--status-red)]/90'
+                : 'bg-[var(--orange)] hover:bg-[var(--orange-press)]'
             }`}
           >
             {submitting

--- a/frontend/src/components/production/OperationRow.jsx
+++ b/frontend/src/components/production/OperationRow.jsx
@@ -14,33 +14,33 @@ import OperationActions from './OperationActions';
 function StatusIndicator({ status }) {
   const configs = {
     pending: {
-      color: 'text-gray-400',
-      bgColor: 'bg-gray-500/20',
+      color: 'text-[var(--ink-4)]',
+      bgColor: 'bg-[var(--paper-sunk)]',
       icon: '○',
       label: 'Pending'
     },
     queued: {
-      color: 'text-blue-400',
-      bgColor: 'bg-blue-500/20',
+      color: 'text-[var(--ink-3)]',
+      bgColor: 'bg-[var(--paper-sunk)]',
       icon: '◐',
       label: 'Queued'
     },
     running: {
-      color: 'text-purple-400',
-      bgColor: 'bg-purple-500/20',
+      color: 'text-[var(--status-amber)]',
+      bgColor: 'bg-[var(--status-amber-tint)]',
       icon: '●',
       label: 'Running',
       pulse: true
     },
     complete: {
-      color: 'text-green-400',
-      bgColor: 'bg-green-500/20',
+      color: 'text-[var(--status-green)]',
+      bgColor: 'bg-[var(--status-green-tint)]',
       icon: '●',
       label: 'Complete'
     },
     skipped: {
-      color: 'text-yellow-400',
-      bgColor: 'bg-yellow-500/20',
+      color: 'text-[var(--status-amber)]',
+      bgColor: 'bg-[var(--status-amber-tint)]',
       icon: '⊘',
       label: 'Skipped'
     }
@@ -115,7 +115,7 @@ function TimingDisplay({ operation }) {
     // Show actual time
     const actualMinutes = (operation.actual_setup_minutes || 0) + (operation.actual_run_minutes || 0);
     return (
-      <span className="text-green-400 text-sm">
+      <span className="text-[var(--status-green)] text-sm">
         {formatDuration(actualMinutes)}
       </span>
     );
@@ -125,16 +125,16 @@ function TimingDisplay({ operation }) {
     // Show elapsed time (calculate from actual_start)
     if (operation.actual_start) {
       return (
-        <span className="text-purple-400 text-sm font-mono">
+        <span className="text-[var(--status-amber)] text-sm font-mono">
           {formatDuration(elapsedMinutes)}
         </span>
       );
     }
-    return <span className="text-purple-400 text-sm">Starting...</span>;
+    return <span className="text-[var(--status-amber)] text-sm">Starting...</span>;
   }
 
   if (operation.status === 'skipped') {
-    return <span className="text-yellow-400 text-sm">—</span>;
+    return <span className="text-[var(--status-amber)] text-sm">—</span>;
   }
 
   // Pending - show estimate (API returns Numeric columns as strings; use parseFloat)
@@ -142,13 +142,13 @@ function TimingDisplay({ operation }) {
   const planned = toMin(operation.planned_setup_minutes) + toMin(operation.planned_run_minutes);
   if (planned > 0) {
     return (
-      <span className="text-gray-500 text-sm">
+      <span className="text-[var(--ink-4)] text-sm">
         Est: {formatDuration(planned)}
       </span>
     );
   }
 
-  return <span className="text-gray-600 text-sm">—</span>;
+  return <span className="text-[var(--ink-4)] text-sm">—</span>;
 }
 
 /**
@@ -171,8 +171,8 @@ export default function OperationRow({
     <div
       className={`
         group p-3 rounded-lg border transition-all
-        ${isActive ? 'border-purple-500/50 bg-purple-500/5' : 'border-gray-800 bg-gray-900/50'}
-        ${isClickable ? 'cursor-pointer hover:border-gray-700 hover:bg-gray-800/50' : ''}
+        ${isActive ? 'border-[var(--status-amber)]/50 bg-[var(--status-amber-tint)]' : 'border-[var(--rule-hair)] bg-[var(--paper)]'}
+        ${isClickable ? 'cursor-pointer hover:border-[var(--rule-hair)] hover:bg-[var(--paper-sunk)]' : ''}
         ${operation.status === 'complete' ? 'opacity-75' : ''}
         ${operation.status === 'skipped' ? 'opacity-50' : ''}
       `}
@@ -182,29 +182,29 @@ export default function OperationRow({
         {/* Left: Sequence, Code, Name */}
         <div className="flex items-center gap-3">
           {/* Sequence number */}
-          <span className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-800 text-gray-400 text-sm font-mono">
+          <span className="w-8 h-8 flex items-center justify-center rounded-full bg-[var(--paper-sunk)] text-[var(--ink-3)] text-sm font-mono">
             {operation.sequence}
           </span>
 
           {/* Operation info */}
           <div>
             <div className="flex items-center gap-2">
-              <span className="text-white font-medium">
+              <span className="text-[var(--ink)] font-medium">
                 {operation.operation_code || `Op ${operation.sequence}`}
               </span>
               {operation.operation_name && (
                 <>
-                  <span className="text-gray-600">—</span>
-                  <span className="text-gray-400">{operation.operation_name}</span>
+                  <span className="text-[var(--ink-4)]">—</span>
+                  <span className="text-[var(--ink-3)]">{operation.operation_name}</span>
                 </>
               )}
             </div>
 
             {/* Work center / resource */}
-            <div className="text-xs text-gray-500 mt-0.5">
+            <div className="text-xs text-[var(--ink-4)] mt-0.5">
               {operation.work_center_name || operation.work_center_code || 'Unassigned'}
               {operation.resource_name && (
-                <span className="text-gray-600"> → {operation.resource_name}</span>
+                <span className="text-[var(--ink-4)]"> → {operation.resource_name}</span>
               )}
             </div>
           </div>
@@ -219,11 +219,11 @@ export default function OperationRow({
 
       {/* Expanded details for running operation */}
       {operation.status === 'running' && (
-        <div className="mt-3 pt-3 border-t border-gray-800 flex items-center justify-between">
-          <div className="text-xs text-gray-500">
+        <div className="mt-3 pt-3 border-t border-[var(--rule-hair)] flex items-center justify-between">
+          <div className="text-xs text-[var(--ink-4)]">
             Started: {operation.actual_start ? formatTime(operation.actual_start) : 'Just now'}
           </div>
-          <div className="text-xs text-purple-400">
+          <div className="text-xs text-[var(--status-amber)]">
             ● In Progress
           </div>
         </div>
@@ -231,27 +231,27 @@ export default function OperationRow({
 
       {/* Materials required for this operation */}
       {operation.materials && operation.materials.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-gray-800">
-          <div className="text-xs text-gray-500 mb-2">Materials:</div>
+        <div className="mt-3 pt-3 border-t border-[var(--rule-hair)]">
+          <div className="text-xs text-[var(--ink-4)] mb-2">Materials:</div>
           <div className="space-y-1">
             {operation.materials.map((mat) => (
               <div key={mat.id} className="flex items-center justify-between text-xs">
                 <div className="flex items-center gap-2">
-                  <span className="text-gray-400">{mat.component_sku || mat.component_name}</span>
+                  <span className="text-[var(--ink-3)]">{mat.component_sku || mat.component_name}</span>
                   {mat.component_name && mat.component_sku && (
-                    <span className="text-gray-600">- {mat.component_name}</span>
+                    <span className="text-[var(--ink-4)]">- {mat.component_name}</span>
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={mat.status === 'consumed' ? 'text-green-400' : 'text-gray-400'}>
+                  <span className={mat.status === 'consumed' ? 'text-[var(--status-green)]' : 'text-[var(--ink-3)]'}>
                     {mat.status === 'consumed'
                       ? `${Number(mat.quantity_consumed).toFixed(2)} ${mat.unit}`
                       : `${Number(mat.quantity_required).toFixed(2)} ${mat.unit}`}
                   </span>
                   <span className={`px-1.5 py-0.5 rounded text-[10px] ${
-                    mat.status === 'consumed' ? 'bg-green-500/20 text-green-400' :
-                    mat.status === 'allocated' ? 'bg-blue-500/20 text-blue-400' :
-                    'bg-gray-700 text-gray-400'
+                    mat.status === 'consumed' ? 'bg-[var(--status-green-tint)] text-[var(--status-green)]' :
+                    mat.status === 'allocated' ? 'bg-[var(--paper-sunk)] text-[var(--ink-2)]' :
+                    'bg-[var(--paper-sunk)] text-[var(--ink-3)]'
                   }`}>
                     {mat.status}
                   </span>
@@ -264,7 +264,7 @@ export default function OperationRow({
 
       {/* Show skip reason if skipped */}
       {operation.status === 'skipped' && operation.notes && (
-        <div className="mt-2 text-xs text-yellow-400/70 italic">
+        <div className="mt-2 text-xs text-[var(--status-amber)]/70 italic">
           Skipped: {operation.notes}
         </div>
       )}

--- a/frontend/src/components/production/OperationSchedulerModal.jsx
+++ b/frontend/src/components/production/OperationSchedulerModal.jsx
@@ -434,14 +434,15 @@ export default function OperationSchedulerModal({
       onClose={handleAutoClose}
       title={modalTitle}
       disableClose={submitting}
+      variant="workbench"
       className="w-full max-w-lg mx-4"
     >
       {/* Header */}
-      <div className="flex items-center justify-between p-6 border-b border-gray-800">
-        <h2 className="text-xl font-semibold text-white">{modalTitle}</h2>
+      <div className="flex items-center justify-between p-6 border-b border-[var(--rule-hair)]">
+        <h2 className="text-xl font-semibold text-[var(--ink)]">{modalTitle}</h2>
         <button
           onClick={handleClose}
-          className="text-gray-400 hover:text-white transition-colors"
+          className="text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
         >
           <svg
             className="w-6 h-6"
@@ -481,12 +482,12 @@ export default function OperationSchedulerModal({
 
         {/* Wizard maintenance warning (SCHED-3b) */}
         {wizardMode && wizardSuggestion?.maintenanceWarning && (
-          <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-3">
+          <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-3">
             <div className="flex items-start gap-2">
-              <svg className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 text-[var(--status-amber)] flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
-              <p className="text-sm text-amber-400">{wizardSuggestion.maintenanceWarning}</p>
+              <p className="text-sm text-[var(--status-amber)]">{wizardSuggestion.maintenanceWarning}</p>
             </div>
           </div>
         )}
@@ -496,19 +497,19 @@ export default function OperationSchedulerModal({
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Operation info */}
             <div className="space-y-2">
-              <div className="flex items-center gap-2 text-white">
+              <div className="flex items-center gap-2 text-[var(--ink)]">
                 <span className="font-medium">{currentOp.sequence}:</span>
                 <span>{currentOp.operation_code}</span>
                 {currentOp.operation_name && (
-                  <span className="text-gray-400">
+                  <span className="text-[var(--ink-3)]">
                     ({currentOp.operation_name})
                   </span>
                 )}
               </div>
-              <div className="text-sm text-gray-500">
+              <div className="text-sm text-[var(--ink-4)]">
                 Production Order: {productionOrder?.code}
               </div>
-              <div className="text-sm text-gray-500">
+              <div className="text-sm text-[var(--ink-4)]">
                 {estimatedMinutes > 0 ? (
                   <>Estimated Duration: {formatDuration(estimatedMinutes)}</>
                 ) : (
@@ -519,13 +520,13 @@ export default function OperationSchedulerModal({
               </div>
             </div>
 
-            <hr className="border-gray-800" />
+            <hr className="border-[var(--rule-hair)]" />
 
             {/* Resource selector */}
             <div>
               <div className="flex items-center justify-between mb-2">
-                <label className="block text-sm font-medium text-gray-400">
-                  Resource <span className="text-red-400">*</span>
+                <label className="block text-sm font-medium text-[var(--ink-3)]">
+                  Resource <span className="text-[var(--status-red)]">*</span>
                 </label>
                 {/* SCHED-3: Auto-pick slot — PRO-gated, only shown when not in edit mode */}
                 {!isEditMode && currentOp?.id && productionOrder?.id && (
@@ -551,7 +552,7 @@ export default function OperationSchedulerModal({
                 value={resourceId}
                 onChange={(e) => setResourceId(e.target.value)}
                 disabled={loadingResources}
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2.5 text-[var(--ink)] focus:ring-2 focus:ring-[var(--orange)] focus:border-transparent"
               >
                 <option value="">
                   {loadingResources ? "Loading..." : "Select a resource..."}
@@ -563,7 +564,7 @@ export default function OperationSchedulerModal({
                 ))}
               </select>
               {resources.length === 0 && !loadingResources && (
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-[var(--ink-4)] mt-1">
                   No resources available for this work center
                 </p>
               )}
@@ -571,22 +572,22 @@ export default function OperationSchedulerModal({
 
             {/* Start time */}
             <div>
-              <label className="block text-sm font-medium text-gray-400 mb-2">
-                Start Time <span className="text-red-400">*</span>
+              <label className="block text-sm font-medium text-[var(--ink-3)] mb-2">
+                Start Time <span className="text-[var(--status-red)]">*</span>
               </label>
               <input
                 type="datetime-local"
                 value={startTime}
                 onChange={(e) => setStartTime(e.target.value)}
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2.5 text-[var(--ink)] focus:ring-2 focus:ring-[var(--orange)] focus:border-transparent"
               />
             </div>
 
             {/* End time (auto-calculated or manual when duration is unknown) */}
             <div>
-              <label className="block text-sm font-medium text-gray-400 mb-2">
-                End Time <span className="text-red-400">*</span>
-                <span className="text-gray-600 font-normal ml-2">
+              <label className="block text-sm font-medium text-[var(--ink-3)] mb-2">
+                End Time <span className="text-[var(--status-red)]">*</span>
+                <span className="text-[var(--ink-4)] font-normal ml-2">
                   {estimatedMinutes > 0 ? "(auto-calculated)" : "(enter manually)"}
                 </span>
               </label>
@@ -594,7 +595,7 @@ export default function OperationSchedulerModal({
                 type="datetime-local"
                 value={endTime}
                 onChange={(e) => setEndTime(e.target.value)}
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2.5 text-[var(--ink-3)] focus:ring-2 focus:ring-[var(--orange)] focus:border-transparent"
               />
             </div>
 
@@ -620,8 +621,8 @@ export default function OperationSchedulerModal({
             {/* Resource conflict alert (live check or server response) */}
             {!predecessorConflict && successorConflicts.length === 0 && (
               checking ? (
-                <div className="text-sm text-gray-500 flex items-center gap-2">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
+                <div className="text-sm text-[var(--ink-4)] flex items-center gap-2">
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[var(--orange)]"></div>
                   Checking for conflicts...
                 </div>
               ) : (
@@ -636,8 +637,8 @@ export default function OperationSchedulerModal({
 
             {/* Error message (only for non-conflict errors) */}
             {error && !predecessorConflict && !serverConflicts.length && successorConflicts.length === 0 && (
-              <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
-                <p className="text-red-400 text-sm">{error}</p>
+              <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3">
+                <p className="text-[var(--status-red)] text-sm">{error}</p>
               </div>
             )}
 
@@ -650,7 +651,7 @@ export default function OperationSchedulerModal({
               />
             )}
 
-            <hr className="border-gray-800" />
+            <hr className="border-[var(--rule-hair)]" />
 
             {/* Actions */}
             <div className="flex justify-between gap-3">
@@ -661,7 +662,7 @@ export default function OperationSchedulerModal({
                     type="button"
                     onClick={() => setShowUnscheduleConfirm(true)}
                     disabled={submitting}
-                    className="px-4 py-2 text-amber-400 hover:text-amber-300 transition-colors disabled:opacity-50"
+                    className="px-4 py-2 text-[var(--status-amber)] hover:opacity-80 transition-colors disabled:opacity-50"
                   >
                     Unschedule
                   </button>
@@ -675,7 +676,7 @@ export default function OperationSchedulerModal({
                     type="button"
                     onClick={onWizardSkip}
                     disabled={submitting}
-                    className="px-4 py-2 text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+                    className="px-4 py-2 text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors disabled:opacity-50"
                   >
                     Skip
                   </button>
@@ -683,7 +684,7 @@ export default function OperationSchedulerModal({
                   <button
                     type="button"
                     onClick={handleClose}
-                    className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+                    className="px-4 py-2 text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
                   >
                     Done
                   </button>
@@ -698,7 +699,7 @@ export default function OperationSchedulerModal({
                       !resourceId ||
                       !startTime
                     }
-                    className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    className="px-6 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     {submitting
                       ? isEditMode ? "Rescheduling..." : "Scheduling..."
@@ -716,7 +717,7 @@ export default function OperationSchedulerModal({
             <button
               type="button"
               onClick={handleClose}
-              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              className="px-6 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] transition-colors"
             >
               Done
             </button>

--- a/frontend/src/components/production/OperationsPanel.jsx
+++ b/frontend/src/components/production/OperationsPanel.jsx
@@ -90,18 +90,18 @@ function OperationsSummary({ operations }) {
   }, 0);
 
   return (
-    <div className="flex items-center justify-between text-sm border-t border-gray-800 pt-3 mt-3">
+    <div className="flex items-center justify-between text-sm border-t border-[var(--rule-hair)] pt-3 mt-3">
       <div className="flex items-center gap-4">
-        <span className="text-gray-500">
+        <span className="text-[var(--ink-4)]">
           {completed + skipped}/{operations.length} complete
         </span>
         {running > 0 && (
-          <span className="text-purple-400">
+          <span className="text-[var(--status-amber)]">
             ● {running} running
           </span>
         )}
       </div>
-      <div className="flex items-center gap-4 text-gray-500">
+      <div className="flex items-center gap-4 text-[var(--ink-4)]">
         {elapsedMinutes > 0 && (
           <span>{formatDuration(elapsedMinutes)} elapsed</span>
         )}
@@ -120,8 +120,8 @@ function EmptyOperations({ orderStatus }) {
   if (orderStatus === 'draft') {
     return (
       <div className="text-center py-8">
-        <div className="text-gray-500 mb-2">No operations yet</div>
-        <div className="text-sm text-gray-600">
+        <div className="text-[var(--ink-3)] mb-2">No operations yet</div>
+        <div className="text-sm text-[var(--ink-4)]">
           Operations will be generated when the order is released
         </div>
       </div>
@@ -130,8 +130,8 @@ function EmptyOperations({ orderStatus }) {
 
   return (
     <div className="text-center py-8">
-      <div className="text-gray-500 mb-2">No operations defined</div>
-      <div className="text-sm text-gray-600">
+      <div className="text-[var(--ink-3)] mb-2">No operations defined</div>
+      <div className="text-sm text-[var(--ink-4)]">
         This product may not have a routing configured
       </div>
     </div>
@@ -223,14 +223,14 @@ export default function OperationsPanel({ productionOrderId, productionOrder, or
   const activeOperation = operations.find(op => op.status === 'running');
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-white">Operations</h2>
+        <h2 className="text-lg font-semibold text-[var(--ink)]">Operations</h2>
         <button
           onClick={handleRefresh}
           disabled={loading}
-          className="text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+          className="text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors disabled:opacity-50"
           title="Refresh"
         >
           <svg
@@ -251,15 +251,15 @@ export default function OperationsPanel({ productionOrderId, productionOrder, or
 
       {/* Error state */}
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mb-4">
-          <p className="text-red-400 text-sm">{error}</p>
+        <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3 mb-4">
+          <p className="text-[var(--status-red)] text-sm">{error}</p>
         </div>
       )}
 
       {/* Loading state */}
       {loading && operations.length === 0 && (
         <div className="flex items-center justify-center py-8">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
         </div>
       )}
 

--- a/frontend/src/components/production/OperationsProgressBar.jsx
+++ b/frontend/src/components/production/OperationsProgressBar.jsx
@@ -8,7 +8,7 @@
 export default function OperationsProgressBar({ operations, showLabels = true }) {
   if (!operations || operations.length === 0) {
     return (
-      <div className="text-xs text-gray-500">No operations</div>
+      <div className="text-xs text-[var(--ink-4)]">No operations</div>
     );
   }
 
@@ -30,17 +30,17 @@ export default function OperationsProgressBar({ operations, showLabels = true })
   return (
     <div className="space-y-1.5">
       {/* Progress bar */}
-      <div className="h-2 bg-gray-800 rounded-full overflow-hidden flex">
+      <div className="h-2 bg-[var(--rule-hair)] rounded-full overflow-hidden flex">
         <div
-          className="bg-green-500 transition-all duration-500"
+          className="bg-[var(--status-green)] transition-all duration-500"
           style={{ width: `${completedPct}%` }}
         />
         <div
-          className="bg-purple-500 animate-pulse transition-all duration-500"
+          className="bg-[var(--status-amber)] animate-pulse transition-all duration-500"
           style={{ width: `${runningPct}%` }}
         />
         <div
-          className="bg-yellow-500/50 transition-all duration-500"
+          className="bg-[var(--status-amber)]/50 transition-all duration-500"
           style={{ width: `${skippedPct}%` }}
         />
       </div>
@@ -48,11 +48,11 @@ export default function OperationsProgressBar({ operations, showLabels = true })
       {/* Labels */}
       {showLabels && (
         <div className="flex justify-between text-xs">
-          <span className="text-gray-500">
+          <span className="text-[var(--ink-4)]">
             {completed + skipped}/{total} ops
           </span>
           {currentOp && (
-            <span className={currentOp.status === 'running' ? 'text-purple-400' : 'text-gray-500'}>
+            <span className={currentOp.status === 'running' ? 'text-[var(--status-amber)]' : 'text-[var(--ink-4)]'}>
               {currentOp.status === 'running' ? '\u25CF ' : ''}
               {currentOp.operation_code || `Op ${currentOp.sequence}`}
             </span>

--- a/frontend/src/components/production/OperationsTimeline.jsx
+++ b/frontend/src/components/production/OperationsTimeline.jsx
@@ -26,25 +26,25 @@ function parseDateTime(datetime) {
  */
 const STATUS_CONFIG = {
   pending: {
-    nodeClass: 'border-2 border-gray-600 bg-gray-900',
-    labelClass: 'text-gray-500',
+    nodeClass: 'border-2 border-[var(--rule-hair)] bg-[var(--paper-sunk)]',
+    labelClass: 'text-[var(--ink-4)]',
     icon: null
   },
   queued: {
-    nodeClass: 'border-2 border-blue-500 bg-gray-900',
-    labelClass: 'text-blue-400',
+    nodeClass: 'border-2 border-[var(--ink-3)] bg-[var(--paper-sunk)]',
+    labelClass: 'text-[var(--ink-3)]',
     icon: null
   },
   running: {
-    nodeClass: 'border-2 border-purple-500 bg-purple-500/20 animate-pulse',
-    labelClass: 'text-purple-400',
+    nodeClass: 'border-2 border-[var(--status-amber)] bg-[var(--status-amber-tint)] animate-pulse',
+    labelClass: 'text-[var(--status-amber)]',
     icon: (
-      <div className="w-2 h-2 rounded-full bg-purple-400 animate-ping" />
+      <div className="w-2 h-2 rounded-full bg-[var(--status-amber)] animate-ping" />
     )
   },
   complete: {
-    nodeClass: 'border-2 border-green-500 bg-green-500',
-    labelClass: 'text-green-400',
+    nodeClass: 'border-2 border-[var(--status-green)] bg-[var(--status-green)]',
+    labelClass: 'text-[var(--status-green)]',
     icon: (
       <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
@@ -52,10 +52,10 @@ const STATUS_CONFIG = {
     )
   },
   skipped: {
-    nodeClass: 'border-2 border-yellow-500 bg-yellow-500/20',
-    labelClass: 'text-yellow-400 line-through',
+    nodeClass: 'border-2 border-[var(--status-amber)] bg-[var(--status-amber-tint)]',
+    labelClass: 'text-[var(--status-amber)] line-through',
     icon: (
-      <svg className="w-3 h-3 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg className="w-3 h-3 text-[var(--status-amber)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
       </svg>
     )
@@ -125,12 +125,12 @@ function TimelineConnector({ prevStatus }) {
   // Use the "more complete" status for coloring
   const getConnectorClass = () => {
     if (prevStatus === 'complete' || prevStatus === 'skipped') {
-      return 'bg-green-500';
+      return 'bg-[var(--status-green)]';
     }
     if (prevStatus === 'running') {
-      return 'bg-gradient-to-r from-purple-500 to-gray-700';
+      return 'bg-gradient-to-r from-[var(--status-amber)] to-[var(--rule-hair)]';
     }
-    return 'bg-gray-700';
+    return 'bg-[var(--rule-hair)]';
   };
 
   return (
@@ -153,8 +153,8 @@ function ProgressSummary({ operations }) {
 
   return (
     <div className="flex items-center justify-between mb-4">
-      <span className="text-sm text-gray-400">Operations Progress</span>
-      <span className="text-sm font-medium text-white">{percentage}%</span>
+      <span className="text-sm text-[var(--ink-3)]">Operations Progress</span>
+      <span className="text-sm font-medium text-[var(--ink)]">{percentage}%</span>
     </div>
   );
 }
@@ -176,20 +176,20 @@ function ProgressBar({ operations }) {
 
   return (
     <div className="mt-4">
-      <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden flex">
+      <div className="h-1.5 bg-[var(--rule-hair)] rounded-full overflow-hidden flex">
         {/* Completed */}
         <div
-          className="bg-green-500 transition-all duration-500"
+          className="bg-[var(--status-green)] transition-all duration-500"
           style={{ width: `${completedPct}%` }}
         />
         {/* Running */}
         <div
-          className="bg-purple-500 animate-pulse transition-all duration-500"
+          className="bg-[var(--status-amber)] animate-pulse transition-all duration-500"
           style={{ width: `${runningPct}%` }}
         />
         {/* Skipped */}
         <div
-          className="bg-yellow-500/50 transition-all duration-500"
+          className="bg-[var(--status-amber)]/50 transition-all duration-500"
           style={{ width: `${skippedPct}%` }}
         />
       </div>
@@ -209,7 +209,7 @@ export default function OperationsTimeline({ operations }) {
   const sortedOps = [...operations].sort((a, b) => a.sequence - b.sequence);
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
       <ProgressSummary operations={sortedOps} />
 
       {/* Timeline */}

--- a/frontend/src/components/production/ProductionOrderModal.jsx
+++ b/frontend/src/components/production/ProductionOrderModal.jsx
@@ -706,27 +706,28 @@ export default function ProductionOrderModal({
       isOpen={true}
       onClose={onClose}
       title={`Production Order ${productionOrder.code}`}
+      variant="workbench"
       className="w-full max-w-3xl mx-4 max-h-[90vh] flex flex-col"
     >
       {/* Header */}
-      <div className="flex justify-between items-start p-6 border-b border-gray-800">
+      <div className="flex justify-between items-start p-6 border-b border-[var(--rule-hair)]">
         <div>
           <div className="flex items-center gap-3">
-            <h2 className="text-xl font-bold text-white">
+            <h2 className="text-xl font-bold text-[var(--ink)]">
               {productionOrder.code}
             </h2>
             <StatusBadge status={productionOrder.status} />
           </div>
-          <p className="text-gray-400 mt-1">
+          <p className="text-[var(--ink-3)] mt-1">
             {productionOrder.product_name ||
               productionOrder.product?.name ||
               "Unknown Product"}
-            <span className="text-gray-500"> × </span>
-            <span className="text-white font-mono">
+            <span className="text-[var(--ink-4)]"> × </span>
+            <span className="text-[var(--ink)] font-mono">
               {productionOrder.quantity_ordered}
             </span>
             {productionOrder.due_date && (
-              <span className="text-gray-500 ml-3">
+              <span className="text-[var(--ink-4)] ml-3">
                 Due: {formatDate(productionOrder.due_date)}
               </span>
             )}
@@ -734,7 +735,7 @@ export default function ProductionOrderModal({
         </div>
         <button
           onClick={onClose}
-          className="text-gray-400 hover:text-white text-2xl leading-none"
+          className="text-[var(--ink-3)] hover:text-[var(--ink)] text-2xl leading-none"
         >
           ×
         </button>
@@ -742,7 +743,7 @@ export default function ProductionOrderModal({
 
       {/* Error */}
       {error && (
-        <div className="mx-6 mt-4 bg-red-900/20 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+        <div className="mx-6 mt-4 bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3 text-[var(--status-red)] text-sm">
           {error}
         </div>
       )}
@@ -751,26 +752,26 @@ export default function ProductionOrderModal({
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Summary stats */}
           <div className="grid grid-cols-3 gap-4">
-            <div className="bg-gray-800/50 rounded-lg p-3">
-              <div className="text-gray-500 text-xs">Operations</div>
-              <div className="text-white font-medium">
+            <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+              <div className="text-[var(--ink-4)] text-xs">Operations</div>
+              <div className="text-[var(--ink)] font-medium">
                 {completedOps}/{operations.length} complete
                 {runningOps > 0 && (
-                  <span className="text-purple-400 ml-1">({runningOps} running)</span>
+                  <span className="text-[var(--status-amber)] ml-1">({runningOps} running)</span>
                 )}
               </div>
             </div>
-            <div className="bg-gray-800/50 rounded-lg p-3">
-              <div className="text-gray-500 text-xs">Est. Duration</div>
-              <div className="text-white font-medium font-mono">
+            <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+              <div className="text-[var(--ink-4)] text-xs">Est. Duration</div>
+              <div className="text-[var(--ink)] font-medium font-mono">
                 {formatDuration(totalMinutes)}
               </div>
             </div>
-            <div className="bg-gray-800/50 rounded-lg p-3">
-              <div className="text-gray-500 text-xs">Materials</div>
+            <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+              <div className="text-[var(--ink-4)] text-xs">Materials</div>
               <div
                 className={`font-medium ${
-                  materialsBlocking.length > 0 ? 'text-red-400' : 'text-green-400'
+                  materialsBlocking.length > 0 ? 'text-[var(--status-red)]' : 'text-[var(--status-green)]'
                 }`}
               >
                 {allMaterials.length > 0
@@ -783,26 +784,26 @@ export default function ProductionOrderModal({
           {/* Cost Summary */}
           {(productionOrder.estimated_material_cost != null || productionOrder.actual_material_cost != null) && (
             <div>
-              <h3 className="text-gray-400 text-sm font-medium mb-3">COST</h3>
+              <h3 className="text-[var(--ink-3)] text-sm font-medium mb-3">COST</h3>
               <div className="grid grid-cols-2 gap-3">
                 {productionOrder.estimated_material_cost != null && (
-                  <div className="bg-gray-800/50 rounded-lg p-3">
-                    <div className="text-gray-500 text-xs mb-1">Estimated</div>
-                    <div className="text-white font-mono text-sm">
+                  <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+                    <div className="text-[var(--ink-4)] text-xs mb-1">Estimated</div>
+                    <div className="text-[var(--ink)] font-mono text-sm">
                       ${(parseFloat(productionOrder.estimated_material_cost) + parseFloat(productionOrder.estimated_labor_cost || 0)).toFixed(2)}
                     </div>
-                    <div className="text-gray-500 text-xs mt-1">
+                    <div className="text-[var(--ink-4)] text-xs mt-1">
                       Mat: ${parseFloat(productionOrder.estimated_material_cost).toFixed(2)} · Labor: ${parseFloat(productionOrder.estimated_labor_cost || 0).toFixed(2)}
                     </div>
                   </div>
                 )}
                 {productionOrder.actual_material_cost != null && (
-                  <div className="bg-gray-800/50 rounded-lg p-3">
-                    <div className="text-gray-500 text-xs mb-1">Actual</div>
-                    <div className="text-white font-mono text-sm">
+                  <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+                    <div className="text-[var(--ink-4)] text-xs mb-1">Actual</div>
+                    <div className="text-[var(--ink)] font-mono text-sm">
                       ${(parseFloat(productionOrder.actual_material_cost) + parseFloat(productionOrder.actual_labor_cost || 0)).toFixed(2)}
                     </div>
-                    <div className="text-gray-500 text-xs mt-1">
+                    <div className="text-[var(--ink-4)] text-xs mt-1">
                       Mat: ${parseFloat(productionOrder.actual_material_cost).toFixed(2)} · Labor: ${parseFloat(productionOrder.actual_labor_cost || 0).toFixed(2)}
                     </div>
                   </div>
@@ -813,19 +814,19 @@ export default function ProductionOrderModal({
 
           {/* Operations */}
           <div>
-            <h3 className="text-gray-400 text-sm font-medium mb-3">OPERATIONS</h3>
+            <h3 className="text-[var(--ink-3)] text-sm font-medium mb-3">OPERATIONS</h3>
             {loading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-purple-500"></div>
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
               </div>
             ) : operations.length === 0 ? (
               <div className="text-center py-8">
-                <p className="text-gray-500 mb-3">No operations defined for this order</p>
+                <p className="text-[var(--ink-4)] mb-3">No operations defined for this order</p>
                 {canRefreshRouting && (
                   <button
                     onClick={handleRefreshRouting}
                     disabled={refreshRoutingLoading}
-                    className="px-4 py-2 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 text-white rounded-lg transition-colors text-sm"
+                    className="px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] disabled:opacity-50 text-white rounded-lg transition-colors text-sm"
                   >
                     {refreshRoutingLoading ? 'Refreshing…' : 'Apply Routing Now'}
                   </button>
@@ -856,8 +857,8 @@ export default function ProductionOrderModal({
           {/* Materials */}
           {allMaterials.length > 0 && (
             <div>
-              <h3 className="text-gray-400 text-sm font-medium mb-3">MATERIALS</h3>
-              <div className="bg-gray-800/30 rounded-lg p-4 space-y-2">
+              <h3 className="text-[var(--ink-3)] text-sm font-medium mb-3">MATERIALS</h3>
+              <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 space-y-2">
                 {allMaterials.slice(0, 5).map((mat, idx) => {
                   const matSpool = assignedSpools.find(
                     (s) => s.product_id === mat.component_id
@@ -865,9 +866,9 @@ export default function ProductionOrderModal({
                   return (
                     <div key={idx} className="space-y-1">
                       <div className="flex items-center justify-between text-sm">
-                        <span className="text-gray-300">
+                        <span className="text-[var(--ink-2)]">
                           {mat.component_name || mat.component_sku || 'Unknown'}
-                          <span className="text-gray-500 ml-2">
+                          <span className="text-[var(--ink-4)] ml-2">
                             × {mat.quantity_required} {mat.unit || ''}
                           </span>
                         </span>
@@ -875,10 +876,10 @@ export default function ProductionOrderModal({
                           <span
                             className={
                               mat.status === 'consumed'
-                                ? 'text-green-400'
+                                ? 'text-[var(--status-green)]'
                                 : mat.status === 'allocated'
-                                ? 'text-blue-400'
-                                : 'text-red-400'
+                                ? 'text-[var(--status-green)]'
+                                : 'text-[var(--status-red)]'
                             }
                           >
                             {mat.status}
@@ -886,7 +887,7 @@ export default function ProductionOrderModal({
                           {mat.component_id && mat.component_is_template && mat.status === "pending" && (
                             <button
                               onClick={() => openVariantPicker(mat.id, mat.component_id)}
-                              className="text-xs px-2 py-0.5 rounded bg-blue-700/50 hover:bg-blue-700 text-blue-200 transition-colors"
+                              className="text-xs px-2 py-0.5 rounded bg-[var(--paper)] border border-[var(--rule-hair)] hover:bg-[var(--rule-hair)] text-[var(--ink-2)] transition-colors"
                               title={`${mat.component_sku || 'Component'} is a template — pick a variant to consume from instead`}
                               aria-label={`Swap ${mat.component_sku || 'component'} to a variant`}
                             >
@@ -896,7 +897,7 @@ export default function ProductionOrderModal({
                           {mat.component_id && (
                             <button
                               onClick={() => openSpoolPicker(mat.component_id)}
-                              className="text-xs px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+                              className="text-xs px-2 py-0.5 rounded bg-[var(--paper)] border border-[var(--rule-hair)] hover:bg-[var(--rule-hair)] text-[var(--ink-2)] transition-colors"
                               title="Assign spool for traceability (optional)"
                             >
                               {matSpool ? '🔗 ' + matSpool.spool_code : 'Assign Spool'}
@@ -908,7 +909,7 @@ export default function ProductionOrderModal({
                   );
                 })}
                 {allMaterials.length > 5 && (
-                  <div className="text-gray-500 text-xs">
+                  <div className="text-[var(--ink-4)] text-xs">
                     +{allMaterials.length - 5} more materials
                   </div>
                 )}
@@ -918,20 +919,20 @@ export default function ProductionOrderModal({
 
           {/* Spool Picker Dropdown */}
           {spoolPickerFor && (
-            <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg p-4 shadow-[var(--shadow-pop)]">
               <div className="flex justify-between items-center mb-3">
-                <h4 className="text-sm font-medium text-white">Select Spool</h4>
+                <h4 className="text-sm font-medium text-[var(--ink)]">Select Spool</h4>
                 <button
                   onClick={() => setSpoolPickerFor(null)}
-                  className="text-gray-400 hover:text-white text-sm"
+                  className="text-[var(--ink-3)] hover:text-[var(--ink)] text-sm"
                 >
                   ✕
                 </button>
               </div>
               {spoolLoading ? (
-                <div className="text-gray-400 text-sm">Loading spools…</div>
+                <div className="text-[var(--ink-3)] text-sm">Loading spools…</div>
               ) : availableSpools.length === 0 ? (
-                <div className="text-gray-500 text-sm">No active spools found for this material.</div>
+                <div className="text-[var(--ink-4)] text-sm">No active spools found for this material.</div>
               ) : (
                 <div className="space-y-1 max-h-40 overflow-y-auto">
                   {availableSpools.map((spool) => (
@@ -939,13 +940,13 @@ export default function ProductionOrderModal({
                       key={spool.id}
                       onClick={() => assignSpool(spool.id)}
                       disabled={spoolLoading}
-                      className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-gray-700 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-[var(--paper-sunk)] text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      <span className="text-white">{spool.spool_number}</span>
-                      <span className="text-gray-400">
+                      <span className="text-[var(--ink)]">{spool.spool_number}</span>
+                      <span className="text-[var(--ink-3)]">
                         {(spool.current_weight_kg ?? 0).toFixed(2)} kg
                         {spool.supplier_lot_number && (
-                          <span className="ml-2 text-gray-500">Lot: {spool.supplier_lot_number}</span>
+                          <span className="ml-2 text-[var(--ink-4)]">Lot: {spool.supplier_lot_number}</span>
                         )}
                       </span>
                     </button>
@@ -957,11 +958,11 @@ export default function ProductionOrderModal({
 
           {/* Variant Picker (Workstream B0) */}
           {variantPickerFor && (
-            <div className="bg-gray-800 border border-blue-700/40 rounded-lg p-4">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg p-4 shadow-[var(--shadow-pop)]">
               <div className="flex justify-between items-center mb-3">
-                <h4 className="text-sm font-medium text-white">
+                <h4 className="text-sm font-medium text-[var(--ink)]">
                   Pick variant to consume
-                  <span className="ml-2 text-xs text-gray-400 font-normal">
+                  <span className="ml-2 text-xs text-[var(--ink-3)] font-normal">
                     (overrides the BOM template for this PO only)
                   </span>
                 </h4>
@@ -976,7 +977,7 @@ export default function ProductionOrderModal({
                     setVariantPickerFor(null);
                     setVariantSwapReason("");
                   }}
-                  className="text-gray-400 hover:text-white text-sm"
+                  className="text-[var(--ink-3)] hover:text-[var(--ink)] text-sm"
                   aria-label="Cancel variant swap"
                 >
                   ✕
@@ -988,12 +989,12 @@ export default function ProductionOrderModal({
                 onChange={(e) => setVariantSwapReason(e.target.value)}
                 maxLength={500}
                 placeholder="Reason (optional, logged for audit)"
-                className="w-full mb-3 px-3 py-1.5 text-sm rounded bg-gray-900 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                className="w-full mb-3 px-3 py-1.5 text-sm rounded bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink)] placeholder-[var(--ink-4)] focus:outline-none focus:border-[var(--orange)]"
               />
               {variantLoading ? (
-                <div className="text-gray-400 text-sm">Loading variants…</div>
+                <div className="text-[var(--ink-3)] text-sm">Loading variants…</div>
               ) : availableVariants.length === 0 ? (
-                <div className="text-gray-500 text-sm">
+                <div className="text-[var(--ink-4)] text-sm">
                   This template has no variants yet. Create some via the items page first.
                 </div>
               ) : (
@@ -1003,13 +1004,13 @@ export default function ProductionOrderModal({
                       key={v.id}
                       onClick={() => swapVariant(v.id)}
                       disabled={variantLoading || !v.active}
-                      className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-gray-700 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-[var(--paper-sunk)] text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      <span className="text-white text-left">
+                      <span className="text-[var(--ink)] text-left">
                         {v.sku}
-                        <span className="text-gray-500 ml-2">{v.name}</span>
+                        <span className="text-[var(--ink-4)] ml-2">{v.name}</span>
                       </span>
-                      <span className={(v.on_hand_qty ?? 0) > 0 ? "text-green-400" : "text-red-400"}>
+                      <span className={(v.on_hand_qty ?? 0) > 0 ? "text-[var(--status-green)]" : "text-[var(--status-red)]"}>
                         {(v.on_hand_qty ?? 0).toFixed(0)} on hand
                       </span>
                     </button>
@@ -1022,15 +1023,15 @@ export default function ProductionOrderModal({
           {/* Assigned Spools Summary */}
           {assignedSpools.length > 0 && (
             <div>
-              <h3 className="text-gray-400 text-sm font-medium mb-3">ASSIGNED SPOOLS</h3>
-              <div className="bg-gray-800/30 rounded-lg p-4 space-y-1">
+              <h3 className="text-[var(--ink-3)] text-sm font-medium mb-3">ASSIGNED SPOOLS</h3>
+              <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-4 space-y-1">
                 {assignedSpools.map((s, idx) => (
                   <div key={idx} className="flex items-center justify-between text-sm">
-                    <span className="text-gray-300">
+                    <span className="text-[var(--ink-2)]">
                       {s.spool_code}
-                      <span className="text-gray-500 ml-2">— {s.product_name}</span>
+                      <span className="text-[var(--ink-4)] ml-2">— {s.product_name}</span>
                     </span>
-                    <span className="text-gray-400 text-xs">
+                    <span className="text-[var(--ink-3)] text-xs">
                       {s.quantity_remaining != null ? `${s.quantity_remaining} kg remaining` : ''}
                     </span>
                   </div>
@@ -1041,27 +1042,27 @@ export default function ProductionOrderModal({
 
           {/* Notes */}
           <div>
-            <h3 className="text-gray-400 text-sm font-medium mb-3">NOTES</h3>
+            <h3 className="text-[var(--ink-3)] text-sm font-medium mb-3">NOTES</h3>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               onBlur={saveNotes}
               rows={3}
               placeholder="Add production notes..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 resize-none focus:border-blue-500 focus:outline-none"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] placeholder-[var(--ink-4)] resize-none focus:border-[var(--orange)] focus:outline-none"
             />
             {notesSaving && (
-              <div className="text-gray-500 text-xs mt-1">Saving...</div>
+              <div className="text-[var(--ink-4)] text-xs mt-1">Saving...</div>
             )}
           </div>
         </div>
 
       {/* Footer */}
-      <div className="flex justify-between items-center p-6 border-t border-gray-800">
+      <div className="flex justify-between items-center p-6 border-t border-[var(--rule-hair)]">
         <div className="flex gap-2">
           <button
             onClick={handleClaim}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded-lg transition-colors"
+            className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] hover:text-[var(--ink)] text-[var(--ink-2)] rounded-lg transition-colors"
           >
             Claim for Me
           </button>
@@ -1069,7 +1070,7 @@ export default function ProductionOrderModal({
             <button
               onClick={handleRefreshRouting}
               disabled={refreshRoutingLoading}
-              className="px-4 py-2 bg-amber-600 hover:bg-amber-500 disabled:opacity-50 text-white rounded-lg transition-colors text-sm"
+              className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] hover:text-[var(--ink)] disabled:opacity-50 rounded-lg transition-colors text-sm"
               title="Re-apply the product's current active routing to this order"
             >
               {refreshRoutingLoading ? "Refreshing…" : "Refresh Routing"}
@@ -1078,7 +1079,7 @@ export default function ProductionOrderModal({
         </div>
         <button
           onClick={onClose}
-          className="px-6 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className="px-6 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] hover:text-[var(--ink)] text-[var(--ink-2)] rounded-lg transition-colors"
         >
           Close
         </button>
@@ -1103,23 +1104,23 @@ export default function ProductionOrderModal({
             className="absolute inset-0 bg-black/60"
             onClick={() => setScheduleModalOpen(false)}
           />
-          <div className="relative bg-gray-900 border border-gray-700 rounded-xl w-full max-w-md mx-4 p-6 space-y-4">
-            <h3 className="text-lg font-semibold text-white">
+          <div className="relative bg-[var(--paper)] border border-[var(--rule-hair)] shadow-[var(--shadow-pop)] rounded-xl w-full max-w-md mx-4 p-6 space-y-4">
+            <h3 className="text-lg font-semibold text-[var(--ink)]">
               Schedule Operation
             </h3>
-            <p className="text-gray-400 text-sm">
+            <p className="text-[var(--ink-3)] text-sm">
               {operationToSchedule.operation_code ||
                 `Op ${operationToSchedule.sequence}`}
             </p>
 
             {/* Work Center */}
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Work Center
               </label>
               {operationToSchedule.work_center_id ? (
                 // Operation has a defined work center - lock it
-                <div className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white">
+                <div className="w-full bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]">
                   {workCenters.find(
                     (wc) => wc.id === operationToSchedule.work_center_id,
                   )?.name ||
@@ -1135,7 +1136,7 @@ export default function ProductionOrderModal({
                       e.target.value ? parseInt(e.target.value) : null,
                     )
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 >
                   <option value="">Select work center...</option>
                   {workCenters.map((wc) => (
@@ -1150,7 +1151,7 @@ export default function ProductionOrderModal({
             {/* Resource */}
             {selectedWorkCenter && (
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Machine/Printer
                 </label>
                 <select
@@ -1161,7 +1162,7 @@ export default function ProductionOrderModal({
                     );
                     setSelectedResource(res || null);
                   }}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 >
                   <option value="">Select machine...</option>
                   {resources.map((res) => (
@@ -1176,27 +1177,27 @@ export default function ProductionOrderModal({
 
             {/* Start Time */}
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <label className="block text-sm text-[var(--ink-3)] mb-1">
                 Start Time
               </label>
               <input
                 type="datetime-local"
                 value={scheduledStart}
                 onChange={(e) => setScheduledStart(e.target.value)}
-                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
               />
             </div>
 
             {/* Suggested Slot (shown after conflict) */}
             {suggestedSlot && (
-              <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-3">
-                <p className="text-blue-300 text-sm mb-2">
+              <div className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
+                <p className="text-[var(--ink-2)] text-sm mb-2">
                   Next available slot:{" "}
                   {parseDateTime(suggestedSlot.start).toLocaleString()}
                 </p>
                 <button
                   onClick={applySuggestedSlot}
-                  className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors"
+                  className="px-3 py-1 bg-[var(--paper)] border border-[var(--rule-hair)] text-[var(--ink-2)] text-sm rounded hover:text-[var(--ink)] transition-colors"
                 >
                   Use This Time
                 </button>
@@ -1207,14 +1208,14 @@ export default function ProductionOrderModal({
             <div className="flex justify-end gap-3 pt-2">
               <button
                 onClick={() => setScheduleModalOpen(false)}
-                className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+                className="px-4 py-2 text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={submitSchedule}
                 disabled={actionLoading || !selectedResource}
-                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="px-6 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {actionLoading ? "Scheduling..." : "Schedule"}
               </button>

--- a/frontend/src/components/production/ProductionQueueList.jsx
+++ b/frontend/src/components/production/ProductionQueueList.jsx
@@ -30,15 +30,15 @@ function StatusBadge({ status }) {
  */
 function OperationsChain({ operations }) {
   if (!operations || operations.length === 0) {
-    return <span className="text-gray-600 text-sm">No operations</span>;
+    return <span className="text-[var(--ink-4)] text-sm">No operations</span>;
   }
 
   const statusIcons = {
-    pending: { icon: '○', color: 'text-gray-400', title: 'Pending' },
-    queued: { icon: '◐', color: 'text-blue-400', title: 'Queued' },
-    running: { icon: '●', color: 'text-purple-400 animate-pulse', title: 'Running' },
-    complete: { icon: '✓', color: 'text-green-400', title: 'Complete' },
-    skipped: { icon: '⊘', color: 'text-yellow-400', title: 'Skipped' },
+    pending: { icon: '○', color: 'text-[var(--ink-3)]', title: 'Pending' },
+    queued: { icon: '◐', color: 'text-[var(--ink-2)]', title: 'Queued' },
+    running: { icon: '●', color: 'text-[var(--status-amber)] animate-pulse', title: 'Running' },
+    complete: { icon: '✓', color: 'text-[var(--status-green)]', title: 'Complete' },
+    skipped: { icon: '⊘', color: 'text-[var(--status-amber)]', title: 'Skipped' },
   };
 
   return (
@@ -58,7 +58,7 @@ function OperationsChain({ operations }) {
               {config.icon}
             </span>
             {idx < operations.length - 1 && (
-              <span className="text-gray-600 mx-0.5">→</span>
+              <span className="text-[var(--ink-4)] mx-0.5">→</span>
             )}
           </div>
         );
@@ -72,7 +72,7 @@ function OperationsChain({ operations }) {
  */
 function MaterialsStatus({ materials }) {
   if (!materials || materials.length === 0) {
-    return <span className="text-gray-600 text-sm">—</span>;
+    return <span className="text-[var(--ink-4)] text-sm">—</span>;
   }
 
   const ready = materials.filter(m => m.status === 'allocated' || m.status === 'consumed').length;
@@ -80,9 +80,9 @@ function MaterialsStatus({ materials }) {
   const hasBlocking = materials.some(m => m.status === 'unavailable' || m.status === 'pending');
 
   return (
-    <span className={`text-sm ${hasBlocking ? 'text-red-400' : ready === total ? 'text-green-400' : 'text-yellow-400'}`}>
+    <span className={`text-sm ${hasBlocking ? 'text-[var(--status-red)]' : ready === total ? 'text-[var(--status-green)]' : 'text-[var(--status-amber)]'}`}>
       {ready}/{total} ready
-      {hasBlocking && <span className="ml-1 text-red-400">!</span>}
+      {hasBlocking && <span className="ml-1 text-[var(--status-red)]">!</span>}
     </span>
   );
 }
@@ -137,25 +137,25 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
 
   return (
     <tr
-      className={`border-b border-gray-800 cursor-pointer transition-colors ${
+      className={`border-b border-[var(--rule-hair)] cursor-pointer transition-colors ${
         runningOp
-          ? 'bg-purple-900/30 hover:bg-purple-900/40 border-l-2 border-l-purple-500'
-          : 'hover:bg-gray-800/50'
+          ? 'bg-[var(--status-amber-tint)] hover:bg-[var(--status-amber)]/25 border-l-2 border-l-[var(--status-amber)]'
+          : 'hover:bg-[var(--paper-sunk)]'
       }`}
       onClick={() => onRowClick(order)}
     >
       {/* Order Code */}
       <td className="px-4 py-3">
-        <div className="font-mono text-white">{order.code}</div>
+        <div className="font-mono text-[var(--ink)]">{order.code}</div>
         {order.sales_order_code && (
-          <div className="text-xs text-blue-400">SO: {order.sales_order_code}</div>
+          <div className="text-xs text-[var(--ink-3)]">SO: {order.sales_order_code}</div>
         )}
       </td>
 
       {/* Product */}
       <td className="px-4 py-3">
-        <div className="text-white">{order.product_name || order.product?.name || 'Unknown'}</div>
-        <div className="text-xs text-gray-500">Qty: {order.quantity_ordered}</div>
+        <div className="text-[var(--ink)]">{order.product_name || order.product?.name || 'Unknown'}</div>
+        <div className="text-xs text-[var(--ink-4)]">Qty: {order.quantity_ordered}</div>
       </td>
 
       {/* Operations */}
@@ -169,12 +169,12 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
           <div className="flex flex-col">
             <ElapsedTimer
               startTime={runningOp.actual_start}
-              className="text-purple-400 text-sm"
+              className="text-[var(--status-amber)] text-sm"
             />
-            <span className="text-gray-500 text-xs">running</span>
+            <span className="text-[var(--ink-4)] text-xs">running</span>
           </div>
         ) : (
-          <span className="text-gray-300 font-mono text-sm">
+          <span className="text-[var(--ink-2)] font-mono text-sm">
             {totalMinutes > 0 ? formatDuration(totalMinutes) : '—'}
           </span>
         )}
@@ -193,11 +193,11 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
       {/* Due Date */}
       <td className="px-4 py-3 text-right">
         {order.due_date ? (
-          <span className="text-gray-400 text-sm">
+          <span className="text-[var(--ink-3)] text-sm">
             {new Date(order.due_date).toLocaleDateString()}
           </span>
         ) : (
-          <span className="text-gray-600 text-sm">—</span>
+          <span className="text-[var(--ink-4)] text-sm">—</span>
         )}
       </td>
 
@@ -212,7 +212,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
                 e.stopPropagation();
                 onDispatch(order, firstPendingOp);
               }}
-              className="text-xs text-blue-400 hover:text-blue-300 border border-blue-500/30 hover:border-blue-400/50 rounded px-2 py-1 transition-colors"
+              className="text-xs text-[var(--ink-2)] hover:text-[var(--ink)] border border-[var(--rule-hair)] hover:border-[var(--ink-4)] rounded px-2 py-1 transition-colors"
               title="Open scheduler for this order's next pending operation"
             >
               Dispatch →
@@ -225,7 +225,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
                 e.stopPropagation();
                 onSplit(order);
               }}
-              className="text-xs text-cyan-400 hover:text-cyan-300 border border-cyan-500/30 hover:border-cyan-400/50 rounded px-2 py-1 transition-colors"
+              className="text-xs text-[var(--ink-2)] hover:text-[var(--ink)] border border-[var(--rule-hair)] hover:border-[var(--ink-4)] rounded px-2 py-1 transition-colors"
               title="Split this order into multiple orders"
             >
               Split
@@ -238,7 +238,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
                 e.stopPropagation();
                 onComplete(order);
               }}
-              className="text-xs text-green-400 hover:text-green-300 border border-green-500/30 hover:border-green-400/50 rounded px-2 py-1 transition-colors"
+              className="text-xs text-[var(--ink-2)] hover:text-[var(--ink)] border border-[var(--rule-hair)] hover:border-[var(--ink-4)] rounded px-2 py-1 transition-colors"
               title="Complete this order"
             >
               Complete
@@ -251,7 +251,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
                 e.stopPropagation();
                 onQC(order);
               }}
-              className="text-xs text-amber-400 hover:text-amber-300 border border-amber-500/30 hover:border-amber-400/50 rounded px-2 py-1 transition-colors"
+              className="text-xs text-[var(--ink-2)] hover:text-[var(--ink)] border border-[var(--rule-hair)] hover:border-[var(--ink-4)] rounded px-2 py-1 transition-colors"
               title="Record a QC inspection for this order"
             >
               QC
@@ -264,7 +264,7 @@ function ProductionQueueRow({ order, operations, onRowClick, onDispatch, onScrap
                 e.stopPropagation();
                 onScrap(order);
               }}
-              className="text-xs text-red-400 hover:text-red-300 border border-red-500/30 hover:border-red-400/50 rounded px-2 py-1 transition-colors"
+              className="text-xs text-[var(--status-red)] hover:bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 hover:border-[var(--status-red)]/50 rounded px-2 py-1 transition-colors"
               title="Record scrap for this order"
             >
               Scrap
@@ -411,32 +411,32 @@ export default function ProductionQueueList({
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-8">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-8">
         <div className="flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-          <span className="ml-3 text-gray-400">Loading production orders...</span>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--orange)]"></div>
+          <span className="ml-3 text-[var(--ink-3)]">Loading production orders...</span>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden relative">
+    <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl shadow-[var(--shadow-pop)] overflow-hidden relative">
       {/* Filters */}
-      <div className="p-4 border-b border-gray-800 flex gap-4">
+      <div className="p-4 border-b border-[var(--rule-hair)] flex gap-4">
         <div className="flex-1">
           <input
             type="text"
             placeholder="Search by PO code, product, or sales order..."
             value={filters?.search || ''}
             onChange={(e) => onFiltersChange?.({ ...filters, search: e.target.value })}
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white placeholder-gray-500"
+            className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)] placeholder-[var(--ink-4)]"
           />
         </div>
         <select
           value={filters?.status || 'active'}
           onChange={(e) => onFiltersChange?.({ ...filters, status: e.target.value })}
-          className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+          className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
         >
           <option value="active">Active Only</option>
           <option value="all">All Status</option>
@@ -449,7 +449,7 @@ export default function ProductionQueueList({
         <select
           value={filters?.workCenter || 'all'}
           onChange={(e) => onFiltersChange?.({ ...filters, workCenter: e.target.value })}
-          className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+          className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
         >
           <option value="all">All Work Centers</option>
           {workCenters.map((wc) => (
@@ -464,15 +464,15 @@ export default function ProductionQueueList({
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
-            <tr className="bg-gray-800/50 text-left">
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Order</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Product</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Operations</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Est. Time</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Materials</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm">Status</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm text-right">Due</th>
-              <th className="px-4 py-3 text-gray-400 font-medium text-sm text-right"></th>
+            <tr className="bg-[var(--paper-sunk)] text-left">
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Order</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Product</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Operations</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Est. Time</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Materials</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm">Status</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm text-right">Due</th>
+              <th className="px-4 py-3 text-[var(--ink-3)] font-medium text-sm text-right"></th>
             </tr>
           </thead>
           <tbody>
@@ -482,12 +482,14 @@ export default function ProductionQueueList({
                   {filters?.search || (filters?.status && filters.status !== 'all') || (filters?.workCenter && filters.workCenter !== 'all') ? (
                     <EmptyState
                       icon="filter"
+                      tone="workbench"
                       title="No orders match your filters"
                       onClearFilters={() => onFiltersChange && onFiltersChange({ search: '', status: 'all', workCenter: 'all' })}
                     />
                   ) : (
                     <EmptyState
                       icon="production"
+                      tone="workbench"
                       title="No production orders yet"
                       description="Create a production order to start tracking your print jobs."
                       actionLabel="Create Production Order"
@@ -517,17 +519,17 @@ export default function ProductionQueueList({
 
       {/* Loading operations overlay - shows on top of table */}
       {loadingOps && (
-        <div className="absolute inset-0 bg-gray-900/80 flex items-center justify-center z-10 rounded-xl">
-          <div className="flex items-center gap-3 px-4 py-3 bg-gray-800 rounded-lg border border-gray-700 shadow-lg">
-            <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent"></div>
-            <span className="text-gray-300 text-sm font-medium">Loading operation details...</span>
+        <div className="absolute inset-0 bg-[var(--paper)]/80 flex items-center justify-center z-10 rounded-xl">
+          <div className="flex items-center gap-3 px-4 py-3 bg-[var(--paper)] rounded-lg border border-[var(--rule-hair)] shadow-[var(--shadow-pop)]">
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-[var(--orange)] border-t-transparent"></div>
+            <span className="text-[var(--ink-2)] text-sm font-medium">Loading operation details...</span>
           </div>
         </div>
       )}
 
       {/* Summary footer */}
       {sortedOrders.length > 0 && (
-        <div className="px-4 py-3 border-t border-gray-800 text-sm text-gray-500 flex justify-between">
+        <div className="px-4 py-3 border-t border-[var(--rule-hair)] text-sm text-[var(--ink-4)] flex justify-between">
           <span>{sortedOrders.length} order{sortedOrders.length !== 1 ? 's' : ''}</span>
           <span>
             {sortedOrders.filter(o => o.status === 'in_progress').length} in progress

--- a/frontend/src/components/production/ReleaseScheduleWizard.jsx
+++ b/frontend/src/components/production/ReleaseScheduleWizard.jsx
@@ -163,9 +163,9 @@ function OfferPrompt({ orderCode, pendingCount, loading, onAccept, onDismiss }) 
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-start gap-4">
-        <div className="flex-shrink-0 w-10 h-10 bg-blue-500/20 rounded-full flex items-center justify-center">
+        <div className="flex-shrink-0 w-10 h-10 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-full flex items-center justify-center">
           <svg
-            className="w-5 h-5 text-blue-400"
+            className="w-5 h-5 text-[var(--ink-2)]"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -179,22 +179,22 @@ function OfferPrompt({ orderCode, pendingCount, loading, onAccept, onDismiss }) 
           </svg>
         </div>
         <div className="flex-1">
-          <h3 className="text-white font-semibold">
+          <h3 className="text-[var(--ink)] font-semibold">
             {orderCode} released to floor
           </h3>
           {loading ? (
-            <p className="text-gray-400 text-sm mt-1">
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               Checking schedulable operations…
             </p>
           ) : pendingCount > 0 ? (
-            <p className="text-gray-400 text-sm mt-1">
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               {pendingCount === 1
                 ? "This order has 1 operation ready to schedule."
                 : `This order has ${pendingCount} operations ready to schedule.`}{" "}
               Schedule them now to assign resources and time slots.
             </p>
           ) : (
-            <p className="text-gray-400 text-sm mt-1">
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               No schedulable operations found — you can schedule them later
               from the operations panel.
             </p>
@@ -206,7 +206,7 @@ function OfferPrompt({ orderCode, pendingCount, loading, onAccept, onDismiss }) 
         <button
           type="button"
           onClick={onDismiss}
-          className="px-4 py-2 text-gray-400 hover:text-white text-sm transition-colors"
+          className="px-4 py-2 text-[var(--ink-3)] hover:text-[var(--ink)] text-sm transition-colors"
         >
           Later
         </button>
@@ -214,7 +214,7 @@ function OfferPrompt({ orderCode, pendingCount, loading, onAccept, onDismiss }) 
           <button
             type="button"
             onClick={onAccept}
-            className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors"
+            className="px-5 py-2 bg-[var(--orange)] text-white text-sm rounded-lg hover:bg-[var(--orange-press)] transition-colors"
           >
             Schedule now
           </button>
@@ -236,7 +236,7 @@ function WizardSummary({ scheduled, skipped, productionOrderId, onClose, onOpenS
       <div className="space-y-3">
         {hasScheduled ? (
           <>
-            <h3 className="text-green-400 font-semibold flex items-center gap-2">
+            <h3 className="text-[var(--status-green)] font-semibold flex items-center gap-2">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
@@ -246,13 +246,13 @@ function WizardSummary({ scheduled, skipped, productionOrderId, onClose, onOpenS
             </h3>
             <ul className="space-y-1 text-sm">
               {scheduled.map((s, idx) => (
-                <li key={idx} className="text-gray-300">
+                <li key={idx} className="text-[var(--ink-2)]">
                   <span className="font-medium">{s.operationLabel}</span>
                   {s.resourceName && (
-                    <span className="text-gray-400"> — {s.resourceName}</span>
+                    <span className="text-[var(--ink-3)]"> — {s.resourceName}</span>
                   )}
                   {s.startTime && (
-                    <span className="text-gray-500 ml-1">
+                    <span className="text-[var(--ink-4)] ml-1">
                       @ {new Date(s.startTime).toLocaleString(undefined, {
                         month: "short", day: "numeric",
                         hour: "2-digit", minute: "2-digit",
@@ -264,25 +264,25 @@ function WizardSummary({ scheduled, skipped, productionOrderId, onClose, onOpenS
             </ul>
           </>
         ) : (
-          <p className="text-gray-400 text-sm">
+          <p className="text-[var(--ink-3)] text-sm">
             No operations were scheduled. You can schedule them anytime from
             the operations panel.
           </p>
         )}
 
         {skipped.length > 0 && (
-          <div className="text-sm text-gray-500">
+          <div className="text-sm text-[var(--ink-4)]">
             Skipped: {skipped.join(", ")}
           </div>
         )}
       </div>
 
       {hasScheduled && (
-        <div className="pt-2 border-t border-gray-800">
+        <div className="pt-2 border-t border-[var(--rule-hair)]">
           <button
             type="button"
             onClick={onOpenScheduler}
-            className="text-sm text-blue-400 hover:text-blue-300 underline"
+            className="text-sm text-[var(--ink-2)] hover:text-[var(--ink)] underline"
           >
             Open scheduler for adjustments
           </button>
@@ -293,7 +293,7 @@ function WizardSummary({ scheduled, skipped, productionOrderId, onClose, onOpenS
         <button
           type="button"
           onClick={onClose}
-          className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors"
+          className="px-5 py-2 bg-[var(--orange)] text-white text-sm rounded-lg hover:bg-[var(--orange-press)] transition-colors"
         >
           Done
         </button>
@@ -495,13 +495,14 @@ export default function ReleaseScheduleWizard({
         isOpen={true}
         onClose={handleDismiss}
         title="Order Released"
+        variant="workbench"
         className="w-full max-w-md mx-4"
       >
-        <div className="flex items-center justify-between p-6 border-b border-gray-800">
-          <h2 className="text-xl font-semibold text-white">Order Released</h2>
+        <div className="flex items-center justify-between p-6 border-b border-[var(--rule-hair)]">
+          <h2 className="text-xl font-semibold text-[var(--ink)]">Order Released</h2>
           <button
             onClick={handleDismiss}
-            className="text-gray-400 hover:text-white transition-colors"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -526,13 +527,14 @@ export default function ReleaseScheduleWizard({
         isOpen={true}
         onClose={handleSummaryClose}
         title="Schedule Summary"
+        variant="workbench"
         className="w-full max-w-md mx-4"
       >
-        <div className="flex items-center justify-between p-6 border-b border-gray-800">
-          <h2 className="text-xl font-semibold text-white">Schedule Summary</h2>
+        <div className="flex items-center justify-between p-6 border-b border-[var(--rule-hair)]">
+          <h2 className="text-xl font-semibold text-[var(--ink)]">Schedule Summary</h2>
           <button
             onClick={handleSummaryClose}
-            className="text-gray-400 hover:text-white transition-colors"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/frontend/src/components/production/SchedulerBoard.jsx
+++ b/frontend/src/components/production/SchedulerBoard.jsx
@@ -92,20 +92,20 @@ export function getTicks(start, end, viewMode) {
 }
 
 const BLOCK_STYLES = {
-  in_progress: "bg-green-600/80 border-green-400 text-white",
-  queued: "bg-blue-600/70 border-blue-400 text-white",
-  scheduled: "bg-blue-600/70 border-blue-400 text-white",
-  pending: "bg-gray-600/70 border-gray-500 text-gray-200",
-  on_hold: "bg-amber-600/70 border-amber-400 text-white",
+  in_progress: "bg-[var(--status-green-tint)] border-[var(--status-green)] text-[var(--status-green)]",
+  queued: "bg-[var(--paper-sunk)] border-[var(--rule-hair)] text-[var(--ink-2)]",
+  scheduled: "bg-[var(--paper-sunk)] border-[var(--rule-hair)] text-[var(--ink-2)]",
+  pending: "bg-[var(--paper-sunk)] border-[var(--rule-hair)] text-[var(--ink-3)]",
+  on_hold: "bg-[var(--status-amber-tint)] border-[var(--status-amber)] text-[var(--status-amber)]",
 };
 
 const LANE_STATUS_STYLES = {
-  maintenance: "text-amber-400",
-  offline: "text-gray-500",
-  busy: "text-green-400",
-  printing: "text-green-400",
-  available: "text-blue-300",
-  idle: "text-blue-300",
+  maintenance: "text-[var(--status-amber)]",
+  offline: "text-[var(--ink-4)]",
+  busy: "text-[var(--status-green)]",
+  printing: "text-[var(--status-green)]",
+  available: "text-[var(--ink-3)]",
+  idle: "text-[var(--ink-3)]",
 };
 
 function toLocalDateInput(d) {
@@ -141,7 +141,7 @@ function OperationBlock({ op, windowStart, windowEnd, onClick }) {
       title={`${op.production_order_code} · ${op.operation_name || op.operation_code}\n${
         op.product_name || ""
       }\n${fmt(start)} → ${fmt(end)} · ${op.status.replace(/_/g, " ")}`}
-      className={`absolute top-1.5 bottom-1.5 rounded border px-1 overflow-hidden text-left transition-opacity hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-white/60 ${style}`}
+      className={`absolute top-1.5 bottom-1.5 rounded border px-1 overflow-hidden text-left transition-opacity hover:opacity-80 focus:outline-none focus:ring-1 focus:ring-[var(--ink)]/60 ${style}`}
       style={{ left: `${left}%`, width: `${width}%` }}
     >
       <span className="block text-[10px] font-medium leading-tight truncate">
@@ -156,7 +156,7 @@ function OperationBlock({ op, windowStart, windowEnd, onClick }) {
 
 // SCHED-7: shared stripe pattern for maintenance blocks (amber diagonal).
 const MAINTENANCE_STRIPES =
-  "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.28) 0 6px, rgba(245, 158, 11, 0.08) 6px 12px)";
+  "repeating-linear-gradient(135deg, color-mix(in srgb, var(--status-amber) 28%, transparent) 0 6px, color-mix(in srgb, var(--status-amber) 8%, transparent) 6px 12px)";
 
 function MaintenanceWindowBlock({ win, windowStart, windowEnd }) {
   // Same naive-UTC convention as OperationBlock.
@@ -180,7 +180,7 @@ function MaintenanceWindowBlock({ win, windowStart, windowEnd }) {
       title={`Maintenance — ${win.reason || "scheduled downtime"}\n${fmt(start)} → ${fmt(
         end
       )} · ${win.status.replace(/_/g, " ")}`}
-      className={`absolute top-0 bottom-0 rounded-sm border-x border-amber-500/50 ${
+      className={`absolute top-0 bottom-0 rounded-sm border-x border-[var(--status-amber)]/50 ${
         win.status === "completed" ? "opacity-40" : ""
       }`}
       style={{
@@ -277,12 +277,12 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
     <div className="space-y-4" data-testid="scheduler-board">
       {/* Header: title + controls */}
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <h2 className="text-xl font-semibold text-white">Production Scheduler</h2>
+        <h2 className="text-xl font-semibold text-[var(--ink)]">Production Scheduler</h2>
         <div className="flex flex-wrap items-center gap-2">
           <select
             value={viewMode}
             onChange={(e) => setViewMode(e.target.value)}
-            className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-3 py-1.5"
+            className="bg-[var(--paper)] border border-[var(--rule-hair)] text-[var(--ink)] text-sm rounded-lg px-3 py-1.5"
             aria-label="View mode"
           >
             <option value="day">Day View</option>
@@ -293,7 +293,7 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
             <button
               type="button"
               onClick={() => shift(-1)}
-              className="px-2 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+              className="px-2 py-1.5 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg text-[var(--ink-2)] hover:text-[var(--ink)] text-sm"
               aria-label="Previous"
             >
               ‹
@@ -305,12 +305,12 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                 const [y, m, d] = e.target.value.split("-").map(Number);
                 if (y && m && d) setAnchor(new Date(y, m - 1, d));
               }}
-              className="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg px-2 py-1.5"
+              className="bg-[var(--paper)] border border-[var(--rule-hair)] text-[var(--ink)] text-sm rounded-lg px-2 py-1.5"
             />
             <button
               type="button"
               onClick={() => shift(1)}
-              className="px-2 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+              className="px-2 py-1.5 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg text-[var(--ink-2)] hover:text-[var(--ink)] text-sm"
               aria-label="Next"
             >
               ›
@@ -319,7 +319,7 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
           <button
             type="button"
             onClick={() => setAnchor(new Date())}
-            className="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-gray-300 hover:text-white text-sm"
+            className="px-3 py-1.5 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg text-[var(--ink-2)] hover:text-[var(--ink)] text-sm"
           >
             Today
           </button>
@@ -327,55 +327,55 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
       </div>
 
       {/* Legend */}
-      <div className="flex flex-wrap items-center gap-4 text-xs text-gray-400">
+      <div className="flex flex-wrap items-center gap-4 text-xs text-[var(--ink-3)]">
         <span className="flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded-sm bg-blue-600/70 border border-blue-400" />
+          <span className="w-3 h-3 rounded-sm bg-[var(--paper-sunk)] border border-[var(--rule-hair)]" />
           Scheduled
         </span>
         <span className="flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded-sm bg-green-600/80 border border-green-400" />
+          <span className="w-3 h-3 rounded-sm bg-[var(--status-green-tint)] border border-[var(--status-green)]" />
           Running
         </span>
         <span className="flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded-sm bg-amber-600/70 border border-amber-400" />
+          <span className="w-3 h-3 rounded-sm bg-[var(--status-amber-tint)] border border-[var(--status-amber)]" />
           On hold
         </span>
         <span className="flex items-center gap-1.5">
           <span
-            className="w-3 h-3 rounded-sm border border-amber-500/50"
+            className="w-3 h-3 rounded-sm border border-[var(--status-amber)]/50"
             style={{ backgroundImage: MAINTENANCE_STRIPES }}
           />
           Maintenance
         </span>
         <span className="flex items-center gap-1.5">
-          <span className="w-0.5 h-3 bg-red-500" />
+          <span className="w-0.5 h-3 bg-[var(--status-red)]" />
           Now
         </span>
       </div>
 
       {error && (
-        <div className="p-3 bg-red-900/20 border border-red-500/30 rounded-lg text-red-400 text-sm">
+        <div className="p-3 bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg text-[var(--status-red)] text-sm">
           {error}
         </div>
       )}
 
       <div className="grid grid-cols-1 xl:grid-cols-4 gap-4">
         {/* Gantt table */}
-        <div className="xl:col-span-3 bg-gray-900 border border-gray-800 rounded-xl overflow-x-auto">
+        <div className="xl:col-span-3 bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl overflow-x-auto shadow-[var(--shadow-pop)]">
           {loading && !board ? (
             <div className="h-48 flex items-center justify-center">
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500" />
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]" />
             </div>
           ) : lanes.length === 0 ? (
-            <div className="p-8 text-center text-gray-500 text-sm">
+            <div className="p-8 text-center text-[var(--ink-4)] text-sm">
               No machines found. Add printers or machine work-center resources to
               see the schedule.
             </div>
           ) : (
             <table className="w-full min-w-[640px]">
               <thead>
-                <tr className="border-b border-gray-800">
-                  <th className="text-left p-3 text-xs font-semibold text-gray-400 uppercase tracking-wider w-44">
+                <tr className="border-b border-[var(--rule-hair)]">
+                  <th className="text-left p-3 text-xs font-semibold text-[var(--ink-3)] uppercase tracking-wider w-44">
                     Machine
                   </th>
                   <th className="p-0 relative h-8">
@@ -384,7 +384,7 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                       {ticks.map((t, i) => (
                         <span
                           key={i}
-                          className="absolute top-1/2 -translate-y-1/2 text-[10px] font-normal text-gray-500 whitespace-nowrap"
+                          className="absolute top-1/2 -translate-y-1/2 text-[10px] font-normal text-[var(--ink-4)] whitespace-nowrap"
                           style={{ left: `${t.pct}%` }}
                         >
                           {t.label}
@@ -397,21 +397,21 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
               <tbody>
                 {lanes.map((lane) => {
                   const laneStatus =
-                    LANE_STATUS_STYLES[lane.status] || "text-gray-400";
+                    LANE_STATUS_STYLES[lane.status] || "text-[var(--ink-3)]";
                   const laneTint =
                     lane.status === "maintenance"
-                      ? "bg-amber-950/20"
+                      ? "bg-[var(--status-amber-tint)]"
                       : lane.status === "offline"
-                      ? "bg-gray-950/40"
+                      ? "bg-[var(--paper-sunk)]"
                       : "";
                   return (
                     <tr
                       key={lane.key}
-                      className={`border-b border-gray-800/60 ${laneTint}`}
+                      className={`border-b border-[var(--rule-hair)] ${laneTint}`}
                       data-testid={`gantt-lane-${lane.key}`}
                     >
                       <td className="p-3 align-middle">
-                        <div className="text-sm text-white font-medium truncate">
+                        <div className="text-sm text-[var(--ink)] font-medium truncate">
                           {lane.code}
                         </div>
                         <div className="flex items-center gap-2">
@@ -419,23 +419,23 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                             {lane.status}
                           </span>
                           {lane.work_center_code && (
-                            <span className="text-[10px] text-gray-600">
+                            <span className="text-[10px] text-[var(--ink-4)]">
                               {lane.work_center_code}
                             </span>
                           )}
                         </div>
                         {/* Utilization bar */}
                         <div
-                          className="mt-1.5 h-1 bg-gray-800 rounded overflow-hidden"
+                          className="mt-1.5 h-1 bg-[var(--rule-hair)] rounded overflow-hidden"
                           title={`${lane.utilization_percent}% booked in window`}
                         >
                           <div
                             className={`h-full ${
                               lane.utilization_percent > 85
-                                ? "bg-red-500/80"
+                                ? "bg-[var(--status-red)]"
                                 : lane.utilization_percent > 60
-                                ? "bg-amber-500/80"
-                                : "bg-blue-500/70"
+                                ? "bg-[var(--status-amber)]"
+                                : "bg-[var(--status-green)]"
                             }`}
                             style={{ width: `${lane.utilization_percent}%` }}
                           />
@@ -446,14 +446,14 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                         {ticks.map((t, i) => (
                           <div
                             key={i}
-                            className="absolute top-0 bottom-0 w-px bg-gray-800/70"
+                            className="absolute top-0 bottom-0 w-px bg-[var(--rule-hair)]"
                             style={{ left: `${t.pct}%` }}
                           />
                         ))}
                         {/* Now line */}
                         {nowPct !== null && (
                           <div
-                            className="absolute top-0 bottom-0 w-0.5 bg-red-500/80 z-10 pointer-events-none"
+                            className="absolute top-0 bottom-0 w-0.5 bg-[var(--status-red)] z-10 pointer-events-none"
                             style={{ left: `${nowPct}%` }}
                             data-testid="now-line"
                           />
@@ -490,17 +490,17 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
         </div>
 
         {/* Unscheduled orders work queue */}
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-          <h3 className="text-sm font-semibold text-white mb-3">
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+          <h3 className="text-sm font-semibold text-[var(--ink)] mb-3">
             Unscheduled Orders
             {unscheduled.length > 0 && (
-              <span className="ml-2 px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded-full">
+              <span className="ml-2 px-2 py-0.5 bg-[var(--status-amber-tint)] text-[var(--status-amber)] text-xs rounded-full">
                 {unscheduled.length}
               </span>
             )}
           </h3>
           {unscheduled.length === 0 ? (
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-[var(--ink-4)]">
               Everything released is on the board. Nice.
             </p>
           ) : (
@@ -508,17 +508,17 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
               {unscheduled.map((item) => (
                 <div
                   key={item.production_order_id}
-                  className="bg-gray-800 rounded-lg p-2.5 flex items-start justify-between gap-2"
+                  className="bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-2.5 flex items-start justify-between gap-2"
                   data-testid={`unscheduled-${item.production_order_code}`}
                 >
                   <div className="min-w-0">
-                    <div className="text-xs font-medium text-white truncate">
+                    <div className="text-xs font-medium text-[var(--ink)] truncate">
                       {item.production_order_code}
                     </div>
-                    <div className="text-[11px] text-gray-400 truncate">
+                    <div className="text-[11px] text-[var(--ink-3)] truncate">
                       {item.product_name}
                     </div>
-                    <div className="text-[10px] text-gray-500">
+                    <div className="text-[10px] text-[var(--ink-4)]">
                       Qty {item.quantity}
                       {item.due_date &&
                         ` · due ${new Date(item.due_date).toLocaleDateString()}`}
@@ -531,7 +531,7 @@ export default function SchedulerBoard({ onScheduleOperation, refreshSignal = 0 
                     type="button"
                     title="Auto-schedule — pick a slot for the next operation"
                     onClick={() => handleUnscheduledClick(item)}
-                    className="shrink-0 px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors"
+                    className="shrink-0 px-2 py-1 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white text-xs rounded transition-colors"
                   >
                     ⚡ Schedule
                   </button>

--- a/frontend/src/components/production/ScrapEntryModal.jsx
+++ b/frontend/src/components/production/ScrapEntryModal.jsx
@@ -16,7 +16,7 @@ import { formatCurrency } from '../../lib/number';
 function CascadeMaterialsTable({ materials, totalCost }) {
   if (!materials || materials.length === 0) {
     return (
-      <div className="text-center py-4 text-gray-500">
+      <div className="text-center py-4 text-[var(--ink-4)]">
         No materials to display
       </div>
     );
@@ -43,12 +43,12 @@ function CascadeMaterialsTable({ materials, totalCost }) {
   return (
     <div className="space-y-3">
       {sortedOps.map((op) => (
-        <div key={op.sequence} className="bg-gray-800/30 rounded-lg p-3">
+        <div key={op.sequence} className="bg-[var(--paper-sunk)] rounded-lg p-3">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-white">
+            <span className="text-sm font-medium text-[var(--ink)]">
               Op {op.sequence}: {op.operation_name}
             </span>
-            <span className="text-sm text-gray-400">
+            <span className="text-sm text-[var(--ink-3)]">
               {formatCurrency(op.subtotal)}
             </span>
           </div>
@@ -56,18 +56,18 @@ function CascadeMaterialsTable({ materials, totalCost }) {
             {op.materials.map((mat, idx) => (
               <div key={idx} className="flex items-center justify-between text-xs">
                 <div className="flex items-center gap-2">
-                  <span className="text-gray-400">{mat.component_sku}</span>
-                  <span className="text-gray-600">-</span>
-                  <span className="text-gray-500">{mat.component_name}</span>
+                  <span className="text-[var(--ink-3)]">{mat.component_sku}</span>
+                  <span className="text-[var(--ink-4)]">-</span>
+                  <span className="text-[var(--ink-4)]">{mat.component_name}</span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-gray-400">
+                  <span className="text-[var(--ink-3)]">
                     {mat.quantity.toFixed(2)} {mat.unit}
                   </span>
-                  <span className="text-gray-400">
+                  <span className="text-[var(--ink-3)]">
                     @ {formatCurrency(mat.unit_cost)}/{mat.unit}
                   </span>
-                  <span className="text-white font-medium w-20 text-right">
+                  <span className="text-[var(--ink)] font-medium w-20 text-right">
                     {formatCurrency(mat.cost)}
                   </span>
                 </div>
@@ -78,9 +78,9 @@ function CascadeMaterialsTable({ materials, totalCost }) {
       ))}
 
       {/* Total */}
-      <div className="flex items-center justify-between pt-2 border-t border-gray-700">
-        <span className="text-sm font-medium text-white">Total Scrap Cost</span>
-        <span className="text-lg font-bold text-red-400">
+      <div className="flex items-center justify-between pt-2 border-t border-[var(--rule-hair)]">
+        <span className="text-sm font-medium text-[var(--ink)]">Total Scrap Cost</span>
+        <span className="text-lg font-bold text-[var(--status-red)]">
           {formatCurrency(totalCost)}
         </span>
       </div>
@@ -229,7 +229,7 @@ export default function ScrapEntryModal({
           toast.success(
             <div>
               <p>{message}</p>
-              <p className="mt-1 text-green-300">
+              <p className="mt-1 text-[var(--status-green)]">
                 Replacement order{' '}
                 <strong>{data.replacement_order.code}</strong> created
               </p>
@@ -258,19 +258,19 @@ export default function ScrapEntryModal({
   const selectedReason = scrapReasons.find((r) => r.code === scrapReason);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Scrap at Operation" disableClose={submitting} className="w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+    <Modal isOpen={isOpen} onClose={onClose} title="Scrap at Operation" variant="workbench" disableClose={submitting} className="w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex justify-between items-center p-6 border-b border-gray-800">
+        <div className="flex justify-between items-center p-6 border-b border-[var(--rule-hair)]">
           <div>
-            <h2 className="text-xl font-bold text-white">Scrap at Operation</h2>
-            <p className="text-gray-400 text-sm mt-1">
+            <h2 className="text-xl font-bold text-[var(--ink)]">Scrap at Operation</h2>
+            <p className="text-[var(--ink-3)] text-sm mt-1">
               {productionOrder?.code} - Op {operation?.sequence}:{' '}
               {operation?.operation_name || operation?.operation_code}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white text-xl"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] text-xl"
           >
             &times;
           </button>
@@ -280,7 +280,7 @@ export default function ScrapEntryModal({
         <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Quantity Input */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Quantity to Scrap *
             </label>
             <input
@@ -289,22 +289,22 @@ export default function ScrapEntryModal({
               onChange={(e) => setQuantity(Math.max(1, Math.min(maxQuantity, parseInt(e.target.value) || 0)))}
               min="1"
               max={maxQuantity}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white text-lg"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] text-lg"
             />
-            <p className="text-gray-500 text-sm mt-1">
+            <p className="text-[var(--ink-4)] text-sm mt-1">
               Max: {maxQuantity} unit{maxQuantity !== 1 ? 's' : ''}
             </p>
           </div>
 
           {/* Scrap Reason */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Scrap Reason *
             </label>
             <select
               value={scrapReason}
               onChange={(e) => setScrapReason(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)]"
             >
               <option value="">Select reason...</option>
               {scrapReasons.map((reason) => (
@@ -314,7 +314,7 @@ export default function ScrapEntryModal({
               ))}
             </select>
             {selectedReason?.description && (
-              <p className="text-gray-500 text-sm mt-1">
+              <p className="text-[var(--ink-4)] text-sm mt-1">
                 {selectedReason.description}
               </p>
             )}
@@ -322,13 +322,13 @@ export default function ScrapEntryModal({
 
           {/* Notes */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">
+            <label className="block text-sm text-[var(--ink-3)] mb-2">
               Additional Notes
             </label>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white h-20 resize-none"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-3 text-[var(--ink)] placeholder-[var(--ink-4)] h-20 resize-none"
               placeholder="Describe what happened..."
             />
           </div>
@@ -336,17 +336,17 @@ export default function ScrapEntryModal({
           {/* Cascading Materials Preview */}
           <div>
             <div className="flex items-center justify-between mb-3">
-              <label className="block text-sm text-gray-400">
+              <label className="block text-sm text-[var(--ink-3)]">
                 Cascading Material Costs
               </label>
               {loading && (
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-400"></div>
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[var(--orange)]"></div>
               )}
             </div>
 
             {cascadeData ? (
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-                <div className="text-xs text-gray-500 mb-3">
+              <div className="bg-[var(--paper-sunk)] rounded-lg p-4 border border-[var(--rule-hair)]">
+                <div className="text-xs text-[var(--ink-4)] mb-3">
                   Materials from {cascadeData.operations_affected} operation
                   {cascadeData.operations_affected !== 1 ? 's' : ''} will be
                   recorded as scrap
@@ -357,26 +357,26 @@ export default function ScrapEntryModal({
                 />
               </div>
             ) : (
-              <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700 text-center text-gray-500">
+              <div className="bg-[var(--paper-sunk)] rounded-lg p-4 border border-[var(--rule-hair)] text-center text-[var(--ink-4)]">
                 {loading ? 'Loading cascade preview...' : 'Enter quantity to see material costs'}
               </div>
             )}
           </div>
 
           {/* Create Replacement Toggle */}
-          <div className="bg-gray-800/50 rounded-lg p-4">
+          <div className="bg-[var(--paper-sunk)] rounded-lg p-4">
             <label className="flex items-center gap-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={createReplacement}
                 onChange={(e) => setCreateReplacement(e.target.checked)}
-                className="w-5 h-5 rounded bg-gray-700 border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                className="w-5 h-5 rounded bg-[var(--paper)] border-[var(--rule-hair)] text-[var(--orange)] focus:ring-[var(--orange)] focus:ring-offset-0"
               />
               <div>
-                <span className="text-white font-medium">
+                <span className="text-[var(--ink)] font-medium">
                   Create Replacement Order
                 </span>
-                <p className="text-gray-400 text-sm">
+                <p className="text-[var(--ink-3)] text-sm">
                   Automatically create a new production order for the scrapped
                   quantity
                 </p>
@@ -385,10 +385,10 @@ export default function ScrapEntryModal({
           </div>
 
           {/* GL Warning */}
-          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3">
+          <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-3">
             <div className="flex gap-2">
               <svg
-                className="w-5 h-5 text-yellow-400 flex-shrink-0"
+                className="w-5 h-5 text-[var(--status-amber)] flex-shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -401,10 +401,10 @@ export default function ScrapEntryModal({
                 />
               </svg>
               <div>
-                <p className="text-yellow-400 text-sm font-medium">
+                <p className="text-[var(--status-amber)] text-sm font-medium">
                   GL Journal Entry
                 </p>
-                <p className="text-yellow-400/80 text-sm">
+                <p className="text-[var(--status-amber)]/80 text-sm">
                   DR: Scrap Expense (5020)
                   {cascadeData?.total_cost
                     ? ` ${formatCurrency(cascadeData.total_cost)}`
@@ -417,17 +417,17 @@ export default function ScrapEntryModal({
         </div>
 
         {/* Footer */}
-        <div className="flex gap-3 p-6 border-t border-gray-800">
+        <div className="flex gap-3 p-6 border-t border-[var(--rule-hair)]">
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
           >
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={!scrapReason || quantity <= 0 || submitting}
-            className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 px-4 py-2 bg-[var(--status-red)] text-white rounded-lg hover:bg-[var(--status-red)]/90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {submitting
               ? 'Processing...'

--- a/frontend/src/components/production/ShortageModal.jsx
+++ b/frontend/src/components/production/ShortageModal.jsx
@@ -61,12 +61,12 @@ export default function ShortageModal({
   if (!isOpen) return null;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Order Short" disableClose={creating} className="w-full max-w-md mx-4">
+    <Modal isOpen={isOpen} onClose={onClose} title="Order Short" variant="workbench" disableClose={creating} className="w-full max-w-md mx-4">
         {/* Header */}
-        <div className="flex items-center gap-3 p-6 border-b border-gray-800">
-          <div className="flex items-center justify-center w-10 h-10 rounded-full bg-orange-500/20">
+        <div className="flex items-center gap-3 p-6 border-b border-[var(--rule-hair)]">
+          <div className="flex items-center justify-center w-10 h-10 rounded-full bg-[var(--status-amber-tint)]">
             <svg
-              className="w-6 h-6 text-orange-400"
+              className="w-6 h-6 text-[var(--status-amber)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -80,26 +80,26 @@ export default function ShortageModal({
             </svg>
           </div>
           <div>
-            <h2 className="text-xl font-semibold text-white">Order Short</h2>
-            <p className="text-sm text-gray-400">{poCode}</p>
+            <h2 className="text-xl font-semibold text-[var(--ink)]">Order Short</h2>
+            <p className="text-sm text-[var(--ink-3)]">{poCode}</p>
           </div>
         </div>
 
         {/* Content */}
         <div className="p-6 space-y-4">
           {/* Shortage Summary */}
-          <div className="bg-gray-800/50 rounded-lg p-4 space-y-2">
+          <div className="bg-[var(--paper-sunk)] rounded-lg p-4 space-y-2">
             <div className="flex justify-between text-sm">
-              <span className="text-gray-400">Ordered</span>
-              <span className="text-white font-mono">{quantityOrdered}</span>
+              <span className="text-[var(--ink-3)]">Ordered</span>
+              <span className="text-[var(--ink)] font-mono">{quantityOrdered}</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-gray-400">Completed</span>
-              <span className="text-green-400 font-mono">{quantityCompleted}</span>
+              <span className="text-[var(--ink-3)]">Completed</span>
+              <span className="text-[var(--status-green)] font-mono">{quantityCompleted}</span>
             </div>
-            <div className="border-t border-gray-700 pt-2 flex justify-between text-sm">
-              <span className="text-orange-400 font-medium">Short</span>
-              <span className="text-orange-400 font-mono font-medium">
+            <div className="border-t border-[var(--rule-hair)] pt-2 flex justify-between text-sm">
+              <span className="text-[var(--status-amber)] font-medium">Short</span>
+              <span className="text-[var(--status-amber)] font-mono font-medium">
                 {quantityShort}
               </span>
             </div>
@@ -107,9 +107,9 @@ export default function ShortageModal({
 
           {/* Sales Order Warning */}
           {salesOrderCode && (
-            <div className="flex items-start gap-2 text-sm bg-blue-500/10 border border-blue-500/30 rounded-lg p-3">
+            <div className="flex items-start gap-2 text-sm bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded-lg p-3">
               <svg
-                className="w-5 h-5 text-blue-400 flex-shrink-0 mt-0.5"
+                className="w-5 h-5 text-[var(--ink-3)] flex-shrink-0 mt-0.5"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -122,7 +122,7 @@ export default function ShortageModal({
                 />
               </svg>
               <div>
-                <span className="text-blue-300">
+                <span className="text-[var(--ink-2)]">
                   Sales Order <span className="font-mono font-medium">{salesOrderCode}</span> requires{' '}
                   <span className="font-medium">{quantityShort} more</span> to fulfill.
                 </span>
@@ -132,8 +132,8 @@ export default function ShortageModal({
 
           {/* Error */}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
-              <p className="text-red-400 text-sm">{error}</p>
+            <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3">
+              <p className="text-[var(--status-red)] text-sm">{error}</p>
             </div>
           )}
 
@@ -141,14 +141,14 @@ export default function ShortageModal({
           <div className="flex gap-3 pt-2">
             <button
               onClick={onClose}
-              className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+              className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] hover:text-[var(--ink)] rounded-lg transition-colors"
             >
               Dismiss
             </button>
             <button
               onClick={handleCreateReplacement}
               disabled={creating}
-              className="flex-1 px-4 py-2 bg-orange-600 hover:bg-orange-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50"
+              className="flex-1 px-4 py-2 bg-[var(--orange)] hover:bg-[var(--orange-press)] text-white rounded-lg font-medium transition-colors disabled:opacity-50"
             >
               {creating ? 'Creating...' : `Create Replacement (${quantityShort})`}
             </button>

--- a/frontend/src/components/production/SkipOperationModal.jsx
+++ b/frontend/src/components/production/SkipOperationModal.jsx
@@ -65,13 +65,13 @@ export default function SkipOperationModal({
   if (!isOpen || !operation) return null;
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Skip Operation" disableClose={submitting} className="w-full max-w-md mx-4">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Skip Operation" variant="workbench" disableClose={submitting} className="w-full max-w-md mx-4">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-800">
-          <h2 className="text-xl font-semibold text-white">Skip Operation</h2>
+        <div className="flex items-center justify-between p-6 border-b border-[var(--rule-hair)]">
+          <h2 className="text-xl font-semibold text-[var(--ink)]">Skip Operation</h2>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-white transition-colors"
+            className="text-[var(--ink-3)] hover:text-[var(--ink)] transition-colors"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -81,36 +81,36 @@ export default function SkipOperationModal({
 
         {/* Content */}
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          <p className="text-gray-300">
+          <p className="text-[var(--ink-2)]">
             Are you sure you want to skip this operation?
           </p>
 
           {/* Operation info */}
-          <div className="bg-gray-800/50 rounded-lg p-4">
-            <div className="text-white font-medium">
+          <div className="bg-[var(--paper-sunk)] rounded-lg p-4">
+            <div className="text-[var(--ink)] font-medium">
               {operation.sequence}: {operation.operation_code}
             </div>
             {operation.operation_name && (
-              <div className="text-gray-400 text-sm">{operation.operation_name}</div>
+              <div className="text-[var(--ink-3)] text-sm">{operation.operation_name}</div>
             )}
           </div>
 
           {/* Reason input */}
           <div>
-            <label className="block text-sm font-medium text-gray-400 mb-2">
-              Reason for skipping <span className="text-red-400">*</span>
+            <label className="block text-sm font-medium text-[var(--ink-3)] mb-2">
+              Reason for skipping <span className="text-[var(--status-red)]">*</span>
             </label>
             <textarea
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               rows={3}
               placeholder="e.g., Customer requested rush delivery, Operation not needed for this order..."
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-gray-500 focus:ring-2 focus:ring-yellow-500 focus:border-transparent resize-none"
+              className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2.5 text-[var(--ink)] placeholder-[var(--ink-4)] focus:ring-2 focus:ring-[var(--orange)] focus:border-transparent resize-none"
             />
           </div>
 
           {/* Warning */}
-          <div className="flex items-start gap-2 text-yellow-400/70 text-sm">
+          <div className="flex items-start gap-2 text-[var(--status-amber)]/70 text-sm">
             <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
@@ -119,8 +119,8 @@ export default function SkipOperationModal({
 
           {/* Error */}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
-              <p className="text-red-400 text-sm">{error}</p>
+            <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3">
+              <p className="text-[var(--status-red)] text-sm">{error}</p>
             </div>
           )}
 
@@ -129,14 +129,14 @@ export default function SkipOperationModal({
             <button
               type="button"
               onClick={handleClose}
-              className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+              className="px-4 py-2 text-[var(--ink-2)] hover:text-[var(--ink)] transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={submitting || !reason.trim()}
-              className="px-6 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-6 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {submitting ? 'Skipping...' : 'Skip Operation'}
             </button>

--- a/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
+++ b/frontend/src/components/production/scheduler/AutoPickSlotButton.jsx
@@ -83,7 +83,7 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
   // resolve the locked vs. active state once flags are known.
   if (!flagsLoading && (!isPro || proUnavailable)) {
     return (
-      <span className="text-xs text-gray-500 italic">
+      <span className="text-xs text-[var(--ink-4)] italic">
         Auto-pick requires FilaOps PRO
       </span>
     );
@@ -95,13 +95,13 @@ export default function AutoPickSlotButton({ operationId, productionOrderId, onS
         type="button"
         onClick={handleClick}
         disabled={disabled || running || !productionOrderId || flagsLoading}
-        className="text-xs text-purple-400 hover:text-purple-300 border border-purple-500/30 hover:border-purple-400/50 rounded px-2 py-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        className="text-xs text-[var(--ink-2)] hover:text-[var(--ink)] border border-[var(--rule-hair)] hover:border-[var(--ink-4)] rounded px-2 py-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         title="Use the PRO auto-scheduler to find the optimal slot"
       >
         {running ? "Finding slot…" : "Auto-pick slot ✦"}
       </button>
       {pickError && (
-        <span className="text-xs text-amber-400">{pickError}</span>
+        <span className="text-xs text-[var(--status-amber)]">{pickError}</span>
       )}
     </span>
   );

--- a/frontend/src/components/production/scheduler/ConflictPanels.jsx
+++ b/frontend/src/components/production/scheduler/ConflictPanels.jsx
@@ -14,15 +14,15 @@ import { formatTime } from "../../../utils/formatting";
 export function SlotSuggestion({ label, nextAvailableStart, nextAvailableEnd, onUseSlot }) {
   if (!nextAvailableStart) return null;
   return (
-    <div className="mt-3 p-2 bg-blue-500/10 border border-blue-500/30 rounded">
-      <p className="text-sm text-blue-300">
+    <div className="mt-3 p-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] rounded">
+      <p className="text-sm text-[var(--ink-2)]">
         {label}: {formatTime(nextAvailableStart)}
         {nextAvailableEnd ? ` – ${formatTime(nextAvailableEnd)}` : ""}
       </p>
       <button
         type="button"
         onClick={() => onUseSlot(nextAvailableStart, nextAvailableEnd)}
-        className="mt-1 text-sm text-blue-400 hover:text-blue-300 underline"
+        className="mt-1 text-sm text-[var(--ink-2)] hover:text-[var(--ink)] underline"
       >
         Use this time
       </button>
@@ -42,10 +42,10 @@ export function ConflictAlert({
   if (!conflicts || conflicts.length === 0) return null;
 
   return (
-    <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4">
+    <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-4">
       <div className="flex items-start gap-3">
         <svg
-          className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5"
+          className="w-5 h-5 text-[var(--status-red)] flex-shrink-0 mt-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -58,17 +58,17 @@ export function ConflictAlert({
           />
         </svg>
         <div className="flex-1">
-          <h4 className="text-red-400 font-medium">Resource Conflict</h4>
-          <p className="text-sm text-red-400/70 mt-1">
+          <h4 className="text-[var(--status-red)] font-medium">Resource Conflict</h4>
+          <p className="text-sm text-[var(--status-red)]/70 mt-1">
             This time slot overlaps with:
           </p>
           <ul className="mt-2 space-y-1">
             {conflicts.map((conflict, idx) => (
-              <li key={idx} className="text-sm text-red-300">
+              <li key={idx} className="text-sm text-[var(--status-red)]">
                 - {conflict.production_order_code || conflict.po_code} -{" "}
                 {conflict.operation_code || "Operation"}
                 {conflict.scheduled_start && (
-                  <span className="text-red-400/50">
+                  <span className="text-[var(--status-red)]/50">
                     {" "}
                     ({formatTime(conflict.scheduled_start)} –{" "}
                     {formatTime(conflict.scheduled_end)})
@@ -84,7 +84,7 @@ export function ConflictAlert({
             onUseSlot={onUseSlot}
           />
           {!nextAvailableStart && (
-            <p className="text-xs text-red-400/50 mt-2">
+            <p className="text-xs text-[var(--status-red)]/50 mt-2">
               Adjust the start time or select a different resource.
             </p>
           )}
@@ -107,10 +107,10 @@ export function PredecessorAlert({
   if (!message) return null;
 
   return (
-    <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+    <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-4">
       <div className="flex items-start gap-3">
         <svg
-          className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5"
+          className="w-5 h-5 text-[var(--status-amber)] flex-shrink-0 mt-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -123,10 +123,10 @@ export function PredecessorAlert({
           />
         </svg>
         <div className="flex-1">
-          <h4 className="text-amber-400 font-medium">Sequence Constraint</h4>
-          <p className="text-sm text-amber-400/70 mt-1">{message}</p>
+          <h4 className="text-[var(--status-amber)] font-medium">Sequence Constraint</h4>
+          <p className="text-sm text-[var(--status-amber)]/70 mt-1">{message}</p>
           {earliestValidStart && (
-            <p className="text-sm text-amber-300 mt-1">
+            <p className="text-sm text-[var(--status-amber)] mt-1">
               Predecessor finishes:{" "}
               <span className="font-medium">{formatTime(earliestValidStart)}</span>
             </p>
@@ -139,7 +139,7 @@ export function PredecessorAlert({
               onUseSlot={onUseSlot}
             />
           ) : (
-            <p className="text-xs text-amber-400/50 mt-2">
+            <p className="text-xs text-[var(--status-amber)]/50 mt-2">
               Schedule the predecessor operation first, then retry.
             </p>
           )}
@@ -156,10 +156,10 @@ export function PredecessorAlert({
 export function SuccessorConflictAlert({ successorConflicts }) {
   if (!successorConflicts || successorConflicts.length === 0) return null;
   return (
-    <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-4">
+    <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-4">
       <div className="flex items-start gap-3">
         <svg
-          className="w-5 h-5 text-orange-400 flex-shrink-0 mt-0.5"
+          className="w-5 h-5 text-[var(--status-amber)] flex-shrink-0 mt-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -172,28 +172,28 @@ export function SuccessorConflictAlert({ successorConflicts }) {
           />
         </svg>
         <div className="flex-1">
-          <h4 className="text-orange-400 font-medium">Successor Conflict</h4>
-          <p className="text-sm text-orange-400/70 mt-1">
+          <h4 className="text-[var(--status-amber)] font-medium">Successor Conflict</h4>
+          <p className="text-sm text-[var(--status-amber)]/70 mt-1">
             Moving this operation would violate existing schedules of:
           </p>
           <ul className="mt-2 space-y-1">
             {successorConflicts.map((sc, idx) => (
-              <li key={idx} className="text-sm text-orange-300">
+              <li key={idx} className="text-sm text-[var(--status-amber)]">
                 - Seq {sc.sequence} ({sc.operation_code || "Operation"})
                 {sc.scheduled_start && (
-                  <span className="text-orange-400/50">
+                  <span className="text-[var(--status-amber)]/50">
                     {" "}currently at {formatTime(sc.scheduled_start)}
                   </span>
                 )}
                 {sc.earliest_valid_start && (
-                  <span className="text-orange-300">
+                  <span className="text-[var(--status-amber)]">
                     {" "}— earliest valid start: {formatTime(sc.earliest_valid_start)}
                   </span>
                 )}
               </li>
             ))}
           </ul>
-          <p className="text-xs text-orange-400/50 mt-2">
+          <p className="text-xs text-[var(--status-amber)]/50 mt-2">
             Reschedule the successor operations first, or choose an earlier end time.
           </p>
         </div>

--- a/frontend/src/components/production/scheduler/SchedulerBanners.jsx
+++ b/frontend/src/components/production/scheduler/SchedulerBanners.jsx
@@ -14,10 +14,10 @@ export function CompatibilityWarning({ reason }) {
   if (!reason) return null;
 
   return (
-    <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3">
+    <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-3">
       <div className="flex items-start gap-2">
         <svg
-          className="w-5 h-5 text-yellow-400 flex-shrink-0 mt-0.5"
+          className="w-5 h-5 text-[var(--status-amber)] flex-shrink-0 mt-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -30,10 +30,10 @@ export function CompatibilityWarning({ reason }) {
           />
         </svg>
         <div>
-          <h4 className="text-yellow-400 font-medium text-sm">
+          <h4 className="text-[var(--status-amber)] font-medium text-sm">
             Incompatible Resource
           </h4>
-          <p className="text-sm text-yellow-400/70 mt-1">{reason}</p>
+          <p className="text-sm text-[var(--status-amber)]/70 mt-1">{reason}</p>
         </div>
       </div>
     </div>
@@ -45,10 +45,10 @@ export function CompatibilityWarning({ reason }) {
  */
 export function ScheduleSuccess({ operationCode, nextOperation, onNext }) {
   return (
-    <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-4">
+    <div className="bg-[var(--status-green-tint)] border border-[var(--status-green)]/30 rounded-lg p-4">
       <div className="flex items-start gap-3">
         <svg
-          className="w-5 h-5 text-green-400 flex-shrink-0 mt-0.5"
+          className="w-5 h-5 text-[var(--status-green)] flex-shrink-0 mt-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -61,24 +61,24 @@ export function ScheduleSuccess({ operationCode, nextOperation, onNext }) {
           />
         </svg>
         <div className="flex-1">
-          <h4 className="text-green-400 font-medium">
+          <h4 className="text-[var(--status-green)] font-medium">
             {operationCode} scheduled
           </h4>
           {nextOperation ? (
             <div className="mt-2 flex items-center gap-3">
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-[var(--ink-3)]">
                 Next: {nextOperation.sequence} — {nextOperation.operation_code}
               </p>
               <button
                 type="button"
                 onClick={onNext}
-                className="text-sm text-blue-400 hover:text-blue-300 underline"
+                className="text-sm text-[var(--ink-2)] hover:text-[var(--ink)] underline"
               >
                 Schedule it now
               </button>
             </div>
           ) : (
-            <p className="text-sm text-gray-400 mt-1">
+            <p className="text-sm text-[var(--ink-3)] mt-1">
               All operations scheduled.
             </p>
           )}
@@ -93,11 +93,11 @@ export function ScheduleSuccess({ operationCode, nextOperation, onNext }) {
  */
 export function UnscheduleConfirm({ onConfirm, onCancel, submitting }) {
   return (
-    <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
-      <p className="text-amber-300 font-medium text-sm">
+    <div className="bg-[var(--status-amber-tint)] border border-[var(--status-amber)]/30 rounded-lg p-4">
+      <p className="text-[var(--status-amber)] font-medium text-sm">
         Unschedule this operation?
       </p>
-      <p className="text-amber-400/70 text-sm mt-1">
+      <p className="text-[var(--status-amber)]/70 text-sm mt-1">
         The operation will return to pending and its time slot will be freed.
       </p>
       <div className="flex gap-3 mt-3">
@@ -105,14 +105,14 @@ export function UnscheduleConfirm({ onConfirm, onCancel, submitting }) {
           type="button"
           onClick={onConfirm}
           disabled={submitting}
-          className="px-4 py-1.5 bg-amber-600 text-white text-sm rounded-lg hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-4 py-1.5 bg-[var(--orange)] text-white text-sm rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           {submitting ? "Unscheduling..." : "Confirm Unschedule"}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-1.5 text-gray-400 hover:text-white text-sm transition-colors"
+          className="px-4 py-1.5 text-[var(--ink-3)] hover:text-[var(--ink)] text-sm transition-colors"
         >
           Cancel
         </button>
@@ -126,12 +126,12 @@ export function UnscheduleConfirm({ onConfirm, onCancel, submitting }) {
  */
 export function WizardStepHeader({ step, total, onSkipAll }) {
   return (
-    <div className="flex items-center justify-between px-6 py-3 bg-blue-950/30 border-b border-blue-800/30">
+    <div className="flex items-center justify-between px-6 py-3 bg-[var(--paper-sunk)] border-b border-[var(--rule-hair)]">
       <div className="flex items-center gap-3">
-        <span className="text-xs font-medium text-blue-300 uppercase tracking-wide">
+        <span className="text-xs font-medium text-[var(--ink-2)] uppercase tracking-wide">
           Schedule Wizard
         </span>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-[var(--ink-4)]">
           Step {step} of {total}
         </span>
         {/* Progress dots */}
@@ -140,7 +140,7 @@ export function WizardStepHeader({ step, total, onSkipAll }) {
             <span
               key={i}
               className={`w-1.5 h-1.5 rounded-full ${
-                i < step ? "bg-blue-400" : "bg-gray-700"
+                i < step ? "bg-[var(--ink)]" : "bg-[var(--rule-hair)]"
               }`}
             />
           ))}
@@ -149,7 +149,7 @@ export function WizardStepHeader({ step, total, onSkipAll }) {
       <button
         type="button"
         onClick={onSkipAll}
-        className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+        className="text-xs text-[var(--ink-4)] hover:text-[var(--ink-2)] transition-colors"
       >
         Skip all / later
       </button>

--- a/frontend/src/lib/__tests__/statusColors.test.js
+++ b/frontend/src/lib/__tests__/statusColors.test.js
@@ -43,8 +43,8 @@ describe('statusColors', () => {
       expect(PRODUCTION_ORDER_BADGE_CONFIGS.cancelled.label).toBe('Cancelled')
     })
 
-    it('uses appropriate color classes', () => {
-      expect(PRODUCTION_ORDER_BADGE_CONFIGS.draft.bg).toContain('gray')
+    it('uses appropriate color classes (Workbench tokens, #846)', () => {
+      expect(PRODUCTION_ORDER_BADGE_CONFIGS.draft.bg).toContain('paper-sunk')
       expect(PRODUCTION_ORDER_BADGE_CONFIGS.complete.text).toContain('green')
       expect(PRODUCTION_ORDER_BADGE_CONFIGS.cancelled.text).toContain('red')
     })
@@ -62,7 +62,8 @@ describe('statusColors', () => {
   describe('getStatusColor', () => {
     it('returns the correct color for a known status', () => {
       const result = getStatusColor(PRODUCTION_ORDER_COLORS, 'draft')
-      expect(result).toBe(BASE_COLORS.gray)
+      expect(result).toBe(PRODUCTION_ORDER_COLORS.draft)
+      expect(result).toContain('paper-sunk')
     })
 
     it('returns fallback for unknown status', () => {

--- a/frontend/src/lib/statusColors.js
+++ b/frontend/src/lib/statusColors.js
@@ -36,15 +36,22 @@ export const SALES_ORDER_COLORS = {
 };
 
 // ── Production order statuses ───────────────────────────────────────
+// Industrial Workbench tokens (#846): consumed ONLY by the re-skinned
+// ProductionOrderDetail page (verified) — the other maps in this file still
+// serve un-migrated dark pages and keep the legacy palette.
 export const PRODUCTION_ORDER_COLORS = {
-  draft: BASE_COLORS.gray,
-  released: BASE_COLORS.blue,
-  in_progress: BASE_COLORS.purple,
-  complete: BASE_COLORS.green,
-  scrapped: BASE_COLORS.red,
-  on_hold: BASE_COLORS.yellow,
-  short: BASE_COLORS.orange,
-  cancelled: BASE_COLORS.gray,
+  draft: "bg-[var(--paper-sunk)] text-[var(--ink-3)]",
+  released: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  scheduled: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  in_progress: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  complete: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+  completed: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+  closed: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+  qc_hold: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  scrapped: "bg-[var(--status-red-tint)] text-[var(--status-red)]",
+  on_hold: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  short: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+  cancelled: "bg-[var(--paper-sunk)] text-[var(--ink-4)]",
 };
 
 // ── Purchase order statuses ─────────────────────────────────────────
@@ -85,19 +92,24 @@ export const PRINTER_COLORS = {
 
 // ── Production order badge configs (with labels) ────────────────────
 // Used by StatusBadge components that need both class and display text.
+// Industrial Workbench tokens (#846): consumed ONLY by the re-skinned
+// production components (ProductionQueueList, ProductionOrderModal) —
+// verified before tokenizing, since the rest of this file still serves
+// un-migrated dark pages. Mapping follows ProductionStatusCards:
+// active-ish → amber, done → green, destroyed → red, inert → neutral.
 export const PRODUCTION_ORDER_BADGE_CONFIGS = {
-  draft: { bg: "bg-gray-500/20", text: "text-gray-400", label: "Draft" },
-  released: { bg: "bg-blue-500/20", text: "text-blue-400", label: "Released" },
-  scheduled: { bg: "bg-cyan-500/20", text: "text-cyan-400", label: "Scheduled" },
-  in_progress: { bg: "bg-purple-500/20", text: "text-purple-400", label: "In Progress" },
-  complete: { bg: "bg-green-500/20", text: "text-green-400", label: "Complete" },
-  completed: { bg: "bg-green-500/20", text: "text-green-400", label: "Complete" },
-  closed: { bg: "bg-green-700/20", text: "text-green-300", label: "Closed" },
-  short: { bg: "bg-orange-500/20", text: "text-orange-400", label: "Short" },
-  qc_hold: { bg: "bg-amber-500/20", text: "text-amber-400", label: "QC Hold" },
-  on_hold: { bg: "bg-yellow-500/20", text: "text-yellow-400", label: "On Hold" },
-  scrapped: { bg: "bg-red-500/20", text: "text-red-400", label: "Scrapped" },
-  cancelled: { bg: "bg-red-500/20", text: "text-red-400", label: "Cancelled" },
+  draft: { bg: "bg-[var(--paper-sunk)]", text: "text-[var(--ink-3)]", label: "Draft" },
+  released: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "Released" },
+  scheduled: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "Scheduled" },
+  in_progress: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "In Progress" },
+  complete: { bg: "bg-[var(--status-green-tint)]", text: "text-[var(--status-green)]", label: "Complete" },
+  completed: { bg: "bg-[var(--status-green-tint)]", text: "text-[var(--status-green)]", label: "Complete" },
+  closed: { bg: "bg-[var(--status-green-tint)]", text: "text-[var(--status-green)]", label: "Closed" },
+  short: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "Short" },
+  qc_hold: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "QC Hold" },
+  on_hold: { bg: "bg-[var(--status-amber-tint)]", text: "text-[var(--status-amber)]", label: "On Hold" },
+  scrapped: { bg: "bg-[var(--status-red-tint)]", text: "text-[var(--status-red)]", label: "Scrapped" },
+  cancelled: { bg: "bg-[var(--status-red-tint)]", text: "text-[var(--status-red)]", label: "Cancelled" },
 };
 
 // ── Helper ──────────────────────────────────────────────────────────

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -60,7 +60,7 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
   if (loading) {
     return (
       <div className="h-32 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-purple-500"></div>
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[var(--orange)]"></div>
       </div>
     );
   }
@@ -121,7 +121,7 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
               key={p.key}
               onClick={() => onPeriodChange(p.key)}
               className={`px-3 py-1 text-xs rounded-md transition-colors ${
-                period === p.key ? "bg-purple-600 text-white" : "bg-gray-800 text-gray-400 hover:bg-gray-700"
+                period === p.key ? "bg-[var(--ink)] text-[var(--paper)]" : "bg-[var(--paper-sunk)] text-[var(--ink-3)] hover:text-[var(--ink)]"
               }`}
             >
               {p.label}
@@ -130,17 +130,17 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
         </div>
         <div className="flex gap-4 text-right">
           <div>
-            <p className="text-sm font-semibold text-purple-400">{data?.total_completed || 0}</p>
-            <p className="text-xs text-gray-500">orders</p>
+            <p className="text-sm font-semibold text-[var(--ink)]">{data?.total_completed || 0}</p>
+            <p className="text-xs text-[var(--ink-4)]">orders</p>
           </div>
           <div>
-            <p className="text-sm font-semibold text-green-400">{data?.total_units || 0}</p>
-            <p className="text-xs text-gray-500">units</p>
+            <p className="text-sm font-semibold text-[var(--status-green)]">{data?.total_units || 0}</p>
+            <p className="text-xs text-[var(--ink-4)]">units</p>
           </div>
           {(data?.pipeline_in_progress > 0 || data?.pipeline_scheduled > 0) && (
             <div>
-              <p className="text-sm font-semibold text-yellow-400">{(data?.pipeline_in_progress || 0) + (data?.pipeline_scheduled || 0)}</p>
-              <p className="text-xs text-gray-500">in pipeline</p>
+              <p className="text-sm font-semibold text-[var(--status-amber)]">{(data?.pipeline_in_progress || 0) + (data?.pipeline_scheduled || 0)}</p>
+              <p className="text-xs text-[var(--ink-4)]">in pipeline</p>
             </div>
           )}
         </div>
@@ -148,19 +148,19 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
 
       <div className="flex gap-4 mb-2 text-xs">
         <div className="flex items-center gap-1">
-          <div className="w-2 h-3 bg-purple-500/30 rounded-sm"></div>
-          <span className="text-gray-500">Daily Completed</span>
+          <div className="w-2 h-3 bg-[var(--orange-tint)] rounded-sm"></div>
+          <span className="text-[var(--ink-4)]">Daily Completed</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-3 h-0.5 bg-green-500"></div>
-          <span className="text-gray-400">Cumulative Units</span>
+          <div className="w-3 h-0.5 bg-[var(--status-green)]"></div>
+          <span className="text-[var(--ink-3)]">Cumulative Units</span>
         </div>
       </div>
 
       {dataPoints.length > 0 ? (
         <div ref={chartRef} className="relative" style={{ height: chartHeight }} onMouseLeave={() => setHoveredIndex(null)}>
           <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="w-full h-full">
-            <line x1="0" y1="50" x2="100" y2="50" stroke="#374151" strokeWidth="0.5" />
+            <line x1="0" y1="50" x2="100" y2="50" stroke="var(--rule-hair)" strokeWidth="0.5" />
             {dataPoints.map((d, i) => {
               const barWidth = 100 / Math.max(dataPoints.length, 1) * 0.6;
               const x = (i / Math.max(dataPoints.length - 1, 1)) * 100 - barWidth / 2;
@@ -169,34 +169,34 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
                 <rect key={`bar-${i}`} x={Math.max(0, x)} y={100 - barHeight} width={barWidth} height={barHeight} fill="url(#productionBarGradient)" opacity="0.4" />
               );
             })}
-            <path d={generateUnitsPath()} fill="none" stroke="#22c55e" strokeWidth="2" vectorEffect="non-scaling-stroke" />
+            <path d={generateUnitsPath()} fill="none" stroke="var(--status-green)" strokeWidth="2" vectorEffect="non-scaling-stroke" />
             {dataPoints.map((_, i) => {
               const sliceWidth = 100 / dataPoints.length;
               return <rect key={`hover-${i}`} x={i * sliceWidth} y={0} width={sliceWidth} height={100} fill="transparent" onMouseMove={(e) => handleMouseMove(e, i)} style={{ cursor: 'crosshair' }} />;
             })}
             {hoveredIndex !== null && cumulativeData[hoveredIndex] && (
-              <circle cx={(hoveredIndex / Math.max(cumulativeData.length - 1, 1)) * 100} cy={100 - (cumulativeData[hoveredIndex].cumulativeUnits / Math.max(maxCumulativeUnits, 1)) * 100} r="3" fill="#22c55e" stroke="white" strokeWidth="1" vectorEffect="non-scaling-stroke" />
+              <circle cx={(hoveredIndex / Math.max(cumulativeData.length - 1, 1)) * 100} cy={100 - (cumulativeData[hoveredIndex].cumulativeUnits / Math.max(maxCumulativeUnits, 1)) * 100} r="3" fill="var(--status-green)" stroke="var(--paper)" strokeWidth="1" vectorEffect="non-scaling-stroke" />
             )}
             <defs>
               <linearGradient id="productionBarGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" stopColor="#a855f7" />
-                <stop offset="100%" stopColor="#a855f7" stopOpacity="0.2" />
+                <stop offset="0%" stopColor="var(--orange)" />
+                <stop offset="100%" stopColor="var(--orange)" stopOpacity="0.2" />
               </linearGradient>
             </defs>
           </svg>
           {hoveredIndex !== null && getHoveredData() && (
-            <div className="absolute z-10 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-3 pointer-events-none" style={{ left: Math.min(mousePos.x + 10, chartWidth - 150), top: Math.max(mousePos.y - 70, 0), minWidth: '140px' }}>
+            <div className="absolute z-10 bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg shadow-[var(--shadow-pop)] p-3 pointer-events-none" style={{ left: Math.min(mousePos.x + 10, chartWidth - 150), top: Math.max(mousePos.y - 70, 0), minWidth: '140px' }}>
               {(() => {
                 const d = getHoveredData();
                 return (
                   <>
-                    <div className="text-white font-medium text-sm mb-2">{d.date}</div>
+                    <div className="text-[var(--ink)] font-medium text-sm mb-2">{d.date}</div>
                     <div className="space-y-1 text-xs">
-                      <div className="flex justify-between gap-4"><span className="text-purple-400">Completed:</span><span className="text-white font-medium">{d.completed}</span></div>
-                      <div className="flex justify-between gap-4"><span className="text-green-400">Units:</span><span className="text-white">{d.dailyUnits}</span></div>
-                      <div className="border-t border-gray-700 my-1 pt-1">
-                        <div className="flex justify-between gap-4"><span className="text-gray-400">Total Orders:</span><span className="text-white">{d.cumulativeCompleted}</span></div>
-                        <div className="flex justify-between gap-4"><span className="text-gray-400">Total Units:</span><span className="text-white">{d.cumulativeUnits}</span></div>
+                      <div className="flex justify-between gap-4"><span className="text-[var(--ink-3)]">Completed:</span><span className="text-[var(--ink)] font-medium">{d.completed}</span></div>
+                      <div className="flex justify-between gap-4"><span className="text-[var(--status-green)]">Units:</span><span className="text-[var(--ink)]">{d.dailyUnits}</span></div>
+                      <div className="border-t border-[var(--rule-hair)] my-1 pt-1">
+                        <div className="flex justify-between gap-4"><span className="text-[var(--ink-3)]">Total Orders:</span><span className="text-[var(--ink)]">{d.cumulativeCompleted}</span></div>
+                        <div className="flex justify-between gap-4"><span className="text-[var(--ink-3)]">Total Units:</span><span className="text-[var(--ink)]">{d.cumulativeUnits}</span></div>
                       </div>
                     </div>
                   </>
@@ -206,11 +206,11 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
           )}
         </div>
       ) : (
-        <div className="h-24 flex items-center justify-center text-gray-500 text-sm">No production completions for this period</div>
+        <div className="h-24 flex items-center justify-center text-[var(--ink-4)] text-sm">No production completions for this period</div>
       )}
 
       {dataPoints.length > 0 && (
-        <div className="flex justify-between text-xs text-gray-500 mt-2">
+        <div className="flex justify-between text-xs text-[var(--ink-4)] mt-2">
           <span>{dataPoints[0]?.date ? parseLocalDate(dataPoints[0].date)?.toLocaleDateString() : ""}</span>
           <span>{dataPoints[dataPoints.length - 1]?.date ? parseLocalDate(dataPoints[dataPoints.length - 1].date)?.toLocaleDateString() : ""}</span>
         </div>
@@ -223,13 +223,13 @@ function ProductionChart({ data, period, onPeriodChange, loading }) {
 const SoLinkBadge = ({ order }) => {
   if (order.sales_order_code) {
     return (
-      <span className="text-xs px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded">
+      <span className="text-xs px-1.5 py-0.5 bg-[var(--paper-sunk)] text-[var(--ink-2)] rounded">
         {order.sales_order_code}
       </span>
     );
   }
   return (
-    <span className="text-xs px-1.5 py-0.5 bg-purple-500/20 text-purple-400 rounded">
+    <span className="text-xs px-1.5 py-0.5 bg-[var(--paper-sunk)] text-[var(--ink-3)] rounded">
       STOCK
     </span>
   );
@@ -424,23 +424,23 @@ export default function AdminProduction() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)] flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-white">Production</h1>
-          <p className="text-gray-400 mt-1">
+          <h1 className="text-2xl font-bold text-[var(--ink)]">Production</h1>
+          <p className="text-[var(--ink-3)] mt-1">
             Track print jobs and production orders
           </p>
         </div>
         <div className="flex items-center gap-3">
           {/* SCHED-5: view toggle */}
-          <div className="flex rounded-lg border border-gray-700 overflow-hidden">
+          <div className="flex rounded-lg border border-[var(--rule-hair)] overflow-hidden">
             <button
               type="button"
               onClick={() => setPageView("queue")}
               className={`px-3 py-2 text-sm transition-colors ${
                 pageView === "queue"
-                  ? "bg-gray-700 text-white"
-                  : "bg-gray-900 text-gray-400 hover:text-white"
+                  ? "bg-[var(--ink)] text-[var(--paper)]"
+                  : "bg-[var(--paper-sunk)] text-[var(--ink-3)] hover:text-[var(--ink)]"
               }`}
             >
               Queue
@@ -450,8 +450,8 @@ export default function AdminProduction() {
               onClick={() => setPageView("scheduler")}
               className={`px-3 py-2 text-sm transition-colors ${
                 pageView === "scheduler"
-                  ? "bg-gray-700 text-white"
-                  : "bg-gray-900 text-gray-400 hover:text-white"
+                  ? "bg-[var(--ink)] text-[var(--paper)]"
+                  : "bg-[var(--paper-sunk)] text-[var(--ink-3)] hover:text-[var(--ink)]"
               }`}
             >
               Scheduler
@@ -459,7 +459,7 @@ export default function AdminProduction() {
           </div>
           <button
             onClick={() => { setShowCreateModal(true); setCreateError(null); }}
-            className="px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500"
+            className="px-4 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)]"
           >
             + Create Production Order
           </button>
@@ -479,7 +479,7 @@ export default function AdminProduction() {
       {pageView === "queue" && (
         <>
       {/* Production Trend Chart */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
         <ProductionChart
           data={productionTrend}
           period={trendPeriod}
@@ -490,27 +490,27 @@ export default function AdminProduction() {
 
       {/* Stats */}
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">Draft</p>
-              <p className="text-2xl font-bold text-gray-400">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">Draft</p>
+              <p className="text-2xl font-bold text-[var(--ink-3)]">
                 {groupedOrders.draft.length}
               </p>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">Released</p>
-              <p className="text-2xl font-bold text-blue-400">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">Released</p>
+              <p className="text-2xl font-bold text-[var(--status-amber)]">
                 {groupedOrders.released.length}
               </p>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">In Progress</p>
-              <p className="text-2xl font-bold text-purple-400">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">In Progress</p>
+              <p className="text-2xl font-bold text-[var(--status-amber)]">
                 {groupedOrders.in_progress.length}
               </p>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">Completed Today</p>
-              <p className="text-2xl font-bold text-green-400">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">Completed Today</p>
+              <p className="text-2xl font-bold text-[var(--status-green)]">
                 {
                   groupedOrders.complete.filter((o) => {
                     const today = new Date().toDateString();
@@ -522,9 +522,9 @@ export default function AdminProduction() {
                 }
               </p>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">Scrapped Today</p>
-              <p className="text-2xl font-bold text-red-400">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">Scrapped Today</p>
+              <p className="text-2xl font-bold text-[var(--status-red)]">
                 {
                   groupedOrders.scrapped.filter((o) => {
                     const today = new Date().toDateString();
@@ -536,9 +536,9 @@ export default function AdminProduction() {
                 }
               </p>
             </div>
-            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-              <p className="text-gray-400 text-sm">Total Active</p>
-              <p className="text-2xl font-bold text-white">
+            <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
+              <p className="text-[var(--ink-3)] text-sm">Total Active</p>
+              <p className="text-2xl font-bold text-[var(--ink)]">
                 {groupedOrders.released.length +
                   groupedOrders.in_progress.length}
               </p>
@@ -547,7 +547,7 @@ export default function AdminProduction() {
 
           {/* Error */}
           {error && (
-            <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4 text-red-400">
+            <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-xl p-4 text-[var(--status-red)]">
               {error}
             </div>
           )}
@@ -555,7 +555,7 @@ export default function AdminProduction() {
           {/* Loading */}
           {loading && (
             <div className="flex items-center justify-center h-32">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--orange)]"></div>
             </div>
           )}
 
@@ -699,19 +699,20 @@ export default function AdminProduction() {
         title="Create Production Order"
         className="w-full max-w-md"
         disableClose={creating}
+        variant="workbench"
       >
         <div className="p-6">
-            <h2 className="text-xl font-bold text-white mb-4">Create Production Order</h2>
+            <h2 className="text-xl font-bold text-[var(--ink)] mb-4">Create Production Order</h2>
             <form onSubmit={handleCreateOrder} className="space-y-4">
               {/* In-modal error feedback (POST failure stays here so the modal remains open) */}
               {createError && (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+                <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-lg p-3 text-[var(--status-red)] text-sm">
                   {createError}
                 </div>
               )}
               {/* Product Selection */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Product *
                 </label>
                 <select
@@ -719,7 +720,7 @@ export default function AdminProduction() {
                   onChange={(e) =>
                     setCreateForm({ ...createForm, product_id: e.target.value })
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                   required
                 >
                   <option value="">Select a product...</option>
@@ -733,7 +734,7 @@ export default function AdminProduction() {
 
               {/* Quantity */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Quantity *
                 </label>
                 <input
@@ -746,14 +747,14 @@ export default function AdminProduction() {
                       quantity_ordered: e.target.value,
                     })
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                   required
                 />
               </div>
 
               {/* Priority */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Priority
                 </label>
                 <select
@@ -761,7 +762,7 @@ export default function AdminProduction() {
                   onChange={(e) =>
                     setCreateForm({ ...createForm, priority: e.target.value })
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                 >
                   <option value="1">1 - Urgent</option>
                   <option value="2">2 - High</option>
@@ -773,7 +774,7 @@ export default function AdminProduction() {
 
               {/* Due Date */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Due Date
                 </label>
                 <input
@@ -782,7 +783,7 @@ export default function AdminProduction() {
                   onChange={(e) =>
                     setCreateForm({ ...createForm, due_date: e.target.value })
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)]"
                   min={new Date().toISOString().split("T")[0]}
                   max="2099-12-31"
                 />
@@ -790,7 +791,7 @@ export default function AdminProduction() {
 
               {/* Notes */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
+                <label className="block text-sm text-[var(--ink-3)] mb-1">
                   Notes
                 </label>
                 <textarea
@@ -798,7 +799,7 @@ export default function AdminProduction() {
                   onChange={(e) =>
                     setCreateForm({ ...createForm, notes: e.target.value })
                   }
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-white h-20"
+                  className="w-full bg-[var(--paper)] border border-[var(--rule-hair)] rounded-lg px-4 py-2 text-[var(--ink)] placeholder-[var(--ink-4)] h-20"
                   placeholder="Optional notes..."
                 />
               </div>
@@ -808,14 +809,14 @@ export default function AdminProduction() {
                 <button
                   type="button"
                   onClick={() => setShowCreateModal(false)}
-                  className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+                  className="flex-1 px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={creating}
-                  className="flex-1 px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-500 hover:to-purple-500 disabled:opacity-50"
+                  className="flex-1 px-4 py-2 bg-[var(--orange)] text-white rounded-lg hover:bg-[var(--orange-press)] disabled:opacity-50"
                 >
                   {creating ? "Creating..." : "Create Order"}
                 </button>

--- a/frontend/src/pages/admin/AdminProduction.jsx
+++ b/frontend/src/pages/admin/AdminProduction.jsx
@@ -492,7 +492,7 @@ export default function AdminProduction() {
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
             <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)]">
               <p className="text-[var(--ink-3)] text-sm">Draft</p>
-              <p className="text-2xl font-bold text-[var(--ink-3)]">
+              <p className="text-2xl font-bold text-[var(--ink)]">
                 {groupedOrders.draft.length}
               </p>
             </div>

--- a/frontend/src/pages/admin/ProductionOrderDetail.jsx
+++ b/frontend/src/pages/admin/ProductionOrderDetail.jsx
@@ -128,31 +128,31 @@ function WorkflowStepCard({ step, onAction, updating }) {
   const Icon = step.icon || Circle;
   const statusStyles = {
     done: {
-      container: "border-emerald-500/50 bg-emerald-950/20",
-      icon: "bg-emerald-500/20 text-emerald-300",
-      label: "text-emerald-300",
-      badge: "bg-emerald-500/20 text-emerald-200",
+      container: "border-[var(--status-green)]/30 bg-[var(--status-green-tint)]",
+      icon: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
+      label: "text-[var(--status-green)]",
+      badge: "bg-[var(--status-green-tint)] text-[var(--status-green)]",
       badgeText: "Done",
     },
     current: {
-      container: "border-blue-500/60 bg-blue-950/20",
-      icon: "bg-blue-500/20 text-blue-300",
-      label: "text-blue-300",
-      badge: "bg-blue-500/20 text-blue-200",
+      container: "border-[var(--status-amber)]/30 bg-[var(--status-amber-tint)]",
+      icon: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
+      label: "text-[var(--status-amber)]",
+      badge: "bg-[var(--status-amber-tint)] text-[var(--status-amber)]",
       badgeText: "Current",
     },
     waiting: {
-      container: "border-yellow-500/60 bg-yellow-950/20",
-      icon: "bg-yellow-500/20 text-yellow-300",
-      label: "text-yellow-300",
-      badge: "bg-yellow-500/20 text-yellow-200",
+      container: "border-[var(--rule-hair)] bg-[var(--paper-sunk)]",
+      icon: "bg-[var(--paper-sunk)] text-[var(--ink-3)]",
+      label: "text-[var(--ink-3)]",
+      badge: "bg-[var(--paper-sunk)] text-[var(--ink-3)]",
       badgeText: "Waiting",
     },
     blocked: {
-      container: "border-gray-700 bg-gray-950/30",
-      icon: "bg-gray-800 text-gray-400",
-      label: "text-gray-400",
-      badge: "bg-gray-800 text-gray-400",
+      container: "border-[var(--rule-hair)] bg-[var(--paper-sunk)]",
+      icon: "bg-[var(--rule-hair)] text-[var(--ink-4)]",
+      label: "text-[var(--ink-4)]",
+      badge: "bg-[var(--rule-hair)] text-[var(--ink-4)]",
       badgeText: "Blocked",
     },
   };
@@ -166,8 +166,8 @@ function WorkflowStepCard({ step, onAction, updating }) {
             <Icon className="h-5 w-5" aria-hidden="true" />
           </div>
           <div>
-            <div className="text-xs uppercase text-gray-500">{step.step}</div>
-            <div className="text-sm font-semibold text-white">{step.title}</div>
+            <div className="text-xs uppercase text-[var(--ink-4)]">{step.step}</div>
+            <div className="text-sm font-semibold text-[var(--ink)]">{step.title}</div>
           </div>
         </div>
         <span className={`rounded-full px-2 py-1 text-xs ${styles.badge}`}>
@@ -177,13 +177,13 @@ function WorkflowStepCard({ step, onAction, updating }) {
       <div className={`mt-4 text-sm font-semibold ${styles.label}`}>
         {step.headline}
       </div>
-      <p className="mt-2 min-h-10 text-sm text-gray-300">{step.detail}</p>
+      <p className="mt-2 min-h-10 text-sm text-[var(--ink-2)]">{step.detail}</p>
       {step.action && (
         <button
           type="button"
           onClick={() => onAction(step.action)}
           disabled={updating}
-          className="mt-4 w-full rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          className="mt-4 w-full rounded-lg bg-[var(--orange)] px-3 py-2 text-sm font-medium text-white hover:bg-[var(--orange-press)] disabled:opacity-50"
         >
           {step.actionLabel}
         </button>
@@ -290,7 +290,7 @@ export default function ProductionOrderDetail() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--orange)]"></div>
       </div>
     );
   }
@@ -298,11 +298,11 @@ export default function ProductionOrderDetail() {
   if (error) {
     return (
       <div className="p-6">
-        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-6 text-center">
-          <p className="text-red-400 mb-4">{error}</p>
+        <div className="bg-[var(--status-red-tint)] border border-[var(--status-red)]/30 rounded-xl p-6 text-center">
+          <p className="text-[var(--status-red)] mb-4">{error}</p>
           <button
             onClick={() => navigate("/admin/production")}
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
           >
             Back to Production
           </button>
@@ -314,11 +314,11 @@ export default function ProductionOrderDetail() {
   if (!order) {
     return (
       <div className="p-6">
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 text-center">
-          <p className="text-gray-400 mb-4">Production order not found</p>
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 text-center shadow-[var(--shadow-pop)]">
+          <p className="text-[var(--ink-3)] mb-4">Production order not found</p>
           <button
             onClick={() => navigate("/admin/production")}
-            className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+            className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
           >
             Back to Production
           </button>
@@ -337,28 +337,30 @@ export default function ProductionOrderDetail() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      {/* Header — own paper card: the AdminLayout shell behind this page is
+          still the un-migrated dark background (a later #846 slice), so
+          ink-toned text needs its own light surface here. */}
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-4 shadow-[var(--shadow-pop)] flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <button
             onClick={() => navigate("/admin/production")}
-            className="mb-2 inline-flex items-center gap-2 text-gray-400 hover:text-white"
+            className="mb-2 inline-flex items-center gap-2 text-[var(--ink-3)] hover:text-[var(--ink)]"
           >
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
             Back to Production
           </button>
-          <h1 className="text-2xl font-bold text-white">
+          <h1 className="text-2xl font-bold text-[var(--ink)]">
             Production Order: {order.code}
           </h1>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-400">
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-[var(--ink-3)]">
             <span>Production Command Center</span>
             {hasLinkedSalesOrder && (
               <>
-                <span className="text-gray-600">-</span>
+                <span className="text-[var(--ink-4)]">-</span>
                 <button
                   type="button"
                   onClick={() => navigate(`/admin/orders/${order.sales_order_id}`)}
-                  className="inline-flex items-center gap-1 text-blue-300 hover:text-blue-200"
+                  className="inline-flex items-center gap-1 text-[var(--ink-2)] hover:text-[var(--ink)]"
                 >
                   <FileText className="h-4 w-4" aria-hidden="true" />
                   {order.sales_order_code || `SO-${order.sales_order_id}`}
@@ -370,7 +372,7 @@ export default function ProductionOrderDetail() {
         <div className="flex flex-wrap gap-2">
           <button
             onClick={fetchOrder}
-            className="inline-flex items-center gap-2 rounded-lg bg-gray-700 px-4 py-2 text-white hover:bg-gray-600"
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--paper-sunk)] border border-[var(--rule-hair)] px-4 py-2 text-[var(--ink-2)] hover:text-[var(--ink)]"
           >
             <RefreshCw className="h-4 w-4" aria-hidden="true" />
             Refresh
@@ -379,7 +381,7 @@ export default function ProductionOrderDetail() {
             <button
               onClick={() => handleStatusUpdate("release")}
               disabled={updating}
-              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--orange)] px-4 py-2 text-white hover:bg-[var(--orange-press)] disabled:opacity-50"
             >
               <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
               Release to Floor
@@ -389,7 +391,7 @@ export default function ProductionOrderDetail() {
             <button
               onClick={() => handleStatusUpdate("start")}
               disabled={updating}
-              className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--orange)] px-4 py-2 text-white hover:bg-[var(--orange-press)] disabled:opacity-50"
             >
               <PlayCircle className="h-4 w-4" aria-hidden="true" />
               Start Production
@@ -399,7 +401,7 @@ export default function ProductionOrderDetail() {
             <button
               onClick={() => handleStatusUpdate("complete")}
               disabled={updating}
-              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--orange)] px-4 py-2 text-white hover:bg-[var(--orange-press)] disabled:opacity-50"
             >
               <PackageCheck className="h-4 w-4" aria-hidden="true" />
               Complete Production
@@ -409,18 +411,18 @@ export default function ProductionOrderDetail() {
       </div>
 
       {/* Production Workflow */}
-      <div className="rounded-xl border border-blue-700/40 bg-blue-950/20 p-6">
+      <div className="rounded-xl border border-[var(--rule-hair)] bg-[var(--paper)] p-6 shadow-[var(--shadow-pop)]">
         <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="flex items-center gap-2 text-lg font-semibold text-white">
-              <Factory className="h-5 w-5 text-blue-300" aria-hidden="true" />
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-[var(--ink)]">
+              <Factory className="h-5 w-5 text-[var(--ink-3)]" aria-hidden="true" />
               Production Workflow
             </h2>
-            <p className="mt-1 text-sm text-gray-400">
+            <p className="mt-1 text-sm text-[var(--ink-3)]">
               Draft, release, run, then complete the work order.
             </p>
           </div>
-          <span className="inline-flex w-fit items-center gap-2 rounded-full bg-gray-800 px-3 py-1 text-sm text-gray-300">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full bg-[var(--paper-sunk)] px-3 py-1 text-sm text-[var(--ink-2)]">
             <Clock3 className="h-4 w-4" aria-hidden="true" />
             {formatStatusLabel(order.status)}
           </span>
@@ -438,23 +440,23 @@ export default function ProductionOrderDetail() {
       </div>
 
       {/* Order Summary */}
-      <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">Order Summary</h2>
+      <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+        <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Order Summary</h2>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
           <div>
-            <div className="text-sm text-gray-400">Product</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Product</div>
+            <div className="text-[var(--ink)] font-medium">
               {order.product_name || order.product_sku || "N/A"}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Quantity</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Quantity</div>
+            <div className="text-[var(--ink)] font-medium">
               {order.quantity_completed || 0} / {order.quantity_ordered}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Status</div>
+            <div className="text-sm text-[var(--ink-3)]">Status</div>
             <span
               className={`inline-block px-2 py-1 rounded-full text-sm ${getProductionStatusColor(order.status)}`}
             >
@@ -462,14 +464,14 @@ export default function ProductionOrderDetail() {
             </span>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Priority</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Priority</div>
+            <div className="text-[var(--ink)] font-medium">
               {order.priority || "Normal"}
             </div>
           </div>
           <div>
-            <div className="text-sm text-gray-400">Due Date</div>
-            <div className="text-white font-medium">
+            <div className="text-sm text-[var(--ink-3)]">Due Date</div>
+            <div className="text-[var(--ink)] font-medium">
               {order.due_date
                 ? new Date(order.due_date).toLocaleDateString()
                 : "Not set"}
@@ -480,12 +482,12 @@ export default function ProductionOrderDetail() {
         {/* Progress Bar */}
         <div className="mt-4">
           <div className="flex justify-between text-sm mb-1">
-            <span className="text-gray-400">Progress</span>
-            <span className="text-white">{progress}%</span>
+            <span className="text-[var(--ink-3)]">Progress</span>
+            <span className="text-[var(--ink)]">{progress}%</span>
           </div>
-          <div className="w-full bg-gray-800 rounded-full h-2">
+          <div className="w-full bg-[var(--rule-hair)] rounded-full h-2">
             <div
-              className="bg-gradient-to-r from-blue-600 to-purple-600 h-2 rounded-full transition-all"
+              className="bg-[var(--status-green)] h-2 rounded-full transition-all"
               style={{ width: `${progress}%` }}
             ></div>
           </div>
@@ -534,10 +536,10 @@ export default function ProductionOrderDetail() {
 
       {/* Order Lineage - Show if this is a remake */}
       {order.remake_of_id && (
-        <div className="bg-gray-900 border border-yellow-600/30 rounded-xl p-6">
+        <div className="bg-[var(--paper)] border border-[var(--status-amber)]/30 rounded-xl p-6 shadow-[var(--shadow-pop)]">
           <div className="flex items-center gap-2 mb-4">
             <svg
-              className="w-5 h-5 text-yellow-500"
+              className="w-5 h-5 text-[var(--status-amber)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -549,20 +551,20 @@ export default function ProductionOrderDetail() {
                 d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
               />
             </svg>
-            <h2 className="text-lg font-semibold text-yellow-400">
+            <h2 className="text-lg font-semibold text-[var(--status-amber)]">
               Remake Order
             </h2>
           </div>
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-gray-400 text-sm mb-1">
+              <p className="text-[var(--ink-3)] text-sm mb-1">
                 This order is a remake of:
               </p>
-              <p className="text-white font-medium">
+              <p className="text-[var(--ink)] font-medium">
                 {order.remake_of_code || `PO-${order.remake_of_id}`}
               </p>
               {order.remake_reason && (
-                <p className="text-yellow-400/80 text-sm mt-1">
+                <p className="text-[var(--status-amber)]/80 text-sm mt-1">
                   Reason: {order.remake_reason}
                 </p>
               )}
@@ -571,7 +573,7 @@ export default function ProductionOrderDetail() {
               onClick={() =>
                 navigate(`/admin/production/${order.remake_of_id}`)
               }
-              className="px-4 py-2 bg-yellow-600/20 text-yellow-400 rounded-lg hover:bg-yellow-600/30"
+              className="px-4 py-2 bg-[var(--paper-sunk)] border border-[var(--rule-hair)] text-[var(--ink-2)] rounded-lg hover:text-[var(--ink)]"
             >
               View Original
             </button>
@@ -581,26 +583,26 @@ export default function ProductionOrderDetail() {
 
       {/* Linked Sales Order */}
       {order.sales_order_id && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
           <div className="mb-4 flex items-center gap-2">
-            <FileText className="h-5 w-5 text-blue-300" aria-hidden="true" />
-            <h2 className="text-lg font-semibold text-white">
+            <FileText className="h-5 w-5 text-[var(--ink-3)]" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-[var(--ink)]">
               Linked Sales Order
             </h2>
           </div>
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-white font-medium">
+              <p className="text-[var(--ink)] font-medium">
                 {order.sales_order_code || `SO-${order.sales_order_id}`}
               </p>
-              <p className="text-gray-400 text-sm">
+              <p className="text-[var(--ink-3)] text-sm">
                 {order.customer_name || "Customer"} - Open the sales order for
                 invoice, payment, and shipment controls.
               </p>
             </div>
             <button
               onClick={() => navigate(`/admin/orders/${order.sales_order_id}`)}
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600/20 px-4 py-2 text-blue-300 hover:bg-blue-600/30"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--paper-sunk)] border border-[var(--rule-hair)] px-4 py-2 text-[var(--ink-2)] hover:text-[var(--ink)]"
             >
               <ArrowLeft className="h-4 w-4 rotate-180" aria-hidden="true" />
               View Sales Order
@@ -611,9 +613,9 @@ export default function ProductionOrderDetail() {
 
       {/* Notes */}
       {order.notes && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-          <h2 className="text-lg font-semibold text-white mb-4">Notes</h2>
-          <p className="text-gray-300">{order.notes}</p>
+        <div className="bg-[var(--paper)] border border-[var(--rule-hair)] rounded-xl p-6 shadow-[var(--shadow-pop)]">
+          <h2 className="text-lg font-semibold text-[var(--ink)] mb-4">Notes</h2>
+          <p className="text-[var(--ink-2)]">{order.notes}</p>
         </div>
       )}
 


### PR DESCRIPTION
## Epic #846 — Production stage: the re-skin

The visual finale for the Production stage, landing on a **fully functional** surface (all five functional PRs merged first: #856 scrap flow, #860 QC/completion, #863+#864 scheduling, #867 dead actions, #868 op-scrap routes — fix-before-dazzle). 27 files, presentation-only: no logic, props, handlers, aria, or test-id changes.

### Scope
`AdminProduction` + `ProductionOrderDetail` pages, the full `components/production/` directory (queue, scheduler board + Gantt, all operation widgets, all modals), the three root-level production modals (Scrap/Complete/QC), and `ReleaseScheduleWizard` — following the `AdminShipping`/`ProductionStatusCards` reference patterns from the shipping slice.

### Shared-component strategy (opt-in, zero blast radius)
Two shared components are consumed app-wide by still-dark pages, so global flips were off the table:
- **`Modal.jsx`** → opt-in `variant="workbench"` paper shell; dark default untouched for every other consumer.
- **`EmptyState.jsx`** → opt-in `tone="workbench"` — **caught by rendered-page verification**, not static checks: it rendered as a legacy dark island inside the paper queue table, invisible to the roster-scoped residue census.
- **`statusColors.js`**: `PRODUCTION_ORDER_BADGE_CONFIGS` + `PRODUCTION_ORDER_COLORS` tokenized after grep-verifying each is consumed **only** by re-skinned production components; all other maps keep the legacy palette for the dark pages. Purple `in_progress` → amber per the Workbench status grammar.

### Verification
- **Rendered-app verification** (dev servers + a throwaway admin and PO, both deleted after): login → `/admin/production` → detail page. Computed-style checks: header ink-on-paper card (the a2007b6 pattern), stat tiles, table head/rows, status badge (`rgb(254,243,199)` amber tint confirmed), row affordances, empty state, and a **400-leaf computed-contrast sweep on ProductionOrderDetail with zero flags**.
- **Residue census** (agent, all 25 roster files): only legitimate `text-white` on solid orange/red/green buttons + Modal's intentional dark variant remain — zero stray palette classes.
- `vite build` ✓ · **581/581** unit tests (incl. updated statusColors/EmptyState assertions) · agents' per-file reports include judgment calls (e.g. WorkflowStepCard's 4-state mapping follows `OP_STATUS_CLASS`; SO-link badges chose neutral over amber since they're category tags, not statuses).

### Deferred (tracked)
Shared `Badge.jsx`/descriptor-tone migration and the remaining `statusColors.js` maps stay legacy until their dark consumers migrate — that's the #858 B7 status-vocab/badge consolidation.

Closes the Production stage of the backward march. Next stage: **Orders**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tone support and an optional “Clear filters” action to empty states.
  * Enhanced order completion with BOM material/spool selection, optional short-close force handling, and remake order creation.
  * Improved production trend chart hover to show cumulative units at the hovered day.

* **Bug Fixes**
  * Made spool availability loading failures non-blocking.
  * Updated production status colors/badges for consistent state display.

* **Style**
  * Re-themed modals and production/scheduling/QC/admin UIs using CSS variable-driven styling, including a new workbench modal variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->