### PR TITLE
feat(accounting): production completion posts to GL + backfill script + GL-health counter (880 PR-3)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -725,6 +725,24 @@ async def get_accounting_dashboard(
     mtd_gross_profit = Decimal(str(mtd_revenue)) - mtd_cogs
     mtd_margin = float(mtd_gross_profit / Decimal(str(mtd_revenue)) * 100) if mtd_revenue > 0 else 0
 
+    # GL-health counter (#880): production consumption/receipt rows the
+    # completion poster has not journaled yet. Non-zero means the GL has
+    # drifted from the inventory ledger (e.g. a swallowed posting failure
+    # on the per-operation auto-complete path, or an in-flight order with
+    # per-op consumption awaiting completion). The completion-GL backfill
+    # script's dry-run doubles as the detailed audit list.
+    unjournaled_txn_count = db.query(func.count(InventoryTransaction.id)).filter(
+        InventoryTransaction.reference_type == 'production_order',
+        InventoryTransaction.transaction_type.in_(['consumption', 'receipt']),
+        InventoryTransaction.journal_entry_id.is_(None),
+        # Held and voided rows never affected on_hand — not GL drift.
+        InventoryTransaction.voided_by.is_(None),
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
+    ).scalar() or 0
+
     return {
         "as_of": now.isoformat(),
         "fiscal_year_start": fiscal_year_start.isoformat(),
@@ -751,6 +769,7 @@ async def get_accounting_dashboard(
             "mtd_gross": float(mtd_gross_profit),
             "mtd_margin_pct": mtd_margin,
         },
+        "unjournaled_txn_count": int(unjournaled_txn_count),
     }
 
 

--- a/backend/app/api/v1/endpoints/production_orders.py
+++ b/backend/app/api/v1/endpoints/production_orders.py
@@ -784,6 +784,7 @@ async def complete_production_order(
         quantity_scrapped=int(request.quantity_scrapped or 0),
         force_close_short=request.force_close_short,
         notes=request.notes,
+        user_id=current_user.id,
     )
 
     db.commit()

--- a/backend/app/schemas/accounting.py
+++ b/backend/app/schemas/accounting.py
@@ -485,6 +485,10 @@ class DashboardResponse(BaseModel):
     tax: DashboardTax
     cogs: DashboardCOGS
     profit: DashboardProfit
+    # GL-health counter (#880): production consumption/receipt inventory
+    # transactions not yet linked to a journal entry (non-held, non-voided).
+    # Zero when the GL mirrors the inventory ledger.
+    unjournaled_txn_count: int = 0
 
 
 # --- Sales Journal ---

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -2057,6 +2057,17 @@ def process_production_completion(
         created_by=created_by,
     )
 
+    # Post the completion journal entry (#880): sweep this order's
+    # unjournaled consumption/receipt transactions (including any posted
+    # earlier by the per-operation path) into ONE GL entry. Runs in the
+    # SAME session/transaction as the consumption + receipts above, so a
+    # poster failure rolls back together with them — no half-posted state.
+    # Lazy import per the service-layer pattern (keeps import graph acyclic).
+    from app.services.production_gl_service import (
+        create_production_completion_gl_entry,
+    )
+    create_production_completion_gl_entry(db, production_order)
+
     return consumption_txns, ordered_txn, overrun_txn
 
 

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -2024,6 +2024,7 @@ def process_production_completion(
     production_order: ProductionOrder,
     quantity_completed: Decimal,
     created_by: Optional[str] = None,
+    user_id: Optional[int] = None,
 ) -> Tuple[List[InventoryTransaction], Optional[InventoryTransaction], Optional[InventoryTransaction]]:
     """
     Process all inventory transactions for production order completion.
@@ -2036,7 +2037,10 @@ def process_production_completion(
         db: Database session
         production_order: The completed production order
         quantity_completed: Number of units completed (may exceed ordered)
-        created_by: User completing the order
+        created_by: User completing the order (email, for inventory txns)
+        user_id: Completing user's id, for journal-entry attribution
+            (GLJournalEntry.created_by/posted_by); None when the caller
+            has no user context
 
     Returns:
         Tuple of (material_consumption_txns, ordered_receipt_txn, overrun_receipt_txn)
@@ -2066,7 +2070,7 @@ def process_production_completion(
     from app.services.production_gl_service import (
         create_production_completion_gl_entry,
     )
-    create_production_completion_gl_entry(db, production_order)
+    create_production_completion_gl_entry(db, production_order, user_id=user_id)
 
     return consumption_txns, ordered_txn, overrun_txn
 

--- a/backend/app/services/operation_status.py
+++ b/backend/app/services/operation_status.py
@@ -165,13 +165,22 @@ def derive_po_status(po: ProductionOrder) -> str:
         return 'in_progress'
 
 
-def update_po_status(db: Session, po: ProductionOrder, created_by: Optional[str] = None) -> None:
+def update_po_status(
+    db: Session,
+    po: ProductionOrder,
+    created_by: Optional[str] = None,
+    user_id: Optional[int] = None,
+) -> None:
     """
     Update PO status based on operations.
 
     When PO transitions to 'complete':
     - Adds finished goods to inventory via process_production_completion
     - Syncs parent sales order status via sync_on_production_complete
+
+    user_id attributes the completion journal entry (#892): the
+    complete-operation path passes the acting user's id; callers without
+    user context (start/skip) leave it None.
     """
     new_status = derive_po_status(po)
     old_status = po.status
@@ -200,6 +209,7 @@ def update_po_status(db: Session, po: ProductionOrder, created_by: Optional[str]
                     production_order=po,
                     quantity_completed=qty_completed,
                     created_by=created_by,
+                    user_id=user_id,
                 )
                 logger.info(
                     f"Auto-completed inventory receipt for {po.code}: "
@@ -505,8 +515,13 @@ def complete_operation(
         po.quantity_scrapped = (po.quantity_scrapped or Decimal("0")) + quantity_scrapped
 
     # Update PO status (uses quantity_completed to determine complete vs short)
-    # Pass operator_name for inventory transaction attribution
-    update_po_status(db, po, created_by=op.operator_name or f"user:{user_id}" if user_id else None)
+    # Pass operator_name for inventory transaction attribution and user_id
+    # for journal-entry attribution (#892) if this completes the PO.
+    update_po_status(
+        db, po,
+        created_by=op.operator_name or f"user:{user_id}" if user_id else None,
+        user_id=user_id,
+    )
 
     db.flush()
     return op, scrap_result

--- a/backend/app/services/production_gl_service.py
+++ b/backend/app/services/production_gl_service.py
@@ -47,7 +47,7 @@ from datetime import date
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session, joinedload
 
 from app.logging_config import get_logger
@@ -56,6 +56,11 @@ from app.models.inventory import InventoryTransaction
 from app.models.production_order import ProductionOrder, ScrapRecord
 
 logger = get_logger(__name__)
+
+# Advisory-lock namespace for the completion poster. Distinct from the
+# entry-number lock (74002) and the ship guard (74003) in
+# transaction_service so completion locks never collide with either.
+_COMPLETION_GUARD_LOCK_NAMESPACE = 74004
 
 RAW_MATERIALS_ACCOUNT = "1200"
 WIP_ACCOUNT = "1210"
@@ -337,6 +342,33 @@ def create_production_completion_gl_entry(
         entry_date: Entry date; defaults to today. The live-books backfill
             passes the PO's completed_at date to backdate corrections.
     """
+    # Serialize concurrent completions of the same production order (#892
+    # CodeRabbit): the sweep predicate (journal_entry_id IS NULL) is a plain
+    # SELECT with no uniqueness constraint on GLJournalEntry
+    # (source_type, source_id), and the per-op auto-complete path
+    # (operation_status -> process_production_completion) reaches here
+    # without a ProductionOrder row lock — so two concurrent completions
+    # could both sweep the same rows and double-post. Transaction-scoped
+    # advisory lock keyed by production_order.id, same pattern as
+    # transaction_service.ship_order (74003) and _next_entry_number (74002).
+    # Living INSIDE the poster covers every caller (bulk complete, per-op
+    # auto-complete, accept-short, backfill script) regardless of its own
+    # locking. Released automatically at commit/rollback.
+    db.execute(
+        text(
+            """
+            SELECT pg_advisory_xact_lock(
+                CAST(:namespace AS integer),
+                CAST(:key AS integer)
+            )
+            """
+        ),
+        {
+            "namespace": _COMPLETION_GUARD_LOCK_NAMESPACE,
+            "key": production_order.id,
+        },
+    )
+
     txns = _sweep_unjournaled_transactions(db, production_order.id)
     if not txns:
         return None

--- a/backend/app/services/production_gl_service.py
+++ b/backend/app/services/production_gl_service.py
@@ -325,10 +325,36 @@ def create_production_completion_gl_entry(
 ) -> Optional[GLJournalEntry]:
     """Post the completion journal entry for one production order.
 
+    Thin wrapper over create_production_completion_gl_entry_with_preview
+    for callers that only need the entry (the app completion paths).
+    Returns the created entry, or None when there is nothing to post.
+    """
+    journal_entry, _ = create_production_completion_gl_entry_with_preview(
+        db, production_order, user_id=user_id, entry_date=entry_date
+    )
+    return journal_entry
+
+
+def create_production_completion_gl_entry_with_preview(
+    db: Session,
+    production_order: ProductionOrder,
+    user_id: Optional[int] = None,
+    entry_date: Optional[date] = None,
+) -> Tuple[Optional[GLJournalEntry], Optional[CompletionGLPreview]]:
+    """Post the completion journal entry for one production order.
+
     Sweeps the order's unjournaled consumption/receipt transactions,
     posts a single balanced entry (see module docstring for the shape),
-    and links every swept transaction to it. Returns the created entry,
-    or None when there is nothing to post.
+    and links every swept transaction to it.
+
+    Returns (journal_entry, preview). The preview is built from the SAME
+    sweep the entry posted — computed after the advisory lock below — so
+    a caller recording what was posted (the backfill manifest) uses this
+    instead of calling compute_completion_gl_preview first, which would
+    both duplicate the sweep and race the lock (#892 round 2).
+    journal_entry is None when nothing posted; preview is None when no
+    rows were sweepable at all (and carries empty lines when the swept
+    rows were all zero-cost).
 
     Runs in the caller's session/transaction — no commit here. The call
     sites run this strictly AFTER consumption + receipts succeed in the
@@ -371,7 +397,7 @@ def create_production_completion_gl_entry(
 
     txns = _sweep_unjournaled_transactions(db, production_order.id)
     if not txns:
-        return None
+        return None, None
 
     preview = _build_preview(db, production_order, txns)
     if not preview.lines:
@@ -384,7 +410,7 @@ def create_production_completion_gl_entry(
             production_order.code,
             len(txns),
         )
-        return None
+        return None, preview
 
     # Lazy import to keep service-layer import graphs acyclic (pattern from
     # sales_order_fulfillment_service).
@@ -419,4 +445,4 @@ def create_production_completion_gl_entry(
         preview.variance,
         len(txns),
     )
-    return journal_entry
+    return journal_entry, preview

--- a/backend/app/services/production_gl_service.py
+++ b/backend/app/services/production_gl_service.py
@@ -1,0 +1,390 @@
+"""
+Production completion GL poster (#880).
+
+When a production order completes, the inventory ledger records material
+consumption and finished-goods receipts — but historically nothing posted
+those movements to the general ledger, so Raw Materials (1200) was never
+relieved and Finished Goods (1220) went negative the moment shipping
+credited it.
+
+This service sweeps a production order's UNJOURNALED consumption/receipt
+inventory transactions and posts ONE journal entry that moves actual
+material cost through WIP (1210) into Finished Goods (1220) at the
+receipt values, routing the difference to 5200 "COGS - Other" as a
+production variance:
+
+    DR 1210  total consumption (materials + packaging + labor)
+    CR 1200  non-packaging material consumption
+    CR 1230  packaging-component consumption
+    CR 5100  SVC- labor consumption
+    DR 1220  finished-goods receipts / CR 1210 same
+    V = FG + S - M   (S = this PO's already-posted scrap-JE 1210 credits)
+      V > 0:  DR 1210 V / CR 5200 V
+      V < 0:  DR 5200 |V| / CR 1210 |V|
+
+The S term guarantees 1210 nets to exactly zero for every completed
+production order even when operation scrap posted DR 5020 / CR 1210
+mid-order.
+
+Why 5200 and not 5030: 5030 "Inventory Adjustment" is seeded at
+Schedule C line '27a' — a persistent credit there surfaces as a negative
+other-expense on the tax export. 5200 "COGS - Other" sits at Schedule C
+line '38', so the variance credit nets INSIDE the Schedule C COGS
+section where it belongs, and 5030 keeps a clean shrinkage-only meaning.
+
+IDEMPOTENCY IS THE SWEEP ITSELF: only transactions with
+journal_entry_id IS NULL are picked up, and every swept transaction is
+linked to the created entry. Re-running is a no-op; per-op consumption
+followed by bulk completion posts each transaction exactly once.
+
+Deliberately NOT a source_type/source_id existence check: scrap journal
+entries share source_type='production_order' AND the same source_id, so
+an existence check would wrongly skip the completion entry for any
+order that scrapped mid-run (pinned by test).
+"""
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.logging_config import get_logger
+from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+from app.models.inventory import InventoryTransaction
+from app.models.production_order import ProductionOrder, ScrapRecord
+
+logger = get_logger(__name__)
+
+RAW_MATERIALS_ACCOUNT = "1200"
+WIP_ACCOUNT = "1210"
+FINISHED_GOODS_ACCOUNT = "1220"
+PACKAGING_ACCOUNT = "1230"
+DIRECT_LABOR_ACCOUNT = "5100"
+COGS_OTHER_ACCOUNT = "5200"
+
+# Convention shared with the COGS summary (admin/accounting.py): consumption
+# rows whose product SKU starts with SVC- are built-in labor, not materials.
+LABOR_SKU_PREFIX = "SVC-"
+
+_MONEY = Decimal("0.01")
+
+# Account attributes mirror migrations 045/052 so older local databases that
+# predate those migrations can still post (same pattern as
+# payment_service._ensure_core_sales_accounts).
+_COMPLETION_GL_ACCOUNTS = {
+    "1200": ("Inventory", "asset", None, True, "Raw materials and finished goods"),
+    "1210": ("WIP Inventory", "asset", None, True, "Work-in-progress: Parts currently in production"),
+    "1220": ("Finished Goods Inventory", "asset", None, True, "Completed parts on shelf, ready to ship"),
+    "1230": ("Packaging Inventory", "asset", None, True, "Boxes, labels, tape for shipping"),
+    "5100": ("COGS - Direct Labor", "expense", "37", False, "Direct labor costs for production"),
+    "5200": ("COGS - Other", "expense", "38", False, "Other production costs"),
+}
+
+
+@dataclass
+class CompletionGLPreview:
+    """What create_production_completion_gl_entry would post for one PO.
+
+    Built by the same code the poster runs, so the backfill script's
+    dry-run output can never drift from the real posting.
+    """
+    production_order_id: int
+    production_order_code: str
+    transaction_ids: List[int]
+    material_cost: Decimal        # consumption, non-packaging, non-SVC → CR 1200
+    packaging_cost: Decimal       # consumption, packaging item_type → CR 1230
+    labor_cost: Decimal           # consumption, SVC- prefix → CR 5100
+    finished_goods_value: Decimal  # receipts → DR 1220 / CR 1210
+    scrap_wip_credits: Decimal    # S: prior scrap-JE 1210 credits
+    variance: Decimal             # V = FG + S − (mat + pkg + labor)
+    lines: List[Tuple[str, Decimal, str]]
+
+    @property
+    def total_consumption(self) -> Decimal:
+        return self.material_cost + self.packaging_cost + self.labor_cost
+
+
+def _ensure_completion_gl_accounts(db: Session) -> None:
+    """Create any missing accounts the completion entry posts to."""
+    existing = {
+        row[0]
+        for row in db.query(GLAccount.account_code).filter(
+            GLAccount.account_code.in_(_COMPLETION_GL_ACCOUNTS.keys())
+        )
+    }
+    for code, (name, account_type, schedule_c_line, is_system, description) in (
+        _COMPLETION_GL_ACCOUNTS.items()
+    ):
+        if code in existing:
+            continue
+        db.add(GLAccount(
+            account_code=code,
+            name=name,
+            account_type=account_type,
+            schedule_c_line=schedule_c_line,
+            is_system=is_system,
+            active=True,
+            description=description,
+        ))
+    db.flush()
+
+
+def _sweep_unjournaled_transactions(
+    db: Session, production_order_id: int
+) -> List[InventoryTransaction]:
+    """This production order's GL-eligible, not-yet-journaled ledger rows.
+
+    Held (requires_approval without approved_by) and voided rows never
+    affected on_hand and are excluded, mirroring the COGS summary and
+    shipment-GL filters. Scrap rows are excluded by type — the scrap
+    poster creates and links its own journal entry.
+    """
+    return (
+        db.query(InventoryTransaction)
+        .options(joinedload(InventoryTransaction.product))
+        .filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == production_order_id,
+            InventoryTransaction.transaction_type.in_(["consumption", "receipt"]),
+            InventoryTransaction.journal_entry_id.is_(None),
+            InventoryTransaction.voided_by.is_(None),
+            ~(
+                InventoryTransaction.requires_approval.is_(True)
+                & InventoryTransaction.approved_by.is_(None)
+            ),
+        )
+        .order_by(InventoryTransaction.id)
+        .all()
+    )
+
+
+def _txn_cost(txn: InventoryTransaction) -> Decimal:
+    """Value one ledger row at its frozen cost.
+
+    total_cost when set, else abs(quantity) × cost_per_unit — the abs()
+    neutralizes legacy positive-sign consumption rows (pre-HARD-4a rows
+    stored magnitudes, modern rows store signed deltas).
+    """
+    if txn.total_cost is not None:
+        return Decimal(str(txn.total_cost or 0)).quantize(_MONEY)
+    quantity = abs(Decimal(str(txn.quantity or 0)))
+    unit_cost = Decimal(str(txn.cost_per_unit or 0))
+    return (quantity * unit_cost).quantize(_MONEY)
+
+
+def _scrap_wip_credits(db: Session, production_order_id: int) -> Decimal:
+    """S term: 1210 credits already posted by this PO's scrap journal entries.
+
+    Scoped to journal entries referenced by ScrapRecord rows (not by
+    source_type/source_id alone) so a prior completion entry's own 1210
+    credits can never leak into S on any re-entry path.
+    """
+    scrap_je_ids = [
+        row[0]
+        for row in db.query(ScrapRecord.journal_entry_id).filter(
+            ScrapRecord.production_order_id == production_order_id,
+            ScrapRecord.journal_entry_id.isnot(None),
+        )
+    ]
+    if not scrap_je_ids:
+        return Decimal("0.00")
+
+    total = (
+        db.query(func.coalesce(func.sum(GLJournalEntryLine.credit_amount), 0))
+        .join(GLJournalEntry, GLJournalEntryLine.journal_entry_id == GLJournalEntry.id)
+        .join(GLAccount, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(
+            GLJournalEntryLine.journal_entry_id.in_(scrap_je_ids),
+            GLJournalEntry.source_type == "production_order",
+            GLJournalEntry.source_id == production_order_id,
+            GLJournalEntry.status != "voided",
+            GLAccount.account_code == WIP_ACCOUNT,
+            GLJournalEntryLine.credit_amount > 0,
+        )
+        .scalar()
+    )
+    return Decimal(str(total or 0)).quantize(_MONEY)
+
+
+def _build_preview(
+    db: Session,
+    production_order: ProductionOrder,
+    txns: List[InventoryTransaction],
+) -> CompletionGLPreview:
+    material = Decimal("0.00")
+    packaging = Decimal("0.00")
+    labor = Decimal("0.00")
+    finished_goods = Decimal("0.00")
+
+    for txn in txns:
+        cost = _txn_cost(txn)
+        if txn.transaction_type == "receipt":
+            # Includes overrun receipts — both rows receive FG at the
+            # product's effective cost frozen on the transaction.
+            finished_goods += cost
+            continue
+        product = txn.product
+        sku = (product.sku if product else "") or ""
+        item_type = (product.item_type if product else "") or ""
+        if sku.startswith(LABOR_SKU_PREFIX):
+            labor += cost
+        elif item_type == "packaging":
+            packaging += cost
+        else:
+            material += cost
+
+    scrap_credits = _scrap_wip_credits(db, production_order.id)
+    total_consumption = material + packaging + labor
+    variance = finished_goods + scrap_credits - total_consumption
+
+    lines: List[Tuple[str, Decimal, str]] = []
+    if total_consumption > 0:
+        lines.append((WIP_ACCOUNT, total_consumption, "DR"))
+    if material > 0:
+        lines.append((RAW_MATERIALS_ACCOUNT, material, "CR"))
+    if packaging > 0:
+        lines.append((PACKAGING_ACCOUNT, packaging, "CR"))
+    if labor > 0:
+        lines.append((DIRECT_LABOR_ACCOUNT, labor, "CR"))
+    if finished_goods > 0:
+        lines.append((FINISHED_GOODS_ACCOUNT, finished_goods, "DR"))
+        lines.append((WIP_ACCOUNT, finished_goods, "CR"))
+    # Variance so WIP nets to exactly zero per completed order — the S term
+    # offsets scrap entries that already credited 1210 mid-order.
+    if variance > 0:
+        lines.append((WIP_ACCOUNT, variance, "DR"))
+        lines.append((COGS_OTHER_ACCOUNT, variance, "CR"))
+    elif variance < 0:
+        lines.append((COGS_OTHER_ACCOUNT, -variance, "DR"))
+        lines.append((WIP_ACCOUNT, -variance, "CR"))
+
+    return CompletionGLPreview(
+        production_order_id=production_order.id,
+        production_order_code=production_order.code,
+        transaction_ids=[txn.id for txn in txns],
+        material_cost=material,
+        packaging_cost=packaging,
+        labor_cost=labor,
+        finished_goods_value=finished_goods,
+        scrap_wip_credits=scrap_credits,
+        variance=variance,
+        lines=lines,
+    )
+
+
+def compute_completion_gl_preview(
+    db: Session, production_order: ProductionOrder
+) -> Optional[CompletionGLPreview]:
+    """Preview the completion entry without posting (backfill dry-run).
+
+    Returns None when the order has no sweepable transactions.
+    """
+    txns = _sweep_unjournaled_transactions(db, production_order.id)
+    if not txns:
+        return None
+    return _build_preview(db, production_order, txns)
+
+
+def find_unjournaled_production_order_ids(
+    db: Session, production_order_ids: Optional[List[int]] = None
+) -> List[int]:
+    """Production orders that have at least one sweepable ledger row.
+
+    Used by the backfill script (candidate discovery) and mirrors the
+    GL-health counter's predicate on the accounting dashboard.
+    """
+    query = db.query(InventoryTransaction.reference_id).filter(
+        InventoryTransaction.reference_type == "production_order",
+        InventoryTransaction.transaction_type.in_(["consumption", "receipt"]),
+        InventoryTransaction.journal_entry_id.is_(None),
+        InventoryTransaction.voided_by.is_(None),
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
+    )
+    if production_order_ids:
+        query = query.filter(
+            InventoryTransaction.reference_id.in_(production_order_ids)
+        )
+    return sorted({row[0] for row in query.distinct() if row[0] is not None})
+
+
+def create_production_completion_gl_entry(
+    db: Session,
+    production_order: ProductionOrder,
+    user_id: Optional[int] = None,
+    entry_date: Optional[date] = None,
+) -> Optional[GLJournalEntry]:
+    """Post the completion journal entry for one production order.
+
+    Sweeps the order's unjournaled consumption/receipt transactions,
+    posts a single balanced entry (see module docstring for the shape),
+    and links every swept transaction to it. Returns the created entry,
+    or None when there is nothing to post.
+
+    Runs in the caller's session/transaction — no commit here. The call
+    sites run this strictly AFTER consumption + receipts succeed in the
+    SAME transaction, so a poster failure rolls everything back together
+    (no half-posted state).
+
+    Args:
+        db: Database session (caller owns the commit boundary)
+        production_order: The production order to journal
+        user_id: Creating user id, if known
+        entry_date: Entry date; defaults to today. The live-books backfill
+            passes the PO's completed_at date to backdate corrections.
+    """
+    txns = _sweep_unjournaled_transactions(db, production_order.id)
+    if not txns:
+        return None
+
+    preview = _build_preview(db, production_order, txns)
+    if not preview.lines:
+        # Every swept row carries zero cost — nothing to post. Leaving the
+        # rows unjournaled is deliberate: they surface in the GL-health
+        # counter instead of being silently linked to nothing.
+        logger.info(
+            "Production completion GL skipped for PO %s: %d transaction(s) "
+            "swept but all zero-cost",
+            production_order.code,
+            len(txns),
+        )
+        return None
+
+    # Lazy import to keep service-layer import graphs acyclic (pattern from
+    # sales_order_fulfillment_service).
+    from app.services.transaction_service import TransactionService
+
+    _ensure_completion_gl_accounts(db)
+    ts = TransactionService(db)
+    journal_entry = ts.create_journal_entry(
+        description=f"Production completion for PO#{production_order.code}",
+        lines=preview.lines,
+        source_type="production_order",
+        source_id=production_order.id,
+        user_id=user_id,
+        entry_date=entry_date,
+    )
+
+    for txn in txns:
+        txn.journal_entry_id = journal_entry.id
+    db.flush()
+
+    logger.info(
+        "Posted production completion GL entry %s for PO %s: "
+        "materials=%s packaging=%s labor=%s fg=%s scrap_credits=%s variance=%s "
+        "(%d transactions linked)",
+        journal_entry.entry_number,
+        production_order.code,
+        preview.material_cost,
+        preview.packaging_cost,
+        preview.labor_cost,
+        preview.finished_goods_value,
+        preview.scrap_wip_credits,
+        preview.variance,
+        len(txns),
+    )
+    return journal_entry

--- a/backend/app/services/production_order_execution_service.py
+++ b/backend/app/services/production_order_execution_service.py
@@ -301,6 +301,16 @@ def accept_short_production_order(
         created_by=user_email,
     )
 
+    # Post the completion journal entry (#880) over the consumption +
+    # receipt transactions just written. This path hand-rolls its FG
+    # receipt (instead of receive_finished_goods), so it must call the
+    # poster itself; the sweep's journal_entry_id-IS-NULL predicate makes
+    # this idempotent with any per-operation consumption already posted.
+    from app.services.production_gl_service import (
+        create_production_completion_gl_entry,
+    )
+    create_production_completion_gl_entry(db, order, user_id=user_id)
+
     # 3. Transition to complete
     order.status = "complete"
     order.completed_at = datetime.now(timezone.utc)

--- a/backend/app/services/production_order_execution_service.py
+++ b/backend/app/services/production_order_execution_service.py
@@ -60,6 +60,7 @@ def complete_production_order(
     quantity_scrapped: int = 0,
     force_close_short: bool = False,
     notes: Optional[str] = None,
+    user_id: Optional[int] = None,
 ) -> ProductionOrder:
     """
     Complete a production order and record finished goods to inventory.
@@ -71,6 +72,9 @@ def complete_production_order(
         quantity_scrapped: Scrapped quantity
         force_close_short: Allow closing order with less than ordered quantity
         notes: Completion notes
+        user_id: Completing user's id for journal-entry attribution (the
+            completion GL entry's created_by/posted_by); optional for
+            backward compatibility
 
     Returns:
         Updated ProductionOrder
@@ -117,6 +121,7 @@ def complete_production_order(
             production_order=order,
             quantity_completed=Decimal(str(quantity_good)),
             created_by=user_email,
+            user_id=user_id,
         )
     except Exception as e:
         logger.error(f"Failed to process production completion: {e}")

--- a/backend/scripts/backfill_production_completion_gl.py
+++ b/backend/scripts/backfill_production_completion_gl.py
@@ -1,0 +1,334 @@
+"""
+Backfill production-completion GL entries (#880).
+
+Historical production completions posted inventory transactions but no
+journal entries, so Raw Materials (1200) was never relieved and Finished
+Goods (1220) carries a credit balance. This script posts the missing
+completion entries using the SAME production code the app now runs at
+completion time (app.services.production_gl_service), backdated to each
+production order's completed_at date.
+
+Usage:
+    # Dry run (DEFAULT — prints per-PO journal-entry previews, writes nothing)
+    python scripts/backfill_production_completion_gl.py
+
+    # Apply for real. REFUSES to run unless --backup-marker points to a
+    # file touched within the last 24 hours (the ops runbook creates the
+    # marker right after pg_dump). Writes a JSON manifest of created
+    # journal entries for scripted rollback.
+    python scripts/backfill_production_completion_gl.py --apply \
+        --backup-marker /root/backups/pg_dump.marker \
+        --manifest backfill_manifest.json
+
+    # Roll back a previous apply: voids every journal entry in the
+    # manifest and unlinks its inventory transactions so a later apply
+    # can re-post them.
+    python scripts/backfill_production_completion_gl.py --rollback backfill_manifest.json
+
+    # Optionally restrict to specific production orders
+    python scripts/backfill_production_completion_gl.py --po-id 3 --po-id 5
+
+Idempotency: posting sweeps only inventory transactions with
+journal_entry_id IS NULL, so re-running --apply after a successful run
+posts nothing.
+"""
+import argparse
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+# Allow running as `python scripts/backfill_production_completion_gl.py`
+# from the backend directory (or anywhere else).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.models.accounting import GLJournalEntry  # noqa: E402
+from app.models.inventory import InventoryTransaction  # noqa: E402
+from app.models.production_order import ProductionOrder  # noqa: E402
+from app.services.production_gl_service import (  # noqa: E402
+    compute_completion_gl_preview,
+    create_production_completion_gl_entry,
+    find_unjournaled_production_order_ids,
+)
+
+BACKUP_MARKER_MAX_AGE_HOURS = 24
+
+
+class BackupMarkerError(RuntimeError):
+    """--apply was requested without a fresh backup marker."""
+
+
+def _load_candidate_orders(
+    db: Session, po_ids: Optional[List[int]] = None
+) -> List[ProductionOrder]:
+    candidate_ids = find_unjournaled_production_order_ids(db, po_ids)
+    if not candidate_ids:
+        return []
+    return (
+        db.query(ProductionOrder)
+        .filter(ProductionOrder.id.in_(candidate_ids))
+        .order_by(ProductionOrder.id)
+        .all()
+    )
+
+
+def _entry_date_for(order: ProductionOrder) -> date:
+    """Backdate to the order's completion date (owner decision); today if unset."""
+    if order.completed_at:
+        return order.completed_at.date()
+    return date.today()
+
+
+def _print_preview(order: ProductionOrder, preview, out=print) -> None:
+    out(f"\nPO#{order.code} (id={order.id}, status={order.status}, "
+        f"entry_date={_entry_date_for(order).isoformat()})")
+    out(f"  swept transactions: {len(preview.transaction_ids)} "
+        f"(ids {preview.transaction_ids})")
+    out(f"  M_mat  (CR 1200): {preview.material_cost}")
+    out(f"  M_pkg  (CR 1230): {preview.packaging_cost}")
+    out(f"  M_labor(CR 5100): {preview.labor_cost}")
+    out(f"  FG     (DR 1220): {preview.finished_goods_value}")
+    out(f"  S (scrap 1210 credits): {preview.scrap_wip_credits}")
+    out(f"  V = FG + S - M = {preview.variance}")
+    if preview.lines:
+        out("  journal entry lines:")
+        for account_code, amount, dr_cr in preview.lines:
+            out(f"    {dr_cr} {account_code}  {amount}")
+    else:
+        out("  (all swept rows zero-cost — nothing would be posted)")
+
+
+def check_backup_marker(backup_marker: Optional[str]) -> None:
+    """Raise BackupMarkerError unless the marker file exists and is fresh."""
+    if not backup_marker:
+        raise BackupMarkerError(
+            "--apply requires --backup-marker <path> pointing to a file "
+            "created right after the pg_dump backup."
+        )
+    marker = Path(backup_marker)
+    if not marker.is_file():
+        raise BackupMarkerError(f"Backup marker not found: {backup_marker}")
+    mtime = datetime.fromtimestamp(marker.stat().st_mtime, tz=timezone.utc)
+    age = datetime.now(timezone.utc) - mtime
+    if age > timedelta(hours=BACKUP_MARKER_MAX_AGE_HOURS):
+        raise BackupMarkerError(
+            f"Backup marker {backup_marker} is {age} old (max "
+            f"{BACKUP_MARKER_MAX_AGE_HOURS}h). Take a fresh pg_dump and "
+            "touch the marker again."
+        )
+
+
+def run_dry_run(db: Session, po_ids: Optional[List[int]] = None, out=print) -> list:
+    """Print per-PO previews. Posts nothing, writes nothing."""
+    orders = _load_candidate_orders(db, po_ids)
+    if not orders:
+        out("No production orders with unjournaled consumption/receipt "
+            "transactions found. Nothing to backfill.")
+        return []
+
+    out(f"DRY RUN — {len(orders)} production order(s) with sweepable rows. "
+        "No changes will be made.")
+    previews = []
+    totals = {
+        "material": 0, "packaging": 0, "labor": 0,
+        "fg": 0, "scrap": 0, "variance": 0, "txns": 0,
+    }
+    for order in orders:
+        preview = compute_completion_gl_preview(db, order)
+        if preview is None:
+            continue
+        _print_preview(order, preview, out=out)
+        previews.append((order, preview))
+        totals["material"] += preview.material_cost
+        totals["packaging"] += preview.packaging_cost
+        totals["labor"] += preview.labor_cost
+        totals["fg"] += preview.finished_goods_value
+        totals["scrap"] += preview.scrap_wip_credits
+        totals["variance"] += preview.variance
+        totals["txns"] += len(preview.transaction_ids)
+
+    out("\n=== TOTALS ===")
+    out(f"  transactions swept: {totals['txns']}")
+    out(f"  materials (CR 1200): {totals['material']}")
+    out(f"  packaging (CR 1230): {totals['packaging']}")
+    out(f"  labor     (CR 5100): {totals['labor']}")
+    out(f"  finished goods (DR 1220): {totals['fg']}")
+    out(f"  scrap 1210 credits (S): {totals['scrap']}")
+    out(f"  net variance (5200; positive = credit): {totals['variance']}")
+    out("\nRun again with --apply --backup-marker <path> to post.")
+    return previews
+
+
+def run_apply(
+    db: Session,
+    manifest_path: str,
+    backup_marker: Optional[str],
+    po_ids: Optional[List[int]] = None,
+    out=print,
+) -> list:
+    """Post completion entries for every candidate order; write the manifest.
+
+    All entries post in ONE transaction — any failure rolls back everything.
+    The manifest (JSON) records created journal-entry ids and per-PO amounts
+    for --rollback.
+    """
+    check_backup_marker(backup_marker)
+
+    orders = _load_candidate_orders(db, po_ids)
+    if not orders:
+        out("Nothing to backfill — no unjournaled production "
+            "consumption/receipt transactions found.")
+        return []
+
+    manifest_entries = []
+    for order in orders:
+        entry_date = _entry_date_for(order)
+        preview = compute_completion_gl_preview(db, order)
+        journal_entry = create_production_completion_gl_entry(
+            db, order, user_id=None, entry_date=entry_date
+        )
+        if journal_entry is None:
+            out(f"PO#{order.code}: skipped (zero-cost rows only)")
+            continue
+        _print_preview(order, preview, out=out)
+        out(f"  -> POSTED {journal_entry.entry_number} "
+            f"(journal_entry_id={journal_entry.id}, entry_date={entry_date})")
+        manifest_entries.append({
+            "production_order_id": order.id,
+            "production_order_code": order.code,
+            "journal_entry_id": journal_entry.id,
+            "entry_number": journal_entry.entry_number,
+            "entry_date": entry_date.isoformat(),
+            "material_cost": str(preview.material_cost),
+            "packaging_cost": str(preview.packaging_cost),
+            "labor_cost": str(preview.labor_cost),
+            "finished_goods_value": str(preview.finished_goods_value),
+            "scrap_wip_credits": str(preview.scrap_wip_credits),
+            "variance": str(preview.variance),
+            "transaction_ids": preview.transaction_ids,
+        })
+
+    db.commit()
+
+    if not manifest_entries:
+        out("Nothing was posted (all candidates zero-cost).")
+        return []
+
+    manifest = {
+        "script": "backfill_production_completion_gl",
+        "issue": "#880",
+        "applied_at": datetime.now(timezone.utc).isoformat(),
+        "entries": manifest_entries,
+    }
+    Path(manifest_path).write_text(json.dumps(manifest, indent=2))
+    out(f"\nPosted {len(manifest_entries)} journal entr(ies). "
+        f"Manifest written to {manifest_path} — keep it for --rollback.")
+    return manifest_entries
+
+
+def run_rollback(db: Session, manifest_path: str, out=print) -> int:
+    """Void every journal entry in the manifest and unlink its transactions.
+
+    Unlinking (journal_entry_id back to NULL) restores the pre-apply state
+    so the sweep can re-post after the rollback; voided entries disappear
+    from the posted-only reports (#880 PR-1).
+    """
+    manifest = json.loads(Path(manifest_path).read_text())
+    entries = manifest.get("entries", [])
+    if not entries:
+        out(f"Manifest {manifest_path} contains no entries — nothing to roll back.")
+        return 0
+
+    voided = 0
+    for item in entries:
+        je_id = item["journal_entry_id"]
+        journal_entry = db.query(GLJournalEntry).filter(
+            GLJournalEntry.id == je_id
+        ).first()
+        if journal_entry is None:
+            out(f"  journal entry {je_id} not found — skipping")
+            continue
+        if journal_entry.status == "voided":
+            out(f"  {journal_entry.entry_number} already voided — skipping")
+            continue
+        journal_entry.status = "voided"
+        journal_entry.voided_at = datetime.now(timezone.utc)
+        journal_entry.void_reason = (
+            "Rollback of #880 production-completion GL backfill "
+            f"(manifest applied {manifest.get('applied_at', 'unknown')})"
+        )
+        unlinked = db.query(InventoryTransaction).filter(
+            InventoryTransaction.journal_entry_id == je_id
+        ).update({"journal_entry_id": None}, synchronize_session="fetch")
+        out(f"  voided {journal_entry.entry_number} "
+            f"(PO#{item.get('production_order_code')}), "
+            f"unlinked {unlinked} transaction(s)")
+        voided += 1
+
+    db.commit()
+    out(f"Rolled back {voided} journal entr(ies) from {manifest_path}.")
+    return voided
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill production-completion GL entries (#880). "
+                    "Dry-run by default."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--apply", action="store_true",
+        help="Post the journal entries for real (requires --backup-marker).",
+    )
+    mode.add_argument(
+        "--rollback", metavar="MANIFEST",
+        help="Void the journal entries listed in a previous apply's manifest.",
+    )
+    parser.add_argument(
+        "--backup-marker", metavar="PATH",
+        help="File touched right after pg_dump; must be < 24h old for --apply.",
+    )
+    parser.add_argument(
+        "--manifest", metavar="PATH",
+        default=f"backfill_production_completion_gl_manifest_"
+                f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json",
+        help="Where --apply writes the rollback manifest.",
+    )
+    parser.add_argument(
+        "--po-id", type=int, action="append", dest="po_ids",
+        help="Restrict to specific production order id(s); repeatable.",
+    )
+    args = parser.parse_args(argv)
+
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        if args.rollback:
+            run_rollback(db, args.rollback)
+        elif args.apply:
+            try:
+                run_apply(
+                    db,
+                    manifest_path=args.manifest,
+                    backup_marker=args.backup_marker,
+                    po_ids=args.po_ids,
+                )
+            except BackupMarkerError as exc:
+                print(f"REFUSING TO APPLY: {exc}", file=sys.stderr)
+                return 2
+        else:
+            run_dry_run(db, po_ids=args.po_ids)
+        return 0
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/backfill_production_completion_gl.py
+++ b/backend/scripts/backfill_production_completion_gl.py
@@ -51,7 +51,7 @@ from app.models.inventory import InventoryTransaction  # noqa: E402
 from app.models.production_order import ProductionOrder  # noqa: E402
 from app.services.production_gl_service import (  # noqa: E402
     compute_completion_gl_preview,
-    create_production_completion_gl_entry,
+    create_production_completion_gl_entry_with_preview,
     find_unjournaled_production_order_ids,
 )
 
@@ -187,8 +187,11 @@ def run_apply(
     manifest_entries = []
     for order in orders:
         entry_date = _entry_date_for(order)
-        preview = compute_completion_gl_preview(db, order)
-        journal_entry = create_production_completion_gl_entry(
+        # One sweep per PO (#892 round 2): the poster returns the preview it
+        # actually posted from, computed AFTER its advisory lock — so the
+        # manifest records exactly what was posted, with no second
+        # sweep-and-compute and no lock race from a precomputed preview.
+        journal_entry, preview = create_production_completion_gl_entry_with_preview(
             db, order, user_id=None, entry_date=entry_date
         )
         if journal_entry is None:

--- a/backend/scripts/backfill_production_completion_gl.py
+++ b/backend/scripts/backfill_production_completion_gl.py
@@ -34,6 +34,7 @@ posts nothing.
 """
 import argparse
 import json
+import os
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -211,9 +212,8 @@ def run_apply(
             "transaction_ids": preview.transaction_ids,
         })
 
-    db.commit()
-
     if not manifest_entries:
+        db.rollback()
         out("Nothing was posted (all candidates zero-cost).")
         return []
 
@@ -223,7 +223,22 @@ def run_apply(
         "applied_at": datetime.now(timezone.utc).isoformat(),
         "entries": manifest_entries,
     }
-    Path(manifest_path).write_text(json.dumps(manifest, indent=2))
+    # Write the rollback record to a temp file BEFORE commit, then rename it
+    # into place after commit succeeds (#892 CodeRabbit): a crash between
+    # commit and manifest write would otherwise leave permanently posted
+    # entries with no record to drive --rollback. The temp file sits in the
+    # manifest's own directory so os.replace() is an atomic same-filesystem
+    # rename; on commit failure it is removed (nothing was posted, so a
+    # stale rollback record would be misleading).
+    final_path = Path(manifest_path)
+    tmp_path = final_path.with_name(final_path.name + ".tmp")
+    tmp_path.write_text(json.dumps(manifest, indent=2))
+    try:
+        db.commit()
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    os.replace(tmp_path, final_path)
     out(f"\nPosted {len(manifest_entries)} journal entr(ies). "
         f"Manifest written to {manifest_path} — keep it for --rollback.")
     return manifest_entries

--- a/backend/tests/test_production_completion_gl.py
+++ b/backend/tests/test_production_completion_gl.py
@@ -16,6 +16,10 @@ Covers:
 - the GL-health counter on the accounting dashboard
 - the backfill script (dry-run, backup-marker gate, apply -> manifest ->
   rollback round-trip)
+- the #892 concurrency guard: pg_advisory_xact_lock(74004, po_id) before
+  the sweep, exactly-once posting across sequential transactions, and the
+  backfill's atomic temp-file manifest lifecycle (rename after commit,
+  delete on commit failure)
 
 All tests are delta-based with per-run unique fixtures (uuid SKUs/codes
 from the conftest factories) because filaops_test accumulates state.
@@ -397,6 +401,85 @@ class TestCompletionGLPoster:
 
 
 # =============================================================================
+# Concurrency guard (#892): advisory lock + exactly-once posting
+# =============================================================================
+
+class TestCompletionAdvisoryLock:
+    """The poster must serialize concurrent completions of the same PO with a
+    transaction-scoped advisory lock (namespace 74004, keyed by PO id) taken
+    BEFORE the sweep, because GLJournalEntry has no (source_type, source_id)
+    uniqueness and the per-op auto-complete path arrives without a
+    ProductionOrder row lock."""
+
+    def _make_sweepable_po(self, db, make_product, make_production_order):
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(item_type="finished_good", average_cost=Decimal("2.00"))
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=2)
+        _seed_stock(db, raw, 20, "0.50")
+        _consume(db, raw, po, 4, "0.50")
+        _receive_fg(db, fg, po, 2, "2.00")
+        return po
+
+    def test_advisory_lock_emitted_with_po_key(
+        self, db, make_product, make_production_order, monkeypatch
+    ):
+        """The completion guard lock is the FIRST statement the poster
+        executes, in its own namespace (74002 = entry-number lock,
+        74003 = ship guard), keyed by the production order id."""
+        from app.services import production_gl_service
+
+        po = self._make_sweepable_po(db, make_product, make_production_order)
+
+        captured = []
+        original_execute = db.execute
+
+        def spy_execute(statement, *args, **kwargs):
+            params = args[0] if args else kwargs.get("params")
+            captured.append((str(statement), params))
+            return original_execute(statement, *args, **kwargs)
+
+        monkeypatch.setattr(db, "execute", spy_execute)
+        je = create_production_completion_gl_entry(db, po)
+        monkeypatch.undo()
+
+        assert je is not None
+        lock_params = [
+            params for sql, params in captured
+            if "pg_advisory_xact_lock" in sql
+        ]
+        assert lock_params, (
+            "expected pg_advisory_xact_lock on the completion-poster path"
+        )
+        assert production_gl_service._COMPLETION_GUARD_LOCK_NAMESPACE == 74004
+        assert lock_params[0]["namespace"] == 74004
+        assert lock_params[0]["key"] == po.id
+
+    def test_posts_exactly_once_across_separate_transactions(
+        self, db, make_product, make_production_order
+    ):
+        """Two sequential completion attempts in separate transactions post
+        exactly one entry: the committed journal_entry_id links make the
+        second sweep empty. This is the exactly-once contract the #892
+        advisory lock extends to CONCURRENT completions — once the first
+        transaction commits and releases the lock, a blocked second caller
+        re-sweeps and finds nothing."""
+        po = self._make_sweepable_po(db, make_product, make_production_order)
+
+        first = create_production_completion_gl_entry(db, po)
+        assert first is not None
+        db.commit()   # transaction 1 ends: links durable, lock released
+
+        second = create_production_completion_gl_entry(db, po)
+        assert second is None
+        db.commit()   # transaction 2
+
+        entries = _completion_entries(db, po)
+        assert len(entries) == 1
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id == entries[0].id
+
+
+# =============================================================================
 # Call sites
 # =============================================================================
 
@@ -656,6 +739,11 @@ class TestBackfillScript:
         )
         assert len(entries) == 1
 
+        # Temp-file lifecycle (#892): the pre-commit temp manifest was
+        # renamed into place — final file present, no *.tmp left behind.
+        assert manifest_path.exists()
+        assert list(tmp_path.glob("*.tmp")) == []
+
         posted = _completion_entries(db, po)
         assert len(posted) == 1
         je = posted[0]
@@ -697,3 +785,41 @@ class TestBackfillScript:
         ]
         assert len(live) == 1
         assert live[0].id != je.id
+
+    def test_apply_commit_failure_removes_temp_manifest(
+        self, db, make_product, make_production_order, tmp_path, monkeypatch
+    ):
+        """#892: the manifest is written to a temp file BEFORE commit and
+        only renamed into place after commit succeeds. When the commit
+        fails, nothing was posted — the temp file must be deleted (a stale
+        rollback record would be misleading) and no final manifest may
+        appear."""
+        po = self._make_unjournaled_po(db, make_product, make_production_order)
+        # Persist the fixture rows to this savepoint so the post-failure
+        # rollback below only undoes the failed apply.
+        db.commit()
+
+        marker = _fresh_marker(tmp_path)
+        manifest_path = tmp_path / "manifest.json"
+
+        def boom():
+            raise RuntimeError("simulated commit failure")
+
+        monkeypatch.setattr(db, "commit", boom)
+        with pytest.raises(RuntimeError, match="simulated commit failure"):
+            backfill.run_apply(
+                db, str(manifest_path), backup_marker=str(marker),
+                po_ids=[po.id], out=lambda *_: None,
+            )
+        monkeypatch.undo()
+
+        # Neither the temp file nor the final manifest survives the failure.
+        assert not manifest_path.exists()
+        assert list(tmp_path.glob("*.tmp")) == []
+
+        # What main() does on any exception — and afterwards the books show
+        # nothing posted and every transaction back to sweepable.
+        db.rollback()
+        assert _completion_entries(db, po) == []
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id is None

--- a/backend/tests/test_production_completion_gl.py
+++ b/backend/tests/test_production_completion_gl.py
@@ -20,6 +20,9 @@ Covers:
   the sweep, exactly-once posting across sequential transactions, and the
   backfill's atomic temp-file manifest lifecycle (rename after commit,
   delete on commit failure)
+- #892 round 2: the _with_preview variant returns the preview of the sweep
+  it actually posted (single sweep for the backfill manifest), and user_id
+  threads through the completion paths into GLJournalEntry.created_by
 
 All tests are delta-based with per-run unique fixtures (uuid SKUs/codes
 from the conftest factories) because filaops_test accumulates state.
@@ -37,6 +40,7 @@ from app.models.inventory import InventoryTransaction
 from app.services import inventory_service
 from app.services.production_gl_service import (
     create_production_completion_gl_entry,
+    create_production_completion_gl_entry_with_preview,
 )
 from app.services.transaction_service import TransactionService
 
@@ -207,6 +211,44 @@ class TestCompletionGLPoster:
         po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
         assert create_production_completion_gl_entry(db, po) is None
         assert _completion_entries(db, po) == []
+
+    def test_with_preview_returns_the_posted_sweep(
+        self, db, make_product, make_production_order
+    ):
+        """#892 round 2: the _with_preview variant hands back the preview
+        built from the SAME sweep the entry posted (after the advisory
+        lock), so the backfill manifest never needs a second
+        sweep-and-compute — and can't race the lock with a precomputed
+        preview."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(item_type="finished_good", average_cost=Decimal("2.00"))
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=5)
+
+        _seed_stock(db, raw, 100, "0.50")
+        _consume(db, raw, po, 10, "0.50")       # 5.00 materials
+        _receive_fg(db, fg, po, 5, "2.00")      # 10.00 FG
+
+        je, preview = create_production_completion_gl_entry_with_preview(db, po)
+
+        assert je is not None
+        assert preview is not None
+        # The preview IS the posted sweep: same linked transactions...
+        assert sorted(preview.transaction_ids) == sorted(
+            txn.id for txn in _po_txns(db, po)
+        )
+        assert preview.material_cost == Decimal("5.00")
+        assert preview.finished_goods_value == Decimal("10.00")
+        assert preview.variance == Decimal("5.00")
+        # ...and its lines aggregate to exactly the entry's per-account nets.
+        expected_net = defaultdict(lambda: Decimal("0"))
+        for account_code, amount, dr_cr in preview.lines:
+            expected_net[account_code] += amount if dr_cr == "DR" else -amount
+        assert _je_net(db, je) == expected_net
+
+        # Nothing left sweepable -> (None, None).
+        assert create_production_completion_gl_entry_with_preview(db, po) == (
+            None, None,
+        )
 
     def test_prior_scrap_je_does_not_block_and_s_term_zeroes_wip(
         self, db, make_product, make_production_order
@@ -443,16 +485,18 @@ class TestCompletionAdvisoryLock:
         monkeypatch.undo()
 
         assert je is not None
-        lock_params = [
-            params for sql, params in captured
-            if "pg_advisory_xact_lock" in sql
-        ]
-        assert lock_params, (
-            "expected pg_advisory_xact_lock on the completion-poster path"
+        assert captured, "expected the poster to execute statements"
+        first_sql, first_params = captured[0]
+        # Literally the FIRST statement (round 3): filtering for the lock
+        # among all captured calls would still pass if a sweep query snuck
+        # in ahead of it — the docstring's ordering claim must be pinned.
+        assert "pg_advisory_xact_lock" in first_sql, (
+            "the completion guard lock must be the first statement the "
+            "poster executes, before the sweep it protects"
         )
         assert production_gl_service._COMPLETION_GUARD_LOCK_NAMESPACE == 74004
-        assert lock_params[0]["namespace"] == 74004
-        assert lock_params[0]["key"] == po.id
+        assert first_params["namespace"] == 74004
+        assert first_params["key"] == po.id
 
     def test_posts_exactly_once_across_separate_transactions(
         self, db, make_product, make_production_order
@@ -510,12 +554,16 @@ class TestCompletionCallSites:
         po = make_production_order(product_id=fg.id, status="in_progress", quantity=5)
 
         completed = complete_production_order(
-            db, po.id, "tester@filaops.dev", quantity_good=5
+            db, po.id, "tester@filaops.dev", quantity_good=5, user_id=1
         )
         assert completed.status == "complete"
 
         entries = _completion_entries(db, po)
         assert len(entries) == 1
+        # #892 round 2: the acting user's id threads through
+        # process_production_completion into the JE's attribution columns.
+        assert entries[0].created_by == 1
+        assert entries[0].posted_by == 1
         net = _je_net(db, entries[0])
         # 500 G x 0.02 = 10.00 consumed; FG 5 x 2.50 = 12.50; V = +2.50
         assert net["1200"] == Decimal("-10.00")
@@ -547,11 +595,14 @@ class TestCompletionCallSites:
         inventory_service.process_production_completion(
             db=db, production_order=po,
             quantity_completed=Decimal("5"), created_by="tester@filaops.dev",
+            user_id=1,
         )
 
         entries = _completion_entries(db, po)
         assert len(entries) == 1
         je = entries[0]
+        # #892 round 2: user_id passed through to the JE attribution.
+        assert je.created_by == 1
 
         # Both the earlier per-op consumption and the new FG receipt are
         # linked to the single entry.
@@ -585,6 +636,7 @@ class TestCompletionCallSites:
 
         entries = _completion_entries(db, po)
         assert len(entries) == 1
+        assert entries[0].created_by == 1
         net = _je_net(db, entries[0])
         # 3 of 5 produced at effective cost 2.00 -> FG 6.00, no consumption.
         assert net["1220"] == Decimal("6.00")
@@ -753,6 +805,14 @@ class TestBackfillScript:
         manifest = json.loads(manifest_path.read_text())
         assert manifest["entries"][0]["journal_entry_id"] == je.id
         assert manifest["entries"][0]["production_order_id"] == po.id
+        # #892 round 2: the manifest is built from the preview the poster
+        # returned — the exact sweep it posted from (5.00 raw consumed,
+        # 8.00 FG received in this fixture).
+        assert manifest["entries"][0]["material_cost"] == "5.00"
+        assert manifest["entries"][0]["finished_goods_value"] == "8.00"
+        assert manifest["entries"][0]["transaction_ids"] == [
+            txn.id for txn in sorted(_po_txns(db, po), key=lambda t: t.id)
+        ]
 
         # --- re-apply: sweep idempotency, posts nothing ---
         manifest2 = tmp_path / "manifest2.json"

--- a/backend/tests/test_production_completion_gl.py
+++ b/backend/tests/test_production_completion_gl.py
@@ -1,0 +1,699 @@
+"""
+Tests for the #880 production-completion GL poster.
+
+Covers:
+- production_gl_service.create_production_completion_gl_entry (the sweep
+  poster: DR 1210 / CR 1200|1230|5100, DR 1220 / CR 1210, 5200 variance)
+- its two call sites (process_production_completion via
+  complete_production_order, and accept_short_production_order)
+- sweep idempotency (re-run no-op; per-op consumption + completion posts
+  each transaction exactly once)
+- the load-bearing "no source-existence check" contract: a prior scrap
+  journal entry with the SAME source_type/source_id must NOT block the
+  completion entry, and the S term makes 1210 net to zero
+- abs() valuation of legacy positive-quantity consumption rows
+- component-aware credits (packaging -> 1230, SVC- labor -> 5100)
+- the GL-health counter on the accounting dashboard
+- the backfill script (dry-run, backup-marker gate, apply -> manifest ->
+  rollback round-trip)
+
+All tests are delta-based with per-run unique fixtures (uuid SKUs/codes
+from the conftest factories) because filaops_test accumulates state.
+"""
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+from app.models.inventory import InventoryTransaction
+from app.services import inventory_service
+from app.services.production_gl_service import (
+    create_production_completion_gl_entry,
+)
+from app.services.transaction_service import TransactionService
+
+# Make backend/scripts importable for the backfill-script tests.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import backfill_production_completion_gl as backfill  # noqa: E402
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _location(db):
+    return inventory_service.get_or_create_default_location(db)
+
+
+def _seed_stock(db, product, qty, cost):
+    """Give a product on-hand stock so consumption is not held for approval."""
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="test_seed",
+        reference_id=0,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _consume(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="consumption",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _receive_fg(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _completion_entries(db, po):
+    return db.query(GLJournalEntry).filter(
+        GLJournalEntry.source_type == "production_order",
+        GLJournalEntry.source_id == po.id,
+        GLJournalEntry.description.like("Production completion%"),
+    ).all()
+
+
+def _je_net(db, je):
+    """account_code -> net (DR - CR) for one journal entry."""
+    net = defaultdict(lambda: Decimal("0"))
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            GLJournalEntryLine.debit_amount,
+            GLJournalEntryLine.credit_amount,
+        )
+        .join(GLJournalEntryLine, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(GLJournalEntryLine.journal_entry_id == je.id)
+        .all()
+    )
+    for code, debit, credit in rows:
+        net[code] += Decimal(str(debit or 0)) - Decimal(str(credit or 0))
+    return net
+
+
+def _wip_net_across_po_entries(db, po):
+    """Net 1210 (DR - CR) across ALL non-voided entries for this PO."""
+    rows = (
+        db.query(GLJournalEntryLine.debit_amount, GLJournalEntryLine.credit_amount)
+        .join(GLJournalEntry, GLJournalEntryLine.journal_entry_id == GLJournalEntry.id)
+        .join(GLAccount, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(
+            GLJournalEntry.source_type == "production_order",
+            GLJournalEntry.source_id == po.id,
+            GLJournalEntry.status != "voided",
+            GLAccount.account_code == "1210",
+        )
+        .all()
+    )
+    total = Decimal("0")
+    for debit, credit in rows:
+        total += Decimal(str(debit or 0)) - Decimal(str(credit or 0))
+    return total
+
+
+def _po_txns(db, po, types=("consumption", "receipt")):
+    return db.query(InventoryTransaction).filter(
+        InventoryTransaction.reference_type == "production_order",
+        InventoryTransaction.reference_id == po.id,
+        InventoryTransaction.transaction_type.in_(types),
+    ).all()
+
+
+# =============================================================================
+# The poster
+# =============================================================================
+
+class TestCompletionGLPoster:
+
+    def test_posts_basic_completion_entry_and_links_txns(
+        self, db, make_product, make_production_order
+    ):
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(item_type="finished_good", average_cost=Decimal("2.00"))
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=5)
+
+        _seed_stock(db, raw, 100, "0.50")
+        _consume(db, raw, po, 10, "0.50")       # 5.00 materials
+        _receive_fg(db, fg, po, 5, "2.00")      # 10.00 FG
+
+        je = create_production_completion_gl_entry(db, po)
+
+        assert je is not None
+        assert je.description == f"Production completion for PO#{po.code}"
+        assert je.source_type == "production_order"
+        assert je.source_id == po.id
+        assert je.status == "posted"
+        assert je.entry_date == date.today()
+
+        net = _je_net(db, je)
+        # DR 1210 5.00 / CR 1200 5.00; DR 1220 10 / CR 1210 10;
+        # V = 10 - 5 = +5 -> DR 1210 5 / CR 5200 5  => 1210 nets to zero.
+        assert net["1210"] == Decimal("0")
+        assert net["1200"] == Decimal("-5.00")
+        assert net["1220"] == Decimal("10.00")
+        assert net["5200"] == Decimal("-5.00")
+
+        # Every swept transaction is linked to the entry.
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id == je.id
+
+    def test_rerun_is_noop(self, db, make_product, make_production_order):
+        raw = make_product(item_type="supply")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        _seed_stock(db, raw, 10, "1.00")
+        _consume(db, raw, po, 2, "1.00")
+        _receive_fg(db, fg, po, 1, "3.00")
+
+        first = create_production_completion_gl_entry(db, po)
+        assert first is not None
+
+        second = create_production_completion_gl_entry(db, po)
+        assert second is None
+        assert len(_completion_entries(db, po)) == 1
+
+    def test_no_sweepable_rows_returns_none(self, db, make_product, make_production_order):
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+        assert create_production_completion_gl_entry(db, po) is None
+        assert _completion_entries(db, po) == []
+
+    def test_prior_scrap_je_does_not_block_and_s_term_zeroes_wip(
+        self, db, make_product, make_production_order
+    ):
+        """LOAD-BEARING: scrap journal entries share source_type=
+        'production_order' AND the same source_id. The poster must not use a
+        source-existence idempotency check, or a mid-order scrap would
+        silently suppress the completion entry. The S term must offset the
+        scrap entry's 1210 credit so WIP nets to exactly zero for the PO."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(item_type="finished_good", average_cost=Decimal("2.00"))
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=4)
+
+        _seed_stock(db, raw, 50, "0.50")
+        _consume(db, raw, po, 20, "0.50")       # M = 10.00
+
+        # Mid-order operation scrap: DR 5020 / CR 1210 for 1.00, with
+        # source_type='production_order' and source_id=po.id.
+        ts = TransactionService(db)
+        _, scrap_je, _ = ts.scrap_materials(
+            production_order_id=po.id,
+            operation_sequence=10,
+            product_id=raw.id,
+            quantity=Decimal("2"),
+            unit_cost=Decimal("0.50"),
+            reason_code="TEST-SCRAP",
+            user_id=1,
+        )
+        assert scrap_je is not None
+        assert scrap_je.source_type == "production_order"
+        assert scrap_je.source_id == po.id
+
+        _receive_fg(db, fg, po, 4, "2.00")      # FG = 8.00
+
+        je = create_production_completion_gl_entry(db, po)
+
+        # The completion entry posted DESPITE the existing scrap entry.
+        assert je is not None
+        assert je.id != scrap_je.id
+
+        # S = 1.00, V = FG + S - M = 8 + 1 - 10 = -1 -> DR 5200 1 / CR 1210 1
+        net = _je_net(db, je)
+        assert net["1200"] == Decimal("-10.00")
+        assert net["1220"] == Decimal("8.00")
+        assert net["5200"] == Decimal("1.00")
+
+        # WIP nets to exactly zero across scrap + completion entries.
+        assert _wip_net_across_po_entries(db, po) == Decimal("0")
+
+        # The scrap entry and its transaction link are untouched.
+        db.refresh(scrap_je)
+        assert scrap_je.status == "posted"
+
+        # Re-run posts nothing (double-post is the highest-severity failure).
+        assert create_production_completion_gl_entry(db, po) is None
+        assert len(_completion_entries(db, po)) == 1
+
+    def test_zero_consumption_completion_posts_fg_against_variance(
+        self, db, make_product, make_production_order
+    ):
+        fg = make_product(item_type="finished_good", average_cost=Decimal("2.50"))
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=4)
+
+        _receive_fg(db, fg, po, 4, "2.50")      # FG = 10.00, no consumption
+
+        je = create_production_completion_gl_entry(db, po)
+
+        assert je is not None
+        net = _je_net(db, je)
+        # Net effect DR 1220 / CR 5200; the 1210 legs cancel exactly.
+        assert net["1220"] == Decimal("10.00")
+        assert net["5200"] == Decimal("-10.00")
+        assert net["1210"] == Decimal("0")
+        assert net["1200"] == Decimal("0")
+
+    def test_legacy_positive_quantity_consumption_valued_with_abs(
+        self, db, make_product, make_production_order
+    ):
+        """Pre-HARD-4a rows store positive magnitudes for consumption (live
+        txn ids 129/130). abs(qty) x cost_per_unit must value them correctly
+        instead of flipping the sign."""
+        raw = make_product(item_type="supply")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        legacy = InventoryTransaction(
+            product_id=raw.id,
+            location_id=_location(db).id,
+            transaction_type="consumption",
+            quantity=Decimal("3"),          # POSITIVE legacy sign
+            cost_per_unit=Decimal("0.10"),
+            total_cost=None,                # force the abs(qty) x cpu path
+            reference_type="production_order",
+            reference_id=po.id,
+        )
+        db.add(legacy)
+        db.flush()
+
+        _receive_fg(db, fg, po, 1, "1.00")
+
+        je = create_production_completion_gl_entry(db, po)
+
+        assert je is not None
+        net = _je_net(db, je)
+        assert net["1200"] == Decimal("-0.30")
+        # V = 1.00 - 0.30 = +0.70 credit to 5200
+        assert net["5200"] == Decimal("-0.70")
+        assert net["1210"] == Decimal("0")
+        assert legacy.journal_entry_id == je.id
+
+    def test_packaging_component_credits_1230(
+        self, db, make_product, make_production_order
+    ):
+        raw = make_product(item_type="supply")
+        box = make_product(item_type="packaging")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=2)
+
+        _seed_stock(db, raw, 100, "0.50")
+        _seed_stock(db, box, 10, "1.50")
+        _consume(db, raw, po, 10, "0.50")       # 5.00 -> CR 1200
+        _consume(db, box, po, 2, "1.50")        # 3.00 -> CR 1230
+        _receive_fg(db, fg, po, 2, "5.00")      # 10.00
+
+        je = create_production_completion_gl_entry(db, po)
+
+        assert je is not None
+        net = _je_net(db, je)
+        assert net["1200"] == Decimal("-5.00")
+        assert net["1230"] == Decimal("-3.00")
+        assert net["1220"] == Decimal("10.00")
+        # V = 10 - 8 = +2 -> CR 5200
+        assert net["5200"] == Decimal("-2.00")
+        assert net["1210"] == Decimal("0")
+
+    def test_svc_labor_row_credits_5100(
+        self, db, make_product, make_production_order
+    ):
+        import uuid
+        raw = make_product(item_type="supply")
+        labor = make_product(
+            sku=f"SVC-LABOR-{uuid.uuid4().hex[:8]}", item_type="service"
+        )
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        _seed_stock(db, raw, 100, "0.50")
+        _seed_stock(db, labor, 10, "5.00")
+        _consume(db, raw, po, 4, "0.50")        # 2.00 -> CR 1200
+        _consume(db, labor, po, 1, "5.00")      # 5.00 -> CR 5100
+        _receive_fg(db, fg, po, 1, "8.00")      # 8.00
+
+        je = create_production_completion_gl_entry(db, po)
+
+        assert je is not None
+        net = _je_net(db, je)
+        assert net["1200"] == Decimal("-2.00")
+        assert net["5100"] == Decimal("-5.00")
+        assert net["1220"] == Decimal("8.00")
+        # V = 8 - 7 = +1 -> CR 5200
+        assert net["5200"] == Decimal("-1.00")
+        assert net["1210"] == Decimal("0")
+
+    def test_held_rows_are_not_swept(self, db, make_product, make_production_order):
+        """A held (requires_approval, unapproved) consumption never touched
+        on_hand — it must not enter the completion entry."""
+        raw = make_product(item_type="supply")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        held = InventoryTransaction(
+            product_id=raw.id,
+            location_id=_location(db).id,
+            transaction_type="consumption",
+            quantity=Decimal("-5"),
+            cost_per_unit=Decimal("1.00"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,          # pending approval, never applied
+        )
+        db.add(held)
+        db.flush()
+
+        _receive_fg(db, fg, po, 1, "2.00")
+
+        je = create_production_completion_gl_entry(db, po)
+        assert je is not None
+        net = _je_net(db, je)
+        assert net["1200"] == Decimal("0")      # held row excluded
+        assert net["1220"] == Decimal("2.00")
+        assert held.journal_entry_id is None
+
+
+# =============================================================================
+# Call sites
+# =============================================================================
+
+class TestCompletionCallSites:
+
+    def test_bulk_complete_posts_and_links(
+        self, db, make_product, make_production_order, make_bom
+    ):
+        """complete_production_order -> process_production_completion ->
+        poster. BOM-backflush consumption + FG receipt end in ONE entry."""
+        from app.services.production_order_execution_service import (
+            complete_production_order,
+        )
+
+        raw = make_product(
+            item_type="supply", unit="G", cost_method="average",
+            average_cost=Decimal("0.02"),
+        )
+        fg = make_product(
+            item_type="finished_good", cost_method="average",
+            average_cost=Decimal("2.50"),
+        )
+        make_bom(product_id=fg.id, lines=[
+            {"component_id": raw.id, "quantity": Decimal("100"), "unit": "G"},
+        ])
+        _seed_stock(db, raw, 10000, "0.02")
+
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=5)
+
+        completed = complete_production_order(
+            db, po.id, "tester@filaops.dev", quantity_good=5
+        )
+        assert completed.status == "complete"
+
+        entries = _completion_entries(db, po)
+        assert len(entries) == 1
+        net = _je_net(db, entries[0])
+        # 500 G x 0.02 = 10.00 consumed; FG 5 x 2.50 = 12.50; V = +2.50
+        assert net["1200"] == Decimal("-10.00")
+        assert net["1220"] == Decimal("12.50")
+        assert net["5200"] == Decimal("-2.50")
+        assert net["1210"] == Decimal("0")
+
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id == entries[0].id
+
+    def test_per_op_consume_then_completion_posts_exactly_once(
+        self, db, make_product, make_production_order
+    ):
+        """Consumption posted earlier (per-operation path) plus the
+        completion receipt are swept into ONE entry, and a re-run posts
+        nothing — each transaction is journaled exactly once."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(
+            item_type="finished_good", cost_method="average",
+            average_cost=Decimal("2.00"),
+        )
+        # No BOM, no routing rows: process_production_completion consumes
+        # nothing new, mirroring an order fully consumed per-op.
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=5)
+
+        _seed_stock(db, raw, 100, "0.50")
+        per_op_txn = _consume(db, raw, po, 10, "0.50")   # the "per-op" row
+
+        inventory_service.process_production_completion(
+            db=db, production_order=po,
+            quantity_completed=Decimal("5"), created_by="tester@filaops.dev",
+        )
+
+        entries = _completion_entries(db, po)
+        assert len(entries) == 1
+        je = entries[0]
+
+        # Both the earlier per-op consumption and the new FG receipt are
+        # linked to the single entry.
+        assert per_op_txn.journal_entry_id == je.id
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id == je.id
+
+        # Second sweep finds nothing.
+        assert create_production_completion_gl_entry(db, po) is None
+        assert len(_completion_entries(db, po)) == 1
+
+    def test_accept_short_posts_completion_entry(
+        self, db, make_product, make_production_order
+    ):
+        from app.services.production_order_execution_service import (
+            accept_short_production_order,
+        )
+
+        fg = make_product(
+            item_type="finished_good", cost_method="average",
+            average_cost=Decimal("2.00"),
+        )
+        po = make_production_order(product_id=fg.id, status="short", quantity=5)
+        po.quantity_completed = 3
+        db.flush()
+
+        accepted = accept_short_production_order(
+            db, po.id, "tester@filaops.dev", user_id=1
+        )
+        assert accepted.status == "complete"
+
+        entries = _completion_entries(db, po)
+        assert len(entries) == 1
+        net = _je_net(db, entries[0])
+        # 3 of 5 produced at effective cost 2.00 -> FG 6.00, no consumption.
+        assert net["1220"] == Decimal("6.00")
+        assert net["5200"] == Decimal("-6.00")
+        assert net["1210"] == Decimal("0")
+
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id == entries[0].id
+
+
+# =============================================================================
+# GL-health counter on the accounting dashboard
+# =============================================================================
+
+class TestUnjournaledCounter:
+
+    def test_dashboard_counts_unjournaled_production_txns(
+        self, client, db, make_product, make_production_order
+    ):
+        baseline = client.get("/api/v1/admin/accounting/dashboard").json()[
+            "unjournaled_txn_count"
+        ]
+
+        raw = make_product(item_type="supply")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+        _seed_stock(db, raw, 10, "1.00")
+        _consume(db, raw, po, 2, "1.00")
+        _receive_fg(db, fg, po, 1, "3.00")
+
+        after = client.get("/api/v1/admin/accounting/dashboard").json()[
+            "unjournaled_txn_count"
+        ]
+        assert after == baseline + 2
+
+        # Held rows are NOT drift (on_hand never moved).
+        other = make_product(item_type="supply")
+        held = InventoryTransaction(
+            product_id=other.id,
+            location_id=_location(db).id,
+            transaction_type="consumption",
+            quantity=Decimal("-5"),
+            cost_per_unit=Decimal("1.00"),
+            reference_type="production_order",
+            reference_id=po.id,
+            requires_approval=True,
+        )
+        db.add(held)
+        db.flush()
+        assert client.get("/api/v1/admin/accounting/dashboard").json()[
+            "unjournaled_txn_count"
+        ] == baseline + 2
+
+        # Posting the completion entry brings the counter back down.
+        create_production_completion_gl_entry(db, po)
+        assert client.get("/api/v1/admin/accounting/dashboard").json()[
+            "unjournaled_txn_count"
+        ] == baseline
+
+
+# =============================================================================
+# Backfill script
+# =============================================================================
+
+def _fresh_marker(tmp_path):
+    marker = tmp_path / "pg_dump.marker"
+    marker.write_text("backup taken")
+    return marker
+
+
+class TestBackfillScript:
+
+    def _make_unjournaled_po(self, db, make_product, make_production_order,
+                             completed_at=None):
+        raw = make_product(item_type="supply")
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="complete", quantity=2)
+        if completed_at is not None:
+            po.completed_at = completed_at
+            db.flush()
+        _seed_stock(db, raw, 100, "0.50")
+        _consume(db, raw, po, 10, "0.50")       # 5.00
+        _receive_fg(db, fg, po, 2, "4.00")      # 8.00
+        return po
+
+    def test_dry_run_prints_and_writes_nothing(
+        self, db, make_product, make_production_order, tmp_path
+    ):
+        po = self._make_unjournaled_po(db, make_product, make_production_order)
+
+        lines = []
+        previews = backfill.run_dry_run(db, po_ids=[po.id], out=lines.append)
+
+        assert len(previews) == 1
+        output = "\n".join(lines)
+        assert f"PO#{po.code}" in output
+        assert "M_mat" in output
+        assert "DRY RUN" in output
+
+        # Nothing posted, nothing linked.
+        assert _completion_entries(db, po) == []
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id is None
+        # No stray files in tmp_path (dry-run writes no manifest).
+        assert list(tmp_path.iterdir()) == []
+
+    def test_apply_refuses_without_backup_marker(
+        self, db, make_product, make_production_order, tmp_path
+    ):
+        po = self._make_unjournaled_po(db, make_product, make_production_order)
+        manifest = tmp_path / "manifest.json"
+
+        with pytest.raises(backfill.BackupMarkerError):
+            backfill.run_apply(db, str(manifest), backup_marker=None,
+                               po_ids=[po.id])
+
+        assert _completion_entries(db, po) == []
+        assert not manifest.exists()
+
+    def test_apply_refuses_stale_backup_marker(
+        self, db, make_product, make_production_order, tmp_path
+    ):
+        import os
+        po = self._make_unjournaled_po(db, make_product, make_production_order)
+        manifest = tmp_path / "manifest.json"
+        marker = _fresh_marker(tmp_path)
+        stale = datetime.now(timezone.utc) - timedelta(hours=25)
+        os.utime(marker, (stale.timestamp(), stale.timestamp()))
+
+        with pytest.raises(backfill.BackupMarkerError):
+            backfill.run_apply(db, str(manifest), backup_marker=str(marker),
+                               po_ids=[po.id])
+
+        assert _completion_entries(db, po) == []
+        assert not manifest.exists()
+
+    def test_apply_manifest_rollback_roundtrip(
+        self, db, make_product, make_production_order, tmp_path
+    ):
+        import json
+        completed = datetime(2026, 6, 15, 12, 0, 0)
+        po = self._make_unjournaled_po(
+            db, make_product, make_production_order, completed_at=completed
+        )
+        marker = _fresh_marker(tmp_path)
+        manifest_path = tmp_path / "manifest.json"
+
+        # --- apply ---
+        entries = backfill.run_apply(
+            db, str(manifest_path), backup_marker=str(marker), po_ids=[po.id],
+            out=lambda *_: None,
+        )
+        assert len(entries) == 1
+
+        posted = _completion_entries(db, po)
+        assert len(posted) == 1
+        je = posted[0]
+        # Backdated to the PO's completion date (owner decision).
+        assert je.entry_date == date(2026, 6, 15)
+
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["entries"][0]["journal_entry_id"] == je.id
+        assert manifest["entries"][0]["production_order_id"] == po.id
+
+        # --- re-apply: sweep idempotency, posts nothing ---
+        manifest2 = tmp_path / "manifest2.json"
+        again = backfill.run_apply(
+            db, str(manifest2), backup_marker=str(marker), po_ids=[po.id],
+            out=lambda *_: None,
+        )
+        assert again == []
+        assert len(_completion_entries(db, po)) == 1
+        assert not manifest2.exists()
+
+        # --- rollback: voids the entry and unlinks its transactions ---
+        voided = backfill.run_rollback(db, str(manifest_path), out=lambda *_: None)
+        assert voided == 1
+        db.refresh(je)
+        assert je.status == "voided"
+        assert je.void_reason and "#880" in je.void_reason
+        for txn in _po_txns(db, po):
+            assert txn.journal_entry_id is None
+
+        # --- re-apply after rollback re-posts cleanly ---
+        manifest3 = tmp_path / "manifest3.json"
+        reposted = backfill.run_apply(
+            db, str(manifest3), backup_marker=str(marker), po_ids=[po.id],
+            out=lambda *_: None,
+        )
+        assert len(reposted) == 1
+        live = [
+            e for e in _completion_entries(db, po) if e.status == "posted"
+        ]
+        assert len(live) == 1
+        assert live[0].id != je.id


### PR DESCRIPTION
# feat(accounting): production completion posts to GL + backfill script + GL-health counter (880 PR-3)

**The core fix of #880.** The modern completion path (`process_production_completion`, #875) posts inventory transactions but zero GL — Raw Materials (1200) was never relieved, WIP (1210) has zero lines, and Finished Goods (1220) sits at −$60.86 on the live books because shipping credits FG the GL never received. This PR makes every production completion post a balanced journal entry, ships the script that corrects the live books with the SAME production code, and exposes a GL-health counter so drift is a number instead of a surprise.

Design: [#880 design comment](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351) §2/§3a/§4 · Owner approval: [#880 approval comment](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880356641) · Builds on PR-1 #890 (posted-only reports) and PR-2 #891 (`entry_date` param, ship guard, item_type PO receipts).

## What

### 1. NEW `app/services/production_gl_service.py` — the completion poster
`create_production_completion_gl_entry(db, production_order, user_id=None, entry_date=None)`:

- **Sweeps** this PO's `InventoryTransaction` rows: `reference_type='production_order' AND reference_id=po.id AND transaction_type IN ('consumption','receipt') AND journal_entry_id IS NULL AND voided_by IS NULL AND NOT (requires_approval AND approved_by IS NULL)` (held/void exclusions mirror the COGS summary and shipment-GL filters).
- **Values** each row at `total_cost if set else abs(qty) × cost_per_unit` — the `abs()` neutralizes the April positive-sign legacy rows (live txn ids 129/130).
- **Posts one entry**: `DR 1210` total consumption / `CR 1200` materials / `CR 1230` packaging components / `CR 5100` SVC- labor rows; `DR 1220 / CR 1210` for FG receipts (incl. overruns); variance `V = FG + S − M` → `CR 5200` if positive, `DR 5200` if negative, where **S = this PO's already-posted scrap-JE 1210 credits** (scoped via `ScrapRecord.journal_entry_id`, so a completion entry's own credits can never leak into S). The S term guarantees **1210 nets to exactly zero per completed PO** even when operation scrap fired mid-order.
- **5200, not 5030**: 5030 is Schedule C '27a' (a persistent credit there reads as negative other-expense on the tax export); 5200 "COGS - Other" is line '38', inside the Schedule C COGS section where a production variance belongs.
- **Idempotency IS the sweep** (`journal_entry_id IS NULL` + linking every swept txn). Deliberately NOT a source_type/source_id existence check — scrap JEs share `source_type='production_order'` and the same `source_id`, so an existence check would wrongly suppress the completion entry for any order that scrapped mid-run. **Pinned by test** (`test_prior_scrap_je_does_not_block_and_s_term_zeroes_wip`), along with re-run-posts-nothing.

### 2. Two call sites, same session/transaction as consumption + receipts
- End of `process_production_completion` (`inventory_service.py`, lazy import per the codebase pattern) — covers bulk complete AND the per-op auto-complete (`operation_status.update_po_status`).
- `accept_short_production_order`'s hand-rolled FG receipt path (`production_order_execution_service.py`).

No separate commit inside the service — a poster failure on the bulk path rolls back consumption + receipts + JE together (no half-posted state).

### 3. NEW `scripts/backfill_production_completion_gl.py` — live-books correction (design §4)
- **Dry-run by DEFAULT**: per-PO JE preview (M_mat, M_pkg, M_labor, FG, S, V + the resulting lines) plus grand totals — this doubles as the detailed audit list behind the GL-health counter.
- `--apply` posts for real via the SAME `create_production_completion_gl_entry`, **backdated** to `entry_date=po.completed_at.date()` (owner decision), single transaction, and writes a **JSON manifest** of created JE ids + per-PO amounts.
- `--apply` **REFUSES to run** unless `--backup-marker <path>` points to a file modified within the last 24h (the ops runbook touches it right after `pg_dump`).
- `--rollback <manifest>` voids the manifest's entries (`status='voided'`, `voided_at`, `void_reason`) and unlinks their inventory transactions so a later apply can re-post cleanly (voided entries vanish from the posted-only reports, PR-1).
- `--po-id` (repeatable) restricts scope. Re-running `--apply` after success posts nothing (sweep idempotency).

### 4. GL-health counter
`unjournaled_txn_count` on `GET /admin/accounting/dashboard` = count of consumption/receipt txns ref `production_order` with `journal_entry_id IS NULL`, non-voided, non-held. Given the per-op swallow at `operation_status.py` stays (FIX-4 deferred by design), this turns silent GL drift into a number the owner can see. Backend field only — the dashboard tab picks it up in PR-5.

## Expected LIVE backfill preview (reviewer: compare the real dry-run on 129 against this)

From the live-129 census (2026-07-03, read-only), across the 5 production orders:

| Metric | Expected |
|---|---|
| Materials swept (CR 1200) | **$17.09** across **14 consumption txns** (incl. cancelled SO-0001's $2.42) |
| FG receipts (DR 1220) | **$64.78** across **5 receipt txns** |
| Net variance (5200) | **credit ≈ $47.69** |

Resulting books after apply: 1200 = 1217.04 − 17.09 = **1199.95** (net of the separate packaging reclass), 1210 = **0**, 1220 = −60.86 + 64.78 = **+3.92** (real FG on hand), 5200 = **47.69 CR**, 5000 unchanged 60.86 DR. Identity: materials in 17.09 = net COGS (60.86 − 47.69 = 13.17) + FG remaining 3.92 ✓. GL-health counter → 0.

## How tested

`DB_PASSWORD=Admin python -m pytest tests/test_production_completion_gl.py tests/services/test_inventory_service.py tests/services/test_inventory_extra.py tests/services/test_operation_services.py tests/services/test_production_order_service.py` against Postgres `filaops_test` — all green, plus ruff on changed files.

New suite (delta-based, uuid-unique fixtures):
- bulk complete posts DR1210/CR1200 + DR1220/CR1210 + 5200 variance and links every txn (through `complete_production_order`)
- per-op consumption then completion posts **exactly once total**; re-run = no-op
- **op-scrap mid-order → completion entry's S term makes 1210 net exactly zero across the PO's entries; prior scrap JE (same source_type/source_id) does NOT block the completion entry** (the load-bearing no-existence-check contract)
- zero-consumption completion (FG only) posts DR1220/CR5200
- accept-short posts and links
- abs() valuation of a positive-quantity legacy consumption row
- packaging component consumption credits 1230; SVC- row credits 5100; held rows excluded from sweep and counter
- dashboard `unjournaled_txn_count`: +2 on unjournaled txns, unchanged on held rows, back to baseline after posting
- backfill: dry-run prints and writes nothing; `--apply` without a fresh backup marker refuses (missing AND stale-25h cases); apply → manifest → `--rollback` round-trip voids + unlinks cleanly and a re-apply re-posts; second apply posts nothing; `entry_date` backdated to `completed_at`
- pinned #875 guardrail + DEFAULT_CONSUME_STAGES tests untouched and green

Zero DB migrations — service layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically posts the “production completion” ledger entry when a production order is completed.
  * Adds a dashboard counter for production-related inventory transactions that are not yet journaled.
  * Introduces a backfill utility to preview, apply, or roll back missing completion postings.

* **Bug Fixes**
  * Excludes held, voided, rejected, and unapproved transactions from completion posting.
  * Prevents duplicate postings and handles concurrent completion safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->