### PR TITLE
fix(inventory): routing-first consumption — restore material drawdown + COGS on routing-built products

### DIFF
--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -25,6 +25,7 @@ from app.services.uom_service import (
     convert_cost_for_unit,
 )
 from app.services.reservation_reconciliation_service import check_allocation_guard
+from app.services.operation_material_mapping import get_consume_stages_for_operation
 
 logger = get_logger(__name__)
 
@@ -1048,19 +1049,29 @@ def release_production_reservations(
     db: Session,
     production_order: ProductionOrder,
     created_by: Optional[str] = None,
+    component_ids: Optional[set] = None,
 ) -> List[Dict[str, Any]]:
     """
     Release (un-allocate) materials that were reserved for a production order.
-    
+
     Called when:
-    - Production order is cancelled/unscheduled
-    - Before consuming actuals (to release then consume)
-    
+    - Production order is cancelled/unscheduled (full release, component_ids=None)
+    - Before consuming actuals for a specific stage (to release then consume;
+      component_ids scopes the release to that stage — see FIX-1/FIX-2)
+
     Args:
         db: Database session
         production_order: The production order
         created_by: User performing the action
-    
+        component_ids: If provided, only release reservations (and clear
+            quantity_allocated) for components in this set. The reservation
+            ledger has no stage column, so consumers that only want to
+            release THEIR stage's share (e.g. consume_production_materials
+            releasing only production-stage components, leaving
+            shipping-stage box/label reservations intact until ship) pass
+            the stage's component-id universe here. None (default) releases
+            everything for the order — the original cancel/delete behavior.
+
     Returns:
         List of release records
     """
@@ -1069,12 +1080,17 @@ def release_production_reservations(
     _location = get_or_create_default_location(db)
 
     # Find all reservation transactions for this PO
-    reservation_txns = db.query(InventoryTransaction).filter(
+    reservation_query = db.query(InventoryTransaction).filter(
         InventoryTransaction.reference_type == "production_order",
         InventoryTransaction.reference_id == production_order.id,
         InventoryTransaction.transaction_type == "reservation",
-    ).all()
-    
+    )
+    if component_ids is not None:
+        reservation_query = reservation_query.filter(
+            InventoryTransaction.product_id.in_(component_ids)
+        )
+    reservation_txns = reservation_query.all()
+
     for txn in reservation_txns:
         # Decrease allocated quantity
         inventory = db.query(Inventory).filter(
@@ -1124,9 +1140,10 @@ def release_production_reservations(
     # Mirror the release on op-material rows: zero out quantity_allocated for
     # any rows that are still in a pre-consumption state (pending / allocated).
     # Rows already consumed retain their quantity_consumed; only the allocation
-    # field is cleared so the two books stay in sync.
+    # field is cleared so the two books stay in sync. Scoped to component_ids
+    # when provided, matching the ledger-side filter above.
     from app.models.production_order import ProductionOrderOperation
-    unconsumed_rows = (
+    unconsumed_query = (
         db.query(ProductionOrderOperationMaterial)
         .join(
             ProductionOrderOperation,
@@ -1137,8 +1154,12 @@ def release_production_reservations(
             ProductionOrderOperation.production_order_id == production_order.id,
             ProductionOrderOperationMaterial.status.in_(["pending", "allocated"]),
         )
-        .all()
     )
+    if component_ids is not None:
+        unconsumed_query = unconsumed_query.filter(
+            ProductionOrderOperationMaterial.component_id.in_(component_ids)
+        )
+    unconsumed_rows = unconsumed_query.all()
     for row in unconsumed_rows:
         row.quantity_allocated = Decimal("0")
 
@@ -1407,6 +1428,188 @@ def _consumption_already_posted(
     return existing is not None
 
 
+class MaterialConsumptionError(Exception):
+    """
+    Raised when a consumption stage had reservations/allocations but nothing
+    was actually consumable (FIX-3 guardrail).
+
+    This replaces the old silent-empty-return behavior: releasing a
+    reservation and then finding no routing op-material rows AND no BOM
+    line to consume from means material was reserved for real inventory
+    that is now being un-reserved with nothing posted in its place — a
+    correctness gap that must be surfaced, not swallowed.
+    """
+    def __init__(self, message: str, production_order_id: Optional[int] = None,
+                 product_id: Optional[int] = None, stage: Optional[str] = None):
+        self.message = message
+        self.production_order_id = production_order_id
+        self.product_id = product_id
+        self.stage = stage
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message
+
+
+def _get_stage_op_materials(
+    db: Session,
+    production_order_id: int,
+    stage: str,
+) -> Tuple[List["ProductionOrderOperationMaterial"], bool]:
+    """
+    Shared routing-first + stage-filter + idempotency resolver for material
+    consumption (FIX-1/FIX-2).
+
+    Mirrors _get_reservation_requirements's routing-first semantics: when a
+    production order has ANY materialized ProductionOrderOperationMaterial
+    rows (copied from the routing at release), those rows are the
+    order-specific truth for consumption and the legacy BOM walk must NOT
+    also run for this order (op rows REPLACE the BOM walk entirely, exactly
+    as reservation already does) — this is what keeps reserve and consume
+    from diverging again.
+
+    Filters to rows whose parent operation's operation_code resolves (via
+    get_consume_stages_for_operation) to include `stage` — e.g. only
+    PRINT/EXTRUDE/etc-coded operations are returned for stage="production",
+    only PACK/SHIP/LABEL-coded operations for stage="shipping". Operations
+    with no operation_code use DEFAULT_CONSUME_STAGES (production + any),
+    matching the mapping module's own default and existing test fixtures
+    that don't set operation_code.
+
+    IDEMPOTENCY: rows already status=='consumed' are excluded — the
+    per-operation path (complete_operation -> consume_operation_materials
+    -> consume_operation_material) may already have posted a transaction
+    for that exact row; this resolver must never hand back a row for a
+    second consumption.
+
+    Args:
+        db: Database session
+        production_order_id: The production order
+        stage: The consume stage to filter to ("production" or "shipping")
+
+    Returns:
+        Tuple of:
+          - list of unconsumed ProductionOrderOperationMaterial rows for
+            this stage (component eagerly usable via row.component_id)
+          - has_any_op_rows: True if the order has ANY op-material rows at
+            all (any stage, any status) — signals routing-first mode is
+            active for this order so the BOM fallback must not also run,
+            even if every routing-stage row for THIS stage was already
+            consumed or filtered out.
+    """
+    all_op_rows = _get_all_op_material_rows(db, production_order_id)
+
+    has_any_op_rows = len(all_op_rows) > 0
+
+    stage_rows = []
+    for row in all_op_rows:
+        if row.status == "consumed":
+            continue
+        op = row.operation
+        stages = get_consume_stages_for_operation(op.operation_code if op else None)
+        if stage in stages:
+            stage_rows.append(row)
+
+    return stage_rows, has_any_op_rows
+
+
+def _get_all_op_material_rows(
+    db: Session,
+    production_order_id: int,
+) -> List["ProductionOrderOperationMaterial"]:
+    """Load ALL ProductionOrderOperationMaterial rows for a production order
+    (any stage, any status), ordered by operation sequence. Shared query
+    used by both _get_stage_op_materials (unconsumed, stage-filtered) and
+    _get_stage_component_ids (full component universe per stage)."""
+    from app.models.production_order import ProductionOrderOperation
+
+    return (
+        db.query(ProductionOrderOperationMaterial)
+        .join(
+            ProductionOrderOperation,
+            ProductionOrderOperationMaterial.production_order_operation_id
+            == ProductionOrderOperation.id,
+        )
+        .filter(
+            ProductionOrderOperation.production_order_id == production_order_id,
+        )
+        .order_by(
+            ProductionOrderOperation.sequence,
+            ProductionOrderOperationMaterial.id,
+        )
+        .all()
+    )
+
+
+def _get_stage_component_ids(
+    db: Session,
+    production_order: ProductionOrder,
+    stage: str,
+) -> set:
+    """
+    Return the set of component_ids that belong to `stage` for this
+    production order — the "universe" of components a stage cares about,
+    used to scope reservation-release and the FIX-3 guardrail's
+    had-a-reservation check to just this stage's components (the
+    reservation ledger itself has no stage column, so this is resolved from
+    the same routing-first-then-BOM-fallback source that drives
+    consumption).
+
+    Routing-first: if the order has ANY op-material rows (any status), the
+    universe is every row (consumed or not) whose parent operation resolves
+    to `stage` — including already-consumed rows, since those components
+    were legitimately part of this stage's reservation even though they're
+    no longer awaiting consumption.
+
+    BOM fallback: only consulted when the order has ZERO op-material rows,
+    matching the "op rows replace the BOM walk entirely" rule used
+    everywhere else in this module.
+    """
+    all_op_rows = _get_all_op_material_rows(db, production_order.id)
+
+    if all_op_rows:
+        component_ids = set()
+        for row in all_op_rows:
+            op = row.operation
+            stages = get_consume_stages_for_operation(op.operation_code if op else None)
+            if stage in stages:
+                component_ids.add(row.component_id)
+        return component_ids
+
+    # FALLBACK — legacy BOM walk
+    bom = db.query(BOM).filter(
+        BOM.product_id == production_order.product_id,
+        BOM.active.is_(True),
+    ).first()
+    if bom:
+        bom_lines = db.query(BOMLine).filter(
+            BOMLine.bom_id == bom.id,
+            BOMLine.consume_stage == stage,
+            BOMLine.is_cost_only.is_(False),
+        ).all()
+        return {line.component_id for line in bom_lines}
+
+    # Order has NEITHER routing op-material rows NOR a BOM at all. There is
+    # no source to attribute a reservation to any particular stage — but if
+    # the ledger nonetheless shows a net-reserved component for this order
+    # (an orphaned/legacy reservation, e.g. from a BOM that has since been
+    # deleted or deactivated), the FIX-3 guardrail still needs to see it so
+    # it doesn't silently vanish. With no BOM/routing at all there is no
+    # shipping-stage concept for this order either, so attribute any
+    # net-reserved component to the "production" stage query only (the
+    # stage every pre-fix reservation implicitly belonged to) — never to
+    # "shipping", so consume_shipping_materials doesn't also try to release
+    # the same orphaned reservation a second time.
+    if stage == "production":
+        net_reserved = _get_net_reserved_by_component(db, production_order.id)
+        return {
+            component_id
+            for component_id, qty in net_reserved.items()
+            if qty > Decimal("0")
+        }
+    return set()
+
+
 def consume_production_materials(
     db: Session,
     production_order: ProductionOrder,
@@ -1415,20 +1618,44 @@ def consume_production_materials(
     release_reservations: bool = True,
 ) -> List[InventoryTransaction]:
     """
-    Consume raw materials based on BOM when production order completes.
+    Consume production-stage raw materials when a production order completes.
 
-    Only consumes items with consume_stage='production' and cost_only=False.
+    FIX-1 (routing-first consumption): mirrors the reservation side's
+    routing-first resolution (_get_reservation_requirements / RESERVE-1).
+    PRIMARY source is materialized ProductionOrderOperationMaterial rows for
+    this order's PRODUCTION-stage operations (resolved via
+    get_consume_stages_for_operation through the shared
+    _get_stage_op_materials helper) — this is the normal case for
+    routing-driven / Intake-Studio products that have NO active BOM at all.
+    FALLBACK — legacy BOM walk (consume_stage='production'): only runs when
+    the order has ZERO op-material rows whatsoever (not just zero for this
+    stage), matching reservation's "op rows REPLACE the BOM walk entirely"
+    rule so the two paths can never diverge again.
 
-    IDEMPOTENCY (HARD-11): Before posting each BOM-line consumption, checks
-    whether a non-voided consumption transaction already exists for
-    (production_order, component).  If per-operation consumption
-    (consume_operation_material) already posted a transaction for a given
-    component, this backflush skips it with a log entry.  The check is
-    keyed on component_id so that if the same component appears on multiple
-    BOM lines (unusual but possible) each line is guarded independently.
+    Only shipping-stage op-materials (PACK/SHIP/LABEL-coded operations) are
+    intentionally excluded here — those are consumed at ship time by
+    consume_shipping_materials (FIX-2), not at production completion.
+
+    IDEMPOTENCY:
+    - Routing-first rows: status=='consumed' rows are skipped by
+      _get_stage_op_materials (the per-operation path may have already
+      consumed them via complete_operation -> consume_operation_material).
+    - BOM fallback (HARD-11): Before posting each BOM-line consumption,
+      checks whether a non-voided consumption transaction already exists
+      for (production_order, component); if per-operation consumption
+      already posted for a component this backflush skips it.
 
     If release_reservations=True (default), first releases any existing
-    reservations before consuming actual quantities.
+    PRODUCTION-stage reservations before consuming actual quantities.
+    Shipping-stage reservations are left alone — they are released by
+    consume_shipping_materials at ship time.
+
+    FIX-3 guardrail: if this production order HAD reservations for the
+    production stage but nothing was consumable (neither routing
+    op-materials nor a BOM line matched), this is logged at ERROR and
+    raised as MaterialConsumptionError rather than silently released with
+    an empty return — a reservation vanishing with nothing posted in its
+    place is exactly the bug this fix closes.
 
     Args:
         db: Database session
@@ -1440,19 +1667,132 @@ def consume_production_materials(
     Returns:
         List of created inventory transactions
     """
-    # Release reservations first if requested
+    # Resolve which components belong to the PRODUCTION stage for this order
+    # (routing-first, BOM-fallback-only-if-no-op-rows — see
+    # _get_stage_component_ids) so both the reservation snapshot and the
+    # release below are scoped to THIS stage and never touch shipping-stage
+    # reservations (e.g. a box reserved for a PACK op).
+    stage_component_ids = _get_stage_component_ids(db, production_order, "production")
+
+    # Snapshot whether this order had any net production-stage reservation
+    # BEFORE releasing it, so the FIX-3 guardrail can tell "nothing to
+    # consume because nothing was reserved" (fine) apart from "something
+    # was reserved but consumption produced nothing" (the bug). Scoped to
+    # production-stage components only — a shipping-stage-only reservation
+    # (e.g. a box) must not trip the production-stage guardrail.
+    net_reserved = _get_net_reserved_by_component(db, production_order.id)
+    had_reservation = any(
+        qty > Decimal("0")
+        for component_id, qty in net_reserved.items()
+        if component_id in stage_component_ids
+    )
+
+    # Release PRODUCTION-stage reservations only — shipping-stage
+    # reservations (e.g. packaging) are left intact for
+    # consume_shipping_materials to release at ship time.
     if release_reservations:
-        release_production_reservations(db, production_order, created_by)
+        release_production_reservations(
+            db, production_order, created_by, component_ids=stage_component_ids
+        )
     transactions = []
     location = get_or_create_default_location(db)
 
-    # Get BOM for the product
+    # FIX-1: routing-first resolution, production stage only.
+    stage_rows, has_any_op_rows = _get_stage_op_materials(
+        db, production_order.id, "production"
+    )
+
+    if stage_rows:
+        for row in stage_rows:
+            component = db.query(Product).filter(Product.id == row.component_id).first()
+            if not component:
+                logger.error(
+                    f"Component {row.component_id} not found for op-material "
+                    f"row {row.id} (PO {production_order.code}) — skipping"
+                )
+                continue
+
+            txn = consume_operation_material(
+                db=db,
+                material=row,
+                production_order=production_order,
+                created_by=created_by,
+            )
+            if txn:
+                transactions.append(txn)
+
+        # Routing-first mode is active for this order (it has op-material
+        # rows) — never fall through to the BOM walk, even if this
+        # particular call posted zero new rows (e.g. every stage_rows entry
+        # was already consumed by a concurrent per-op call).
+        if had_reservation and not transactions:
+            logger.error(
+                "Production-stage reservation existed for PO %s (product %s) "
+                "but zero production-stage op-materials were actually "
+                "consumed this call (all already consumed per-operation) — "
+                "routing-first mode is active so the BOM fallback does not "
+                "apply.",
+                production_order.code,
+                production_order.product_id,
+            )
+            raise MaterialConsumptionError(
+                f"No production-stage material was consumed for PO "
+                f"{production_order.code} despite an existing reservation, "
+                f"and routing-first mode is active (order has op-material "
+                f"rows) so the BOM fallback does not apply.",
+                production_order_id=production_order.id,
+                product_id=production_order.product_id,
+                stage="production",
+            )
+        return transactions
+
+    elif has_any_op_rows:
+        # Order has op-material rows, just none for the production stage
+        # (e.g. a shipping-only routing) — routing-first mode still applies;
+        # do not fall back to the BOM walk.
+        if had_reservation:
+            logger.error(
+                "Production-stage reservation existed for PO %s (product %s) "
+                "but no consumable production-stage source was found "
+                "(routing op-materials all non-production-stage or already "
+                "consumed, no BOM fallback applies in routing-first mode).",
+                production_order.code,
+                production_order.product_id,
+            )
+            raise MaterialConsumptionError(
+                f"No production-stage material was consumed for PO "
+                f"{production_order.code} despite an existing reservation, "
+                f"and routing-first mode is active (order has op-material "
+                f"rows) so the BOM fallback does not apply.",
+                production_order_id=production_order.id,
+                product_id=production_order.product_id,
+                stage="production",
+            )
+        return transactions
+
+    # FALLBACK — legacy BOM walk (no op-material rows on this order at all)
     bom = db.query(BOM).filter(
         BOM.product_id == production_order.product_id,
         BOM.active.is_(True)
     ).first()
 
     if not bom:
+        if had_reservation:
+            logger.error(
+                "Production-stage reservation existed for PO %s (product %s) "
+                "but no active BOM and no routing op-material rows exist — "
+                "nothing was consumed.",
+                production_order.code,
+                production_order.product_id,
+            )
+            raise MaterialConsumptionError(
+                f"No production-stage material was consumed for PO "
+                f"{production_order.code} despite an existing reservation: "
+                f"no active BOM and no routing op-material rows.",
+                production_order_id=production_order.id,
+                product_id=production_order.product_id,
+                stage="production",
+            )
         logger.warning(f"No active BOM found for product {production_order.product_id}")
         return transactions
 
@@ -1538,6 +1878,24 @@ def consume_production_materials(
             f"Consumed {total_qty} {component_unit} of {component.sku} "
             f"for production order {production_order.id}"
             f"{f' (tracked in {len(lot_consumptions)} lot(s))' if lot_consumptions else ''}"
+        )
+
+    if had_reservation and not transactions:
+        logger.error(
+            "Production-stage reservation existed for PO %s (product %s) "
+            "but the BOM produced zero consumable production-stage lines "
+            "(all cost-only, missing components, or already consumed "
+            "per-op) — nothing was consumed.",
+            production_order.code,
+            production_order.product_id,
+        )
+        raise MaterialConsumptionError(
+            f"No production-stage material was consumed for PO "
+            f"{production_order.code} despite an existing reservation: "
+            f"BOM lines produced no consumable output.",
+            production_order_id=production_order.id,
+            product_id=production_order.product_id,
+            stage="production",
         )
 
     return transactions
@@ -1662,9 +2020,35 @@ def consume_shipping_materials(
     created_by: Optional[str] = None,
 ) -> List[InventoryTransaction]:
     """
-    Consume packaging materials based on BOM when order ships.
+    Consume shipping-stage packaging materials when a sales order ships.
 
-    Only consumes items with consume_stage='shipping' from the order's product BOMs.
+    FIX-2 (routing-first shipping consumption): supports BOTH sources at
+    once, since either can exist depending on how the product was built:
+      - Routing-first: ProductionOrderOperationMaterial rows on the
+        shipped product's production order(s) whose parent operation
+        resolves to stage "shipping" (PACK/SHIP/LABEL-coded ops) — the
+        normal case for routing-driven / Intake-Studio products that put
+        the box on a PACK/SHIP op and have no BOM at all.
+      - BOM: BOMLine rows with consume_stage='shipping' on the product's
+        active BOM — the existing/legacy path where packaging is a BOM
+        shipping line.
+    Both are consumed when both exist; there is no "replaces" relationship
+    between BOM and routing at the PER-PRODUCT level the way there is for
+    the (single) production-stage BOM-vs-routing choice, because shipping
+    packaging is commonly modeled either way per product.
+
+    IDEMPOTENCY: routing op-material rows already status=='consumed' are
+    skipped (via the shared _get_stage_op_materials helper) — a component
+    consumed once (per-op or by a prior ship call) is never double-posted.
+
+    Reservations: releases only SHIPPING-stage reservations for each
+    production order tied to this sales order (component_ids resolved via
+    _get_stage_component_ids), leaving production-stage reservations alone
+    (those are released by consume_production_materials at completion).
+
+    FIX-3 guardrail: if a production order tied to this sales order HAD a
+    shipping-stage reservation but nothing was consumed for it from either
+    source, this is logged at ERROR and raised as MaterialConsumptionError.
 
     Args:
         db: Database session
@@ -1688,64 +2072,160 @@ def consume_shipping_materials(
         products_to_ship.append((sales_order.product_id, sales_order.quantity or 1))
 
     for product_id, qty in products_to_ship:
-        # Get BOM for product
+        product_had_reservation = False
+        product_consumed_anything = False
+
+        # --- Routing-first: shipping-stage op-materials on this sales
+        # order's production order(s) for this product ---
+        production_orders = (
+            db.query(ProductionOrder)
+            .filter(
+                ProductionOrder.sales_order_id == sales_order.id,
+                ProductionOrder.product_id == product_id,
+            )
+            .all()
+        )
+
+        for po in production_orders:
+            stage_component_ids = _get_stage_component_ids(db, po, "shipping")
+
+            net_reserved = _get_net_reserved_by_component(db, po.id)
+            po_had_reservation = any(
+                net_qty > Decimal("0")
+                for component_id, net_qty in net_reserved.items()
+                if component_id in stage_component_ids
+            )
+            product_had_reservation = product_had_reservation or po_had_reservation
+
+            # Release SHIPPING-stage reservations for this PO only —
+            # production-stage reservations were already released (or will
+            # be) by consume_production_materials.
+            release_production_reservations(
+                db, po, created_by, component_ids=stage_component_ids
+            )
+
+            stage_rows, _has_any_op_rows = _get_stage_op_materials(db, po.id, "shipping")
+            for row in stage_rows:
+                component = db.query(Product).filter(Product.id == row.component_id).first()
+                if not component:
+                    logger.error(
+                        f"Component {row.component_id} not found for shipping "
+                        f"op-material row {row.id} (PO {po.code}) — skipping"
+                    )
+                    continue
+
+                txn = consume_operation_material(
+                    db=db,
+                    material=row,
+                    production_order=po,
+                    created_by=created_by,
+                )
+                if txn:
+                    transactions.append(txn)
+                    product_consumed_anything = True
+
+        # --- BOM: shipping-stage BOM lines on the product's active BOM ---
         bom = db.query(BOM).filter(
             BOM.product_id == product_id,
             BOM.active.is_(True)
         ).first()
 
-        if not bom:
-            continue
+        if bom:
+            # Get BOM lines for shipping consumption
+            bom_lines = db.query(BOMLine).filter(
+                BOMLine.bom_id == bom.id,
+                BOMLine.consume_stage == "shipping",
+            ).all()
 
-        # Get BOM lines for shipping consumption
-        bom_lines = db.query(BOMLine).filter(
-            BOMLine.bom_id == bom.id,
-            BOMLine.consume_stage == "shipping",
-        ).all()
+            for line in bom_lines:
+                if line.is_cost_only:
+                    continue
 
-        for line in bom_lines:
-            if line.is_cost_only:
-                continue
+                component = db.query(Product).filter(Product.id == line.component_id).first()
+                if not component:
+                    continue
 
-            component = db.query(Product).filter(Product.id == line.component_id).first()
-            if not component:
-                continue
+                # HARD-11-style idempotency: skip if a non-voided shipping
+                # consumption already posted for this component on this
+                # sales order (e.g. a prior call, or this same product
+                # appearing on multiple lines).
+                existing = (
+                    db.query(InventoryTransaction)
+                    .filter(
+                        InventoryTransaction.reference_type == "sales_order",
+                        InventoryTransaction.reference_id == sales_order.id,
+                        InventoryTransaction.transaction_type == "consumption",
+                        InventoryTransaction.product_id == line.component_id,
+                        InventoryTransaction.voided_by.is_(None),
+                    )
+                    .first()
+                )
+                if existing:
+                    logger.info(
+                        "Skipping BOM shipping-line consumption for component %s "
+                        "(SO %s) — a non-voided consumption transaction already "
+                        "exists",
+                        component.sku,
+                        sales_order.order_number,
+                    )
+                    continue
 
-            # Calculate quantity to consume
-            bom_qty = Decimal(str(line.quantity)) * Decimal(str(qty))
+                # Calculate quantity to consume
+                bom_qty = Decimal(str(line.quantity)) * Decimal(str(qty))
 
-            # UOM Conversion: Convert BOM line unit to component's inventory unit
-            line_unit = (line.unit or component.unit or "EA").upper()
-            component_unit = (component.unit or "EA").upper()
+                # UOM Conversion: Convert BOM line unit to component's inventory unit
+                line_unit = (line.unit or component.unit or "EA").upper()
+                component_unit = (component.unit or "EA").upper()
 
-            total_qty, notes = convert_and_generate_notes(
-                db=db,
-                bom_qty=bom_qty,
-                line_unit=line_unit,
-                component_unit=component_unit,
-                component_name=component.name,
-                component_sku=component.sku,
-                reference_prefix="Shipping materials for SO#",
-                reference_code=sales_order.order_number,
+                total_qty, notes = convert_and_generate_notes(
+                    db=db,
+                    bom_qty=bom_qty,
+                    line_unit=line_unit,
+                    component_unit=component_unit,
+                    component_name=component.name,
+                    component_sku=component.sku,
+                    reference_prefix="Shipping materials for SO#",
+                    reference_code=sales_order.order_number,
+                )
+
+                txn = create_inventory_transaction(
+                    db=db,
+                    product_id=line.component_id,
+                    location_id=location.id,
+                    transaction_type="consumption",
+                    quantity=total_qty,
+                    reference_type="sales_order",
+                    reference_id=sales_order.id,
+                    notes=notes,
+                    cost_per_unit=get_effective_cost_per_inventory_unit(component),
+                    created_by=created_by,
+                )
+                transactions.append(txn)
+                product_consumed_anything = True
+
+                logger.info(
+                    f"Consumed {total_qty} {component_unit} of {component.sku} "
+                    f"for shipping order {sales_order.id}"
+                )
+
+        # FIX-3 guardrail: a shipping-stage reservation existed for this
+        # product's production order(s) but neither routing op-materials
+        # nor a BOM shipping line produced any consumption.
+        if product_had_reservation and not product_consumed_anything:
+            logger.error(
+                "Shipping-stage reservation existed for product %s on SO %s "
+                "but no consumable shipping-stage source was found (no "
+                "matching routing op-materials, no BOM shipping line) — "
+                "nothing was consumed.",
+                product_id,
+                sales_order.order_number,
             )
-
-            txn = create_inventory_transaction(
-                db=db,
-                product_id=line.component_id,
-                location_id=location.id,
-                transaction_type="consumption",
-                quantity=total_qty,
-                reference_type="sales_order",
-                reference_id=sales_order.id,
-                notes=notes,
-                cost_per_unit=get_effective_cost_per_inventory_unit(component),
-                created_by=created_by,
-            )
-            transactions.append(txn)
-
-            logger.info(
-                f"Consumed {total_qty} {component_unit} of {component.sku} "
-                f"for shipping order {sales_order.id}"
+            raise MaterialConsumptionError(
+                f"No shipping-stage material was consumed for product "
+                f"{product_id} on SO {sales_order.order_number} despite an "
+                f"existing reservation.",
+                product_id=product_id,
+                stage="shipping",
             )
 
     return transactions

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -1513,6 +1513,32 @@ def _get_stage_op_materials(
     return stage_rows, has_any_op_rows
 
 
+def _stage_has_consumed_op_materials(
+    db: Session,
+    production_order_id: int,
+    stage: str,
+) -> bool:
+    """Return True if this order has AT LEAST ONE ProductionOrderOperationMaterial
+    row for `stage` that is already status=='consumed'.
+
+    Used by the FIX-3 guardrail to distinguish "nothing was consumed because
+    there was no source" (a real bug — raise) from "nothing was consumed
+    THIS call because the stage's materials were ALREADY consumed by the
+    per-operation path (complete_operation -> consume_operation_material,
+    which posts the consumption + marks the row 'consumed' but does NOT
+    release the reservation)". The latter is a correctly-completed order
+    finalizing through the bulk/auto-complete path — it must NOT false-raise
+    merely because the still-open reservation makes had_reservation True."""
+    for row in _get_all_op_material_rows(db, production_order_id):
+        if row.status != "consumed":
+            continue
+        op = row.operation
+        stages = get_consume_stages_for_operation(op.operation_code if op else None)
+        if stage in stages:
+            return True
+    return False
+
+
 def _get_all_op_material_rows(
     db: Session,
     production_order_id: int,
@@ -1725,13 +1751,24 @@ def consume_production_materials(
         # rows) — never fall through to the BOM walk, even if this
         # particular call posted zero new rows (e.g. every stage_rows entry
         # was already consumed by a concurrent per-op call).
-        if had_reservation and not transactions:
+        #
+        # FIX-3 guardrail — but suppress the FALSE POSITIVE where the stage
+        # was ALREADY fully consumed by the per-operation path
+        # (complete_operation -> consume_operation_material posts the
+        # consumption + marks the row 'consumed' but does NOT release the
+        # reservation, so had_reservation is still True here even though the
+        # material was correctly consumed). Only raise when the stage has no
+        # already-consumed rows either — i.e. genuinely nothing consumable.
+        if (
+            had_reservation
+            and not transactions
+            and not _stage_has_consumed_op_materials(db, production_order.id, "production")
+        ):
             logger.error(
                 "Production-stage reservation existed for PO %s (product %s) "
-                "but zero production-stage op-materials were actually "
-                "consumed this call (all already consumed per-operation) — "
-                "routing-first mode is active so the BOM fallback does not "
-                "apply.",
+                "but zero production-stage op-materials were consumable and "
+                "none were previously consumed either — routing-first mode is "
+                "active so the BOM fallback does not apply.",
                 production_order.code,
                 production_order.product_id,
             )
@@ -1747,15 +1784,24 @@ def consume_production_materials(
         return transactions
 
     elif has_any_op_rows:
-        # Order has op-material rows, just none for the production stage
-        # (e.g. a shipping-only routing) — routing-first mode still applies;
-        # do not fall back to the BOM walk.
-        if had_reservation:
+        # Order has op-material rows, just none UNCONSUMED for the production
+        # stage — routing-first mode still applies; do not fall back to the
+        # BOM walk.
+        #
+        # FIX-3 guardrail — suppress the same false positive: if the
+        # production stage was already fully consumed per-operation (rows
+        # exist and are all status='consumed'), this is a correctly-completed
+        # order finalizing, NOT a missing-source bug. The lingering
+        # reservation was already released above; return quietly.
+        if had_reservation and not _stage_has_consumed_op_materials(
+            db, production_order.id, "production"
+        ):
             logger.error(
                 "Production-stage reservation existed for PO %s (product %s) "
-                "but no consumable production-stage source was found "
-                "(routing op-materials all non-production-stage or already "
-                "consumed, no BOM fallback applies in routing-first mode).",
+                "but no consumable production-stage source was found and none "
+                "were previously consumed either (routing op-materials all "
+                "non-production-stage, no BOM fallback applies in "
+                "routing-first mode).",
                 production_order.code,
                 production_order.product_id,
             )
@@ -2074,6 +2120,7 @@ def consume_shipping_materials(
     for product_id, qty in products_to_ship:
         product_had_reservation = False
         product_consumed_anything = False
+        product_stage_already_consumed = False
 
         # --- Routing-first: shipping-stage op-materials on this sales
         # order's production order(s) for this product ---
@@ -2096,6 +2143,15 @@ def consume_shipping_materials(
                 if component_id in stage_component_ids
             )
             product_had_reservation = product_had_reservation or po_had_reservation
+
+            # Track whether this PO already has shipping-stage op-materials
+            # consumed (per-op or a prior ship call) — used to suppress the
+            # FIX-3 guardrail false positive below (see production-stage note:
+            # consume_operation_material posts + marks 'consumed' but does NOT
+            # release the reservation, so a fully-consumed shipping stage on a
+            # finalizing call still shows had_reservation=True).
+            if _stage_has_consumed_op_materials(db, po.id, "shipping"):
+                product_stage_already_consumed = True
 
             # Release SHIPPING-stage reservations for this PO only —
             # production-stage reservations were already released (or will
@@ -2209,14 +2265,25 @@ def consume_shipping_materials(
                 )
 
         # FIX-3 guardrail: a shipping-stage reservation existed for this
-        # product's production order(s) but neither routing op-materials
-        # nor a BOM shipping line produced any consumption.
-        if product_had_reservation and not product_consumed_anything:
+        # product's production order(s) but neither routing op-materials nor
+        # a BOM shipping line produced any consumption.
+        #
+        # Suppress the false positive where the shipping stage was ALREADY
+        # consumed per-operation / by a prior ship call (rows are all
+        # status='consumed'): consume_operation_material leaves the
+        # reservation open, so product_had_reservation is still True on this
+        # finalizing call even though the box was correctly consumed. Only
+        # raise when nothing was consumed AND nothing was previously consumed.
+        if (
+            product_had_reservation
+            and not product_consumed_anything
+            and not product_stage_already_consumed
+        ):
             logger.error(
                 "Shipping-stage reservation existed for product %s on SO %s "
-                "but no consumable shipping-stage source was found (no "
-                "matching routing op-materials, no BOM shipping line) — "
-                "nothing was consumed.",
+                "but no consumable shipping-stage source was found and none "
+                "were previously consumed either (no matching routing "
+                "op-materials, no BOM shipping line) — nothing was consumed.",
                 product_id,
                 sales_order.order_number,
             )

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -2269,6 +2269,187 @@ class TestGuardrailSurfacesUnconsumableReservation:
         assert txns == []
 
 
+class TestGuardrailNoFalsePositiveOnAlreadyConsumedStage:
+    """PR #875 review regression: consume_operation_material posts the
+    consumption + marks the row status='consumed' but does NOT release the
+    reservation. So an order fully completed via the per-operation path still
+    has OPEN production-stage reservations. When that order then finalizes
+    through consume_production_materials (the update_po_status auto-complete
+    path), had_reservation is True but stage_rows is empty (all consumed) —
+    the guardrail must NOT false-raise. It must instead release the lingering
+    reservation and return with zero NEW transactions."""
+
+    def test_fully_per_op_consumed_order_finalizes_without_raise(self, db, make_product):
+        fg = make_product(item_type="finished_good")
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id, sequence=10)
+        op.operation_code = "PRINT"
+        mat = _make_op_material(db, op.id, filament.id, Decimal("370"), unit="G")
+        db.flush()
+
+        # Reserve production materials (routing-first) — this posts a real
+        # 'reservation' ledger row and bumps allocated_quantity. No BOM.
+        reservations = inventory_service.reserve_production_materials(db, po)
+        assert len(reservations) == 1, "Routing-first reservation must post"
+        db.flush()
+
+        # Per-operation path consumes the whole stage (marks row 'consumed',
+        # posts the consumption) but LEAVES the reservation open — this is
+        # the exact real-world precondition for the false positive.
+        per_op_txn = inventory_service.consume_operation_material(db, mat, po)
+        assert per_op_txn is not None
+        db.refresh(mat)
+        assert mat.status == "consumed"
+
+        # Sanity: the production-stage reservation is STILL open post per-op.
+        net = inventory_service._get_net_reserved_by_component(db, po.id)
+        assert net.get(filament.id, Decimal("0")) > Decimal("0"), (
+            "Precondition: per-op consumption must leave the reservation open"
+        )
+
+        # Now finalize through the bulk completion path (release_reservations
+        # defaults True, matching process_production_completion). This MUST
+        # NOT raise despite had_reservation=True + zero unconsumed rows.
+        bulk_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1")
+        )
+
+        # No NEW consumption transactions (no double-consume).
+        assert bulk_txns == []
+
+        # The lingering reservation was released (net back to zero).
+        net_after = inventory_service._get_net_reserved_by_component(db, po.id)
+        assert net_after.get(filament.id, Decimal("0")) == Decimal("0"), (
+            "Finalizing call must release the lingering reservation"
+        )
+
+        # Exactly one consumption row total (the per-op one) — no duplicate.
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(rows) == 1
+
+        # on_hand decremented exactly once (1000 - 370).
+        inv = db.query(Inventory).filter(
+            Inventory.product_id == filament.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert inv.on_hand_quantity == Decimal("630")
+
+    def test_partially_consumed_stage_still_consumes_remainder_no_raise(
+        self, db, make_product
+    ):
+        """Two production op-materials, one already consumed per-op with its
+        reservation left open. The finalizing bulk call must consume the
+        remaining row and must NOT raise (it posted a transaction)."""
+        fg = make_product(item_type="finished_good")
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+        insert = make_product(unit="EA", cost_method="average", average_cost=Decimal("1.00"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+        _make_inventory(db, insert.id, location.id, Decimal("100"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op1 = _make_operation(db, po.id, wc.id, sequence=10)
+        op1.operation_code = "PRINT"
+        mat1 = _make_op_material(db, op1.id, filament.id, Decimal("370"), unit="G")
+        op2 = _make_operation(db, po.id, wc.id, sequence=20)
+        op2.operation_code = "PRINT"
+        _make_op_material(db, op2.id, insert.id, Decimal("2"), unit="EA")
+        db.flush()
+
+        inventory_service.reserve_production_materials(db, po)
+        db.flush()
+
+        # Consume only op1 per-op (reservation left open).
+        inventory_service.consume_operation_material(db, mat1, po)
+
+        # Bulk finalize: must consume op2's insert, must NOT raise.
+        bulk_txns = inventory_service.consume_production_materials(db, po, Decimal("1"))
+        assert len(bulk_txns) == 1
+        assert bulk_txns[0].product_id == insert.id
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(rows) == 2  # filament (per-op) + insert (bulk)
+
+    def test_fully_per_op_consumed_shipping_stage_finalizes_without_raise(
+        self, db, make_product, make_sales_order
+    ):
+        """Same false-positive shape on the SHIPPING stage: a box on a PACK
+        op, reserved and already consumed per-op (reservation left open). A
+        second/finalizing consume_shipping_materials call must NOT raise and
+        must not double-consume."""
+        fg = make_product(item_type="finished_good")
+        box = make_product(
+            item_type="packaging", unit="EA", cost_method="average",
+            average_cost=Decimal("1.50"),
+        )
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, box.id, location.id, Decimal("100"))
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        po.sales_order_id = so.id
+        wc = _make_work_center(db)
+        pack_op = _make_operation(db, po.id, wc.id, sequence=10)
+        pack_op.operation_code = "PACK"
+        box_mat = _make_op_material(db, pack_op.id, box.id, Decimal("1"), unit="EA")
+        db.flush()
+
+        # Reserve (routing-first reserves the box too) then consume the box
+        # per-op, leaving the shipping-stage reservation OPEN.
+        inventory_service.reserve_production_materials(db, po)
+        db.flush()
+        inventory_service.consume_operation_material(db, box_mat, po)
+        db.refresh(box_mat)
+        assert box_mat.status == "consumed"
+
+        net = inventory_service._get_net_reserved_by_component(db, po.id)
+        assert net.get(box.id, Decimal("0")) > Decimal("0"), (
+            "Precondition: box reservation must still be open after per-op consume"
+        )
+
+        # Finalizing ship call: box already consumed, reservation open ->
+        # must NOT raise, must not double-post.
+        txns = inventory_service.consume_shipping_materials(db, so)
+        assert txns == [], "No new shipping consumption; box already consumed per-op"
+
+        net_after = inventory_service._get_net_reserved_by_component(db, po.id)
+        assert net_after.get(box.id, Decimal("0")) == Decimal("0"), (
+            "Finalizing ship call must release the lingering shipping reservation"
+        )
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(rows) == 1  # only the per-op consumption
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("99")  # decremented once
+
+
 class TestCogsSelfHealsAfterRoutingFirstFix:
     """Integration: get_cogs_summary (untouched by this fix) returns NONZERO
     material COGS for a completed routing-only order once FIX-1 posts real

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -1931,3 +1931,386 @@ class TestAccountingEndpointsExcludeGhostRows:
         assert body["costs"]["materials"]["total"] == 0.0, (
             "Unapplied held consumption must not inflate material cost"
         )
+
+
+# =============================================================================
+# FIX-1/2/3: routing-first material consumption (restores drawdown + COGS)
+#
+# Root cause: reservation (_get_reservation_requirements) was already
+# routing-first (RESERVE-1), but consumption (consume_production_materials /
+# consume_shipping_materials) was BOM-only — for routing-driven / Intake
+# Studio products with NO active BOM, completion/ship posted ZERO consumption
+# transactions, so on_hand never decremented and COGS stayed at $0.
+#
+# These tests assert ACTUAL POSTED InventoryTransaction rows (not just that
+# the functions ran without error) — that is the entire point of the fix.
+# =============================================================================
+
+class TestRoutingFirstConsumptionRestoresPosting:
+    """FIX-1: a routing-driven order with NO BOM posts real consumption rows."""
+
+    def test_routing_only_order_posts_consumption_and_decrements_on_hand(
+        self, db, make_product
+    ):
+        """A production order for a product with NO active BOM, whose routing
+        materialized ProductionOrderOperationMaterial rows on a PRINT-coded
+        op, must post a real 'consumption' InventoryTransaction for the
+        filament component when the order completes — and on_hand must
+        actually decrement. Before FIX-1 this posted ZERO transactions."""
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id, sequence=10)
+        op.operation_code = "PRINT"
+        mat = _make_op_material(db, op.id, filament.id, Decimal("370"), unit="G")
+        db.flush()
+
+        # No BOM exists for `fg` at all (has_bom=False shape, the normal
+        # Intake-Studio / routing-only state this bug targeted).
+        assert db.query(BOM).filter(BOM.product_id == fg.id).first() is None
+
+        txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+
+        assert len(txns) == 1, "Routing-only order must post exactly one consumption row"
+        txn = txns[0]
+        assert txn.transaction_type == "consumption"
+        assert txn.product_id == filament.id
+        assert txn.reference_type == "production_order"
+        assert txn.reference_id == po.id
+        assert txn.quantity == Decimal("-370")  # signed delta (HARD-4a)
+        assert txn.cost_per_unit == Decimal("0.02")
+
+        # Assert the row is really in the DB, not just returned in-memory.
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(rows) == 1
+
+        # on_hand actually decremented.
+        inv = db.query(Inventory).filter(
+            Inventory.product_id == filament.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert inv.on_hand_quantity == Decimal("630")  # 1000 - 370
+
+        # The op-material row itself is marked consumed (per-op accounting
+        # stays consistent even though this went through the bulk path).
+        db.refresh(mat)
+        assert mat.status == "consumed"
+
+    def test_legacy_bom_driven_product_still_consumes_correctly(self, db, make_product):
+        """FALLBACK check: a product with a BOM and NO routing op-material
+        rows must still consume via the legacy BOM walk (fallback intact)."""
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        component = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        _make_bom_with_lines(db, fg.id, [
+            {"component_id": component.id, "quantity": Decimal("100"), "unit": "G",
+             "consume_stage": "production"},
+        ])
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, component.id, location.id, Decimal("2000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=5)
+        txns = inventory_service.consume_production_materials(
+            db, po, Decimal("5"), release_reservations=False
+        )
+
+        assert len(txns) == 1
+        assert txns[0].transaction_type == "consumption"
+        assert txns[0].product_id == component.id
+        assert txns[0].quantity == Decimal("-500")  # 100 * 5, signed
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(rows) == 1
+
+        inv = db.query(Inventory).filter(
+            Inventory.product_id == component.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert inv.on_hand_quantity == Decimal("1500")  # 2000 - 500
+
+
+class TestShippingStageOpMaterialDeferredToShip(object):
+    """FIX-2: a SHIPPING-stage op-material (box on a PACK/SHIP op) must NOT
+    be consumed at production completion, and must be consumed at ship."""
+
+    def _setup(self, db, make_product):
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+        box = make_product(
+            item_type="packaging", unit="EA", cost_method="average",
+            average_cost=Decimal("1.50"),
+        )
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+        _make_inventory(db, box.id, location.id, Decimal("100"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+
+        print_op = _make_operation(db, po.id, wc.id, sequence=10)
+        print_op.operation_code = "PRINT"
+        filament_mat = _make_op_material(db, print_op.id, filament.id, Decimal("370"), unit="G")
+
+        pack_op = _make_operation(db, po.id, wc.id, sequence=20)
+        pack_op.operation_code = "PACK"
+        box_mat = _make_op_material(db, pack_op.id, box.id, Decimal("1"), unit="EA")
+        db.flush()
+
+        return fg, filament, box, location, po, filament_mat, box_mat
+
+    def test_shipping_stage_material_not_consumed_at_production_completion(
+        self, db, make_product
+    ):
+        fg, filament, box, location, po, filament_mat, box_mat = self._setup(db, make_product)
+
+        txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+
+        # Only the PRINT-stage filament consumes at completion.
+        assert len(txns) == 1
+        assert txns[0].product_id == filament.id
+
+        box_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows) == 0, "Box (shipping-stage) must NOT consume at production completion"
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("100"), "Box on_hand must be untouched"
+
+        db.refresh(box_mat)
+        assert box_mat.status != "consumed", "Box op-material row must remain unconsumed"
+
+    def test_shipping_stage_material_consumed_at_ship(self, db, make_product, make_sales_order):
+        fg, filament, box, location, po, filament_mat, box_mat = self._setup(db, make_product)
+
+        # Complete production first (consumes filament only).
+        inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po.sales_order_id = so.id
+        db.flush()
+
+        txns = inventory_service.consume_shipping_materials(db, so)
+
+        assert len(txns) == 1
+        assert txns[0].product_id == box.id
+        assert txns[0].transaction_type == "consumption"
+        assert txns[0].reference_type == "production_order"
+        assert txns[0].reference_id == po.id
+        assert txns[0].quantity == Decimal("-1")
+
+        box_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows) == 1
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id,
+            Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("99"), "Box on_hand must decrement at ship"
+
+        db.refresh(box_mat)
+        assert box_mat.status == "consumed"
+
+    def test_double_ship_call_does_not_double_consume_box(self, db, make_product, make_sales_order):
+        """Idempotency: calling consume_shipping_materials twice must not
+        double-post the routing-first shipping op-material."""
+        fg, filament, box, location, po, filament_mat, box_mat = self._setup(db, make_product)
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po.sales_order_id = so.id
+        db.flush()
+
+        first = inventory_service.consume_shipping_materials(db, so)
+        assert len(first) == 1
+
+        second = inventory_service.consume_shipping_materials(db, so)
+        assert len(second) == 0, "Second ship call must be idempotent (box already consumed)"
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(rows) == 1
+
+
+class TestBulkPathDoesNotDoubleConsumeAlreadyCompletedOp:
+    """FIX-1 idempotency: an op-material row already consumed per-operation
+    (status='consumed') must NOT be double-consumed by the bulk completion
+    path — the guardrail introduced by FIX-3 must also stay quiet here,
+    since routing-first mode correctly finds nothing left to do."""
+
+    def test_per_op_consumed_row_skipped_by_bulk_completion(self, db, make_product):
+        fg = make_product(item_type="finished_good")
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id, sequence=10)
+        op.operation_code = "PRINT"
+        mat = _make_op_material(db, op.id, filament.id, Decimal("370"), unit="G")
+        db.flush()
+
+        # Simulate the per-operation path (complete_operation) already having
+        # consumed this material row.
+        first_txn = inventory_service.consume_operation_material(db, mat, po)
+        assert first_txn is not None
+        db.refresh(mat)
+        assert mat.status == "consumed"
+
+        # Bulk completion path must find nothing left to consume, and must
+        # NOT raise (nothing was reserved in this test, so the FIX-3
+        # guardrail must not fire) and must NOT double-post.
+        bulk_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert bulk_txns == []
+
+        rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(rows) == 1, "Only the per-op consumption may exist; bulk must not duplicate"
+
+
+class TestGuardrailSurfacesUnconsumableReservation:
+    """FIX-3: a reservation with nothing consumable behind it must raise
+    MaterialConsumptionError (and log at ERROR), never silently
+    release-and-return-empty."""
+
+    def test_production_stage_reservation_with_no_source_raises(self, db, make_product):
+        """A production-stage reservation exists (ledger 'reservation' row)
+        but the order has NO BOM and NO routing op-material rows at all —
+        the old code released the reservation and returned [] silently;
+        FIX-3 must raise instead."""
+        fg = make_product(item_type="finished_good")
+        component = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, component.id, location.id, Decimal("1000"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+
+        # Manually post a reservation ledger row for `component` against this
+        # PO, simulating a state where reservation succeeded (e.g. via an
+        # older BOM that has since been deleted/deactivated) but consumption
+        # now has nothing to work from.
+        inventory = db.query(Inventory).filter(
+            Inventory.product_id == component.id,
+            Inventory.location_id == location.id,
+        ).first()
+        inventory.allocated_quantity = Decimal("100")
+        reservation_txn = InventoryTransaction(
+            product_id=component.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            quantity=Decimal("100"),
+            reference_type="production_order",
+            reference_id=po.id,
+            notes="Test reservation with no consumable source",
+            unit="G",
+        )
+        db.add(reservation_txn)
+        db.flush()
+
+        with pytest.raises(inventory_service.MaterialConsumptionError):
+            inventory_service.consume_production_materials(
+                db, po, Decimal("1"), release_reservations=True
+            )
+
+    def test_guardrail_does_not_fire_when_nothing_was_reserved(self, db, make_product):
+        """Sanity check: the guardrail must stay silent (return []) for the
+        ordinary 'no BOM, nothing was ever reserved' case — this is NOT a
+        bug, just a product with no material requirements."""
+        fg = make_product(item_type="finished_good")
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+
+        txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=True
+        )
+        assert txns == []
+
+
+class TestCogsSelfHealsAfterRoutingFirstFix:
+    """Integration: get_cogs_summary (untouched by this fix) returns NONZERO
+    material COGS for a completed routing-only order once FIX-1 posts real
+    consumption transactions — proving the chain end-to-end without
+    modifying the COGS aggregation itself."""
+
+    def test_cogs_summary_nonzero_for_completed_routing_order(
+        self, db, client, make_product, make_sales_order
+    ):
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="shipped")
+        so.shipped_at = datetime.now(timezone.utc)
+
+        po = _make_production_order(db, fg.id, qty_ordered=1, status="in_progress")
+        po.sales_order_id = so.id
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id, sequence=10)
+        op.operation_code = "PRINT"
+        _make_op_material(db, op.id, filament.id, Decimal("370"), unit="G")
+        db.flush()
+
+        # No BOM for `fg` — routing-only, the shape this fix targets.
+        assert db.query(BOM).filter(BOM.product_id == fg.id).first() is None
+
+        # FIX-1: complete production -> posts real consumption transactions.
+        consumption_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert len(consumption_txns) == 1
+        db.commit()
+
+        response = client.get("/api/v1/admin/accounting/cogs-summary", params={"days": 30})
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["cogs"]["materials"] > 0.0, (
+            "COGS materials must be nonzero once FIX-1 posts real consumption "
+            "transactions for a routing-only completed order"
+        )
+        assert data["cogs"]["total"] > 0.0


### PR DESCRIPTION
## Root cause

Reservation and consumption diverged. `_get_reservation_requirements` (RESERVE-1, PR #728) is already **routing-first**: it reads `ProductionOrderOperationMaterial` rows materialized from the routing at release, and only falls back to the legacy BOM walk when an order has zero op-material rows.

Consumption never got the same fix:

- `consume_production_materials` released reservations, then queried `BOM` directly. If the product had no active BOM (the **normal** state for routing-driven / Intake Studio products — they carry the full material explosion on the routing, not a BOM), it logged a warning and returned an empty list. Nothing was consumed, `on_hand` never decremented, and zero `consumption` `InventoryTransaction` rows existed.
- `get_cogs_summary` sums only `consumption` transactions, so completed routing-only orders showed **$0 material COGS**.
- `consume_shipping_materials` had the same shape: BOM-only, silently skipping products with no BOM, so packaging (e.g. a box materialized on a routing PACK/SHIP operation) never consumed at ship.

## What changed

**FIX-1 — `consume_production_materials` is now routing-first, production-stage only.**
Mirrors `_get_reservation_requirements`'s resolution: pulls unconsumed `ProductionOrderOperationMaterial` rows for the order's **production**-stage operations (via `get_consume_stages_for_operation`) and consumes each through `consume_operation_material` (same pricing path as the per-operation flow: `get_effective_cost_per_inventory_unit`). Falls back to the legacy BOM walk **only** when the order has zero op-material rows at all — matching RESERVE-1's "op rows replace the BOM walk entirely" rule so reserve and consume can never diverge again. Shipping-stage op-materials (PACK/SHIP/LABEL-coded ops) are explicitly excluded here; they're left for FIX-2 at ship time. Only **production**-stage reservations are released here (see shared helper below) — shipping-stage reservations (e.g. a box) are left intact.

**FIX-2 — `consume_shipping_materials` now also consumes shipping-stage routing op-materials.**
For each product being shipped, resolves the sales order's production order(s) and consumes unconsumed shipping-stage op-materials (PACK/SHIP/LABEL ops), **in addition to** the existing BOM `consume_stage='shipping'` lines — both packaging models (routing-based box, BOM-based packaging line) are supported simultaneously since a product could be built either way. Releases only shipping-stage reservations for the relevant production order(s) at ship time.

**FIX-3 — guardrail against silent release-into-void.**
Both consumers now check whether the relevant stage had a net reservation before releasing it. If a reservation existed but neither routing op-materials nor a BOM line produced anything consumable, this is logged at `ERROR` and raised as a new `MaterialConsumptionError` (mirrors the existing `OperationError`/`ScrapError` custom-exception pattern in this codebase) instead of the old silent `return []`. Verified call sites: `production_order_execution_service.complete_production_order` already wraps `process_production_completion` in try/except and converts to `HTTPException(500)` — the guardrail surfaces cleanly there. `operation_status.update_po_status`'s auto-complete path already wraps the same call in try/except-log-and-continue (by design, so one bad PO doesn't block the status transition) — the guardrail is at least **logged at ERROR**, which is still a strict improvement over the prior fully-silent empty return. `sales_order_fulfillment_service.ship_order` has no existing try/except around `process_shipment`, so the raise propagates as an unhandled 500 — also non-silent, and the least invasive change given no existing guard to fit into.

**Shared helper** (`_get_stage_op_materials` / `_get_stage_component_ids` / `_get_all_op_material_rows`): the routing-first-then-BOM-fallback resolution, stage filtering (via `get_consume_stages_for_operation`), and idempotency (skip `status=='consumed'` rows) are implemented **once** and used by both FIX-1 and FIX-2. Divergence between reserve and consume is exactly what caused this bug — a shared resolver is the guard against it recurring.

**Idempotency vs. the per-operation path.** The per-operation path (`complete_operation` -> `consume_operation_materials` -> `consume_operation_material`) may already have consumed a row before the bulk/ship path runs. `_get_stage_op_materials` excludes `status=='consumed'` rows, so the bulk paths never double-post a routing op-material row. The pre-existing BOM-side idempotency (HARD-11's `_consumption_already_posted`, keyed on non-voided consumption transactions per component) is preserved unchanged for the BOM fallback and the new BOM shipping-line path.

**Reservation scoping.** `release_production_reservations` gained an optional `component_ids` filter (default `None` = release everything, preserving the existing cancel/delete callers unchanged). FIX-1 passes the production-stage component universe; FIX-2 passes the shipping-stage universe per production order — so releasing at completion never touches a still-pending shipping-stage (packaging) reservation, and vice versa.

**`get_cogs_summary` is unchanged** — it already sums generically over `consumption`-type `InventoryTransaction` rows regardless of origin (BOM or routing), so it self-heals automatically once FIX-1/FIX-2 post real transactions.

## Review fix (2nd commit — `0a6c3ea`)

A careful review found a **guardrail false positive**: `consume_operation_material` posts the consumption and marks the op-material row `status='consumed'` but does **not** release the reservation. So an order completed entirely via the per-operation path (`complete_operation` for every op) still has open production-stage reservations. When it then finalized through `consume_production_materials` (the `update_po_status` auto-complete path), `had_reservation` was `True` while every stage row was already consumed — and the guardrail raised `MaterialConsumptionError` on a correctly-completed order. Fixed with a new `_stage_has_consumed_op_materials` helper that distinguishes "nothing consumed because there was no source" (real bug → raise) from "nothing consumed this call because the stage was already consumed per-op" (success → release the lingering reservation, return quietly). Applied to both production-stage guardrail branches and the shipping-stage guardrail. New regression tests (`test_fully_per_op_consumed_order_finalizes_without_raise`, `test_fully_per_op_consumed_shipping_stage_finalizes_without_raise`, `test_partially_consumed_stage_still_consumes_remainder_no_raise`) were verified to fail against the pre-fix code and pass after.

## Out of scope (noted, not fixed here)

- **FIX-4 (follow-up):** unifying the bulk force-complete loop and the QC-completion path to route through `complete_operation` per-operation consumption instead of the bulk backflush. Larger refactor, separate PR.
- **`standard_cost` / the #187 recost path** — independent issue, not touched.
- **Data backfill** for production orders that already completed/shipped under the old BOM-only code (and therefore have zero consumption transactions and are missing COGS) — this is a data-remediation task, tracked separately from this code fix.
- **COGS packaging sub-bucket (cosmetic follow-up):** the routing-first shipping consumption posts via `consume_operation_material`, which uses `reference_type='production_order'`, whereas the existing BOM shipping-line path uses `reference_type='sales_order'`. `get_cogs_summary` buckets `production_order`-referenced consumption under **materials** and `shipment`/`sales_order`-referenced under **packaging**, so routing-based packaging cost lands in the "materials" sub-bucket rather than "packaging". **Total COGS is unaffected** — purely a sub-category split cosmetic difference. Left as a follow-up rather than touching `get_cogs_summary` here (explicitly out of scope for this fix).

## Tests

All new tests assert **actual posted `InventoryTransaction` rows** (not just that the function ran), per the task requirement:

1. `test_routing_only_order_posts_consumption_and_decrements_on_hand` — a routing-driven PO with **no BOM** posts a `consumption` row for its production-stage op-material (filament): correct `component_id`, signed `quantity`, `cost_per_unit`, `reference_type='production_order'`, and `on_hand` actually decremented.
2. `test_shipping_stage_material_not_consumed_at_production_completion` / `test_shipping_stage_material_consumed_at_ship` — a box on a PACK op is NOT consumed at production completion, and IS consumed (posted row + `on_hand` decrement) at ship.
3. `test_double_ship_call_does_not_double_consume_box` / `test_per_op_consumed_row_skipped_by_bulk_completion` — idempotency: an already-consumed op-material row is never double-posted by the bulk or ship path.
4. `test_legacy_bom_driven_product_still_consumes_correctly` — the pre-existing BOM-only fallback path still posts correctly (regression guard).
5. `test_production_stage_reservation_with_no_source_raises` / `test_guardrail_does_not_fire_when_nothing_was_reserved` — the guardrail raises `MaterialConsumptionError` when a reservation has no consumable source, and stays silent (returns `[]`) for the ordinary "nothing was ever reserved" case.
6. `test_cogs_summary_nonzero_for_completed_routing_order` — integration: `get_cogs_summary` returns nonzero material COGS end-to-end for a completed routing-only order, proving the self-heal.
7. **(review fix)** `test_fully_per_op_consumed_order_finalizes_without_raise` / `test_fully_per_op_consumed_shipping_stage_finalizes_without_raise` / `test_partially_consumed_stage_still_consumes_remainder_no_raise` — a stage already fully consumed per-op (reservation left open) must finalize without a false-positive raise, release the lingering reservation, and not double-consume.

**Results:**
- `pytest backend/tests -q -k "consum or inventory or cogs or completion or production"`: **1032 passed** (incl. the review-fix regression tests).
- Full suite (`pytest backend/tests -q`, `DB_PASSWORD=Admin`): all inventory/consumption/production/cogs tests green; the only failures are in `test_admin_orders.py` / `test_order_import_service.py` — an unrelated CSV-order-import `unit_price` NOT NULL issue confirmed present on the unmodified `origin/main` baseline (not introduced by this change).
- `ruff check`: `app/services/inventory_service.py` is fully clean; the pre-existing lint findings in `test_inventory_extra.py` all predate this change (both commits are purely additive to that file) and are unrelated to the lines added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
