### PR TITLE
fix(sales-order): remove Raw Materials tab from the customer order picker (#886)

### DIFF
--- a/frontend/src/components/sales-order/ProductSelectionStep.jsx
+++ b/frontend/src/components/sales-order/ProductSelectionStep.jsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
 import ItemCreationWizard from "./ItemCreationWizard";
 
+// Raw materials are intentionally NOT sellable on a customer sales order (#886) —
+// a print shop sells finished goods, not its filament. The "materials" render
+// block further down is left intact but unreachable (no tab drives activeTab to
+// "materials"), so material resale could be re-enabled as a config-gated option
+// later without rebuilding it.
 const TABS = [
   { id: "products", label: "Finished Goods" },
-  { id: "materials", label: "Raw Materials" },
   { id: "fees", label: "Fees" },
 ];
 


### PR DESCRIPTION
## Problem
The Create Sales Order product picker had a **"Raw Materials"** tab that let you put raw materials (filament, etc.) as line items on a **customer** sales order — something a print shop would never do.

## Fix
Remove the `materials` entry from `TABS` in `ProductSelectionStep.jsx`. The tab disappears; `activeTab` can only be `products` (Finished Goods) or `fees`. The materials render block is left intact but unreachable (still referenced, so no unused-variable churn), with a comment noting material resale could be re-enabled as a config-gated option later.

No behavior change to Finished Goods or Fees.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)