### PR TITLE
fix(shipping): mark-shipped + consolidated buy-label post GL and gate status (880 PR-4)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
+++ b/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
@@ -377,7 +377,9 @@ async def buy_consolidated_shipping_label(
     if len(order_ids) < 2:
         raise HTTPException(status_code=400, detail="Need at least 2 orders to consolidate")
 
-    # Fetch all orders
+    # Pre-check (unlocked): fail fast — before spending money on a label —
+    # if any order is missing or not ready. The authoritative gate is the
+    # FOR UPDATE re-check below.
     orders = db.query(SalesOrder).filter(
         SalesOrder.id.in_(order_ids),
         SalesOrder.status == "ready_to_ship"
@@ -397,6 +399,49 @@ async def buy_consolidated_shipping_label(
             status_code=500,
             detail=f"Failed to purchase label: {result.error}"
         )
+
+    # =========================================================================
+    # ATOMIC SHIP GATE (#893)
+    #
+    # Row-lock EVERY order in the consolidation and re-check status under
+    # the lock, holding it through the packaging/FG posting, GL, status
+    # flip, and commit below. Without this, two concurrent requests
+    # sharing an order can both pass the unlocked pre-check and
+    # double-relieve inventory — the one-JE-per-SO guard only dedupes GL.
+    #
+    # Locks are taken in ascending id order so two overlapping
+    # consolidations acquire them in the same sequence and cannot
+    # deadlock. The carrier purchase above stays OUTSIDE the locked
+    # section so a slow EasyPost call never holds row locks.
+    # populate_existing() refreshes rows already loaded by the pre-check,
+    # so the re-check sees a status flipped by a concurrent winner.
+    # =========================================================================
+    locked_orders = (
+        db.query(SalesOrder)
+        .filter(SalesOrder.id.in_(order_ids))
+        .order_by(SalesOrder.id)
+        .populate_existing()
+        .with_for_update()
+        .all()
+    )
+    not_ready = [o.order_number for o in locked_orders if o.status != "ready_to_ship"]
+    if len(locked_orders) != len(order_ids) or not_ready:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Orders changed while the label was being purchased "
+                f"({', '.join(not_ready) if not_ready else 'some orders no longer exist'}) "
+                "— nothing was shipped. The purchased label is unused; refund it "
+                "via the carrier."
+            ),
+        )
+
+    # Deterministic packaging attribution (#893): the FIRST order of the
+    # REQUEST (order_ids[0]) — not database row order — consumes the
+    # packaging and carries the DR 5010 / CR 1230 GL lines, so iteration
+    # below preserves the request order.
+    orders_by_id = {order.id: order for order in locked_orders}
+    orders = [orders_by_id[order_id] for order_id in order_ids]
 
     # Consume packaging from FIRST order only (consolidated = one box)
     packaging_consumed = []
@@ -560,8 +605,9 @@ async def buy_consolidated_shipping_label(
     # Per-order 5010 attribution is therefore approximate; the
     # consolidation's GL TOTALS are exact.
     #
-    # Retry safety: the status filter above (all orders must be
-    # 'ready_to_ship') rejects re-runs after the flip below, and
+    # Retry safety: the FOR UPDATE status re-check above rejects re-runs
+    # and concurrent duplicates — the gate is atomic with this posting
+    # because the row locks are held through the commit below — and
     # _create_shipment_gl_entry's one-JE-per-SO guard backstops against
     # double-posting GL for an order that already has a shipment entry.
     # =========================================================================
@@ -1189,14 +1235,28 @@ async def mark_order_shipped(
     Issues finished goods and posts the shipment journal entry
     (DR 5000 COGS / CR 1220 FG) like the other ship paths (#880 PR-4).
     """
-    order = db.query(SalesOrder).filter(SalesOrder.id == sales_order_id).first()
+    # Atomic ship gate (#893): row-lock the order BEFORE the status check
+    # and hold the lock through the FG relief, GL posting, status flip,
+    # and commit below. Without the lock, two concurrent mark-shipped
+    # requests can both pass the status gate and double-relieve finished
+    # goods — the one-JE-per-SO guard only dedupes GL, not inventory.
+    # Mirrors ship_order()'s FOR UPDATE gate in
+    # sales_order_fulfillment_service.
+    order = (
+        db.query(SalesOrder)
+        .filter(SalesOrder.id == sales_order_id)
+        .with_for_update()
+        .first()
+    )
 
     if not order:
         raise HTTPException(status_code=404, detail="Sales order not found")
 
-    # Status gate (#880 PR-4): an order already in a shipped-family status
-    # must not be marked shipped again — the FG issue below would
-    # double-decrement finished goods and re-post COGS.
+    # Status gate (#880 PR-4), re-checked under the row lock above: an
+    # order already in a shipped-family status must not be marked shipped
+    # again — the FG issue below would double-decrement finished goods
+    # and re-post COGS. A concurrent request serializes on the lock and
+    # sees the status flipped by the winner, so it 409s here.
     if order.status in SHIPPED_ORDER_STATUSES:
         raise HTTPException(
             status_code=409,

--- a/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
+++ b/backend/app/api/v1/endpoints/admin/fulfillment_shipping.py
@@ -39,7 +39,15 @@ from app.services.transaction_service import (
     PackagingUsed,
 )
 from app.services import inventory_ledger
-from app.services.inventory_service import get_effective_cost_per_inventory_unit, get_or_create_default_location
+from app.services.inventory_service import (
+    get_effective_cost_per_inventory_unit,
+    get_or_create_default_location,
+    issue_shipped_goods,
+)
+from app.services.sales_order_fulfillment_service import (
+    SHIPPED_ORDER_STATUSES,
+    _create_shipment_gl_entry,
+)
 from app.api.v1.deps import get_current_staff_user
 
 router = APIRouter(prefix="/fulfillment", tags=["Admin - Fulfillment Shipping"])
@@ -356,12 +364,15 @@ async def buy_consolidated_shipping_label(
     rate_id: str,
     shipment_id: str,
     db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_staff_user),
 ):
     """
     Purchase a shipping label for consolidated orders.
 
     Updates ALL orders with the same tracking number.
     Only consumes packaging from ONE order (avoids double-consumption).
+    Relieves finished goods and posts a shipment journal entry per order
+    (#880 PR-4).
     """
     if len(order_ids) < 2:
         raise HTTPException(status_code=400, detail="Need at least 2 orders to consolidate")
@@ -389,6 +400,7 @@ async def buy_consolidated_shipping_label(
 
     # Consume packaging from FIRST order only (consolidated = one box)
     packaging_consumed = []
+    packaging_txns = []  # ledger rows, fed into the first order's GL entry
     first_order = orders[0]
 
     production_orders = db.query(ProductionOrder).filter(
@@ -445,7 +457,7 @@ async def buy_consolidated_shipping_label(
             # The poster acquires a FOR UPDATE lock via
             # get_or_create_inventory_row and writes both the ledger
             # row and the on_hand delta atomically (HARD-4a contract).
-            inventory_ledger.post(
+            pkg_txn = inventory_ledger.post(
                 db,
                 product_id=res_txn.product_id,
                 location_id=location_id,
@@ -461,6 +473,7 @@ async def buy_consolidated_shipping_label(
                 ),
                 created_by="system",
             )
+            packaging_txns.append(pkg_txn)
 
             packaging_consumed.append({
                 "component_sku": component.sku if component else "N/A",
@@ -532,6 +545,35 @@ async def buy_consolidated_shipping_label(
                         created_by="system",
                     )
                     db.add(release_txn)
+
+    # =========================================================================
+    # FG RELIEF + GL — one shipment journal entry per order (#880 PR-4)
+    #
+    # Every order in the consolidation ships its finished goods, so each
+    # gets an FG issue (relieving 1220) and its own journal entry
+    # (DR 5000 COGS / CR 1220 FG). Before this, consolidated shipments
+    # flipped status without relieving FG or posting any GL.
+    #
+    # Packaging attribution constraint: packaging is consumed against the
+    # FIRST order only (one physical box — existing behavior, kept), so the
+    # first order's JE carries the DR 5010 / CR 1230 packaging line.
+    # Per-order 5010 attribution is therefore approximate; the
+    # consolidation's GL TOTALS are exact.
+    #
+    # Retry safety: the status filter above (all orders must be
+    # 'ready_to_ship') rejects re-runs after the flip below, and
+    # _create_shipment_gl_entry's one-JE-per-SO guard backstops against
+    # double-posting GL for an order that already has a shipment entry.
+    # =========================================================================
+    for order in orders:
+        issue_pairs = issue_shipped_goods(db, order, created_by=current_admin.email)
+        issue_txns = [txn for _, txn in issue_pairs]
+        gl_txns = (
+            [*packaging_txns, *issue_txns]
+            if order.id == first_order.id
+            else issue_txns
+        )
+        _create_shipment_gl_entry(db, order, current_admin.id, gl_txns)
 
     # Update ALL orders with same tracking
     order_numbers = []
@@ -1144,11 +1186,26 @@ async def mark_order_shipped(
     Manually mark an order as shipped (for when label was created outside system).
 
     Updates tracking info and optionally sends notification to customer.
+    Issues finished goods and posts the shipment journal entry
+    (DR 5000 COGS / CR 1220 FG) like the other ship paths (#880 PR-4).
     """
     order = db.query(SalesOrder).filter(SalesOrder.id == sales_order_id).first()
 
     if not order:
         raise HTTPException(status_code=404, detail="Sales order not found")
+
+    # Status gate (#880 PR-4): an order already in a shipped-family status
+    # must not be marked shipped again — the FG issue below would
+    # double-decrement finished goods and re-post COGS.
+    if order.status in SHIPPED_ORDER_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Order {order.order_number} is already '{order.status}' — "
+                "marking it shipped again would double-relieve finished "
+                "goods and double-post COGS."
+            ),
+        )
 
     # Update order
     order.tracking_number = request.tracking_number
@@ -1195,7 +1252,7 @@ async def mark_order_shipped(
                 # replacing the float-math direct mutation and the
                 # hand-built InventoryTransaction that bypassed locking.
                 location_id = fg_inventory.location_id or get_or_create_default_location(db).id
-                inventory_ledger.post(
+                ship_txn = inventory_ledger.post(
                     db,
                     product_id=quote.product_id,
                     location_id=location_id,
@@ -1208,6 +1265,12 @@ async def mark_order_shipped(
                     notes=f"Shipped {qty_shipped} units for {order.order_number}",
                     created_by="system",
                 )
+
+                # Journal the shipment (#880 PR-4): DR 5000 COGS / CR 1220 FG,
+                # linked to the ledger row above. _create_shipment_gl_entry
+                # has its own one-JE-per-SO guard, so even a request that
+                # slips past the status gate cannot double-post GL.
+                _create_shipment_gl_entry(db, order, current_admin.id, [ship_txn])
 
                 # Read back the updated on_hand for the response payload.
                 db.flush()

--- a/backend/tests/endpoints/test_fulfillment_endpoint.py
+++ b/backend/tests/endpoints/test_fulfillment_endpoint.py
@@ -2397,7 +2397,7 @@ class TestMarkShippedExtended:
     def test_mark_shipped_from_draft_succeeds(
         self, client, db, make_product, make_sales_order
     ):
-        """Mark shipped works from any status (no status guard)."""
+        """Mark shipped works from any non-shipped status (draft included)."""
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(
             product_id=product.id,
@@ -2413,7 +2413,8 @@ class TestMarkShippedExtended:
                 "carrier": "USPS",
             },
         )
-        # mark-shipped has no status guard, so it succeeds from any status
+        # mark-shipped only gates the shipped-family statuses (#880 PR-4),
+        # so it still succeeds from draft (label made outside the system).
         assert resp.status_code == 200
         db.refresh(so)
         assert so.status == "shipped"
@@ -2939,3 +2940,412 @@ class TestDuplicateShipmentGuard409:
         assert so.status == "confirmed"
         db.refresh(inv)
         assert inv.on_hand_quantity == Decimal("10")
+
+
+# =============================================================================
+# Ship-path completeness (#880 PR-4) — mark-shipped + consolidated buy-label
+# post GL and gate status
+# =============================================================================
+
+def _seed_default_location_inventory(db, product_id, on_hand, allocated=Decimal("0")):
+    """Seed stock at the DEFAULT location (where issue_shipped_goods posts)."""
+    from app.models.inventory import Inventory
+    from app.services.inventory_service import get_or_create_default_location
+
+    location = get_or_create_default_location(db)
+    inv = db.query(Inventory).filter(
+        Inventory.product_id == product_id,
+        Inventory.location_id == location.id,
+    ).first()
+    if inv is None:
+        inv = Inventory(
+            product_id=product_id,
+            location_id=location.id,
+            on_hand_quantity=on_hand,
+            allocated_quantity=allocated,
+        )
+        db.add(inv)
+    else:
+        inv.on_hand_quantity = on_hand
+        inv.allocated_quantity = allocated
+    db.flush()
+    return inv
+
+
+def _shipment_jes(db, so_id):
+    """Non-voided shipment journal entries for a sales order."""
+    from app.models.accounting import GLJournalEntry
+
+    return db.query(GLJournalEntry).filter(
+        GLJournalEntry.source_type == "sales_order",
+        GLJournalEntry.source_id == so_id,
+        GLJournalEntry.status != "voided",
+    ).all()
+
+
+def _je_lines_by_code(db, je_id):
+    """{account_code: (total_debit, total_credit)} for a journal entry."""
+    from app.models.accounting import GLAccount, GLJournalEntryLine
+
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            GLJournalEntryLine.debit_amount,
+            GLJournalEntryLine.credit_amount,
+        )
+        .select_from(GLJournalEntryLine)
+        .join(GLAccount, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(GLJournalEntryLine.journal_entry_id == je_id)
+        .all()
+    )
+    totals = {}
+    for code, debit, credit in rows:
+        dr, cr = totals.get(code, (Decimal("0"), Decimal("0")))
+        totals[code] = (
+            dr + Decimal(str(debit or 0)),
+            cr + Decimal(str(credit or 0)),
+        )
+    return totals
+
+
+def _assert_je_balanced(totals):
+    total_dr = sum(dr for dr, _ in totals.values())
+    total_cr = sum(cr for _, cr in totals.values())
+    assert total_dr == total_cr, f"JE does not balance: DR {total_dr} != CR {total_cr}"
+
+
+def _fg_shipment_txns(db, so_id):
+    from app.models.inventory import InventoryTransaction
+
+    return db.query(InventoryTransaction).filter(
+        InventoryTransaction.reference_type == "sales_order",
+        InventoryTransaction.reference_id == so_id,
+        InventoryTransaction.transaction_type == "shipment",
+    ).all()
+
+
+class TestMarkShippedGL:
+    """mark-shipped posts a DR 5000 / CR 1220 JE and gates shipped statuses (#880 PR-4)."""
+
+    def _make_shippable_order(self, db, make_product, make_quote, make_sales_order,
+                              quantity=2, status="ready_to_ship"):
+        product = make_product(
+            item_type="finished_good",
+            standard_cost=Decimal("5.00"),
+            selling_price=Decimal("20.00"),
+        )
+        quote = make_quote(product_id=product.id)
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=quantity,
+            unit_price=Decimal("20.00"),
+            status=status,
+            quote_id=quote.id,
+        )
+        inv = _seed_default_location_inventory(db, product.id, Decimal("10"))
+        return product, so, inv
+
+    def test_mark_shipped_posts_shipment_txn_and_je(
+        self, client, db, make_product, make_quote, make_sales_order
+    ):
+        """Happy path: FG issue posts a shipment txn AND a linked DR5000/CR1220 JE."""
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, quantity=2
+        )
+
+        resp = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-1", "carrier": "USPS"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["finished_goods_shipped"] is not None
+
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("8")
+
+        txns = _fg_shipment_txns(db, so.id)
+        assert len(txns) == 1
+
+        jes = _shipment_jes(db, so.id)
+        assert len(jes) == 1
+        assert txns[0].journal_entry_id == jes[0].id
+
+        totals = _je_lines_by_code(db, jes[0].id)
+        assert totals["5000"] == (Decimal("10.00"), Decimal("0"))  # 2 x 5.00 COGS
+        assert totals["1220"] == (Decimal("0"), Decimal("10.00"))  # FG relief
+        _assert_je_balanced(totals)
+
+    def test_mark_shipped_already_shipped_409_no_double_decrement(
+        self, client, db, make_product, make_quote, make_sales_order
+    ):
+        """mark-shipped on an already-shipped order 409s and touches nothing."""
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, status="shipped"
+        )
+
+        resp = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-2", "carrier": "USPS"},
+        )
+        assert resp.status_code == 409
+        assert "already" in resp.json()["detail"].lower()
+
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("10")
+        assert _fg_shipment_txns(db, so.id) == []
+        assert _shipment_jes(db, so.id) == []
+
+    @pytest.mark.parametrize("terminal_status", ["delivered", "completed"])
+    def test_mark_shipped_terminal_statuses_409(
+        self, client, db, make_product, make_quote, make_sales_order, terminal_status
+    ):
+        """delivered/completed orders are also gated (SHIPPED_ORDER_STATUSES)."""
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, status=terminal_status
+        )
+
+        resp = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-3", "carrier": "USPS"},
+        )
+        assert resp.status_code == 409
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("10")
+
+    def test_mark_shipped_retry_409_posts_exactly_once(
+        self, client, db, make_product, make_quote, make_sales_order
+    ):
+        """First mark-shipped succeeds; the retry 409s via the status gate,
+        leaving exactly one shipment txn and one JE."""
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, quantity=2
+        )
+
+        first = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-4", "carrier": "USPS"},
+        )
+        assert first.status_code == 200
+
+        retry = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-4-RETRY", "carrier": "USPS"},
+        )
+        assert retry.status_code == 409
+
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("8")  # decremented ONCE
+        assert len(_fg_shipment_txns(db, so.id)) == 1
+        assert len(_shipment_jes(db, so.id)) == 1
+
+    def test_mark_shipped_je_guard_backstop(
+        self, client, db, make_product, make_quote, make_sales_order
+    ):
+        """A ready_to_ship order that somehow already has a shipment JE passes
+        the status gate, but _create_shipment_gl_entry's one-JE-per-SO guard
+        prevents a second journal entry."""
+        from datetime import date
+        from app.models.accounting import GLJournalEntry
+
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, quantity=2
+        )
+        pre_existing = GLJournalEntry(
+            entry_number=f"JE-TEST-{_uid()}",
+            entry_date=date.today(),
+            description=f"Shipment for SO#{so.order_number}",
+            source_type="sales_order",
+            source_id=so.id,
+            status="posted",
+        )
+        db.add(pre_existing)
+        db.flush()
+
+        resp = client.post(
+            f"{BASE}/ship/{so.id}/mark-shipped",
+            json={"tracking_number": "TRK-GL-5", "carrier": "USPS"},
+        )
+        assert resp.status_code == 200  # status gate passes (ready_to_ship)
+
+        db.refresh(inv)
+        assert inv.on_hand_quantity == Decimal("8")  # FG still relieved
+        jes = _shipment_jes(db, so.id)
+        assert len(jes) == 1  # guard: no second JE
+        assert jes[0].id == pre_existing.id
+
+
+class TestConsolidatedBuyLabelGL:
+    """Consolidated buy-label relieves FG for EVERY order and posts one JE
+    per order; the first order's JE carries the packaging (5010) line (#880 PR-4)."""
+
+    _ADDRESS = dict(
+        shipping_address_line1="123 Main St",
+        shipping_city="Austin",
+        shipping_state="TX",
+        shipping_zip="78701",
+    )
+
+    def _make_consolidation(self, db, make_product, make_sales_order):
+        fg1 = make_product(item_type="finished_good", standard_cost=Decimal("5.00"))
+        fg2 = make_product(item_type="finished_good", standard_cost=Decimal("3.00"))
+        so1 = make_sales_order(
+            product_id=fg1.id, quantity=1, unit_price=Decimal("20.00"),
+            status="ready_to_ship", **self._ADDRESS,
+        )
+        so2 = make_sales_order(
+            product_id=fg2.id, quantity=2, unit_price=Decimal("15.00"),
+            status="ready_to_ship", **self._ADDRESS,
+        )
+        inv1 = _seed_default_location_inventory(db, fg1.id, Decimal("5"))
+        inv2 = _seed_default_location_inventory(db, fg2.id, Decimal("5"))
+        return fg1, fg2, so1, so2, inv1, inv2
+
+    def _add_packaging_reservation(
+        self, db, make_product, make_bom, make_production_order, first_so, fg_product
+    ):
+        """Give the first order a shipping-stage packaging reservation, the way
+        production leaves it: BOM shipping line + reservation txn + allocation."""
+        from app.models.inventory import InventoryTransaction
+        from app.services.inventory_service import get_or_create_default_location
+
+        pkg = make_product(
+            item_type="packaging",
+            standard_cost=Decimal("0.50"),
+            name=f"Test box 6x4x3 {_uid()}",
+        )
+        location = get_or_create_default_location(db)
+        _seed_default_location_inventory(
+            db, pkg.id, Decimal("5"), allocated=Decimal("1")
+        )
+        bom = make_bom(product_id=fg_product.id, lines=[
+            {"component_id": pkg.id, "quantity": Decimal("1")},
+        ])
+        bom.lines[0].consume_stage = "shipping"
+        po = make_production_order(
+            product_id=fg_product.id,
+            status="completed",
+            quantity=1,
+            sales_order_id=first_so.id,
+            bom_id=bom.id,
+        )
+        res_txn = InventoryTransaction(
+            product_id=pkg.id,
+            location_id=location.id,
+            transaction_type="reservation",
+            reference_type="production_order",
+            reference_id=po.id,
+            quantity=Decimal("1"),
+            cost_per_unit=Decimal("0.50"),
+            unit="EA",
+            created_by="test",
+        )
+        db.add(res_txn)
+        db.flush()
+        return pkg
+
+    def test_consolidated_relieves_fg_and_posts_je_per_order(
+        self, client, db, make_product, make_sales_order, make_bom,
+        make_production_order, fake_shipping_service,
+    ):
+        """Each order gets FG relief + its own balanced JE; the first order's
+        JE carries the 5010/1230 packaging pair."""
+        fg1, fg2, so1, so2, inv1, inv2 = self._make_consolidation(
+            db, make_product, make_sales_order
+        )
+        pkg = self._add_packaging_reservation(
+            db, make_product, make_bom, make_production_order, so1, fg1
+        )
+
+        resp = client.post(
+            f"{BASE}/ship/consolidate/buy-label?rate_id=rate_1&shipment_id=shp_1",
+            json=[so1.id, so2.id],
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["success"] is True
+
+        # Both orders shipped
+        db.refresh(so1)
+        db.refresh(so2)
+        assert so1.status == "shipped"
+        assert so2.status == "shipped"
+
+        # FG relieved for EVERY order
+        db.refresh(inv1)
+        db.refresh(inv2)
+        assert inv1.on_hand_quantity == Decimal("4")  # 5 - 1
+        assert inv2.on_hand_quantity == Decimal("3")  # 5 - 2
+
+        txns1 = _fg_shipment_txns(db, so1.id)
+        txns2 = _fg_shipment_txns(db, so2.id)
+        assert len(txns1) == 1
+        assert len(txns2) == 1
+
+        # One JE per order, each balanced and linked to its txns
+        jes1 = _shipment_jes(db, so1.id)
+        jes2 = _shipment_jes(db, so2.id)
+        assert len(jes1) == 1
+        assert len(jes2) == 1
+        assert txns1[0].journal_entry_id == jes1[0].id
+        assert txns2[0].journal_entry_id == jes2[0].id
+
+        # First order's JE: FG COGS + the packaging pair
+        totals1 = _je_lines_by_code(db, jes1[0].id)
+        assert totals1["5000"] == (Decimal("5.00"), Decimal("0"))  # 1 x 5.00
+        assert totals1["1220"] == (Decimal("0"), Decimal("5.00"))
+        assert totals1["5010"] == (Decimal("0.50"), Decimal("0"))  # packaging
+        assert totals1["1230"] == (Decimal("0"), Decimal("0.50"))
+        _assert_je_balanced(totals1)
+
+        # Second order's JE: FG COGS only — no packaging lines
+        totals2 = _je_lines_by_code(db, jes2[0].id)
+        assert totals2["5000"] == (Decimal("6.00"), Decimal("0"))  # 2 x 3.00
+        assert totals2["1220"] == (Decimal("0"), Decimal("6.00"))
+        assert "5010" not in totals2
+        assert "1230" not in totals2
+        _assert_je_balanced(totals2)
+
+        # Packaging consumed once, against the first order's JE
+        from app.models.inventory import Inventory, InventoryTransaction
+        pkg_txns = db.query(InventoryTransaction).filter(
+            InventoryTransaction.product_id == pkg.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(pkg_txns) == 1
+        assert pkg_txns[0].journal_entry_id == jes1[0].id
+        pkg_inv = db.query(Inventory).filter(
+            Inventory.product_id == pkg.id
+        ).first()
+        assert pkg_inv.on_hand_quantity == Decimal("4")  # 5 - 1
+        assert pkg_inv.allocated_quantity == Decimal("0")  # reservation released
+
+    def test_consolidated_retry_rejected_no_double_post(
+        self, client, db, make_product, make_sales_order, fake_shipping_service,
+    ):
+        """A retry after a successful consolidation is rejected by the
+        ready_to_ship status filter and posts nothing new."""
+        fg1, fg2, so1, so2, inv1, inv2 = self._make_consolidation(
+            db, make_product, make_sales_order
+        )
+
+        first = client.post(
+            f"{BASE}/ship/consolidate/buy-label?rate_id=rate_1&shipment_id=shp_1",
+            json=[so1.id, so2.id],
+        )
+        assert first.status_code == 200
+
+        retry = client.post(
+            f"{BASE}/ship/consolidate/buy-label?rate_id=rate_1&shipment_id=shp_1",
+            json=[so1.id, so2.id],
+        )
+        assert retry.status_code == 400
+        assert "not found or not ready" in retry.json()["detail"].lower()
+
+        # Nothing double-posted
+        db.refresh(inv1)
+        db.refresh(inv2)
+        assert inv1.on_hand_quantity == Decimal("4")
+        assert inv2.on_hand_quantity == Decimal("3")
+        assert len(_fg_shipment_txns(db, so1.id)) == 1
+        assert len(_fg_shipment_txns(db, so2.id)) == 1
+        assert len(_shipment_jes(db, so1.id)) == 1
+        assert len(_shipment_jes(db, so2.id)) == 1

--- a/backend/tests/endpoints/test_fulfillment_endpoint.py
+++ b/backend/tests/endpoints/test_fulfillment_endpoint.py
@@ -3143,13 +3143,24 @@ class TestMarkShippedGL:
     ):
         """A ready_to_ship order that somehow already has a shipment JE passes
         the status gate, but _create_shipment_gl_entry's one-JE-per-SO guard
-        prevents a second journal entry."""
+        prevents a second journal entry.
+
+        The seeded JE is a realistic posted shipment entry — balanced
+        DR 5000 / CR 1220 lines, source-linked to the sales order — so the
+        guard is proven against the shape a real prior shipment leaves
+        behind, not just a bare header row (#893)."""
         from datetime import date
-        from app.models.accounting import GLJournalEntry
+        from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+        from app.services.payment_service import ensure_core_sales_accounts
 
         product, so, inv = self._make_shippable_order(
             db, make_product, make_quote, make_sales_order, quantity=2
         )
+        ensure_core_sales_accounts(db)
+        accounts = {
+            code: db.query(GLAccount).filter(GLAccount.account_code == code).first()
+            for code in ("5000", "1220")
+        }
         pre_existing = GLJournalEntry(
             entry_number=f"JE-TEST-{_uid()}",
             entry_date=date.today(),
@@ -3159,6 +3170,23 @@ class TestMarkShippedGL:
             status="posted",
         )
         db.add(pre_existing)
+        db.flush()
+        db.add_all([
+            GLJournalEntryLine(
+                journal_entry_id=pre_existing.id,
+                account_id=accounts["5000"].id,
+                debit_amount=Decimal("10.00"),
+                credit_amount=Decimal("0"),
+                line_order=1,
+            ),
+            GLJournalEntryLine(
+                journal_entry_id=pre_existing.id,
+                account_id=accounts["1220"].id,
+                debit_amount=Decimal("0"),
+                credit_amount=Decimal("10.00"),
+                line_order=2,
+            ),
+        ])
         db.flush()
 
         resp = client.post(
@@ -3172,6 +3200,71 @@ class TestMarkShippedGL:
         jes = _shipment_jes(db, so.id)
         assert len(jes) == 1  # guard: no second JE
         assert jes[0].id == pre_existing.id
+
+        # The guard must skip cleanly: the seeded entry's lines are untouched
+        # (no lines appended, amounts unchanged).
+        totals = _je_lines_by_code(db, pre_existing.id)
+        assert totals["5000"] == (Decimal("10.00"), Decimal("0"))
+        assert totals["1220"] == (Decimal("0"), Decimal("10.00"))
+        _assert_je_balanced(totals)
+
+        # The new shipment txn IS recorded, and intentionally stays unlinked:
+        # the guard's contract is skip-don't-adopt (it never claims a JE it
+        # did not create). Happy-path linkage is pinned in
+        # test_mark_shipped_posts_shipment_txn_and_je; asserting None here
+        # makes any future guard-linkage change deliberate, not silent.
+        txns = _fg_shipment_txns(db, so.id)
+        assert len(txns) == 1
+        assert txns[0].journal_entry_id is None
+
+    def test_mark_shipped_locks_order_before_inventory_relief(
+        self, client, db, make_product, make_quote, make_sales_order
+    ):
+        """#893: the shipped-status gate must be atomic with inventory relief.
+        mark-shipped takes a SELECT ... FOR UPDATE row lock on the sales
+        order BEFORE the status check and holds it through the ledger
+        posting, so a concurrent request serializes on the lock and 409s
+        instead of double-relieving finished goods. In-process concurrency
+        is not exercisable through TestClient, so the lock is pinned via
+        SQL emission (maintenance-window lock-test precedent)."""
+        from sqlalchemy import event
+
+        product, so, inv = self._make_shippable_order(
+            db, make_product, make_quote, make_sales_order, quantity=2
+        )
+
+        captured: list[str] = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            captured.append(statement)
+
+        bind = db.get_bind()
+        event.listen(bind, "before_cursor_execute", _capture)
+        try:
+            resp = client.post(
+                f"{BASE}/ship/{so.id}/mark-shipped",
+                json={"tracking_number": "TRK-GL-LOCK", "carrier": "USPS"},
+            )
+        finally:
+            event.remove(bind, "before_cursor_execute", _capture)
+        assert resp.status_code == 200
+
+        lock_indices = [
+            i for i, s in enumerate(captured)
+            if "FOR UPDATE" in s and "sales_orders" in s
+        ]
+        assert lock_indices, (
+            "mark-shipped must row-lock the sales order (SELECT ... FOR "
+            f"UPDATE) before the status gate; statements seen: {captured}"
+        )
+        relief_indices = [
+            i for i, s in enumerate(captured) if "inventory_transactions" in s
+        ]
+        assert relief_indices, "expected inventory ledger activity in mark-shipped"
+        assert lock_indices[0] < relief_indices[0], (
+            "the sales-order row lock must be acquired before any inventory "
+            "ledger activity"
+        )
 
 
 class TestConsolidatedBuyLabelGL:
@@ -3349,3 +3442,106 @@ class TestConsolidatedBuyLabelGL:
         assert len(_fg_shipment_txns(db, so2.id)) == 1
         assert len(_shipment_jes(db, so1.id)) == 1
         assert len(_shipment_jes(db, so2.id)) == 1
+
+    def test_consolidated_packaging_follows_request_order(
+        self, client, db, make_product, make_sales_order, make_bom,
+        make_production_order, fake_shipping_service,
+    ):
+        """#893: 'first order' means order_ids[0] of the REQUEST, not database
+        row order. Request the higher-id order first: its JE — not the
+        lower-id order that an unordered IN query would surface first —
+        must carry the DR 5010 / CR 1230 packaging pair."""
+        fg1, fg2, so1, so2, inv1, inv2 = self._make_consolidation(
+            db, make_product, make_sales_order
+        )
+        assert so1.id < so2.id  # created in this sequence — precondition
+        pkg = self._add_packaging_reservation(
+            db, make_product, make_bom, make_production_order, so2, fg2
+        )
+
+        # so2 (higher id, later DB row) is order_ids[0]
+        resp = client.post(
+            f"{BASE}/ship/consolidate/buy-label?rate_id=rate_1&shipment_id=shp_1",
+            json=[so2.id, so1.id],
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["packaging_consumed"], (
+            "packaging must be consumed from the first REQUESTED order (so2)"
+        )
+
+        # so2's JE carries the packaging pair on top of its FG COGS
+        jes2 = _shipment_jes(db, so2.id)
+        assert len(jes2) == 1
+        totals2 = _je_lines_by_code(db, jes2[0].id)
+        assert totals2["5010"] == (Decimal("0.50"), Decimal("0"))
+        assert totals2["1230"] == (Decimal("0"), Decimal("0.50"))
+        _assert_je_balanced(totals2)
+
+        # so1's JE has no packaging lines
+        jes1 = _shipment_jes(db, so1.id)
+        assert len(jes1) == 1
+        totals1 = _je_lines_by_code(db, jes1[0].id)
+        assert "5010" not in totals1
+        assert "1230" not in totals1
+        _assert_je_balanced(totals1)
+
+        # And the single consumption txn links to so2's JE
+        from app.models.inventory import InventoryTransaction
+        pkg_txns = db.query(InventoryTransaction).filter(
+            InventoryTransaction.product_id == pkg.id,
+            InventoryTransaction.transaction_type == "consumption",
+        ).all()
+        assert len(pkg_txns) == 1
+        assert pkg_txns[0].reference_id == so2.id
+        assert pkg_txns[0].journal_entry_id == jes2[0].id
+
+    def test_consolidated_locks_orders_in_id_order_before_relief(
+        self, client, db, make_product, make_sales_order, fake_shipping_service,
+    ):
+        """#893: consolidated buy-label re-checks order statuses under
+        SELECT ... FOR UPDATE — ordered by id so overlapping consolidations
+        sharing orders acquire locks in the same sequence and cannot
+        deadlock — before any packaging/FG ledger activity. Pinned via SQL
+        emission (see mark-shipped lock test for rationale)."""
+        from sqlalchemy import event
+
+        fg1, fg2, so1, so2, inv1, inv2 = self._make_consolidation(
+            db, make_product, make_sales_order
+        )
+
+        captured: list[str] = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            captured.append(statement)
+
+        bind = db.get_bind()
+        event.listen(bind, "before_cursor_execute", _capture)
+        try:
+            resp = client.post(
+                f"{BASE}/ship/consolidate/buy-label?rate_id=rate_1&shipment_id=shp_1",
+                json=[so1.id, so2.id],
+            )
+        finally:
+            event.remove(bind, "before_cursor_execute", _capture)
+        assert resp.status_code == 200, resp.text
+
+        lock_stmts = [
+            (i, s) for i, s in enumerate(captured)
+            if "FOR UPDATE" in s and "sales_orders" in s
+        ]
+        assert lock_stmts, (
+            "consolidated buy-label must row-lock the sales orders "
+            f"(SELECT ... FOR UPDATE); statements seen: {captured}"
+        )
+        first_lock_idx, first_lock_sql = lock_stmts[0]
+        assert "ORDER BY" in first_lock_sql, (
+            "the lock SELECT must order by id for deadlock-free acquisition"
+        )
+        relief_indices = [
+            i for i, s in enumerate(captured) if "inventory_transactions" in s
+        ]
+        assert relief_indices, "expected inventory ledger activity in consolidation"
+        assert first_lock_idx < relief_indices[0], (
+            "the sales-order row locks must be acquired before any inventory "
+            "ledger activity"
+        )


### PR DESCRIPTION
## What

880 PR-4 — the last two ship paths that flipped order status without complete books:

1. **`POST /ship/{id}/mark-shipped`** (label made outside the system)
   - **409 status gate**: orders already in a shipped-family status (`shipped`/`delivered`/`completed`, via `SHIPPED_ORDER_STATUSES` from `sales_order_fulfillment_service`) are rejected instead of double-decrementing FG and re-posting COGS on retry.
   - **Journaled**: after the FG shipment ledger row posts, `_create_shipment_gl_entry` posts DR 5000 COGS / CR 1220 FG linked to that row. Its one-JE-per-SO guard backstops the gate, so GL can never double-post.

2. **`POST /ship/consolidate/buy-label`** (consolidated shipments)
   - **FG relief for EVERY order** via `issue_shipped_goods` — previously consolidated orders shipped with no FG relief and no GL at all.
   - **One journal entry per order.** Packaging stays consumed against the FIRST order only (one physical box — existing behavior kept), so the first order's JE carries the DR 5010 / CR 1230 packaging pair; a code comment notes per-order 5010 attribution is approximate while the consolidation's GL totals are exact.
   - Existing reservation-release logic for the other orders is unchanged.

## Why

From the #880 GL-vs-dashboard reconciliation: these two ship paths were "status-flip only" — goods left the building with 1220 never relieved and no COGS posted, which is exactly the class of gap that made the GL and the consumption dashboard disjoint. Design: https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351 (§3c). Owner approval: https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880356641.

## How tested

`DB_PASSWORD=Admin python -m pytest` (delta-based, uuid fixtures, EasyPost mocked like the existing #891 tests):

- `tests/endpoints/test_fulfillment_endpoint.py` — **164 passed**, including new:
  - `TestMarkShippedGL`: happy path posts shipment txn AND linked DR5000/CR1220 JE; already-shipped → 409 with zero inventory/GL side effects; `delivered`/`completed` also gated; retry posts exactly once; JE-guard backstop (pre-existing shipment JE → FG still relieved, no second JE).
  - `TestConsolidatedBuyLabelGL`: both orders get FG relief + their own balanced JE, first order's JE carries the 5010/1230 packaging pair (second order's has none), packaging consumed once and linked to the first order's JE, reservation released; retry rejected by the `ready_to_ship` filter with nothing double-posted.
  - All pre-existing #891 duplicate-shipment 409 tests stay green.
- `tests/api/v1/test_fulfillment.py` + `tests/services/test_inventory_ledger.py` — **97 passed** (other mark-shipped / consolidated-consumption coverage).
- `python -m ruff check` clean on the changed app file.

Refs #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shipping actions to prevent duplicate inventory relief and duplicate accounting entries when an order is already shipped or retried.
  * Consolidated shipments now update all related orders consistently, with inventory and billing records kept in sync.
  * Added stronger safeguards for terminal order states so shipped actions are rejected when already completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->