### PR TITLE
feat(accounting): COGS dashboard derives from the GL — one COGS story (880 PR-5)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -36,6 +36,7 @@ from app.models.company_settings import CompanySettings
 from app.models.user import User
 from app.api.v1.deps import get_current_staff_user
 from app.services.payment_service import outstanding_balance_summary
+from app.services import cogs_report_service
 from app.schemas.accounting import (
     InventoryByAccountResponse,
     TransactionsJournalResponse,
@@ -208,9 +209,17 @@ async def get_transactions_as_journal(
     order_id: Optional[int] = Query(None, description="Filter by sales order"),
 ) -> TransactionsJournalResponse:
     """
-    Get inventory transactions formatted as journal entries.
+    Inventory activity (non-GL) — a synthesized, illustrative debit/credit
+    view over raw InventoryTransaction rows, NOT the posted general ledger.
 
-    Each transaction maps to a debit/credit pair based on transaction type:
+    The account codes and pairings below (1300/1310/1320/5100, etc.) are a
+    fictional/simplified chart used only to make this feed readable; they do
+    not match the real chart of accounts the GL posts to (1200/1210/1220/
+    1230/5000/5010/5200 — see gl_accounts / gl_journal_entries). For the
+    real, GL-derived COGS story use /cogs-summary or /dashboard.
+
+    Each transaction maps to an illustrative debit/credit pair based on
+    transaction type:
     - reservation: DR WIP (1310), CR Raw Materials (1300)
     - consumption: DR COGS (5100), CR WIP (1310)
     - receipt (finished goods): DR Finished Goods (1320), CR WIP (1310)
@@ -458,9 +467,13 @@ async def get_cogs_summary(
     days: int = Query(30, description="Number of days"),
 ) -> COGSSummaryResponse:
     """
-    Get COGS summary for recent period.
+    Get COGS summary for recent period — derived from the persisted GL (#880 PR-5).
 
-    Shows total cost of goods sold broken down by category.
+    Anchor is unchanged: shipped/completed sales orders with
+    shipped_at >= now - days. COGS buckets now come from posted
+    gl_journal_entry_lines (shipment JEs' 5000/5010 debits, and the linked
+    production orders' completion-variance 5200 credits), not from a live
+    InventoryTransaction re-sum. See app/services/cogs_report_service.py.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
@@ -471,106 +484,23 @@ async def get_cogs_summary(
     ).all()
 
     total_revenue = Decimal("0")
-    total_material = Decimal("0")
-    total_labor = Decimal("0")
-    total_packaging = Decimal("0")
     total_shipping = Decimal("0")
-
-    # Batch queries to avoid N+1
-    shipped_order_ids = [order.id for order in shipped_orders]
-    
-    # Get all production orders for shipped orders
-    sales_to_po_map = {}
-    all_po_ids = []
-    if shipped_order_ids:
-        production_orders = db.query(ProductionOrder).filter(
-            ProductionOrder.sales_order_id.in_(shipped_order_ids)
-        ).all()
-        for po in production_orders:
-            if po.sales_order_id not in sales_to_po_map:
-                sales_to_po_map[po.sales_order_id] = []
-            sales_to_po_map[po.sales_order_id].append(po.id)
-            all_po_ids.append(po.id)
-    
-    # Get all consumption and scrap transactions in one query.
-    # Scrap = materials consumed in failed WOs (remake costs roll into COGS).
-    # HARD-11: exclude rows that are either:
-    #   (a) unapplied held transactions (requires_approval=True, approved_by IS NULL)
-    #   (b) voided/rejected transactions (voided_by IS NOT NULL)
-    # Both states mean the consumption never actually affected on_hand.
-    po_consumptions = {}
-    if all_po_ids:
-        consumptions = db.query(InventoryTransaction).options(
-            joinedload(InventoryTransaction.product)
-        ).filter(
-            InventoryTransaction.reference_type == 'production_order',
-            InventoryTransaction.reference_id.in_(all_po_ids),
-            InventoryTransaction.transaction_type.in_(['consumption', 'scrap']),
-            # Exclude unapplied held rows
-            ~(
-                InventoryTransaction.requires_approval.is_(True)
-                & InventoryTransaction.approved_by.is_(None)
-            ),
-            # Exclude voided/rejected rows
-            InventoryTransaction.voided_by.is_(None),
-        ).all()
-        
-        for txn in consumptions:
-            if txn.reference_id not in po_consumptions:
-                po_consumptions[txn.reference_id] = []
-            po_consumptions[txn.reference_id].append(txn)
-    
-    # Get all packaging transactions in one query.
-    # HARD-11: same exclusions as production consumptions — unapplied and voided rows
-    # are not real costs (on_hand was never mutated).
-    pkg_consumptions_map = {}
-    if shipped_order_ids:
-        pkg_consumptions = db.query(InventoryTransaction).filter(
-            InventoryTransaction.reference_type.in_(['shipment', 'consolidated_shipment']),
-            InventoryTransaction.reference_id.in_(shipped_order_ids),
-            InventoryTransaction.transaction_type == 'consumption',
-            ~(
-                InventoryTransaction.requires_approval.is_(True)
-                & InventoryTransaction.approved_by.is_(None)
-            ),
-            InventoryTransaction.voided_by.is_(None),
-        ).all()
-        
-        for txn in pkg_consumptions:
-            if txn.reference_id not in pkg_consumptions_map:
-                pkg_consumptions_map[txn.reference_id] = []
-            pkg_consumptions_map[txn.reference_id].append(txn)
-
     for order in shipped_orders:
         # Revenue excludes tax per GAAP
         total_revenue += (order.total_price or Decimal("0"))
         total_shipping += order.shipping_cost or Decimal("0")
 
-        # Get costs from batched transactions
-        po_ids = sales_to_po_map.get(order.id, [])
-        for po_id in po_ids:
-            for txn in po_consumptions.get(po_id, []):
-                product = txn.product
-                sku = product.sku if product else ""
-                qty = abs(float(txn.quantity)) if txn.quantity else 0
-                unit_cost = float(txn.cost_per_unit) if txn.cost_per_unit else 0
-                value = Decimal(str(qty * unit_cost))
+    shipped_order_ids = [order.id for order in shipped_orders]
+    gl_cogs = cogs_report_service.gl_derived_cogs_for_orders(db, shipped_order_ids)
+    reconciliation = gl_cogs.reconciliation
 
-                if sku.startswith("SVC-"):
-                    total_labor += value
-                else:
-                    total_material += value
+    out_of_pocket = reconciliation.out_of_pocket_cogs
+    full_product = reconciliation.full_product_cogs
 
-        # Packaging from batched data
-        for txn in pkg_consumptions_map.get(order.id, []):
-            qty = abs(float(txn.quantity)) if txn.quantity else 0
-            unit_cost = float(txn.cost_per_unit) if txn.cost_per_unit else 0
-            total_packaging += Decimal(str(qty * unit_cost))
-
-    # COGS = production costs only (materials, labor, packaging)
-    # Shipping is an operating expense, not COGS
-    total_cogs = total_material + total_labor + total_packaging
-    gross_profit = total_revenue - total_cogs
+    # Legacy "total" bucket = materials+labor+packaging re-sum, kept for one
+    # release for existing consumers of the cogs.total field.
+    legacy_total = gl_cogs.legacy_total
+    gross_profit = total_revenue - out_of_pocket
     margin = (gross_profit / total_revenue * 100) if total_revenue > 0 else Decimal("0")
 
     return {
@@ -578,10 +508,17 @@ async def get_cogs_summary(
         "orders_shipped": len(shipped_orders),
         "revenue": float(total_revenue),
         "cogs": {
-            "materials": float(total_material),
-            "labor": float(total_labor),
-            "packaging": float(total_packaging),
-            "total": float(total_cogs),
+            "materials": float(gl_cogs.legacy_materials),
+            "labor": float(gl_cogs.legacy_labor),
+            "packaging": float(gl_cogs.legacy_packaging),
+            "total": float(legacy_total),
+        },
+        "out_of_pocket_cogs": float(out_of_pocket),
+        "full_product_cogs": float(full_product),
+        "reconciliation": {
+            "ship_cogs_5000": float(reconciliation.ship_cogs_5000),
+            "packaging_5010": float(reconciliation.packaging_5010),
+            "completion_variance_5200": float(reconciliation.completion_variance_5200),
         },
         "shipping_expense": float(total_shipping),  # Separate operating expense
         "gross_profit": float(gross_profit),
@@ -667,59 +604,16 @@ async def get_accounting_dashboard(
         SalesOrder.status.in_(["shipped", "completed"])
     ).all()
 
-    mtd_cogs = Decimal("0")
-    
-    # Batch queries to avoid N+1
+    # COGS this month — GL-derived (#880 PR-5), same derivation as
+    # get_cogs_summary and get_profit_summary. mtd figure is
+    # out_of_pocket_cogs (materials + packaging actually spent, built-in
+    # labor/machine value backed out via the 5200 variance) so this and the
+    # COGS tab tell the same story.
     shipped_order_ids = [order.id for order in shipped_mtd]
-    
-    # Build mapping of sales_order_id -> list of production_order_ids
-    sales_to_po_map = {}
-    all_po_ids = []
-    if shipped_order_ids:
-        production_orders = db.query(ProductionOrder).filter(
-            ProductionOrder.sales_order_id.in_(shipped_order_ids)
-        ).all()
-        
-        for po in production_orders:
-            if po.sales_order_id not in sales_to_po_map:
-                sales_to_po_map[po.sales_order_id] = []
-            sales_to_po_map[po.sales_order_id].append(po.id)
-            all_po_ids.append(po.id)
-    
-    # Query all material costs in one batch (including scrap from failed WOs).
-    # HARD-11: exclude unapplied held rows and voided rows — they never
-    # affected on_hand and must not inflate COGS.
-    po_material_costs = {}
-    if all_po_ids:
-        material_costs_result = db.query(
-            InventoryTransaction.reference_id,
-            func.coalesce(
-                func.sum(func.abs(InventoryTransaction.quantity) * func.coalesce(InventoryTransaction.cost_per_unit, 0)),
-                0
-            ).label('material_cost')
-        ).filter(
-            InventoryTransaction.reference_type == 'production_order',
-            InventoryTransaction.reference_id.in_(all_po_ids),
-            InventoryTransaction.transaction_type.in_(['consumption', 'scrap']),
-            # Exclude unapplied held rows
-            ~(
-                InventoryTransaction.requires_approval.is_(True)
-                & InventoryTransaction.approved_by.is_(None)
-            ),
-            # Exclude voided/rejected rows
-            InventoryTransaction.voided_by.is_(None),
-        ).group_by(InventoryTransaction.reference_id).all()
-        
-        po_material_costs = {row.reference_id: row.material_cost for row in material_costs_result}
-    
-    # Calculate COGS using batched data
-    # Note: Only include actual production costs, not customer shipping charges
-    for order in shipped_mtd:
-        # Add material costs from production orders
-        po_ids = sales_to_po_map.get(order.id, [])
-        for po_id in po_ids:
-            material_cost = po_material_costs.get(po_id, Decimal("0"))
-            mtd_cogs += material_cost
+    mtd_gl_cogs = cogs_report_service.gl_derived_cogs_for_orders(
+        db, shipped_order_ids, include_legacy=False
+    )
+    mtd_cogs = mtd_gl_cogs.out_of_pocket_cogs
 
     # Gross profit = Revenue - COGS (tax excluded per GAAP)
     mtd_gross_profit = Decimal(str(mtd_revenue)) - mtd_cogs

--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -469,19 +469,19 @@ async def get_cogs_summary(
     """
     Get COGS summary for recent period — derived from the persisted GL (#880 PR-5).
 
-    Anchor is unchanged: shipped/completed sales orders with
-    shipped_at >= now - days. COGS buckets now come from posted
-    gl_journal_entry_lines (shipment JEs' 5000/5010 debits, and the linked
-    production orders' completion-variance 5200 credits), not from a live
-    InventoryTransaction re-sum. See app/services/cogs_report_service.py.
+    Anchor: the shared cogs_report_service anchor set (shipped/completed/
+    delivered sales orders with shipped_at >= now - days) — the SAME helper
+    /accounting/dashboard and /dashboard/profit-summary use, so no COGS
+    surface can disagree about which orders are in the window. COGS buckets
+    come from posted gl_journal_entry_lines (shipment JEs' 5000/5010 debits,
+    and the linked production orders' completion-variance 5200 credits), not
+    from a live InventoryTransaction re-sum.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
-    # Get shipped orders in period
-    shipped_orders = db.query(SalesOrder).filter(
-        SalesOrder.status.in_(['shipped', 'completed']),
-        SalesOrder.shipped_at >= cutoff
-    ).all()
+    # Anchor orders in period — full rows (revenue needs amounts), from the
+    # one shared anchor helper so revenue and COGS use the same status set.
+    shipped_orders = cogs_report_service.shipped_orders_in_window(db, start=cutoff)
 
     total_revenue = Decimal("0")
     total_shipping = Decimal("0")
@@ -558,22 +558,20 @@ async def get_accounting_dashboard(
     else:
         fiscal_year_start = today_start.replace(year=now.year - 1, month=fiscal_month, day=1)
 
-    # Revenue MTD (recognized at shipment per GAAP)
-    mtd_orders = db.query(SalesOrder).filter(
-        SalesOrder.shipped_at >= month_start,
-        SalesOrder.status.in_(["shipped", "completed"])
-    ).all()
+    # Revenue MTD (recognized at shipment per GAAP) — anchored on the shared
+    # cogs_report_service anchor set (shipped/completed/delivered) so revenue
+    # and the MTD COGS below can never use different status sets.
+    mtd_orders = cogs_report_service.shipped_orders_in_window(db, start=month_start)
 
     # Revenue excludes tax and shipping (liabilities/operating expenses, not revenue)
     mtd_revenue = sum(float(_order_revenue_amount(o)) for o in mtd_orders)
     mtd_tax = sum(float(o.tax_amount or 0) for o in mtd_orders)
     mtd_orders_count = len(mtd_orders)
 
-    # Revenue YTD
-    ytd_orders = db.query(SalesOrder).filter(
-        SalesOrder.shipped_at >= fiscal_year_start,
-        SalesOrder.status.in_(["shipped", "completed"])
-    ).all()
+    # Revenue YTD — same shared anchor helper.
+    ytd_orders = cogs_report_service.shipped_orders_in_window(
+        db, start=fiscal_year_start
+    )
 
     # Revenue excludes tax and shipping (liabilities/operating expenses, not revenue)
     ytd_revenue = sum(float(_order_revenue_amount(o)) for o in ytd_orders)
@@ -598,18 +596,14 @@ async def get_accounting_dashboard(
     # SalesOrder.payment_status labels do not skew AR.
     total_outstanding, outstanding_order_count = outstanding_balance_summary(db)
 
-    # COGS this month (from shipped orders)
-    shipped_mtd = db.query(SalesOrder).filter(
-        SalesOrder.shipped_at >= month_start,
-        SalesOrder.status.in_(["shipped", "completed"])
-    ).all()
-
     # COGS this month — GL-derived (#880 PR-5), same derivation as
-    # get_cogs_summary and get_profit_summary. mtd figure is
+    # get_cogs_summary and get_profit_summary. Anchored on the SAME
+    # mtd_orders rows the revenue figures above use (one anchor query, one
+    # status set — no separate re-query that could drift). mtd figure is
     # out_of_pocket_cogs (materials + packaging actually spent, built-in
     # labor/machine value backed out via the 5200 variance) so this and the
     # COGS tab tell the same story.
-    shipped_order_ids = [order.id for order in shipped_mtd]
+    shipped_order_ids = [order.id for order in mtd_orders]
     mtd_gl_cogs = cogs_report_service.gl_derived_cogs_for_orders(
         db, shipped_order_ids, include_legacy=False
     )

--- a/backend/app/api/v1/endpoints/admin/dashboard.py
+++ b/backend/app/api/v1/endpoints/admin/dashboard.py
@@ -19,10 +19,10 @@ from app.models.sales_order import SalesOrder
 from app.models.production_order import ProductionOrder
 from app.models.bom import BOM
 from app.models.product import Product
-from app.models.inventory import InventoryTransaction
 from app.models.payment import Payment
 from app.api.v1.deps import get_current_staff_user
 from app.services import notification_service
+from app.services import cogs_report_service
 
 router = APIRouter(prefix="/dashboard", tags=["Admin - Dashboard"])
 
@@ -1123,7 +1123,9 @@ async def get_profit_summary(
 
     Calculates:
     - Revenue from completed/shipped sales orders (this month and YTD)
-    - COGS from material consumption in production (this month and YTD)
+    - COGS derived from the persisted GL (#880 PR-5) — same derivation as
+      /accounting/cogs-summary and /accounting/dashboard, so this and those
+      surfaces never disagree
     - Gross profit and gross margin percentages
 
     Admin only. Freemium tier - basic profit view.
@@ -1162,47 +1164,25 @@ async def get_profit_summary(
     )
     revenue_ytd = revenue_ytd_result or Decimal("0")
 
-    # ========== COGS CALCULATION ==========
-    # Sum of material costs consumed in production
-    # We use inventory transactions with transaction_type='consumption'
-    # and reference_type='production_order' to track material usage
-    # The cost_per_unit field contains the material cost
-
-    # COGS this month (material consumption)
-    # abs(): ledger rows store signed quantities post-HARD-4a (legacy rows
-    # mixed both conventions) — cost is a magnitude either way.
-    cogs_this_month_result = (
-        db.query(
-            func.sum(
-                func.abs(InventoryTransaction.quantity) *
-                func.coalesce(InventoryTransaction.cost_per_unit, 0)
-            )
-        )
-        .filter(
-            InventoryTransaction.transaction_type == "consumption",
-            InventoryTransaction.reference_type == "production_order",
-            InventoryTransaction.created_at >= month_start,
-        )
-        .scalar()
+    # ========== COGS CALCULATION (GL-derived, #880 PR-5) ==========
+    # out_of_pocket_cogs anchored on the same shipped/completed +
+    # shipped_at-window sales-order set the other COGS surfaces use — see
+    # app/services/cogs_report_service.py. Anchored on shipped_at (not
+    # InventoryTransaction.created_at) so this and /accounting/cogs-summary
+    # never disagree about which orders are "this month".
+    month_order_ids = cogs_report_service.shipped_order_ids_in_window(
+        db, start=month_start
     )
-    cogs_this_month = cogs_this_month_result or Decimal("0")
+    cogs_this_month = cogs_report_service.gl_derived_cogs_for_orders(
+        db, month_order_ids, include_legacy=False
+    ).out_of_pocket_cogs
 
-    # COGS YTD
-    cogs_ytd_result = (
-        db.query(
-            func.sum(
-                func.abs(InventoryTransaction.quantity) *
-                func.coalesce(InventoryTransaction.cost_per_unit, 0)
-            )
-        )
-        .filter(
-            InventoryTransaction.transaction_type == "consumption",
-            InventoryTransaction.reference_type == "production_order",
-            InventoryTransaction.created_at >= year_start,
-        )
-        .scalar()
+    year_order_ids = cogs_report_service.shipped_order_ids_in_window(
+        db, start=year_start
     )
-    cogs_ytd = cogs_ytd_result or Decimal("0")
+    cogs_ytd = cogs_report_service.gl_derived_cogs_for_orders(
+        db, year_order_ids, include_legacy=False
+    ).out_of_pocket_cogs
 
     # ========== PROFIT CALCULATION ==========
     gross_profit_this_month = revenue_this_month - cogs_this_month
@@ -1224,7 +1204,7 @@ async def get_profit_summary(
     # Add note if COGS tracking is limited
     note = None
     if cogs_this_month == 0 and cogs_ytd == 0:
-        note = "COGS tracking requires inventory consumption transactions from production orders. Values may be zero if material consumption is not being tracked."
+        note = "COGS is derived from posted GL journal entries for shipped orders. Values may be zero if no orders have shipped, or if shipments haven't posted GL entries yet."
 
     return ProfitSummary(
         revenue_this_month=revenue_this_month,

--- a/backend/app/schemas/accounting.py
+++ b/backend/app/schemas/accounting.py
@@ -440,8 +440,8 @@ class COGSBreakdown(BaseModel):
 class COGSReconciliationSchema(BaseModel):
     """The GL identity behind the two headline COGS numbers.
 
-    full_product_cogs (ship_cogs_5000) - completion_variance_5200
-        == out_of_pocket_cogs
+    ship_cogs_5000 + packaging_5010 - completion_variance_5200 (net linked
+        credit) == out_of_pocket_cogs
     """
     ship_cogs_5000: float
     packaging_5010: float

--- a/backend/app/schemas/accounting.py
+++ b/backend/app/schemas/accounting.py
@@ -423,19 +423,53 @@ class OrderCostBreakdownResponse(BaseModel):
 # --- COGS Summary ---
 
 class COGSBreakdown(BaseModel):
-    """COGS breakdown by category."""
+    """COGS breakdown by category.
+
+    Legacy bucket split (materials/labor/packaging), kept populated for one
+    release from a re-sum of the same InventoryTransaction rows this
+    endpoint used before #880 PR-5. `total` mirrors the legacy total
+    (materials+labor+packaging) — use out_of_pocket_cogs/full_product_cogs
+    on COGSSummaryResponse for the GL-derived numbers.
+    """
     materials: float
     labor: float
     packaging: float
     total: float
 
 
+class COGSReconciliationSchema(BaseModel):
+    """The GL identity behind the two headline COGS numbers.
+
+    full_product_cogs (ship_cogs_5000) - completion_variance_5200
+        == out_of_pocket_cogs
+    """
+    ship_cogs_5000: float
+    packaging_5010: float
+    completion_variance_5200: float
+
+
 class COGSSummaryResponse(BaseModel):
-    """Response for GET /cogs-summary."""
+    """Response for GET /cogs-summary.
+
+    GL-derived (#880 PR-5): buckets come from posted gl_journal_entry_lines
+    on the shipment JEs (5000/5010) and the linked production orders'
+    completion-variance JEs (5200), not from a live re-sum of
+    InventoryTransaction. See app/services/cogs_report_service.py.
+
+    - out_of_pocket_cogs: what the shipped orders cost out of pocket
+      (materials + packaging actually spent; built-in labor/machine value
+      backed out via the 5200 variance).
+    - full_product_cogs: full FG-cost COGS (5000 debits) for margin
+      analysis — includes built-in labor & machine.
+    - reconciliation: the three GL buckets so the UI can show the identity.
+    """
     period: str
     orders_shipped: int
     revenue: float
     cogs: COGSBreakdown
+    out_of_pocket_cogs: float
+    full_product_cogs: float
+    reconciliation: COGSReconciliationSchema
     shipping_expense: float
     gross_profit: float
     gross_margin_pct: float

--- a/backend/app/services/cogs_report_service.py
+++ b/backend/app/services/cogs_report_service.py
@@ -1,0 +1,284 @@
+"""
+COGS reporting from the persisted GL (#880 PR-5).
+
+One COGS story everywhere: the accounting dashboard, the COGS summary tab,
+and the freemium profit summary all derive their COGS numbers from the SAME
+posted `gl_journal_entry_lines` — no more parallel InventoryTransaction
+re-sums that can (and did) disagree with the GL.
+
+Anchor: shipped/completed sales orders in a window, exactly as before
+(status in shipped/completed, shipped_at >= cutoff). For each anchor order:
+
+- Ship-side (5000, 5010): sum DEBIT lines on posted journal entries with
+  source_type='sales_order' AND source_id IN (anchor ids). These are the
+  shipment GL entries posted by `_create_shipment_gl_entry`
+  (sales_order_fulfillment_service.py) — 5000 = COGS at FG cost, 5010 =
+  shipping supplies (packaging).
+- Completion-variance side (5200): for the anchor orders' linked production
+  orders (production_orders.sales_order_id IN anchor ids), sum posted
+  journal entries with source_type='production_order' AND source_id IN
+  (those PO ids), net CREDIT minus DEBIT on 5200. Scoped STRICTLY to POs
+  linked to an anchor order — a cancelled order's PO variance must never
+  leak into another order's window (live data has exactly this case).
+
+Two headline numbers:
+- out_of_pocket_cogs = (5000 + 5010 debits) - (net linked 5200 credits)
+  ~= actual materials + packaging spend (labor/machine value backed out).
+- full_product_cogs = Σ 5000 debits (margin-analysis view, full FG cost).
+
+Draft/voided journal entries are excluded (status == 'posted' only).
+"""
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, Iterable, List, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
+from app.models.production_order import ProductionOrder
+from app.models.sales_order import SalesOrder
+
+SHIP_COGS_ACCOUNT = "5000"
+SHIP_PACKAGING_ACCOUNT = "5010"
+COMPLETION_VARIANCE_ACCOUNT = "5200"
+
+_MONEY = Decimal("0.01")
+
+
+@dataclass
+class COGSReconciliation:
+    """The GL identity behind the two headline numbers.
+
+    full_product_cogs (5000) - completion_variance_5200 (net linked credit)
+        == out_of_pocket_cogs
+    """
+    ship_cogs_5000: Decimal = Decimal("0.00")
+    packaging_5010: Decimal = Decimal("0.00")
+    completion_variance_5200: Decimal = Decimal("0.00")
+
+    @property
+    def out_of_pocket_cogs(self) -> Decimal:
+        return (
+            self.ship_cogs_5000 + self.packaging_5010 - self.completion_variance_5200
+        ).quantize(_MONEY)
+
+    @property
+    def full_product_cogs(self) -> Decimal:
+        return self.ship_cogs_5000.quantize(_MONEY)
+
+
+@dataclass
+class GLDerivedCOGS:
+    """GL-derived COGS for a set of anchor (shipped) sales orders."""
+    order_ids: List[int] = field(default_factory=list)
+    reconciliation: COGSReconciliation = field(default_factory=COGSReconciliation)
+
+    # Legacy buckets, computed from the SAME anchor set, preserved so
+    # existing API consumers keep working for one release. These are NOT
+    # GL-derived (the GL doesn't split materials vs labor vs packaging by
+    # component) — they are the pre-#880 InventoryTransaction re-sum, kept
+    # verbatim for backward compatibility. New code should use
+    # out_of_pocket_cogs / full_product_cogs / reconciliation instead.
+    legacy_materials: Decimal = Decimal("0.00")
+    legacy_labor: Decimal = Decimal("0.00")
+    legacy_packaging: Decimal = Decimal("0.00")
+
+    @property
+    def out_of_pocket_cogs(self) -> Decimal:
+        return self.reconciliation.out_of_pocket_cogs
+
+    @property
+    def full_product_cogs(self) -> Decimal:
+        return self.reconciliation.full_product_cogs
+
+    @property
+    def legacy_total(self) -> Decimal:
+        return (
+            self.legacy_materials + self.legacy_labor + self.legacy_packaging
+        ).quantize(_MONEY)
+
+
+def _sum_ship_side(db: Session, order_ids: List[int]) -> Dict[str, Decimal]:
+    """Σ DEBIT lines on posted ship JEs for these orders, by account code."""
+    totals = {SHIP_COGS_ACCOUNT: Decimal("0.00"), SHIP_PACKAGING_ACCOUNT: Decimal("0.00")}
+    if not order_ids:
+        return totals
+
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            func.coalesce(func.sum(GLJournalEntryLine.debit_amount), 0),
+        )
+        .join(GLJournalEntryLine, GLJournalEntryLine.account_id == GLAccount.id)
+        .join(GLJournalEntry, GLJournalEntryLine.journal_entry_id == GLJournalEntry.id)
+        .filter(
+            GLJournalEntry.source_type == "sales_order",
+            GLJournalEntry.source_id.in_(order_ids),
+            GLJournalEntry.status == "posted",
+            GLAccount.account_code.in_([SHIP_COGS_ACCOUNT, SHIP_PACKAGING_ACCOUNT]),
+        )
+        .group_by(GLAccount.account_code)
+        .all()
+    )
+    for code, total in rows:
+        totals[code] = Decimal(str(total or 0)).quantize(_MONEY)
+    return totals
+
+
+def _linked_production_order_ids(db: Session, order_ids: List[int]) -> List[int]:
+    if not order_ids:
+        return []
+    return [
+        row[0]
+        for row in db.query(ProductionOrder.id).filter(
+            ProductionOrder.sales_order_id.in_(order_ids)
+        )
+    ]
+
+
+def _sum_completion_variance(db: Session, production_order_ids: List[int]) -> Decimal:
+    """Net CREDIT - DEBIT on 5200 for posted completion JEs of these POs only.
+
+    Scoped strictly to production_order_ids linked to the anchor sales
+    orders — a cancelled order's own PO variance must not count toward a
+    different order's window (live data: PO-0001 belongs to cancelled
+    SO-0001, and must not leak into other orders' out_of_pocket_cogs).
+    """
+    if not production_order_ids:
+        return Decimal("0.00")
+
+    row = (
+        db.query(
+            func.coalesce(func.sum(GLJournalEntryLine.credit_amount), 0),
+            func.coalesce(func.sum(GLJournalEntryLine.debit_amount), 0),
+        )
+        .join(GLJournalEntry, GLJournalEntryLine.journal_entry_id == GLJournalEntry.id)
+        .join(GLAccount, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(
+            GLJournalEntry.source_type == "production_order",
+            GLJournalEntry.source_id.in_(production_order_ids),
+            GLJournalEntry.status == "posted",
+            GLAccount.account_code == COMPLETION_VARIANCE_ACCOUNT,
+        )
+        .first()
+    )
+    credit_total, debit_total = row if row else (0, 0)
+    net = Decimal(str(credit_total or 0)) - Decimal(str(debit_total or 0))
+    return net.quantize(_MONEY)
+
+
+def _legacy_buckets(db, order_ids: List[int]) -> Dict[str, Decimal]:
+    """Pre-#880 InventoryTransaction re-sum, preserved verbatim for the
+    legacy response keys (materials/labor/packaging split the GL doesn't
+    carry). Mirrors the exact filters get_cogs_summary used before this PR.
+    """
+    from app.models.inventory import InventoryTransaction
+
+    materials = Decimal("0.00")
+    labor = Decimal("0.00")
+    packaging = Decimal("0.00")
+
+    if not order_ids:
+        return {"materials": materials, "labor": labor, "packaging": packaging}
+
+    po_ids = _linked_production_order_ids(db, order_ids)
+
+    if po_ids:
+        consumptions = db.query(InventoryTransaction).options(
+            joinedload(InventoryTransaction.product)
+        ).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id.in_(po_ids),
+            InventoryTransaction.transaction_type.in_(["consumption", "scrap"]),
+            ~(
+                InventoryTransaction.requires_approval.is_(True)
+                & InventoryTransaction.approved_by.is_(None)
+            ),
+            InventoryTransaction.voided_by.is_(None),
+        ).all()
+        for txn in consumptions:
+            product = txn.product
+            sku = product.sku if product else ""
+            qty = abs(Decimal(str(txn.quantity))) if txn.quantity else Decimal("0")
+            unit_cost = Decimal(str(txn.cost_per_unit)) if txn.cost_per_unit else Decimal("0")
+            value = qty * unit_cost
+            if sku.startswith("SVC-"):
+                labor += value
+            else:
+                materials += value
+
+    pkg_consumptions = db.query(InventoryTransaction).filter(
+        InventoryTransaction.reference_type.in_(["shipment", "consolidated_shipment"]),
+        InventoryTransaction.reference_id.in_(order_ids),
+        InventoryTransaction.transaction_type == "consumption",
+        ~(
+            InventoryTransaction.requires_approval.is_(True)
+            & InventoryTransaction.approved_by.is_(None)
+        ),
+        InventoryTransaction.voided_by.is_(None),
+    ).all()
+    for txn in pkg_consumptions:
+        qty = abs(Decimal(str(txn.quantity))) if txn.quantity else Decimal("0")
+        unit_cost = Decimal(str(txn.cost_per_unit)) if txn.cost_per_unit else Decimal("0")
+        packaging += qty * unit_cost
+
+    return {
+        "materials": materials.quantize(_MONEY),
+        "labor": labor.quantize(_MONEY),
+        "packaging": packaging.quantize(_MONEY),
+    }
+
+
+def gl_derived_cogs_for_orders(
+    db: Session, order_ids: Iterable[int], include_legacy: bool = True
+) -> GLDerivedCOGS:
+    """GL-derived COGS for an arbitrary set of anchor (shipped) sales order ids.
+
+    Callers pass whatever window/anchor query they need (cogs-summary's
+    `days` window, the accounting dashboard's MTD window, or the freemium
+    profit-summary's month/YTD windows) — this function only needs the
+    resulting order ids, so all three surfaces share one derivation.
+    """
+    ids = sorted({int(i) for i in order_ids})
+
+    ship_totals = _sum_ship_side(db, ids)
+    po_ids = _linked_production_order_ids(db, ids)
+    variance = _sum_completion_variance(db, po_ids)
+
+    reconciliation = COGSReconciliation(
+        ship_cogs_5000=ship_totals[SHIP_COGS_ACCOUNT],
+        packaging_5010=ship_totals[SHIP_PACKAGING_ACCOUNT],
+        completion_variance_5200=variance,
+    )
+
+    legacy = (
+        _legacy_buckets(db, ids)
+        if include_legacy
+        else {"materials": Decimal("0.00"), "labor": Decimal("0.00"), "packaging": Decimal("0.00")}
+    )
+
+    return GLDerivedCOGS(
+        order_ids=ids,
+        reconciliation=reconciliation,
+        legacy_materials=legacy["materials"],
+        legacy_labor=legacy["labor"],
+        legacy_packaging=legacy["packaging"],
+    )
+
+
+def shipped_order_ids_in_window(
+    db: Session, *, start: Optional[datetime] = None, end: Optional[datetime] = None
+) -> List[int]:
+    """Anchor query shared by callers: shipped/completed orders whose
+    shipped_at falls in [start, end). Either bound may be omitted.
+    """
+    query = db.query(SalesOrder.id).filter(
+        SalesOrder.status.in_(["shipped", "completed"])
+    )
+    if start is not None:
+        query = query.filter(SalesOrder.shipped_at >= start)
+    if end is not None:
+        query = query.filter(SalesOrder.shipped_at < end)
+    return [row[0] for row in query.all()]

--- a/backend/app/services/cogs_report_service.py
+++ b/backend/app/services/cogs_report_service.py
@@ -6,8 +6,11 @@ and the freemium profit summary all derive their COGS numbers from the SAME
 posted `gl_journal_entry_lines` — no more parallel InventoryTransaction
 re-sums that can (and did) disagree with the GL.
 
-Anchor: shipped/completed sales orders in a window, exactly as before
-(status in shipped/completed, shipped_at >= cutoff). For each anchor order:
+Anchor: shipped/completed/delivered sales orders in a window (status in
+shipped/completed/delivered, shipped_at >= cutoff). A delivered order was
+shipped — its ship JE already exists — so it belongs in the same anchor set
+revenue uses; excluding it left delivered orders with revenue but zero COGS
+in gross_profit/gross_margin. For each anchor order:
 
 - Ship-side (5000, 5010): sum DEBIT lines on posted journal entries with
   source_type='sales_order' AND source_id IN (anchor ids). These are the
@@ -51,8 +54,8 @@ _MONEY = Decimal("0.01")
 class COGSReconciliation:
     """The GL identity behind the two headline numbers.
 
-    full_product_cogs (5000) - completion_variance_5200 (net linked credit)
-        == out_of_pocket_cogs
+    ship_cogs_5000 + packaging_5010 - completion_variance_5200 (net linked
+        credit) == out_of_pocket_cogs
     """
     ship_cogs_5000: Decimal = Decimal("0.00")
     packaging_5010: Decimal = Decimal("0.00")
@@ -271,11 +274,17 @@ def gl_derived_cogs_for_orders(
 def shipped_order_ids_in_window(
     db: Session, *, start: Optional[datetime] = None, end: Optional[datetime] = None
 ) -> List[int]:
-    """Anchor query shared by callers: shipped/completed orders whose
-    shipped_at falls in [start, end). Either bound may be omitted.
+    """Anchor query shared by callers: shipped/completed/delivered orders
+    whose shipped_at falls in [start, end). Either bound may be omitted.
+
+    `delivered` is included alongside `shipped`/`completed` because a
+    delivered order was shipped — its ship JE (5000/5010) already posted —
+    so it must anchor COGS the same way it anchors revenue. Dropping it here
+    left delivered orders contributing revenue with zero COGS in the
+    dashboard's gross_profit/gross_margin (CodeRabbit #897).
     """
     query = db.query(SalesOrder.id).filter(
-        SalesOrder.status.in_(["shipped", "completed"])
+        SalesOrder.status.in_(["shipped", "completed", "delivered"])
     )
     if start is not None:
         query = query.filter(SalesOrder.shipped_at >= start)

--- a/backend/app/services/cogs_report_service.py
+++ b/backend/app/services/cogs_report_service.py
@@ -47,6 +47,15 @@ SHIP_COGS_ACCOUNT = "5000"
 SHIP_PACKAGING_ACCOUNT = "5010"
 COMPLETION_VARIANCE_ACCOUNT = "5200"
 
+# THE anchor status set for every COGS surface (and the revenue queries
+# paired with them). One definition so /accounting/cogs-summary,
+# /accounting/dashboard and /admin/dashboard/profit-summary can never
+# disagree about which orders are "in the window" — that disagreement is
+# exactly the bug class #880 PR-5 exists to kill. `delivered` is included
+# because a delivered order was shipped (its ship JE posted); see
+# shipped_order_ids_in_window below.
+ANCHOR_STATUSES = ("shipped", "completed", "delivered")
+
 _MONEY = Decimal("0.01")
 
 
@@ -271,6 +280,29 @@ def gl_derived_cogs_for_orders(
     )
 
 
+def _anchor_window_query(
+    db: Session, *, start: Optional[datetime] = None, end: Optional[datetime] = None
+):
+    """The one anchor-window filter every COGS surface shares."""
+    query = db.query(SalesOrder).filter(SalesOrder.status.in_(ANCHOR_STATUSES))
+    if start is not None:
+        query = query.filter(SalesOrder.shipped_at >= start)
+    if end is not None:
+        query = query.filter(SalesOrder.shipped_at < end)
+    return query
+
+
+def shipped_orders_in_window(
+    db: Session, *, start: Optional[datetime] = None, end: Optional[datetime] = None
+) -> List[SalesOrder]:
+    """Full SalesOrder rows for the anchor set (same window semantics as
+    shipped_order_ids_in_window). For callers that also need revenue/tax
+    amounts off the anchored orders — so their revenue and COGS can never
+    be computed from different status sets.
+    """
+    return _anchor_window_query(db, start=start, end=end).all()
+
+
 def shipped_order_ids_in_window(
     db: Session, *, start: Optional[datetime] = None, end: Optional[datetime] = None
 ) -> List[int]:
@@ -283,11 +315,9 @@ def shipped_order_ids_in_window(
     left delivered orders contributing revenue with zero COGS in the
     dashboard's gross_profit/gross_margin (CodeRabbit #897).
     """
-    query = db.query(SalesOrder.id).filter(
-        SalesOrder.status.in_(["shipped", "completed", "delivered"])
-    )
-    if start is not None:
-        query = query.filter(SalesOrder.shipped_at >= start)
-    if end is not None:
-        query = query.filter(SalesOrder.shipped_at < end)
-    return [row[0] for row in query.all()]
+    return [
+        row[0]
+        for row in _anchor_window_query(db, start=start, end=end)
+        .with_entities(SalesOrder.id)
+        .all()
+    ]

--- a/backend/tests/test_cogs_gl_derivation.py
+++ b/backend/tests/test_cogs_gl_derivation.py
@@ -26,7 +26,10 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from app.services import inventory_service
-from app.services.cogs_report_service import gl_derived_cogs_for_orders
+from app.services.cogs_report_service import (
+    gl_derived_cogs_for_orders,
+    shipped_order_ids_in_window,
+)
 from app.services.production_gl_service import create_production_completion_gl_entry
 from app.services.transaction_service import ShipmentItem, TransactionService
 
@@ -280,11 +283,24 @@ class TestCOGSSummaryGLDerived:
         resp = client.get(f"{BASE}/cogs-summary", params={"days": 7})
         data = resp.json()
 
-        # The order shouldn't be counted in orders_shipped for this window —
-        # can't assert a global zero (shared DB), so assert the specific
-        # order's ship JE amount isn't force-included by checking the
-        # order count doesn't include it via a narrower probe: re-derive
-        # directly and compare against a wide window that DOES include it.
+        # Directly assert the 60-day-old order's id is ABSENT from the
+        # narrow (7-day) anchor set, and present in a wide (90-day) window
+        # that does cover it — this proves the window actually excludes it,
+        # rather than just comparing aggregate counts (which would pass
+        # even if the order were wrongly included).
+        narrow_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        narrow_ids = shipped_order_ids_in_window(db, start=narrow_cutoff)
+        assert so.id not in narrow_ids
+
+        wide_cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+        wide_ids = shipped_order_ids_in_window(db, start=wide_cutoff)
+        assert so.id in wide_ids
+
+        # The order's own COGS contribution must likewise be absent from the
+        # narrow window's derivation.
+        narrow_derivation = gl_derived_cogs_for_orders(db, narrow_ids)
+        assert so.id not in narrow_derivation.order_ids
+
         wide_resp = client.get(f"{BASE}/cogs-summary", params={"days": 90})
         wide_data = wide_resp.json()
         assert wide_data["orders_shipped"] >= data["orders_shipped"]
@@ -314,11 +330,6 @@ class TestDashboardAgreesWithCOGSSummary:
             shipped_at=now,
         )
         db.commit()
-
-        from app.services.cogs_report_service import (
-            gl_derived_cogs_for_orders,
-            shipped_order_ids_in_window,
-        )
 
         month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         month_order_ids = shipped_order_ids_in_window(db, start=month_start)
@@ -350,3 +361,59 @@ class TestDashboardAgreesWithCOGSSummary:
         data = resp.json()
         assert "entries" in data
         assert "transaction_count" in data
+
+
+# =============================================================================
+# /admin/dashboard/profit-summary — delivered orders must count in BOTH
+# revenue and COGS (CodeRabbit #897 review comment 3523975559)
+# =============================================================================
+
+DASHBOARD_BASE = "/api/v1/admin/dashboard"
+
+
+class TestDeliveredOrdersCountInRevenueAndCOGS:
+
+    def test_delivered_order_counted_in_both_revenue_and_cogs_anchor(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        """A 'delivered' order was shipped — its ship JE (5000/5010) already
+        posted — so it must anchor COGS the same way it anchors revenue.
+        Before the fix, shipped_order_ids_in_window() only anchored
+        shipped/completed orders while /profit-summary's revenue query
+        already included delivered, so a delivered order contributed
+        revenue with zero COGS to gross_profit/gross_margin.
+        """
+        now = datetime.now(timezone.utc)
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("4.00"), fg_receipt_value=Decimal("11.00"),
+            ship_qty=1, ship_unit_cost=Decimal("11.00"),
+            shipped_at=now, so_status="delivered",
+        )
+        db.commit()
+
+        # The shared anchor helper must pick up the delivered order.
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        month_order_ids = shipped_order_ids_in_window(db, start=month_start)
+        assert so.id in month_order_ids
+
+        # And its own GL-derived COGS must be non-zero (the ship JE posted).
+        single_order = gl_derived_cogs_for_orders(db, [so.id], include_legacy=False)
+        assert single_order.out_of_pocket_cogs > Decimal("0.00")
+
+        # The dashboard endpoint's revenue (which already included
+        # 'delivered') and COGS (via the now-widened anchor) must both
+        # reflect this order — i.e. it must not be revenue-with-zero-COGS.
+        resp = client.get(f"{DASHBOARD_BASE}/profit-summary")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert Decimal(str(data["revenue_this_month"])) >= so.grand_total - Decimal("0.01")
+        # If COGS were still anchored on shipped/completed only, this
+        # delivered order's cogs_this_month contribution would be zero,
+        # inflating gross_profit_this_month by its full revenue. Assert the
+        # dashboard's own gross profit is consistent with revenue minus at
+        # least this order's COGS contribution (i.e. COGS was NOT skipped).
+        assert Decimal(str(data["gross_profit_this_month"])) <= Decimal(
+            str(data["revenue_this_month"])
+        ) - single_order.out_of_pocket_cogs + Decimal("0.01")

--- a/backend/tests/test_cogs_gl_derivation.py
+++ b/backend/tests/test_cogs_gl_derivation.py
@@ -417,3 +417,70 @@ class TestDeliveredOrdersCountInRevenueAndCOGS:
         assert Decimal(str(data["gross_profit_this_month"])) <= Decimal(
             str(data["revenue_this_month"])
         ) - single_order.out_of_pocket_cogs + Decimal("0.01")
+
+    def test_delivered_order_counts_identically_across_all_three_cogs_surfaces(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        """Cross-surface consistency: ONE delivered order must move
+        /accounting/cogs-summary, /accounting/dashboard (cogs.mtd) and
+        /admin/dashboard/profit-summary (cogs_this_month) by exactly the
+        same GL-derived amount — its own out_of_pocket_cogs. All three now
+        anchor via cogs_report_service's shared anchor helpers; before, the
+        two accounting.py endpoints used their own inline
+        ['shipped','completed'] queries, so a delivered order counted on
+        one surface but not the others (a third answer).
+
+        Delta-based (shared filaops_test DB): snapshot each surface before
+        and after seeding, and compare the deltas.
+        """
+        before_summary = client.get(f"{BASE}/cogs-summary", params={"days": 30}).json()
+        before_dash = client.get(f"{BASE}/dashboard").json()
+        before_pm = client.get(f"{DASHBOARD_BASE}/profit-summary").json()
+
+        now = datetime.now(timezone.utc)
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("6.00"), fg_receipt_value=Decimal("14.00"),
+            ship_qty=1, ship_unit_cost=Decimal("14.00"),
+            shipped_at=now, so_status="delivered",
+        )
+        db.commit()
+
+        single = gl_derived_cogs_for_orders(
+            db, [so.id], include_legacy=False
+        ).out_of_pocket_cogs
+        assert single > Decimal("0.00")  # ship JE posted, material spent
+
+        after_summary = client.get(f"{BASE}/cogs-summary", params={"days": 30}).json()
+        after_dash = client.get(f"{BASE}/dashboard").json()
+        after_pm = client.get(f"{DASHBOARD_BASE}/profit-summary").json()
+
+        delta_summary = Decimal(str(after_summary["out_of_pocket_cogs"])) - Decimal(
+            str(before_summary["out_of_pocket_cogs"])
+        )
+        delta_dash_mtd = Decimal(str(after_dash["cogs"]["mtd"])) - Decimal(
+            str(before_dash["cogs"]["mtd"])
+        )
+        delta_pm = Decimal(str(after_pm["cogs_this_month"])) - Decimal(
+            str(before_pm["cogs_this_month"])
+        )
+
+        tol = Decimal("0.01")
+        assert abs(delta_summary - single) <= tol, (
+            f"/cogs-summary moved by {delta_summary}, expected {single}"
+        )
+        assert abs(delta_dash_mtd - single) <= tol, (
+            f"/accounting/dashboard cogs.mtd moved by {delta_dash_mtd}, expected {single}"
+        )
+        assert abs(delta_pm - single) <= tol, (
+            f"/profit-summary cogs_this_month moved by {delta_pm}, expected {single}"
+        )
+
+        # And the delivered order's revenue moved with its COGS on the two
+        # dashboard surfaces (no revenue-without-COGS or COGS-without-revenue).
+        assert Decimal(str(after_pm["revenue_this_month"])) - Decimal(
+            str(before_pm["revenue_this_month"])
+        ) >= so.grand_total - tol
+        assert after_dash["revenue"]["mtd_orders"] == (
+            before_dash["revenue"]["mtd_orders"] + 1
+        )

--- a/backend/tests/test_cogs_gl_derivation.py
+++ b/backend/tests/test_cogs_gl_derivation.py
@@ -1,0 +1,352 @@
+"""
+Tests for the #880 PR-5 GL-derived COGS story.
+
+Covers:
+- app.services.cogs_report_service.gl_derived_cogs_for_orders: the shared
+  helper that derives COGS from posted gl_journal_entry_lines (ship JEs'
+  5000/5010 debits, linked production orders' 5200 completion-variance
+  credits), scoped strictly to each order's OWN linked production orders.
+- The full mini-cycle: a shipped sales order with its production order's
+  completion JE (including a 5200 variance) and ship JE, PLUS a separate
+  CANCELLED sales order with its own production order's completion JE —
+  the cancelled order's variance must never leak into the shipped order's
+  out_of_pocket_cogs (this is the live-data PO-0001/SO-0001 case).
+- /admin/accounting/cogs-summary: headline/secondary/reconciliation fields,
+  legacy keys still populated, drafts/voided excluded, days-window respects
+  shipped_at.
+- /admin/accounting/dashboard: mtd COGS agrees with cogs-summary on the
+  same seeded data (same GL derivation, same anchor).
+
+All tests are delta-based with per-run unique fixtures (uuid SKUs/codes
+from the conftest factories) because filaops_test accumulates state; each
+test seeds its own orders/products, so window-scoped assertions look at
+INDIVIDUAL order buckets, not global totals.
+"""
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from app.services import inventory_service
+from app.services.cogs_report_service import gl_derived_cogs_for_orders
+from app.services.production_gl_service import create_production_completion_gl_entry
+from app.services.transaction_service import ShipmentItem, TransactionService
+
+BASE = "/api/v1/admin/accounting"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _location(db):
+    return inventory_service.get_or_create_default_location(db)
+
+
+def _seed_stock(db, product, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="test_seed",
+        reference_id=0,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _consume(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="consumption",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _receive_fg(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _build_shipped_cycle(
+    db, make_product, make_sales_order, make_production_order,
+    *, material_cost, fg_receipt_value, ship_qty, ship_unit_cost,
+    shipped_at=None, so_status="shipped",
+):
+    """One full mini-cycle: PO completion (with GL variance) + ship JE.
+
+    Returns (sales_order, production_order, completion_je, ship_je).
+    """
+    raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+    fg = make_product(item_type="finished_good", average_cost=Decimal(str(ship_unit_cost)))
+
+    so = make_sales_order(
+        product_id=fg.id,
+        quantity=ship_qty,
+        unit_price=Decimal(str(ship_unit_cost)) * 2,
+        status=so_status,
+        shipped_at=shipped_at or datetime.now(timezone.utc),
+    )
+    po = make_production_order(
+        product_id=fg.id, status="completed", quantity=ship_qty,
+        sales_order_id=so.id,
+    )
+
+    _seed_stock(db, raw, 1000, "0.50")
+    _consume(db, raw, po, material_cost / Decimal("0.50"), "0.50")  # material_cost total
+    _receive_fg(db, fg, po, ship_qty, fg_receipt_value / Decimal(str(ship_qty)))
+
+    completion_je = create_production_completion_gl_entry(db, po)
+    db.flush()
+
+    # Seed FG on-hand so ship_order's shipment txn doesn't go held/negative.
+    _seed_stock(db, fg, ship_qty, str(ship_unit_cost))
+
+    ts = TransactionService(db)
+    _inv_txns, ship_je = ts.ship_order(
+        sales_order_id=so.id,
+        items=[ShipmentItem(product_id=fg.id, quantity=Decimal(str(ship_qty)), unit_cost=Decimal(str(ship_unit_cost)))],
+    )
+    db.flush()
+
+    return so, po, completion_je, ship_je
+
+
+# =============================================================================
+# gl_derived_cogs_for_orders — the shared helper
+# =============================================================================
+
+class TestGLDerivedCOGSForOrders:
+
+    def test_full_mini_cycle_out_of_pocket_and_full_product_cogs(
+        self, db, make_product, make_sales_order, make_production_order
+    ):
+        """DR 1210 material=5 / CR 1200; DR 1220 FG=12 / CR 1210;
+        V = 12 - 5 = +7 -> CR 5200 7. Ship 1 unit at $12 -> DR 5000 12 / CR 1220 12.
+
+        full_product_cogs = 12 (5000 debits)
+        completion_variance_5200 = 7
+        out_of_pocket_cogs = 12 - 7 = 5 (== the material cost actually spent)
+        """
+        so, po, completion_je, ship_je = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("5.00"), fg_receipt_value=Decimal("12.00"),
+            ship_qty=1, ship_unit_cost=Decimal("12.00"),
+        )
+        db.commit()
+
+        result = gl_derived_cogs_for_orders(db, [so.id])
+
+        assert result.reconciliation.ship_cogs_5000 == Decimal("12.00")
+        assert result.reconciliation.completion_variance_5200 == Decimal("7.00")
+        assert result.full_product_cogs == Decimal("12.00")
+        assert result.out_of_pocket_cogs == Decimal("5.00")
+
+    def test_cancelled_order_variance_does_not_leak(
+        self, db, make_product, make_sales_order, make_production_order
+    ):
+        """The live-data case: a cancelled SO's own PO completion variance
+        must NOT count toward a different (shipped) order's out_of_pocket.
+        """
+        shipped_so, shipped_po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("10.00"), fg_receipt_value=Decimal("20.00"),
+            ship_qty=1, ship_unit_cost=Decimal("20.00"),
+        )
+
+        # A second, CANCELLED sales order with its own PO + completion JE.
+        raw2 = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg2 = make_product(item_type="finished_good", average_cost=Decimal("8.00"))
+        cancelled_so = make_sales_order(
+            product_id=fg2.id, quantity=1, unit_price=Decimal("16.00"),
+            status="cancelled",
+        )
+        cancelled_po = make_production_order(
+            product_id=fg2.id, status="completed", quantity=1,
+            sales_order_id=cancelled_so.id,
+        )
+        _seed_stock(db, raw2, 100, "0.50")
+        _consume(db, raw2, cancelled_po, 2, "0.50")   # 1.00 material
+        _receive_fg(db, fg2, cancelled_po, 1, "8.00")  # 8.00 FG -> variance 7.00
+        create_production_completion_gl_entry(db, cancelled_po)
+        db.commit()
+
+        # Query ONLY the shipped order — the cancelled order's PO variance
+        # must not appear.
+        result = gl_derived_cogs_for_orders(db, [shipped_so.id])
+
+        assert result.reconciliation.completion_variance_5200 == Decimal("10.00")
+        # (20 FG - 10 material = 10 variance for the shipped order alone)
+        assert result.out_of_pocket_cogs == Decimal("10.00")  # 20 - 10, NOT touched by cancelled_po's 7.00
+
+    def test_drafts_and_voided_journal_entries_excluded(
+        self, db, make_product, make_sales_order, make_production_order
+    ):
+        so, po, completion_je, ship_je = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("3.00"), fg_receipt_value=Decimal("9.00"),
+            ship_qty=1, ship_unit_cost=Decimal("9.00"),
+        )
+        db.commit()
+
+        baseline = gl_derived_cogs_for_orders(db, [so.id])
+        assert baseline.reconciliation.ship_cogs_5000 == Decimal("9.00")
+
+        # Void the ship JE — its debits must disappear from the derivation.
+        ship_je.status = "voided"
+        db.commit()
+
+        after_void = gl_derived_cogs_for_orders(db, [so.id])
+        assert after_void.reconciliation.ship_cogs_5000 == Decimal("0.00")
+
+    def test_legacy_keys_still_populated(
+        self, db, make_product, make_sales_order, make_production_order
+    ):
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("4.00"), fg_receipt_value=Decimal("10.00"),
+            ship_qty=1, ship_unit_cost=Decimal("10.00"),
+        )
+        db.commit()
+
+        result = gl_derived_cogs_for_orders(db, [so.id])
+        assert result.legacy_materials == Decimal("4.00")
+        assert result.legacy_total == result.legacy_materials + result.legacy_labor + result.legacy_packaging
+
+    def test_empty_order_set_returns_zeros(self, db):
+        result = gl_derived_cogs_for_orders(db, [])
+        assert result.out_of_pocket_cogs == Decimal("0.00")
+        assert result.full_product_cogs == Decimal("0.00")
+        assert result.legacy_total == Decimal("0.00")
+
+
+# =============================================================================
+# /admin/accounting/cogs-summary — the endpoint
+# =============================================================================
+
+class TestCOGSSummaryGLDerived:
+
+    def test_out_of_pocket_and_full_product_and_reconciliation_present(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("6.00"), fg_receipt_value=Decimal("15.00"),
+            ship_qty=1, ship_unit_cost=Decimal("15.00"),
+        )
+        db.commit()
+
+        resp = client.get(f"{BASE}/cogs-summary", params={"days": 30})
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "out_of_pocket_cogs" in data
+        assert "full_product_cogs" in data
+        assert "reconciliation" in data
+        recon = data["reconciliation"]
+        assert "ship_cogs_5000" in recon
+        assert "packaging_5010" in recon
+        assert "completion_variance_5200" in recon
+
+        # Legacy keys still present and populated.
+        assert "cogs" in data
+        assert set(data["cogs"].keys()) == {"materials", "labor", "packaging", "total"}
+
+    def test_window_filter_respects_shipped_at(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        """An order shipped 60 days ago must not appear in a 7-day window."""
+        old_shipped_at = datetime.now(timezone.utc) - timedelta(days=60)
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("2.00"), fg_receipt_value=Decimal("5.00"),
+            ship_qty=1, ship_unit_cost=Decimal("5.00"),
+            shipped_at=old_shipped_at,
+        )
+        db.commit()
+
+        resp = client.get(f"{BASE}/cogs-summary", params={"days": 7})
+        data = resp.json()
+
+        # The order shouldn't be counted in orders_shipped for this window —
+        # can't assert a global zero (shared DB), so assert the specific
+        # order's ship JE amount isn't force-included by checking the
+        # order count doesn't include it via a narrower probe: re-derive
+        # directly and compare against a wide window that DOES include it.
+        wide_resp = client.get(f"{BASE}/cogs-summary", params={"days": 90})
+        wide_data = wide_resp.json()
+        assert wide_data["orders_shipped"] >= data["orders_shipped"]
+
+
+# =============================================================================
+# /admin/accounting/dashboard agrees with /cogs-summary
+# =============================================================================
+
+class TestDashboardAgreesWithCOGSSummary:
+
+    def test_mtd_cogs_matches_cogs_summary_gl_derivation(
+        self, client, db, make_product, make_sales_order, make_production_order
+    ):
+        """Ship inside the current month so both MTD (dashboard) and a wide
+        days-window (cogs-summary) pick up the same order, then check the
+        per-order GL derivation used by both agrees (same helper, same
+        anchor semantics) via direct service comparison — the shared DB
+        means absolute totals can differ from unrelated orders, so we
+        compare the underlying derivation for THIS order specifically.
+        """
+        now = datetime.now(timezone.utc)
+        so, po, _, _ = _build_shipped_cycle(
+            db, make_product, make_sales_order, make_production_order,
+            material_cost=Decimal("3.50"), fg_receipt_value=Decimal("8.00"),
+            ship_qty=1, ship_unit_cost=Decimal("8.00"),
+            shipped_at=now,
+        )
+        db.commit()
+
+        from app.services.cogs_report_service import (
+            gl_derived_cogs_for_orders,
+            shipped_order_ids_in_window,
+        )
+
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        month_order_ids = shipped_order_ids_in_window(db, start=month_start)
+        assert so.id in month_order_ids
+
+        dashboard_style = gl_derived_cogs_for_orders(db, month_order_ids, include_legacy=False)
+        single_order = gl_derived_cogs_for_orders(db, [so.id], include_legacy=False)
+
+        # This order's contribution to the MTD-anchored set must equal its
+        # own out_of_pocket_cogs (additive — no double counting/omission).
+        assert single_order.out_of_pocket_cogs <= dashboard_style.out_of_pocket_cogs
+
+        resp = client.get(f"{BASE}/dashboard")
+        assert resp.status_code == 200
+        dash = resp.json()
+        assert "cogs" in dash and "mtd" in dash["cogs"]
+        # Dashboard's MTD COGS must be >= this single order's out-of-pocket
+        # contribution (other MTD orders from prior tests may also be in
+        # the shared DB window).
+        assert Decimal(str(dash["cogs"]["mtd"])) >= single_order.out_of_pocket_cogs - Decimal("0.01")
+
+    def test_transactions_journal_labeled_non_gl(self, client):
+        """Item 3: the synthesized pseudo-view is relabeled, not logic-changed."""
+        resp = client.get(f"{BASE}/transactions-journal")
+        assert resp.status_code == 200
+        # Docstring relabeling isn't visible in the JSON response (no
+        # behavior change was requested) — this test just pins that the
+        # endpoint still works unchanged.
+        data = resp.json()
+        assert "entries" in data
+        assert "transaction_count" in data

--- a/frontend/src/components/accounting/COGSTab.jsx
+++ b/frontend/src/components/accounting/COGSTab.jsx
@@ -112,16 +112,16 @@ export default function COGSTab() {
         </div>
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
           <div className="text-gray-400 text-sm mb-1">
-            Total COGS
+            What Your Shipped Orders Cost You Out Of Pocket
             <span
               className="ml-1 text-xs"
-              title="Production costs only (materials, labor, packaging)"
+              title="Materials + packaging you actually paid for. Built-in labor and machine value are backed out via the production-variance credit — this is the tax-correct Schedule C answer."
             >
               ℹ️
             </span>
           </div>
           <div className="text-2xl font-bold text-red-400">
-            {formatCurrency(data?.cogs?.total)}
+            {formatCurrency(data?.out_of_pocket_cogs)}
           </div>
         </div>
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
@@ -129,7 +129,7 @@ export default function COGSTab() {
             Gross Profit
             <span
               className="ml-1 text-xs"
-              title="Revenue - COGS (before operating expenses)"
+              title="Revenue - out-of-pocket COGS (before operating expenses)"
             >
               ℹ️
             </span>
@@ -143,12 +143,43 @@ export default function COGSTab() {
         </div>
       </div>
 
+      {/* Secondary: full product-cost COGS for margin analysis */}
+      <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-gray-400 text-sm">
+              Full Product-Cost COGS
+              <span className="ml-2 text-xs text-gray-500 font-normal">
+                (includes your built-in labor &amp; machine)
+              </span>
+            </div>
+            <div className="text-xs text-gray-500 mt-1">
+              For margin analysis — the full cost of the finished goods you shipped.
+            </div>
+          </div>
+          <div className="text-xl font-bold text-white">
+            {formatCurrency(data?.full_product_cogs)}
+          </div>
+        </div>
+        {data?.reconciliation && (
+          <div className="border-t border-gray-700 mt-3 pt-3 text-xs text-gray-500 flex flex-wrap items-center gap-1">
+            <span>{formatCurrency(data.full_product_cogs)} full COGS</span>
+            <span>&minus;</span>
+            <span>{formatCurrency(data.reconciliation.completion_variance_5200)} labor/machine variance</span>
+            <span>=</span>
+            <span className="text-gray-300 font-medium">
+              {formatCurrency(data.out_of_pocket_cogs)} out of pocket
+            </span>
+          </div>
+        )}
+      </div>
+
       {/* COGS Breakdown */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
         <h3 className="text-lg font-semibold text-white mb-4">
           COGS Breakdown
           <span className="ml-2 text-xs text-gray-400 font-normal">
-            (Production costs only)
+            (Legacy category split — materials/labor/packaging)
           </span>
         </h3>
         <div className="space-y-3">
@@ -171,7 +202,7 @@ export default function COGSTab() {
             </span>
           </div>
           <div className="border-t border-gray-700 pt-3 flex items-center justify-between">
-            <span className="text-white font-semibold">Total COGS</span>
+            <span className="text-white font-semibold">Total (legacy)</span>
             <span className="text-red-400 font-bold">
               {formatCurrency(data?.cogs?.total)}
             </span>

--- a/frontend/src/components/accounting/COGSTab.jsx
+++ b/frontend/src/components/accounting/COGSTab.jsx
@@ -164,6 +164,8 @@ export default function COGSTab() {
         {data?.reconciliation && (
           <div className="border-t border-gray-700 mt-3 pt-3 text-xs text-gray-500 flex flex-wrap items-center gap-1">
             <span>{formatCurrency(data.full_product_cogs)} full COGS</span>
+            <span>+</span>
+            <span>{formatCurrency(data.reconciliation.packaging_5010)} packaging</span>
             <span>&minus;</span>
             <span>{formatCurrency(data.reconciliation.completion_variance_5200)} labor/machine variance</span>
             <span>=</span>

--- a/frontend/src/components/accounting/DashboardTab.jsx
+++ b/frontend/src/components/accounting/DashboardTab.jsx
@@ -66,9 +66,28 @@ export default function DashboardTab() {
   // Check if there's no shipped orders yet (common for new installations)
   const hasNoShippedOrders = data?.revenue?.mtd_orders === 0 && data?.revenue?.ytd_orders === 0;
   const hasOutstandingOrders = data?.payments?.outstanding_orders > 0;
+  const unjournaledCount = data?.unjournaled_txn_count || 0;
 
   return (
     <div className="space-y-6">
+      {/* GL-health warning: production consumption/receipt rows not yet
+          journaled — the GL has drifted from the inventory ledger. */}
+      {unjournaledCount > 0 && (
+        <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-xl p-4 flex items-start gap-3">
+          <svg className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <div>
+            <p className="text-yellow-400 font-medium text-sm">
+              GL out of sync with inventory ({unjournaledCount} unjournaled transaction{unjournaledCount === 1 ? "" : "s"})
+            </p>
+            <p className="text-gray-400 text-xs mt-1">
+              Some production consumption/receipt activity hasn't posted to the general ledger yet. COGS figures below may understate until this resolves.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Helpful hint for new users */}
       {hasNoShippedOrders && hasOutstandingOrders && (
         <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4 flex items-start gap-3">
@@ -186,7 +205,7 @@ export default function DashboardTab() {
             COGS MTD
             <span
               className="ml-1 text-xs"
-              title="Direct material costs of shipped goods"
+              title="Out-of-pocket cost of shipped goods, derived from the GL (materials + packaging; built-in labor/machine backed out)"
             >
               ℹ️
             </span>


### PR DESCRIPTION
## What

The COGS dashboard now derives from the persisted GL instead of re-summing
`InventoryTransaction` rows — one COGS story everywhere:

- **`get_cogs_summary`** (`/admin/accounting/cogs-summary`): anchor unchanged
  (shipped/completed sales orders, `shipped_at >= now - days`). Buckets now
  come from posted `gl_journal_entry_lines`:
  - Ship-side: Σ DEBIT lines on posted JEs with `source_type='sales_order'`,
    `source_id IN (anchor ids)`, accounts 5000 (COGS) and 5010 (packaging).
  - Completion-variance side: for the anchor orders' linked production
    orders, Σ posted JEs with `source_type='production_order'`,
    `source_id IN (those PO ids)`, net CREDIT − DEBIT on 5200. Scoped
    **strictly** to POs linked to an anchor order, so a cancelled order's
    own PO variance never leaks into another order's window.
  - New primary fields: `out_of_pocket_cogs` = (5000+5010 debits) − (net
    linked 5200 credits); `full_product_cogs` = Σ 5000 debits; plus a
    `reconciliation` object (`ship_cogs_5000`, `packaging_5010`,
    `completion_variance_5200`) so the UI can show the identity.
- **`get_accounting_dashboard`** mtd COGS and **`get_profit_summary`**
  (month/YTD) now call the same shared helper
  (`app/services/cogs_report_service.py`), anchored the same way
  (shipped/completed + `shipped_at` window) so no third COGS answer
  survives. `get_profit_summary` previously anchored on
  `InventoryTransaction.created_at` — that's now `shipped_at`-anchored to
  match the other two surfaces.
- **`transactions-journal`** (`/admin/accounting/transactions-journal`):
  docstring/response now labeled "Inventory activity (non-GL)" — a
  synthesized, illustrative debit/credit view over raw inventory rows using
  a fictional/simplified chart of accounts, explicitly NOT the posted GL.
  No logic change.
- **`COGSTab.jsx`**: headline card "What Your Shipped Orders Cost You Out
  Of Pocket" (`out_of_pocket_cogs`), secondary card "Full Product-Cost COGS
  (includes your built-in labor & machine)" (`full_product_cogs`), and a
  small reconciliation line (full − variance = out-of-pocket). Days-window
  selector unchanged. Legacy "COGS Breakdown" card kept, relabeled as
  "(Legacy category split)".
- **`DashboardTab.jsx`**: added a small warning badge (only rendered when
  `unjournaled_txn_count > 0`) surfacing the #892 GL-health counter that
  was already on `get_accounting_dashboard`'s response but not shown in the
  UI. Also updated the COGS MTD tooltip to describe the out-of-pocket
  definition.

## Why

Per the #880 finding (design comment
[issuecomment-4880247351](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351)),
the GL and the dashboard told two different COGS stories: GL 5000 =
$60.86 (FG cost at ship, stale pre-recost standards including built-in
labor) vs. dashboard = $14.67 (raw-material actuals). PR-1 through PR-4
made the GL the complete, correct system of record (posted-only reports,
JE entry_date + ship idempotency + item_type-aware PO receipts, the
completion-GL poster + backfill + GL-health counter, and ship-path
completeness). The live-129 books correction ran and reconciled
end-to-end — see
[issuecomment-4882705712](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4882705712)
(the hard deploy gate for this PR). This PR makes the dashboard read from
that now-correct GL instead of a parallel, disagreeing re-sum.

## Live-data sanity math (from the reconciled 129 books)

Per the final trial balance in issuecomment-4882705712: `5000 = 60.86`,
`5200 = −47.70` (net credit), `5030 = 3.92` (unrelated cycle-count
write-off) → net `60.86 − 47.70 = 13.16` ≈ materials actually consumed
(**17.09** lifetime is the all-time consumption figure; the ship-JE-linked
variance nets to the identity within the 4 shipped orders' completion
JEs). The design's target math for `out_of_pocket_cogs` restricted to the
4 shipped orders (excluding cancelled SO-0001's own PO-0001 variance of
1.50): `5000=60.86`, `5010=0`, linked `5200` net credit `=46.20`,
`out_of_pocket = 60.86 − 46.20 = 14.66`.

## Legacy-key strategy

Kept every legacy `COGSSummaryResponse.cogs` key (`materials`, `labor`,
`packaging`, `total`) populated for one release. They're computed by
`cogs_report_service._legacy_buckets`, which mirrors — verbatim — the old
`InventoryTransaction` re-sum this endpoint used before this PR (same
filters: exclude held/unapplied rows, exclude voided rows, SVC- prefix →
labor). This is **not** GL-derived (the GL doesn't carry a
materials/labor/packaging three-way split), so `cogs.total` no longer
equals `out_of_pocket_cogs` — it's the old number, kept for backward
compatibility only. New consumers should read `out_of_pocket_cogs` /
`full_product_cogs` / `reconciliation` instead. The COGSTab UI already
switched to the new fields in this same PR; the legacy card is relabeled
"(Legacy category split)" to signal that it's not the primary number
anymore.

## GL-health counter (item 5)

Cheap addition: `DashboardTab.jsx` now shows a small yellow warning badge
when `unjournaled_txn_count > 0` (the #892 counter already returned by
`get_accounting_dashboard`, previously unused in the UI). No new backend
work — just wiring an existing field into the dashboard tab.

## Tests

New `backend/tests/test_cogs_gl_derivation.py` — seeds a full mini-cycle
with uuid fixtures (production-completion GL entry incl. a 5200 variance,
plus a real ship JE via `TransactionService.ship_order`) and a separate
CANCELLED sales order with its own production order's completion JE, to
pin that the cancelled order's variance never leaks into a different
order's `out_of_pocket_cogs`. Also covers: drafts/voided JEs excluded,
days-window respects `shipped_at`, legacy keys still populated, and that
`/admin/accounting/dashboard` agrees with `/admin/accounting/cogs-summary`
on the same GL derivation.

Reference: design comment
[issuecomment-4880247351](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880247351),
gate-satisfied comment
[issuecomment-4882705712](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4882705712).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GL-derived COGS reporting with clearer “out-of-pocket” totals, “full product” COGS, and reconciliation details on accounting screens.
  * Added a dashboard warning when GL and inventory data are out of sync.
* **Bug Fixes**
  * Updated COGS/margin calculations to use shipped/completed order activity and posted accounting entries for more accurate month-to-date and summary reporting.
  * Improved handling of delivered orders and ensured legacy breakdowns remain available for comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->