### PR TITLE
fix(products): expose has_routing so routing-built FGs are sellable (#883)

### DIFF
--- a/backend/app/api/v1/endpoints/products.py
+++ b/backend/app/api/v1/endpoints/products.py
@@ -66,6 +66,7 @@ class ProductResponse(BaseModel):
     weight: Optional[float] = None
     is_raw_material: bool
     has_bom: bool
+    has_routing: bool = False
     active: bool
     woocommerce_product_id: Optional[int] = None
     image_url: Optional[str] = None
@@ -120,6 +121,29 @@ async def list_products(
             limit=limit,
             offset=offset,
         )
+
+        # Populate computed has_routing (an active routing exists for the product).
+        # The sales-order product picker treats a product as sellable when it has
+        # a BOM OR a routing; without this field, routing-built finished goods
+        # (which have no BOM — the norm for PRO/Intake products) are silently
+        # filtered out as "No sellable products". See issue #883.
+        from app.models.manufacturing import Routing
+        product_ids = [p.id for p in products]
+        routing_ids: set[int] = set()
+        if product_ids:
+            routing_ids = {
+                r[0]
+                for r in db.query(Routing.product_id)
+                .filter(
+                    Routing.product_id.in_(product_ids),
+                    Routing.is_active.is_(True),
+                )
+                .distinct()
+                .all()
+            }
+        for p in products:
+            # transient attribute read by ProductResponse (from_attributes)
+            p.has_routing = p.id in routing_ids
 
         return ProductListResponse(
             total=total,

--- a/backend/tests/api/v1/test_products.py
+++ b/backend/tests/api/v1/test_products.py
@@ -90,6 +90,24 @@ class TestProductList:
         skus = [item["sku"] for item in body["items"]]
         assert product.sku in skus
 
+    def test_list_exposes_has_routing(self, client, db, make_product):
+        """Routing-built products (no BOM) must report has_routing=True so the
+        sales-order product picker treats them as sellable. Without this field
+        the picker filters them out as "No sellable products" (issue #883)."""
+        from app.models.manufacturing import Routing
+
+        uid = _uid()
+        routed = make_product(sku=f"HASRT-{uid}", name=f"Routed {uid}")
+        db.add(Routing(product_id=routed.id, code=f"RT-{uid}", name="R", is_active=True))
+        plain = make_product(sku=f"NORT-{uid}", name=f"Plain {uid}")
+        db.flush()
+
+        resp = client.get(BASE_URL, params={"search": uid})
+        assert resp.status_code == 200
+        items = {i["sku"]: i for i in resp.json()["items"]}
+        assert items[routed.sku]["has_routing"] is True
+        assert items[plain.sku]["has_routing"] is False
+
     @pytest.mark.parametrize("legacy_unit", [None, "", "   "])
     def test_list_defaults_legacy_blank_unit(self, client, db, make_product, legacy_unit):
         """Legacy product rows with NULL/blank unit should not break API responses."""


### PR DESCRIPTION
## Problem
Creating a sales order shows **"No sellable products available"** even though all finished goods exist — because they're routing-built (34/34 FGs have a routing, only 2 have a BOM). The picker's filter is correct (`has_bom || has_routing`), but the wizard fetches from the legacy `/api/v1/products` endpoint whose response **omitted `has_routing`** (it's computed, not a column), so routing-built FGs were filtered out.

## Fix
Compute and expose `has_routing` on the `/products` list response (batched active-routing lookup, transient attribute read by `ProductResponse`) — mirroring what `/items` already does. No frontend change: the picker was already correct, it just wasn't receiving the field.

## Test
`test_list_exposes_has_routing` — routing-built product → `has_routing=True`, plain product → `False`. Passes; ruff clean.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product lists now show whether each product has an active routing, making it easier to identify items that are ready to be sold.
  * Products without a bill of materials can still be marked as available when routing exists.

* **Tests**
  * Added coverage to verify the product list returns the new routing status for both routed and non-routed products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->