### PR TITLE
fix(accounting): GL report counts posted entries only (880 PR-1)

### DIFF
--- a/backend/app/api/v1/endpoints/accounting.py
+++ b/backend/app/api/v1/endpoints/accounting.py
@@ -263,6 +263,7 @@ class RecentEntriesResponse(BaseModel):
 async def get_trial_balance(
     as_of_date: Optional[date] = Query(None, description="Balance as of this date (default: today)"),
     include_zero_balances: bool = Query(False, description="Include accounts with zero balance"),
+    include_unposted: bool = Query(False, description="Include draft and voided journal entries (default: posted only)"),
     db: Session = Depends(get_db),
     current_admin: User = Depends(get_current_admin_user),
 ):
@@ -281,6 +282,7 @@ async def get_trial_balance(
         db,
         as_of_date=as_of_date,
         include_zero_balances=include_zero_balances,
+        include_unposted=include_unposted,
     )
 
 
@@ -339,6 +341,7 @@ async def get_transaction_ledger(
     end_date: Optional[date] = Query(None, description="Filter transactions to this date"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum transactions to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
+    include_unposted: bool = Query(False, description="Include draft and voided journal entries (default: posted only)"),
     db: Session = Depends(get_db),
     current_admin: User = Depends(get_current_admin_user),
 ):
@@ -364,6 +367,7 @@ async def get_transaction_ledger(
         end_date=end_date,
         limit=limit,
         offset=offset,
+        include_unposted=include_unposted,
     )
 
 

--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 from fastapi import HTTPException
-from sqlalchemy import case, func
+from sqlalchemy import and_, case, func
 from sqlalchemy.orm import Session
 
 from app.logging_config import get_logger
@@ -76,13 +76,24 @@ def get_trial_balance(
     *,
     as_of_date: date | None = None,
     include_zero_balances: bool = False,
+    include_unposted: bool = False,
 ) -> dict:
-    """Generate a trial balance report. Returns dict matching TrialBalanceResponse."""
+    """Generate a trial balance report. Returns dict matching TrialBalanceResponse.
+
+    Only posted journal entries are counted unless ``include_unposted`` is True
+    (drafts are editable and voids are cancelled — neither belongs in reports).
+    """
     if as_of_date is None:
         as_of_date = date.today()
 
     # Query to sum debits and credits by account
-    # Use conditional sums so accounts with only future entries still appear
+    # Use conditional sums so accounts with only future entries still appear.
+    # The posted-status filter must live INSIDE the case() (not a WHERE clause)
+    # so the outerjoin keeps zero-activity accounts listed.
+    entry_condition = GLJournalEntry.entry_date <= as_of_date
+    if not include_unposted:
+        entry_condition = and_(entry_condition, GLJournalEntry.status == "posted")
+
     query = db.query(
         GLAccount.account_code,
         GLAccount.name,
@@ -90,7 +101,7 @@ def get_trial_balance(
         func.coalesce(
             func.sum(
                 case(
-                    (GLJournalEntry.entry_date <= as_of_date, GLJournalEntryLine.debit_amount),
+                    (entry_condition, GLJournalEntryLine.debit_amount),
                     else_=Decimal("0"),
                 )
             ),
@@ -99,7 +110,7 @@ def get_trial_balance(
         func.coalesce(
             func.sum(
                 case(
-                    (GLJournalEntry.entry_date <= as_of_date, GLJournalEntryLine.credit_amount),
+                    (entry_condition, GLJournalEntryLine.credit_amount),
                     else_=Decimal("0"),
                 )
             ),
@@ -310,9 +321,14 @@ def get_transaction_ledger(
     end_date: date | None = None,
     limit: int = 100,
     offset: int = 0,
+    include_unposted: bool = False,
 ) -> dict:
     """Get the transaction ledger for a specific GL account.
-    Returns dict matching LedgerResponse."""
+    Returns dict matching LedgerResponse.
+
+    Only posted journal entries are counted unless ``include_unposted`` is True
+    (drafts are editable and voids are cancelled — neither belongs in reports).
+    """
     # Get the account
     account = db.query(GLAccount).filter(
         GLAccount.account_code == account_code
@@ -346,6 +362,9 @@ def get_transaction_ledger(
         GLJournalEntryLine.account_id == account.id
     )
 
+    if not include_unposted:
+        query = query.filter(GLJournalEntry.status == "posted")
+
     # Apply date filters
     if start_date:
         query = query.filter(GLJournalEntry.entry_date >= start_date)
@@ -377,6 +396,9 @@ def get_transaction_ledger(
             GLJournalEntryLine.account_id == account.id,
             GLJournalEntry.entry_date < start_date,
         )
+
+        if not include_unposted:
+            opening_query = opening_query.filter(GLJournalEntry.status == "posted")
 
         opening_result = opening_query.first()
         if opening_result:

--- a/backend/tests/services/test_gl_report_posted_only.py
+++ b/backend/tests/services/test_gl_report_posted_only.py
@@ -1,0 +1,266 @@
+"""
+Tests for GL report posted-only semantics (#880 PR-1).
+
+Covers:
+- get_trial_balance: draft/voided entries excluded; zero-activity accounts
+  (including draft-only accounts) still listed; include_unposted=True restores
+  the old include-everything behavior
+- get_transaction_ledger: draft/voided entries excluded from the transaction
+  list AND the opening balance; include_unposted=True restores old behavior
+
+Deltas are measured against a pre-snapshot so accumulated data from other
+tests/runs cannot skew the assertions.
+"""
+import uuid
+from datetime import date
+from decimal import Decimal
+
+from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+from app.services import accounting_service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _make_journal_entry(db, *, entry_date, status, lines):
+    """Create a GLJournalEntry with lines.
+
+    ``lines`` is a list of dicts: {"account_id": int, "debit": Decimal, "credit": Decimal}.
+    """
+    entry = GLJournalEntry(
+        entry_number=f"JE-T-{_uid()}",
+        entry_date=entry_date,
+        description=f"Posted-only test JE ({status})",
+        status=status,
+    )
+    db.add(entry)
+    db.flush()
+
+    for i, line in enumerate(lines):
+        db.add(GLJournalEntryLine(
+            journal_entry_id=entry.id,
+            account_id=line["account_id"],
+            debit_amount=line.get("debit", Decimal("0")),
+            credit_amount=line.get("credit", Decimal("0")),
+            line_order=i,
+        ))
+    db.flush()
+    return entry
+
+
+def _get_account(db, code: str) -> GLAccount:
+    """Fetch a seeded GL account by code."""
+    acct = db.query(GLAccount).filter(GLAccount.account_code == code).first()
+    assert acct is not None, f"Seed account {code} missing"
+    return acct
+
+
+def _make_status_trio(db, *, cash_id, revenue_id, entry_date):
+    """Create one posted (100), one draft (999), and one voided (555) JE."""
+    for status, amount in (
+        ("posted", Decimal("100")),
+        ("draft", Decimal("999")),
+        ("voided", Decimal("555")),
+    ):
+        _make_journal_entry(db, entry_date=entry_date, status=status, lines=[
+            {"account_id": cash_id, "debit": amount, "credit": Decimal("0")},
+            {"account_id": revenue_id, "debit": Decimal("0"), "credit": amount},
+        ])
+
+
+def _tb_account(result, code):
+    return next(
+        (a for a in result["accounts"] if a["account_code"] == code), None,
+    )
+
+
+def _tb_debit_balance(result, code) -> Decimal:
+    row = _tb_account(result, code)
+    return row["debit_balance"] if row else Decimal("0")
+
+
+# ===========================================================================
+# get_trial_balance — posted-only
+# ===========================================================================
+
+
+class TestTrialBalancePostedOnly:
+    """Draft and voided journal entries must not move trial balance figures."""
+
+    def test_draft_and_voided_excluded(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+        as_of = date(2060, 1, 31)
+
+        before = accounting_service.get_trial_balance(db, as_of_date=as_of)
+        before_cash = _tb_debit_balance(before, "1000")
+
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2060, 1, 15),
+        )
+
+        after = accounting_service.get_trial_balance(db, as_of_date=as_of)
+        after_cash = _tb_debit_balance(after, "1000")
+
+        # Only the posted 100 counts — not the draft 999 or the voided 555
+        assert after_cash - before_cash == Decimal("100")
+        assert after["is_balanced"] is True
+
+    def test_include_unposted_restores_old_behavior(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+        as_of = date(2060, 2, 28)
+
+        before = accounting_service.get_trial_balance(
+            db, as_of_date=as_of, include_unposted=True,
+        )
+        before_cash = _tb_debit_balance(before, "1000")
+
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2060, 2, 15),
+        )
+
+        after = accounting_service.get_trial_balance(
+            db, as_of_date=as_of, include_unposted=True,
+        )
+        after_cash = _tb_debit_balance(after, "1000")
+
+        # Old behavior: every entry counts regardless of status
+        assert after_cash - before_cash == Decimal("100") + Decimal("999") + Decimal("555")
+
+    def test_zero_activity_account_still_listed(self, db):
+        """The outerjoin must keep no-entry accounts in the trial balance."""
+        code = f"ZT-{_uid()}"  # unique, cannot collide with seeded numeric codes
+        acct = GLAccount(
+            account_code=code,
+            name=f"Zero Activity Test {code}",
+            account_type="asset",
+        )
+        db.add(acct)
+        db.flush()
+
+        result = accounting_service.get_trial_balance(
+            db, include_zero_balances=True,
+        )
+        row = _tb_account(result, code)
+        assert row is not None
+        assert row["debit_balance"] == Decimal("0")
+        assert row["credit_balance"] == Decimal("0")
+
+    def test_draft_only_account_still_listed_with_zero_balance(self, db):
+        """An account whose ONLY activity is a draft JE must still appear
+        (with zero balance) — the status filter lives in the case(), not a
+        WHERE clause, so it must not drop the account row entirely."""
+        code = f"ZD-{_uid()}"
+        acct = GLAccount(
+            account_code=code,
+            name=f"Draft Only Test {code}",
+            account_type="asset",
+        )
+        db.add(acct)
+        db.flush()
+
+        cash = _get_account(db, "1000")
+        _make_journal_entry(db, entry_date=date(2060, 3, 15), status="draft", lines=[
+            {"account_id": acct.id, "debit": Decimal("42"), "credit": Decimal("0")},
+            {"account_id": cash.id, "debit": Decimal("0"), "credit": Decimal("42")},
+        ])
+
+        result = accounting_service.get_trial_balance(
+            db, as_of_date=date(2060, 3, 31), include_zero_balances=True,
+        )
+        row = _tb_account(result, code)
+        assert row is not None
+        assert row["debit_balance"] == Decimal("0")
+        assert row["credit_balance"] == Decimal("0")
+
+
+# ===========================================================================
+# get_transaction_ledger — posted-only
+# ===========================================================================
+
+
+class TestTransactionLedgerPostedOnly:
+    """Draft and voided journal entries must not appear in the ledger."""
+
+    def test_draft_and_voided_excluded_from_transactions(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2061, 3, 15),
+        )
+
+        result = accounting_service.get_transaction_ledger(
+            db, "1000",
+            start_date=date(2061, 3, 1),
+            end_date=date(2061, 3, 31),
+        )
+        debits = [t["debit"] for t in result["transactions"]]
+        assert Decimal("100") in debits
+        assert Decimal("999") not in debits
+        assert Decimal("555") not in debits
+        assert result["total_debits"] == Decimal("100")
+        assert result["transaction_count"] == 1
+
+    def test_opening_balance_excludes_draft_and_voided(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+        window = dict(start_date=date(2062, 2, 1), end_date=date(2062, 2, 28))
+
+        before = accounting_service.get_transaction_ledger(db, "1000", **window)
+
+        # All three entries fall BEFORE the queried window
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2062, 1, 10),
+        )
+
+        after = accounting_service.get_transaction_ledger(db, "1000", **window)
+        # Only the posted 100 rolls into the opening balance
+        assert after["opening_balance"] - before["opening_balance"] == Decimal("100")
+
+    def test_include_unposted_restores_old_behavior(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2063, 5, 15),
+        )
+
+        result = accounting_service.get_transaction_ledger(
+            db, "1000",
+            start_date=date(2063, 5, 1),
+            end_date=date(2063, 5, 31),
+            include_unposted=True,
+        )
+        debits = [t["debit"] for t in result["transactions"]]
+        assert Decimal("100") in debits
+        assert Decimal("999") in debits
+        assert Decimal("555") in debits
+        assert result["total_debits"] == Decimal("100") + Decimal("999") + Decimal("555")
+        assert result["transaction_count"] == 3
+
+    def test_include_unposted_opening_balance(self, db):
+        cash = _get_account(db, "1000")
+        revenue = _get_account(db, "4000")
+        window = dict(start_date=date(2064, 2, 1), end_date=date(2064, 2, 28))
+
+        before = accounting_service.get_transaction_ledger(
+            db, "1000", include_unposted=True, **window,
+        )
+
+        _make_status_trio(
+            db, cash_id=cash.id, revenue_id=revenue.id, entry_date=date(2064, 1, 10),
+        )
+
+        after = accounting_service.get_transaction_ledger(
+            db, "1000", include_unposted=True, **window,
+        )
+        assert after["opening_balance"] - before["opening_balance"] == (
+            Decimal("100") + Decimal("999") + Decimal("555")
+        )


### PR DESCRIPTION
## What

Makes the Core GL reports posted-only, per the #880 final design ([design comment](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351), §3d; scope green-lit [here](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880356641)):

- **`get_trial_balance`** (`backend/app/services/accounting_service.py`): `GLJournalEntry.status == "posted"` added **inside both `case()` conditions** (debit and credit sums) — deliberately *not* a `WHERE` clause, so the `outerjoin` keeps zero-activity accounts listed, including accounts whose only activity is a draft entry.
- **`get_transaction_ledger`**: same posted filter on the main lines query **and** the opening-balance query.
- **Endpoints** (`backend/app/api/v1/endpoints/accounting.py`): new optional `include_unposted: bool = false` query param on `/trial-balance` and `/ledger/{account_code}`, threaded through to the service functions. `include_unposted=true` restores the previous include-everything behavior exactly.

## Why

The reports summed every JE line regardless of status, so draft and voided entries moved trial-balance and ledger figures. The `GLJournalEntry` model has documented since inception that drafts and voids are "not included in reports" — the reports never enforced it. Fixing this:

- matches the PRO reports' posted-only semantics (`filaops_pro/services/accounting_reports.py`),
- makes **JE-void a clean reversal tool** for the #880 live-books correction (voided entries vanish from posted-only reports — required by the correction runbook's `--rollback` manifest).

**Live impact today: $0** — no draft or voided entries exist on the brownfield.

## How tested

New focused test file `backend/tests/services/test_gl_report_posted_only.py` (8 tests, delta-based so accumulated test data cannot skew assertions):

- draft + voided JEs excluded from trial balance; still balanced
- draft + voided JEs excluded from ledger transactions **and** opening balance
- zero-activity account still listed in trial balance
- account whose **only** activity is a draft JE still listed (zero balance) — the exact regression a WHERE-clause placement would cause
- `include_unposted=true` restores old behavior for trial balance, ledger transactions, and opening balance

Local runs (filaops_test DB):
- `pytest tests/services/test_gl_report_posted_only.py` → **8 passed**
- `pytest tests/services/test_accounting_service.py tests/api/v1/test_accounting.py tests/test_accounting.py` → **81 passed, 3 skipped**
- `ruff check` on changed files → clean

Part of the #880 PR train: **PR-1 (this)** → PR-2 (JE engine + ship guard) → PR-3 (completion GL poster) → PR-4 (ship-path completeness) → OPS correction → PR-5 (dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include unposted accounting activity in Trial Balance and Transaction Ledger reports.
  * Users can now switch between posted-only results and combined posted/unposted results for these reports.

* **Bug Fixes**
  * Report balances and opening totals now consistently match the selected activity scope.
  * Zero-activity accounts continue to appear in Trial Balance results when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->