### PR TITLE
feat(accounting): JE entry_date, ship_order idempotency guard, item_type-aware PO receipts (880 PR-2)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
+++ b/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
@@ -32,7 +32,12 @@ from app.models.bom import BOM
 from app.models.inventory import Inventory, InventoryTransaction
 from app.models.traceability import SerialNumber
 from app.services.shipping_service import shipping_service
-from app.services.transaction_service import TransactionService, ShipmentItem, PackagingUsed
+from app.services.transaction_service import (
+    DuplicateShipmentError,
+    TransactionService,
+    ShipmentItem,
+    PackagingUsed,
+)
 from app.services import inventory_ledger
 from app.services.inventory_service import get_effective_cost_per_inventory_unit, get_or_create_default_location
 from app.api.v1.deps import get_current_staff_user
@@ -791,11 +796,21 @@ async def buy_shipping_label(
         )]
 
         txn_service = TransactionService(db)
-        inv_txns, journal_entry = txn_service.ship_order(
-            sales_order_id=sales_order_id,
-            items=shipment_items,
-            packaging=packaging_list if packaging_list else None,
-        )
+        try:
+            inv_txns, journal_entry = txn_service.ship_order(
+                sales_order_id=sales_order_id,
+                items=shipment_items,
+                packaging=packaging_list if packaging_list else None,
+            )
+        except DuplicateShipmentError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Order {order.order_number} already has a shipment journal "
+                    "entry — it was already shipped. Retrying would double-post "
+                    "inventory and COGS."
+                ),
+            ) from exc
 
         # Get updated FG inventory for response
         fg_inventory = db.query(Inventory).filter(
@@ -1054,11 +1069,21 @@ async def ship_from_stock(
                 })
 
     # Execute shipment
-    inv_txns, journal_entry = txn_service.ship_order(
-        sales_order_id=sales_order_id,
-        items=shipment_items,
-        packaging=packaging_list if packaging_list else None,
-    )
+    try:
+        inv_txns, journal_entry = txn_service.ship_order(
+            sales_order_id=sales_order_id,
+            items=shipment_items,
+            packaging=packaging_list if packaging_list else None,
+        )
+    except DuplicateShipmentError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Order {order.order_number} already has a shipment journal "
+                "entry — it was already shipped. Retrying would double-post "
+                "inventory and COGS."
+            ),
+        ) from exc
 
     # Get updated inventory for response
     fg_inventory = db.query(Inventory).filter(

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -24,9 +24,20 @@ from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.inventory import InventoryTransaction
 from app.models.production_order import ScrapRecord
 from app.models.product import Product
+from app.models.sales_order import SalesOrder
 from app.services import inventory_ledger
 
 _JOURNAL_ENTRY_NUMBER_LOCK_NAMESPACE = 74002
+
+
+class DuplicateShipmentError(Exception):
+    """Raised when ship_order is retried for a sales order that already has a
+    non-voided shipment journal entry.
+
+    A retry that skipped the JE but still posted inventory would silently
+    double-decrement finished goods, so the guard raises BEFORE any inventory
+    transaction is posted (#880). Callers convert this to HTTP 409.
+    """
 
 
 class MaterialConsumption(NamedTuple):
@@ -123,6 +134,7 @@ class TransactionService:
         source_type: Optional[str] = None,
         source_id: Optional[int] = None,
         user_id: Optional[int] = None,
+        entry_date: Optional[date] = None,
     ) -> GLJournalEntry:
         """Create a balanced posted journal entry for service-level callers."""
         return self._create_journal_entry(
@@ -131,6 +143,7 @@ class TransactionService:
             source_type=source_type,
             source_id=source_id,
             user_id=user_id,
+            entry_date=entry_date,
         )
 
     def _create_journal_entry(
@@ -140,6 +153,7 @@ class TransactionService:
         source_type: str = None,
         source_id: int = None,
         user_id: int = None,
+        entry_date: Optional[date] = None,
     ) -> GLJournalEntry:
         """
         Create balanced journal entry with lines.
@@ -150,6 +164,8 @@ class TransactionService:
             source_type: 'production_order', 'sales_order', 'purchase_order', etc.
             source_id: ID of source document
             user_id: Creating user ID
+            entry_date: Entry date; defaults to today. Lets correction posters
+                (e.g. the #880 completion-GL backfill) backdate entries.
 
         Returns:
             GLJournalEntry with lines attached
@@ -159,7 +175,7 @@ class TransactionService:
         """
         je = GLJournalEntry(
             entry_number=self._next_entry_number(),
-            entry_date=date.today(),
+            entry_date=entry_date or date.today(),
             description=description,
             source_type=source_type,
             source_id=source_id,
@@ -578,7 +594,31 @@ class TransactionService:
 
         Returns:
             Tuple of (list of inventory transactions, journal entry)
+
+        Raises:
+            DuplicateShipmentError: If a non-voided shipment journal entry
+                already exists for this sales order (retry would double-relieve
+                FG inventory). Raised BEFORE any inventory transaction posts.
         """
+        # Idempotency guard (#880): same predicate as _create_shipment_gl_entry
+        # in sales_order_fulfillment_service. A skip-and-continue retry would
+        # still double-decrement FG, so raise before touching inventory.
+        existing_je = self.db.query(GLJournalEntry.id).filter(
+            GLJournalEntry.source_type == "sales_order",
+            GLJournalEntry.source_id == sales_order_id,
+            GLJournalEntry.status != "voided",
+        ).first()
+        if existing_je:
+            raise DuplicateShipmentError(
+                f"Sales order {sales_order_id} already has a shipment journal "
+                f"entry (id {existing_je.id}); refusing to ship again"
+            )
+
+        # Unify JE description with the fulfillment path's order_number format
+        # (falls back to the numeric id when no SalesOrder row exists).
+        order = self.db.get(SalesOrder, sales_order_id)
+        order_ref = order.order_number if order and order.order_number else sales_order_id
+
         inv_txns = []
         je_lines = []
 
@@ -629,7 +669,7 @@ class TransactionService:
         total_amount = fg_total + pkg_total
         if total_amount > 0:
             je = self._create_journal_entry(
-                description=f"Shipment for SO#{sales_order_id}",
+                description=f"Shipment for SO#{order_ref}",
                 lines=je_lines,
                 source_type="sales_order",
                 source_id=sales_order_id,
@@ -653,17 +693,33 @@ class TransactionService:
         Receive materials from vendor.
 
         Inventory: RECEIPT for each item (positive qty)
-        Accounting: DR Raw Materials (1200), CR Accounts Payable (2000)
+        Accounting: DR inventory account by item_type — packaging (1230),
+            finished goods (1220), default Raw Materials (1200) — CR
+            Accounts Payable (2000)
 
         Returns:
             Tuple of (list of inventory transactions, journal entry)
         """
         inv_txns = []
         total_cost = Decimal("0")
+        cost_by_account: dict[str, Decimal] = {}
 
         for item in items:
             cost = item.quantity * item.unit_cost
             total_cost += cost
+
+            # Same item_type -> account map as cycle_count_adjustment (#880):
+            # a flat DR 1200 sends packaging purchases to Raw Materials while
+            # shipping credits 1230, driving Packaging Inventory negative.
+            product = self.db.get(Product, item.product_id)
+            inv_account = "1200"  # Default: Raw Materials
+            if product and product.item_type == "finished_good":
+                inv_account = "1220"
+            elif product and product.item_type == "packaging":
+                inv_account = "1230"
+            cost_by_account[inv_account] = (
+                cost_by_account.get(inv_account, Decimal("0")) + cost
+            )
 
             inv_txn = self._post_inventory(
                 product_id=item.product_id,
@@ -678,13 +734,16 @@ class TransactionService:
             )
             inv_txns.append(inv_txn)
 
-        # Create journal entry: DR Raw Materials, CR AP
+        # Create journal entry: DR inventory accounts by item_type, CR AP
+        je_lines: List[Tuple[str, Decimal, str]] = [
+            (account, amount, "DR")
+            for account, amount in sorted(cost_by_account.items())
+        ]
+        je_lines.append(("2000", total_cost, "CR"))  # Accounts Payable
+
         je = self._create_journal_entry(
             description=f"PO#{purchase_order_id} receipt",
-            lines=[
-                ("1200", total_cost, "DR"),  # Raw Materials
-                ("2000", total_cost, "CR"),  # Accounts Payable
-            ],
+            lines=je_lines,
             source_type="purchase_order",
             source_id=purchase_order_id,
             user_id=user_id,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -28,11 +28,13 @@ from app.models.sales_order import SalesOrder
 from app.services import inventory_ledger
 
 _JOURNAL_ENTRY_NUMBER_LOCK_NAMESPACE = 74002
+# Distinct namespace so ship-guard locks never collide with entry-number locks.
+_SHIPMENT_GUARD_LOCK_NAMESPACE = 74003
 
 
 class DuplicateShipmentError(Exception):
     """Raised when ship_order is retried for a sales order that already has a
-    non-voided shipment journal entry.
+    non-voided shipment journal entry or shipment inventory transaction.
 
     A retry that skipped the JE but still posted inventory would silently
     double-decrement finished goods, so the guard raises BEFORE any inventory
@@ -596,10 +598,30 @@ class TransactionService:
             Tuple of (list of inventory transactions, journal entry)
 
         Raises:
-            DuplicateShipmentError: If a non-voided shipment journal entry
-                already exists for this sales order (retry would double-relieve
-                FG inventory). Raised BEFORE any inventory transaction posts.
+            DuplicateShipmentError: If a non-voided shipment journal entry OR
+                a non-voided shipment inventory transaction already exists for
+                this sales order (retry would double-relieve FG inventory).
+                Raised BEFORE any inventory transaction posts.
         """
+        # Serialize concurrent ships of the same order (#880 CodeRabbit): the
+        # existing-JE lookup below is a plain SELECT with no uniqueness
+        # constraint on (source_type, source_id), so two concurrent requests
+        # could both pass it and double-post. Transaction-scoped advisory lock
+        # keyed by sales_order_id — same pattern as _next_entry_number, but a
+        # distinct namespace so ship locks never collide with entry-number
+        # locks. Released automatically at commit/rollback.
+        self.db.execute(
+            text(
+                """
+                SELECT pg_advisory_xact_lock(
+                    CAST(:namespace AS integer),
+                    CAST(:key AS integer)
+                )
+                """
+            ),
+            {"namespace": _SHIPMENT_GUARD_LOCK_NAMESPACE, "key": sales_order_id},
+        )
+
         # Idempotency guard (#880): same predicate as _create_shipment_gl_entry
         # in sales_order_fulfillment_service. A skip-and-continue retry would
         # still double-decrement FG, so raise before touching inventory.
@@ -612,6 +634,23 @@ class TransactionService:
             raise DuplicateShipmentError(
                 f"Sales order {sales_order_id} already has a shipment journal "
                 f"entry (id {existing_je.id}); refusing to ship again"
+            )
+
+        # Zero-cost shipments post NO journal entry (total_amount == 0 below),
+        # so the JE guard alone can't see them — a retry would double-relieve
+        # FG. Also refuse when a non-voided shipment inventory transaction
+        # already exists for this order.
+        existing_ship_txn = self.db.query(InventoryTransaction.id).filter(
+            InventoryTransaction.transaction_type == "shipment",
+            InventoryTransaction.reference_type == "sales_order",
+            InventoryTransaction.reference_id == sales_order_id,
+            InventoryTransaction.voided_by.is_(None),
+        ).first()
+        if existing_ship_txn:
+            raise DuplicateShipmentError(
+                f"Sales order {sales_order_id} already has a shipment "
+                f"inventory transaction (id {existing_ship_txn.id}); "
+                f"refusing to ship again"
             )
 
         # Unify JE description with the fulfillment path's order_number format
@@ -704,6 +743,13 @@ class TransactionService:
         total_cost = Decimal("0")
         cost_by_account: dict[str, Decimal] = {}
 
+        # Batch-load products once (CodeRabbit: avoid N+1 db.get per item).
+        product_ids = {item.product_id for item in items}
+        products_by_id: dict[int, Product] = {
+            p.id: p
+            for p in self.db.query(Product).filter(Product.id.in_(product_ids))
+        } if product_ids else {}
+
         for item in items:
             cost = item.quantity * item.unit_cost
             total_cost += cost
@@ -711,7 +757,7 @@ class TransactionService:
             # Same item_type -> account map as cycle_count_adjustment (#880):
             # a flat DR 1200 sends packaging purchases to Raw Materials while
             # shipping credits 1230, driving Packaging Inventory negative.
-            product = self.db.get(Product, item.product_id)
+            product = products_by_id.get(item.product_id)
             inv_account = "1200"  # Default: Raw Materials
             if product and product.item_type == "finished_good":
                 inv_account = "1220"

--- a/backend/tests/endpoints/test_fulfillment_endpoint.py
+++ b/backend/tests/endpoints/test_fulfillment_endpoint.py
@@ -2799,3 +2799,143 @@ class TestAvailableBoxesExtended:
             assert box["dimensions"]["width"] == 6.0
             assert box["dimensions"]["height"] == 4.0
             assert box["volume"] == 192.0
+
+
+# =============================================================================
+# Duplicate-shipment guard (#880 PR-2) — ship retries return 409
+# =============================================================================
+
+@pytest.fixture
+def fake_shipping_service(monkeypatch):
+    """Replace the module-level shipping_service with a stub whose buy_label
+    succeeds, so the request reaches the TransactionService.ship_order guard."""
+    from types import SimpleNamespace
+
+    fake = SimpleNamespace(
+        buy_label=lambda *args, **kwargs: SimpleNamespace(
+            success=True,
+            tracking_number="TRACK-TEST-409",
+            carrier="USPS",
+            label_url="https://example.com/label.pdf",
+            rate=5.00,
+            error=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.admin.fulfillment_shipping.shipping_service",
+        fake,
+    )
+    return fake
+
+
+class TestDuplicateShipmentGuard409:
+    """Retrying a ship after a shipment JE exists must 409, not double-post."""
+
+    @staticmethod
+    def _post_shipment_je(db, so):
+        """Create the non-voided shipment JE the guard looks for."""
+        from datetime import date
+        from app.models.accounting import GLJournalEntry
+
+        je = GLJournalEntry(
+            entry_number=f"JE-TEST-{_uid()}",
+            entry_date=date.today(),
+            description=f"Shipment for SO#{so.order_number}",
+            source_type="sales_order",
+            source_id=so.id,
+            status="posted",
+        )
+        db.add(je)
+        db.flush()
+        return je
+
+    @staticmethod
+    def _shipment_txn_count(db, so_id):
+        from app.models.inventory import InventoryTransaction
+
+        return db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "sales_order",
+            InventoryTransaction.reference_id == so_id,
+        ).count()
+
+    def test_buy_label_duplicate_shipment_409(
+        self, client, db, make_product, make_sales_order, make_quote,
+        fake_shipping_service,
+    ):
+        """buy-label on an order that already has a shipment JE returns 409
+        and posts zero new inventory transactions."""
+        product = make_product(
+            item_type="finished_good",
+            standard_cost=Decimal("5.00"),
+        )
+        quote = make_quote(product_id=product.id)
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("20.00"),
+            status="ready_to_ship",
+            quote_id=quote.id,
+        )
+        self._post_shipment_je(db, so)
+        count_before = self._shipment_txn_count(db, so.id)
+
+        resp = client.post(
+            f"{BASE}/ship/{so.id}/buy-label?rate_id=rate_1&shipment_id=shp_1"
+        )
+
+        assert resp.status_code == 409
+        assert "already" in resp.json()["detail"].lower()
+        assert self._shipment_txn_count(db, so.id) == count_before
+
+    def test_ship_from_stock_duplicate_shipment_409(
+        self, client, db, make_product, make_sales_order, make_quote,
+        fake_shipping_service,
+    ):
+        """ship-from-stock on an order that already has a shipment JE returns
+        409, posts zero inventory transactions, and does not flip status."""
+        from app.models.inventory import Inventory, InventoryLocation
+
+        product = make_product(
+            item_type="finished_good",
+            standard_cost=Decimal("5.00"),
+            selling_price=Decimal("20.00"),
+        )
+        quote = make_quote(product_id=product.id)
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("20.00"),
+            status="confirmed",
+            quote_id=quote.id,
+        )
+
+        location = db.query(InventoryLocation).filter(
+            InventoryLocation.active.is_(True)
+        ).first()
+        inv = Inventory(
+            product_id=product.id,
+            location_id=location.id,
+            on_hand_quantity=Decimal("10"),
+            allocated_quantity=Decimal("0"),
+        )
+        db.add(inv)
+        db.flush()
+
+        self._post_shipment_je(db, so)
+        count_before = self._shipment_txn_count(db, so.id)
+
+        resp = client.post(
+            f"{BASE}/ship-from-stock/{so.id}/ship",
+            json={
+                "rate_id": "rate_test123",
+                "shipment_id": "shp_test123",
+            },
+        )
+
+        assert resp.status_code == 409
+        assert "already" in resp.json()["detail"].lower()
+        assert self._shipment_txn_count(db, so.id) == count_before
+        db.refresh(so)
+        assert so.status == "confirmed"
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("10")

--- a/backend/tests/integration/test_transaction_flows.py
+++ b/backend/tests/integration/test_transaction_flows.py
@@ -40,6 +40,16 @@ from app.services.transaction_service import (
 # FIXTURES
 # =============================================================================
 
+def _unique_so_id() -> int:
+    """Unique fake sales-order id for ship_order calls.
+
+    These tests commit, and the #880 duplicate-shipment guard checks
+    committed shipment JEs by source_id — so reruns against a non-fresh
+    database must not reuse hardcoded ids.
+    """
+    return uuid.uuid4().int % 1_000_000_000 + 1_000_000
+
+
 @pytest.fixture
 def db():
     """Create a database session for testing."""
@@ -411,7 +421,7 @@ class TestShipmentFlow:
         expected_shipping = pkg_qty * pkg_cost  # $2.50
 
         inv_txns, je = txn_service.ship_order(
-            sales_order_id=999,
+            sales_order_id=_unique_so_id(),
             items=[ShipmentItem(
                 product_id=test_finished_good.id,
                 quantity=ship_qty,
@@ -569,7 +579,7 @@ class TestFullMTOFlow:
 
         # Step 4: Ship to customer
         txn_service.ship_order(
-            sales_order_id=300,
+            sales_order_id=_unique_so_id(),
             items=[ShipmentItem(
                 product_id=test_finished_good.id,
                 quantity=fg_qty,

--- a/backend/tests/services/test_purchase_order_service.py
+++ b/backend/tests/services/test_purchase_order_service.py
@@ -2444,16 +2444,17 @@ class TestLandedCostCapitalization:
         # Total should be $60 (base $50 + landed $10)
         assert total_dr == pytest.approx(Decimal("60.00"), rel=1e-4)
 
-        # Confirm accounts: 1200 DR, 2000 CR
+        # Confirm accounts: 1220 DR (purchased finished_good — PO receipt
+        # debits are item_type-aware since #880), 2000 CR
         account_ids_dr = {
             jl.account_id for jl in je_lines if Decimal(str(jl.debit_amount)) > 0
         }
         account_ids_cr = {
             jl.account_id for jl in je_lines if Decimal(str(jl.credit_amount)) > 0
         }
-        inv_acct = db.query(GLAccount).filter(GLAccount.account_code == "1200").first()
+        inv_acct = db.query(GLAccount).filter(GLAccount.account_code == "1220").first()
         ap_acct = db.query(GLAccount).filter(GLAccount.account_code == "2000").first()
-        assert inv_acct.id in account_ids_dr, "1200 (Inventory) must be debited"
+        assert inv_acct.id in account_ids_dr, "1220 (FG Inventory) must be debited"
         assert ap_acct.id in account_ids_cr, "2000 (AP) must be credited"
 
     def test_decimal_precision_no_penny_drift(

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -902,6 +902,64 @@ class TestShipOrder:
         finally:
             db.rollback()
 
+    def test_zero_cost_ship_retry_raises_and_posts_no_inventory(
+        self, db: Session, test_finished_good: Product
+    ):
+        """A zero-cost shipment mints NO journal entry, so the JE-based guard
+        alone can't see it — the shipment inventory-transaction guard must
+        still block a retry from double-relieving FG (#880 CodeRabbit)"""
+        ts = TransactionService(db)
+
+        try:
+            so = self._make_sales_order(db)
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("100"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            items = [ShipmentItem(
+                product_id=test_finished_good.id,
+                quantity=Decimal("5"),
+                unit_cost=Decimal("0.00"),
+            )]
+
+            # First ship posts inventory but NO journal entry (zero cost)
+            inv_txns, je = ts.ship_order(sales_order_id=so.id, items=items)
+            db.flush()
+            assert je is None
+            assert len(inv_txns) == 1
+
+            def txn_count() -> int:
+                return db.query(InventoryTransaction).filter(
+                    InventoryTransaction.reference_type == "sales_order",
+                    InventoryTransaction.reference_id == so.id,
+                ).count()
+
+            count_before = txn_count()
+            on_hand_before = db.query(Inventory).filter(
+                Inventory.product_id == test_finished_good.id
+            ).first().on_hand_quantity
+
+            # Retry raises and posts ZERO new inventory transactions
+            with pytest.raises(
+                DuplicateShipmentError,
+                match="already has a shipment inventory transaction",
+            ):
+                ts.ship_order(sales_order_id=so.id, items=items)
+            db.flush()
+
+            assert txn_count() == count_before
+            on_hand_after = db.query(Inventory).filter(
+                Inventory.product_id == test_finished_good.id
+            ).first().on_hand_quantity
+            assert on_hand_after == on_hand_before
+        finally:
+            db.rollback()
+
 
 # ============================================================================
 # Receive Purchase Order Tests

--- a/backend/tests/services/test_transaction_service.py
+++ b/backend/tests/services/test_transaction_service.py
@@ -16,6 +16,8 @@ Run with:
 Run with coverage:
     pytest tests/services/test_transaction_service.py -v --cov=app/services/transaction_service
 """
+import uuid
+
 import pytest
 from decimal import Decimal
 from datetime import date
@@ -24,6 +26,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import SessionLocal
 from app.services.transaction_service import (
+    DuplicateShipmentError,
     TransactionService,
     MaterialConsumption,
     ShipmentItem,
@@ -34,6 +37,7 @@ from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.inventory import Inventory, InventoryTransaction
 from app.models.production_order import ProductionOrder, ScrapRecord
 from app.models.product import Product
+from app.models.sales_order import SalesOrder
 
 
 # ============================================================================
@@ -203,6 +207,52 @@ class TestTransactionServiceHelpers:
             assert seq2 == seq1 + 1
         finally:
             # Cleanup
+            db.rollback()
+
+
+# ============================================================================
+# Journal Entry Date Tests (#880 PR-2)
+# ============================================================================
+
+class TestJournalEntryDate:
+    """Test the optional entry_date parameter on create_journal_entry"""
+
+    def test_entry_date_defaults_to_today(self, db: Session):
+        """Omitting entry_date should keep the existing today() behavior"""
+        ts = TransactionService(db)
+
+        try:
+            je = ts.create_journal_entry(
+                description="Entry date default test",
+                lines=[
+                    ("1200", Decimal("10.00"), "DR"),
+                    ("2000", Decimal("10.00"), "CR"),
+                ],
+            )
+            db.flush()
+
+            assert je.entry_date == date.today()
+        finally:
+            db.rollback()
+
+    def test_explicit_entry_date_lands_on_journal_entry(self, db: Session):
+        """An explicit (backdated) entry_date should land on the JE"""
+        ts = TransactionService(db)
+        backdated = date(2026, 4, 15)
+
+        try:
+            je = ts.create_journal_entry(
+                description="Backdated entry test",
+                lines=[
+                    ("1200", Decimal("10.00"), "DR"),
+                    ("2000", Decimal("10.00"), "CR"),
+                ],
+                entry_date=backdated,
+            )
+            db.flush()
+
+            assert je.entry_date == backdated
+        finally:
             db.rollback()
 
 
@@ -710,6 +760,148 @@ class TestShipOrder:
         finally:
             db.rollback()
 
+    def _make_sales_order(self, db: Session, status: str = "ready_to_ship") -> SalesOrder:
+        """Create a SalesOrder row (guard + description tests need a real SO)."""
+        uid = uuid.uuid4().hex[:8]
+        so = SalesOrder(
+            order_number=f"SO-TEST-{uid}",
+            user_id=1,
+            product_name=f"Test Product {uid}",
+            quantity=5,
+            material_type="PLA",
+            unit_price=Decimal("20.00"),
+            total_price=Decimal("100.00"),
+            grand_total=Decimal("100.00"),
+            status=status,
+        )
+        db.add(so)
+        db.flush()
+        return so
+
+    def test_je_description_uses_order_number(self, db: Session, test_finished_good: Product):
+        """JE description should use the order_number format shared with the
+        fulfillment path, not the numeric sales order id (#880)"""
+        ts = TransactionService(db)
+
+        try:
+            so = self._make_sales_order(db)
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("100"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            items = [ShipmentItem(
+                product_id=test_finished_good.id,
+                quantity=Decimal("5"),
+                unit_cost=Decimal("20.00"),
+            )]
+
+            inv_txns, je = ts.ship_order(
+                sales_order_id=so.id,
+                items=items,
+            )
+            db.flush()
+
+            assert je.description == f"Shipment for SO#{so.order_number}"
+        finally:
+            db.rollback()
+
+    def test_second_ship_raises_and_posts_no_inventory(self, db: Session, test_finished_good: Product):
+        """Retrying ship_order for an already-shipped SO must raise
+        DuplicateShipmentError BEFORE posting any inventory transaction (#880)"""
+        ts = TransactionService(db)
+
+        try:
+            so = self._make_sales_order(db)
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("100"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            items = [ShipmentItem(
+                product_id=test_finished_good.id,
+                quantity=Decimal("5"),
+                unit_cost=Decimal("20.00"),
+            )]
+
+            # First ship posts inventory + JE
+            inv_txns, je = ts.ship_order(sales_order_id=so.id, items=items)
+            db.flush()
+            assert je is not None
+
+            def txn_count() -> int:
+                return db.query(InventoryTransaction).filter(
+                    InventoryTransaction.reference_type == "sales_order",
+                    InventoryTransaction.reference_id == so.id,
+                ).count()
+
+            count_before = txn_count()
+            on_hand_before = db.query(Inventory).filter(
+                Inventory.product_id == test_finished_good.id
+            ).first().on_hand_quantity
+
+            # Retry raises and posts ZERO new inventory transactions
+            with pytest.raises(DuplicateShipmentError, match="already has a shipment"):
+                ts.ship_order(sales_order_id=so.id, items=items)
+            db.flush()
+
+            assert txn_count() == count_before
+            on_hand_after = db.query(Inventory).filter(
+                Inventory.product_id == test_finished_good.id
+            ).first().on_hand_quantity
+            assert on_hand_after == on_hand_before
+        finally:
+            db.rollback()
+
+    def test_voided_shipment_je_does_not_block_reship(self, db: Session, test_finished_good: Product):
+        """A voided shipment JE is a correction artifact — it must not trip
+        the duplicate-shipment guard (#880)"""
+        ts = TransactionService(db)
+
+        try:
+            so = self._make_sales_order(db)
+            inv = Inventory(
+                product_id=test_finished_good.id,
+                location_id=1,
+                on_hand_quantity=Decimal("100"),
+                allocated_quantity=Decimal("0"),
+            )
+            db.add(inv)
+            db.flush()
+
+            voided_je = GLJournalEntry(
+                entry_number=f"JE-TEST-{uuid.uuid4().hex[:8]}",
+                entry_date=date.today(),
+                description=f"Shipment for SO#{so.order_number}",
+                source_type="sales_order",
+                source_id=so.id,
+                status="voided",
+            )
+            db.add(voided_je)
+            db.flush()
+
+            items = [ShipmentItem(
+                product_id=test_finished_good.id,
+                quantity=Decimal("5"),
+                unit_cost=Decimal("20.00"),
+            )]
+
+            inv_txns, je = ts.ship_order(sales_order_id=so.id, items=items)
+            db.flush()
+
+            assert je is not None
+            assert je.id != voided_je.id
+        finally:
+            db.rollback()
+
 
 # ============================================================================
 # Receive Purchase Order Tests
@@ -795,6 +987,118 @@ class TestReceivePurchaseOrder:
             ).first()
             assert inv is not None
             assert inv.on_hand_quantity == Decimal("1000")
+        finally:
+            db.rollback()
+
+    def test_packaging_receipt_debits_1230(self, db: Session, test_packaging: Product):
+        """Packaging PO receipt should debit Packaging Inventory (1230), not
+        Raw Materials — otherwise 1230 goes negative at ship (#880)"""
+        ts = TransactionService(db)
+
+        try:
+            items = [ReceiptItem(
+                product_id=test_packaging.id,
+                quantity=Decimal("100"),
+                unit_cost=Decimal("2.50"),
+            )]
+
+            inv_txns, je = ts.receive_purchase_order(
+                purchase_order_id=1,
+                items=items,
+            )
+            db.flush()
+
+            assert je.is_balanced
+
+            dr_line = next(line for line in je.lines if line.debit_amount > 0)
+            cr_line = next(line for line in je.lines if line.credit_amount > 0)
+
+            assert dr_line.account.account_code == "1230"  # Packaging Inventory
+            assert dr_line.debit_amount == Decimal("250.00")
+            assert cr_line.account.account_code == "2000"  # AP
+        finally:
+            db.rollback()
+
+    def test_finished_good_receipt_debits_1220(self, db: Session, test_finished_good: Product):
+        """Purchased finished-good receipt should debit FG Inventory (1220)"""
+        ts = TransactionService(db)
+
+        try:
+            items = [ReceiptItem(
+                product_id=test_finished_good.id,
+                quantity=Decimal("10"),
+                unit_cost=Decimal("10.00"),
+            )]
+
+            inv_txns, je = ts.receive_purchase_order(
+                purchase_order_id=1,
+                items=items,
+            )
+            db.flush()
+
+            assert je.is_balanced
+
+            dr_line = next(line for line in je.lines if line.debit_amount > 0)
+            cr_line = next(line for line in je.lines if line.credit_amount > 0)
+
+            assert dr_line.account.account_code == "1220"  # FG Inventory
+            assert cr_line.account.account_code == "2000"  # AP
+        finally:
+            db.rollback()
+
+    def test_mixed_po_receipt_multi_line_je_balances(
+        self,
+        db: Session,
+        test_material: Product,
+        test_packaging: Product,
+        test_finished_good: Product,
+    ):
+        """Mixed PO produces ONE JE with a DR line per inventory account and
+        a single CR 2000 for the total"""
+        ts = TransactionService(db)
+
+        try:
+            items = [
+                ReceiptItem(
+                    product_id=test_material.id,
+                    quantity=Decimal("1000"),
+                    unit_cost=Decimal("0.02"),
+                    unit="G",
+                ),
+                ReceiptItem(
+                    product_id=test_packaging.id,
+                    quantity=Decimal("10"),
+                    unit_cost=Decimal("2.50"),
+                ),
+                ReceiptItem(
+                    product_id=test_finished_good.id,
+                    quantity=Decimal("5"),
+                    unit_cost=Decimal("10.00"),
+                ),
+            ]
+
+            inv_txns, je = ts.receive_purchase_order(
+                purchase_order_id=1,
+                items=items,
+            )
+            db.flush()
+
+            assert je.is_balanced
+
+            dr_by_account = {
+                line.account.account_code: line.debit_amount
+                for line in je.lines if line.debit_amount > 0
+            }
+            cr_lines = [line for line in je.lines if line.credit_amount > 0]
+
+            assert dr_by_account == {
+                "1200": Decimal("20.00"),   # 1000g @ 0.02
+                "1230": Decimal("25.00"),   # 10 @ 2.50
+                "1220": Decimal("50.00"),   # 5 @ 10.00
+            }
+            assert len(cr_lines) == 1
+            assert cr_lines[0].account.account_code == "2000"
+            assert cr_lines[0].credit_amount == Decimal("95.00")
         finally:
             db.rollback()
 


### PR DESCRIPTION
## What

PR-2 of the #880 fin-integrity sweep (design: https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351, scope approval: https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880356641). Three service-layer changes in `TransactionService` plus the two endpoint callers:

1. **Optional `entry_date` on `create_journal_entry` / `_create_journal_entry`** — used as `entry_date or date.today()`. Additive; every existing caller unchanged. This is the hook the PR-3 completion-GL backfill uses to backdate correction entries to each PO's `completed_at`.
2. **`ship_order` pre-flight idempotency guard** — queries non-voided `GLJournalEntry` with `source_type='sales_order' AND source_id=<order>` (the exact predicate `_create_shipment_gl_entry` already uses) and raises a new `DuplicateShipmentError` **before any inventory transaction posts**. Raising, not skipping: a skip-and-link retry would still double-decrement FG. `buy-label` and `ship-from-stock` endpoints convert it to **HTTP 409**. The ship JE description is unified to the `order_number` format used by the fulfillment path (`Shipment for SO#<order_number>`), so all ship JEs read uniformly.
3. **Item_type-aware PO receipts** — `receive_purchase_order` debits now use the exact account map proven in `cycle_count_adjustment`: packaging→**1230**, purchased finished_good→**1220**, default **1200**; lines grouped by resolved account into ONE journal entry with multiple DR lines and a single CR 2000 for the total.

## Why

From the #880 findings: `ship_order` had no idempotency guard (double-ship = double COGS + double FG decrement — the dual-GL collision with `_create_shipment_gl_entry`), and PO receipts posted flat DR 1200, so packaging bought into Raw Materials while shipping credits 1230 — driving Packaging Inventory negative the moment a box ships. `entry_date` is required plumbing for the live-129 books correction (backfill posts at `completed_at`).

## ⚠️ Behavior change (BREAKING-ish)

**Ship retries now return HTTP 409 instead of silently double-posting.** External scripts/integrations calling `POST .../ship/{id}/buy-label` or `POST .../ship-from-stock/{id}/ship` must treat 409 as "already shipped", not as a retryable error.

Also: purchased finished goods now debit 1220 (not 1200) at PO receipt; packaging debits 1230.

## How tested

`DB_PASSWORD=Admin py -m pytest` against `filaops_test`:

- `tests/services/test_transaction_service.py` — **40 passed** (8 new: entry_date default pinned + explicit entry_date; second `ship_order` raises with ZERO new inventory txns and unchanged on_hand; voided JE does not block re-ship; JE description = order_number format; packaging receipt debits 1230; FG receipt debits 1220; mixed PO → multi-DR-line JE that balances with single CR 2000)
- `tests/endpoints/test_fulfillment_endpoint.py` — **156 passed** (2 new: buy-label and ship-from-stock return 409 with zero new inventory txns, status not flipped)
- Full relevant set (`test_fulfillment.py`, `test_sales_accounting_posting.py`, `test_sales_order_service.py`, `test_transaction_flows.py`, `test_quote_to_cash.py`, `test_full_business_cycle.py`, `test_accounting.py`) — **481 passed, 3 skipped** (skips pre-existing conditional skips in `test_accounting.py`)
- PO-receipt callers (`test_purchase_order_service.py`, `test_purchase_orders*` endpoint/api, `test_procure_to_pay.py`, `test_traceability.py`, `test_supply_netting.py`) — **423 passed**
- `ruff check` clean on both changed app files (CI gate `ruff check app/` unaffected)

Test-only adjustments: integration ship tests commit fake hardcoded sales-order ids (999/300) — reruns against a non-fresh DB would trip the new guard on committed leftovers, so they now use unique per-run ids; the landed-cost GL test's product is a purchased finished_good and now correctly asserts a 1220 debit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shipping actions (`buy-label` and `ship-from-stock`) now block duplicate retries and return HTTP 409 with an “already shipped / avoid double-posting” message.
  * Retrying an already-shipped order no longer creates extra inventory transactions or accounting entries.
  * Shipment journal entry descriptions now reference the sales order number for clearer tracking.
  * Purchase receiving now posts inventory costs to the correct GL account by item type (finished goods vs packaging vs raw materials), with journal entry dates preserved when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->