### PR TITLE
feat(items): persistent slice-file download button

### DIFF
--- a/backend/app/api/v1/endpoints/items.py
+++ b/backend/app/api/v1/endpoints/items.py
@@ -116,6 +116,7 @@ def _build_item_response(item, db: Session) -> ItemResponse:
         allocated_qty=data["allocated_qty"],
         has_bom=data["has_bom"],
         bom_count=data["bom_count"],
+        gcode_file_path=data.get("gcode_file_path"),
         created_at=data["created_at"],
         updated_at=data["updated_at"],
     )
@@ -271,6 +272,7 @@ async def list_items(
             image_url=item.get("image_url"),
             has_bom=item.get("has_bom", False),
             has_routing=item.get("has_routing", False),
+            gcode_file_path=item.get("gcode_file_path"),
             parent_product_id=item.get("parent_product_id"),
             is_template=item.get("is_template", False),
             variant_count=item.get("variant_count", 0),

--- a/backend/app/schemas/item.py
+++ b/backend/app/schemas/item.py
@@ -256,6 +256,10 @@ class ItemListResponse(BaseModel):
     has_bom: bool = False
     has_routing: bool = False
 
+    # Slice file (populated by the PRO intake flow; full download path to the
+    # saved .gcode.3mf, e.g. /api/v1/pro/intake/products/{id}/slice-file)
+    gcode_file_path: Optional[str] = None
+
     # Material info (for filament items)
     material_type_id: Optional[int] = None
     color_id: Optional[int] = None
@@ -299,6 +303,10 @@ class ItemResponse(ItemBase):
     has_bom: bool = False
     bom_count: int = 0
     has_routing: bool = False
+
+    # Slice file (populated by the PRO intake flow; full download path to the
+    # saved .gcode.3mf, e.g. /api/v1/pro/intake/products/{id}/slice-file)
+    gcode_file_path: Optional[str] = None
 
     # Material info (for filament items)
     material_type_code: Optional[str] = None

--- a/backend/app/services/item_service.py
+++ b/backend/app/services/item_service.py
@@ -598,6 +598,7 @@ def list_items(
                 "image_url": item.image_url,
                 "has_bom": item.has_bom or item.id in bom_ids,
                 "has_routing": item.id in routing_ids,
+                "gcode_file_path": item.gcode_file_path,
                 "parent_product_id": item.parent_product_id,
                 "is_template": item.is_template,
                 "variant_count": variant_count_map.get(item.id, 0),
@@ -990,6 +991,7 @@ def build_item_response_data(item: Product, db: Session) -> dict:
         "has_bom": item.has_bom or bom_count > 0,
         "bom_count": bom_count,
         "has_routing": has_active_routing,
+        "gcode_file_path": item.gcode_file_path,
         "created_at": item.created_at,
         "updated_at": item.updated_at,
     }

--- a/backend/tests/api/v1/test_items.py
+++ b/backend/tests/api/v1/test_items.py
@@ -201,6 +201,24 @@ class TestListItems:
         body = resp.json()
         assert len(body["items"]) <= 2
 
+    def test_list_response_has_gcode_file_path(self, client, make_product):
+        product = make_product(
+            name="List Slice File Test",
+            gcode_file_path="/api/v1/pro/intake/products/456/slice-file",
+        )
+        resp = client.get(BASE_URL, params={"search": "List Slice File Test"})
+        assert resp.status_code == 200
+        body = resp.json()
+        item = next(item for item in body["items"] if item["sku"] == product.sku)
+        assert item["gcode_file_path"] == "/api/v1/pro/intake/products/456/slice-file"
+
+    def test_list_response_gcode_file_path_null_when_unset(self, client, make_product):
+        product = make_product(name="List No Slice File Test")
+        resp = client.get(BASE_URL, params={"search": "List No Slice File Test"})
+        body = resp.json()
+        item = next(item for item in body["items"] if item["sku"] == product.sku)
+        assert item["gcode_file_path"] is None
+
     def test_list_pagination_offset(self, client, make_product):
         for i in range(5):
             make_product(name=f"Offset Item {i}")
@@ -478,6 +496,21 @@ class TestGetItem:
         body = resp.json()
         assert "created_at" in body
         assert "updated_at" in body
+
+    def test_get_item_response_has_gcode_file_path(self, client, make_product):
+        product = make_product(
+            name="Slice File Test",
+            gcode_file_path="/api/v1/pro/intake/products/123/slice-file",
+        )
+        resp = client.get(f"{BASE_URL}/{product.id}")
+        body = resp.json()
+        assert body["gcode_file_path"] == "/api/v1/pro/intake/products/123/slice-file"
+
+    def test_get_item_response_gcode_file_path_null_when_unset(self, client, make_product):
+        product = make_product(name="No Slice File Test")
+        resp = client.get(f"{BASE_URL}/{product.id}")
+        body = resp.json()
+        assert body["gcode_file_path"] is None
 
 
 # =============================================================================

--- a/backend/tests/endpoints/test_items_endpoint.py
+++ b/backend/tests/endpoints/test_items_endpoint.py
@@ -155,6 +155,51 @@ class TestGetItem:
 
 
 # =============================================================================
+# gcode_file_path — slice-file download path exposed on detail + list
+# =============================================================================
+
+class TestSliceFilePath:
+    """The PRO intake flow stores a slice-file download path on the product;
+    the item API must surface it (on both detail and list responses) so a
+    persistent download button can link to the saved .gcode.3mf.
+    """
+
+    def _slice_path(self, product_id):
+        # Mirror the value the PRO wheel writes onto Product.gcode_file_path.
+        return f"/api/v1/pro/intake/products/{product_id}/slice-file"
+
+    def test_detail_exposes_gcode_file_path_when_set(self, client, make_product):
+        p = make_product(name=f"SliceDetail-{_uid()}")
+        p.gcode_file_path = self._slice_path(p.id)
+        resp = client.get(f"{BASE}/{p.id}")
+        assert resp.status_code == 200
+        assert resp.json()["gcode_file_path"] == self._slice_path(p.id)
+
+    def test_list_exposes_gcode_file_path_when_set(self, client, make_product):
+        uid = _uid()
+        p = make_product(name=f"SliceList-{uid}")
+        p.gcode_file_path = self._slice_path(p.id)
+        resp = client.get(BASE, params={"search": f"SliceList-{uid}"})
+        assert resp.status_code == 200
+        match = next(i for i in resp.json()["items"] if i["id"] == p.id)
+        assert match["gcode_file_path"] == self._slice_path(p.id)
+
+    def test_detail_gcode_file_path_null_safe_when_unset(self, client, make_product):
+        p = make_product(name=f"SliceNoneDetail-{_uid()}")
+        resp = client.get(f"{BASE}/{p.id}")
+        assert resp.status_code == 200
+        assert resp.json()["gcode_file_path"] is None
+
+    def test_list_gcode_file_path_null_safe_when_unset(self, client, make_product):
+        uid = _uid()
+        p = make_product(name=f"SliceNoneList-{uid}")
+        resp = client.get(BASE, params={"search": f"SliceNoneList-{uid}"})
+        assert resp.status_code == 200
+        match = next(i for i in resp.json()["items"] if i["id"] == p.id)
+        assert match["gcode_file_path"] is None
+
+
+# =============================================================================
 # POST /api/v1/items — create item
 # =============================================================================
 

--- a/backend/tests/services/test_item_service.py
+++ b/backend/tests/services/test_item_service.py
@@ -1424,3 +1424,37 @@ class TestRecostAllItems:
         result = item_service.recost_all_items(db)
         skipped_or_not = True  # The function skips items with total_cost == 0
         assert "skipped" in result
+
+
+class TestSliceFileExposure:
+    """gcode_file_path (the saved .gcode.3mf download path set by the PRO intake
+    flow) must be exposed on BOTH the item detail and list payloads, so an
+    operator can reprint from a persistent page rather than only the intake
+    wizard's post-create success screen."""
+
+    SLICE_PATH = "/api/v1/pro/intake/products/{id}/slice-file"
+
+    def test_detail_response_includes_gcode_file_path(self, db, make_product):
+        product = make_product(sku="SLICE-DETAIL-001")
+        product.gcode_file_path = self.SLICE_PATH.format(id=product.id)
+        db.commit()
+
+        data = item_service.build_item_response_data(product, db)
+        assert data["gcode_file_path"] == self.SLICE_PATH.format(id=product.id)
+
+    def test_detail_response_gcode_file_path_none_when_unset(self, db, make_product):
+        product = make_product(sku="SLICE-DETAIL-NONE")
+        db.commit()
+
+        data = item_service.build_item_response_data(product, db)
+        assert data["gcode_file_path"] is None
+
+    def test_list_response_includes_gcode_file_path(self, db, make_product):
+        product = make_product(sku="SLICE-LIST-001")
+        product.gcode_file_path = self.SLICE_PATH.format(id=product.id)
+        db.commit()
+
+        rows, _total = item_service.list_items(db, search="SLICE-LIST-001")
+        match = next((r for r in rows if r["sku"] == "SLICE-LIST-001"), None)
+        assert match is not None
+        assert match["gcode_file_path"] == self.SLICE_PATH.format(id=product.id)

--- a/frontend/src/components/items/ItemsTable.jsx
+++ b/frontend/src/components/items/ItemsTable.jsx
@@ -2,6 +2,7 @@
  * ItemsTable - Table view for items with sorting, inline editing, bulk selection, and pagination.
  */
 import { useFormatCurrency } from "../../hooks/useFormatCurrency";
+import { API_URL } from "../../config/api";
 
 // Item type options (for display labels)
 const ITEM_TYPES = [
@@ -524,6 +525,16 @@ export default function ItemsTable({
                         Route/BOM
                       </button>
                     </>
+                  )}
+                  {item.gcode_file_path && (
+                    <a
+                      href={`${API_URL}${item.gcode_file_path}`}
+                      download
+                      className="text-cyan-400 hover:text-cyan-300 text-sm"
+                      title="Download the saved slice file (.gcode.3mf) to send to a printer"
+                    >
+                      Slice file
+                    </a>
                   )}
                 </div>
               </td>


### PR DESCRIPTION
## Problem
Single-plate intake saves the sliced `.gcode.3mf` to the product (`ProProductSliceFile` + `Product.gcode_file_path`) with a working download endpoint, but the only UI link is on the intake wizard's success screen — once you navigate away there's no way back to it, so an operator can't fetch the file to send to a printer.

## Fix
- **Backend (additive):** expose `Product.gcode_file_path` on `ItemResponse` (detail) + `ItemListResponse` (list) — threaded through `build_item_response_data`, `list_items`, `_build_item_response`, and the list endpoint constructor.
- **Frontend:** a conditional "Slice file" download button in the items-table actions cell, shown when `item.gcode_file_path` is set, pointing at the existing `GET /api/v1/pro/intake/products/{id}/slice-file`.
- **No new endpoint** — the PRO download route already exists.

## Tests
`TestSliceFileExposure` in `test_item_service.py`: detail + list both surface `gcode_file_path` when set, null-safe when unset.

## Note
Assembly *components* don't have slice files attached yet (separate worker/wheel work); this button lights up for them automatically once they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item list and item detail responses now include an optional `gcode_file_path`.
  * The items table now shows a “Slice file” download link when a slice file path is available.
* **Bug Fixes**
  * When no slice file path is set, APIs return `null` and the UI link is hidden.
* **Tests**
  * Added API and service tests to confirm `gcode_file_path` is correctly returned for both list and detail endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->