### PR TITLE
fix(security): require auth on GET /sales-orders/{id}/shipping-events

### DIFF
--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -1321,9 +1321,15 @@ async def list_shipping_events(
     order_id: int,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List shipping events for a sales order."""
+    """List shipping events for a sales order.
+
+    Requires authentication — this was the only endpoint in the router without
+    an auth dependency, so tracking numbers, carrier, and shipment locations
+    were readable unauthenticated by order-id enumeration.
+    """
     # Verify order exists (raises 404 if not found)
     sales_order_service.get_sales_order(db, order_id)
 

--- a/backend/app/api/v1/endpoints/sales_orders.py
+++ b/backend/app/api/v1/endpoints/sales_orders.py
@@ -1326,12 +1326,17 @@ async def list_shipping_events(
 ):
     """List shipping events for a sales order.
 
-    Requires authentication — this was the only endpoint in the router without
-    an auth dependency, so tracking numbers, carrier, and shipment locations
-    were readable unauthenticated by order-id enumeration.
+    Owner-or-admin only (matching get_sales_order_details): this was the sole
+    endpoint in the router with no auth dependency, so tracking numbers,
+    carrier, and shipment locations were readable unauthenticated — and even
+    once authenticated, a signed-in non-owner could read another customer's
+    shipment PII by enumerating order ids.
     """
-    # Verify order exists (raises 404 if not found)
-    sales_order_service.get_sales_order(db, order_id)
+    order = sales_order_service.get_sales_order(db, order_id)
+
+    is_admin = getattr(current_user, "account_type", None) == "admin" or getattr(current_user, "is_admin", False)
+    if order.user_id != current_user.id and not is_admin:
+        raise HTTPException(status_code=403, detail="Not authorized to view this order")
 
     query = db.query(ShippingEvent).filter(
         ShippingEvent.sales_order_id == order_id
@@ -1377,8 +1382,12 @@ async def add_shipping_event(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Add a shipping event to a sales order."""
+    """Add a shipping event to a sales order (owner-or-admin only)."""
     order = sales_order_service.get_sales_order(db, order_id)
+
+    is_admin = getattr(current_user, "account_type", None) == "admin" or getattr(current_user, "is_admin", False)
+    if order.user_id != current_user.id and not is_admin:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this order")
 
     event = record_shipping_event(
         db=db,

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -119,6 +119,19 @@ class TestSalesOrderAuth:
         })
         assert response.status_code == 401
 
+    def test_list_shipping_events_requires_auth(self, unauthed_client):
+        """Regression: this was the sole router endpoint without an auth
+        dependency, exposing tracking/carrier/location by id enumeration."""
+        response = unauthed_client.get(f"{BASE_URL}/1/shipping-events")
+        assert response.status_code == 401
+
+    def test_add_shipping_event_requires_auth(self, unauthed_client):
+        response = unauthed_client.post(f"{BASE_URL}/1/shipping-events", json={
+            "event_type": "shipped",
+            "title": "Shipped",
+        })
+        assert response.status_code == 401
+
 
 # =============================================================================
 # Status Transitions Metadata

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -133,6 +133,56 @@ class TestSalesOrderAuth:
         assert response.status_code == 401
 
 
+class TestShippingEventsAuthorization:
+    """Owner-or-admin guard on shipping-events (#872 CodeRabbit follow-up):
+    an authenticated non-owner must not read/write another customer's shipment
+    events, matching get_sales_order_details."""
+
+    def _as_new_customer(self, client, db, suffix):
+        from app.core.security import create_access_token
+        from app.models.user import User
+        other = User(
+            email=f"outsider-{suffix}@filaops.dev",
+            password_hash="not-a-real-hash",
+            first_name="Out", last_name="Sider",
+            account_type="customer",
+        )
+        db.add(other)
+        db.flush()
+        client.headers["Authorization"] = f"Bearer {create_access_token(user_id=other.id)}"
+        return other
+
+    def test_non_owner_cannot_list_shipping_events(self, client, db, make_product, make_sales_order):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, quantity=1, unit_price=Decimal("10.00"))
+        db.flush()  # order is owned by the seeded admin (user_id=1)
+        self._as_new_customer(client, db, f"list-{so.id}")
+
+        response = client.get(f"{BASE_URL}/{so.id}/shipping-events")
+        assert response.status_code == 403
+
+    def test_non_owner_cannot_add_shipping_event(self, client, db, make_product, make_sales_order):
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, quantity=1, unit_price=Decimal("10.00"))
+        db.flush()
+        self._as_new_customer(client, db, f"add-{so.id}")
+
+        response = client.post(
+            f"{BASE_URL}/{so.id}/shipping-events",
+            json={"event_type": "delivered", "title": "Delivered"},
+        )
+        assert response.status_code == 403
+
+    def test_admin_can_list_shipping_events(self, client, db, make_product, make_sales_order):
+        """The default client is the seeded admin — the guard must not block it."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, quantity=1, unit_price=Decimal("10.00"))
+        db.flush()
+
+        response = client.get(f"{BASE_URL}/{so.id}/shipping-events")
+        assert response.status_code == 200
+
+
 # =============================================================================
 # Status Transitions Metadata
 # =============================================================================


### PR DESCRIPTION
## Security hotfix — unauthenticated shipping-events read

Surfaced by the Orders-stage audit (workflow `weto3ruqa`), verified by hand.

`GET /api/v1/sales-orders/{id}/shipping-events` was the **only endpoint in the entire 30-endpoint sales-orders router without an auth dependency** — every sibling (including its own `POST` twin one line below) uses `Depends(get_current_user)`. An unauthenticated caller could read **tracking numbers, carrier, and shipment city/state/zip** for any order by enumerating `order_id`:

```
curl http://<host>/api/v1/sales-orders/1/shipping-events   # 200, full shipment PII
```

### Fix
One line: add `current_user: User = Depends(get_current_user)` to `list_shipping_events`, bringing it in line with all 29 siblings. Confirmed via a router-wide scan that this was the sole omission — an accidental gap, not a deliberate public endpoint.

### Tests
+2 regression tests in `TestSalesOrderAuth` (GET **and** POST shipping-events return 401 unauthenticated). `TestSalesOrderAuth` 15/15, ruff clean.

### Scope note
This is the clear, one-line critical pulled ahead of the Orders slice (same pattern as the #851/#852 hotfixes). A broader authorization question — the router grants any *authenticated* user access to any order (no per-order ownership check on reads or the shipping-event POST) — is real but is an architectural review, not a hotfix; it'll be filed from the audit tracker rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The sales orders shipping-events endpoints now enforce authentication, returning `401` when requests are unauthenticated.
  * Authenticated requests are now authorized to ensure only the order owner (or an admin) can list or add shipping events; unauthorized users receive `403`.
* **Tests**
  * Added automated coverage for unauthenticated (`401`) and authorization (`403`/`200`) scenarios for both shipping-events routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->