### PR TITLE
feat(mrp): operation-type catalog — schema, seed, resolver (876 PR-1, inert)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -44,6 +44,7 @@ from app.api.v1.endpoints import (
     system_settings,
     system_license,
     dispatch,
+    operation_types,
 )
 from app.api.v1.endpoints.admin import router as admin_router
 from app.api.v1.endpoints.test import test_endpoints_enabled
@@ -179,6 +180,9 @@ router.include_router(
     prefix="/routings",
     tags=["manufacturing"]
 )
+
+# Operation Types (catalog — #876 PR-1, feeds the routing editor Type picker)
+router.include_router(operation_types.router)
 
 # B2B Portal API is a PRO feature
 

--- a/backend/app/api/v1/endpoints/operation_types.py
+++ b/backend/app/api/v1/endpoints/operation_types.py
@@ -1,0 +1,34 @@
+"""
+Operation Type Catalog endpoints (#876 PR-1).
+
+GET /operation-types -> list active types ordered by sort_order, feeding
+the future routing-editor Type picker (#876 PR-4). Authenticated read only
+in this PR; admin CRUD (create/update/deactivate) + the audit/classifier
+surfaces ship in #876 PR-3.
+"""
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models.manufacturing import OperationType
+from app.models.user import User
+from app.api.v1.deps import get_current_user
+from app.schemas.operation_type import OperationTypeResponse
+
+router = APIRouter(prefix="/operation-types", tags=["Operation Types"])
+
+
+@router.get("", response_model=List[OperationTypeResponse])
+def list_operation_types(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List active operation types, ordered for picker display."""
+    return (
+        db.query(OperationType)
+        .filter(OperationType.is_active.is_(True))
+        .order_by(OperationType.sort_order, OperationType.code)
+        .all()
+    )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,7 +15,7 @@ from app.models.vendor import Vendor
 from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine
 from app.models.purchase_order_document import PurchaseOrderDocument, VendorItem
 from app.models.work_center import WorkCenter
-from app.models.manufacturing import Routing, RoutingOperation, Resource, RoutingOperationMaterial
+from app.models.manufacturing import Routing, RoutingOperation, Resource, RoutingOperationMaterial, OperationType
 from app.models.mrp import MRPRun, PlannedOrder
 from app.models.traceability import (
     SerialNumber, MaterialLot, ProductionLotConsumption, CustomerTraceabilityProfile
@@ -103,6 +103,7 @@ __all__ = [
     "Routing",
     "RoutingOperation",
     "RoutingOperationMaterial",
+    "OperationType",
     "ProductionOrderOperationMaterial",
     "ScrapRecord",
     "QCInspection",

--- a/backend/app/models/manufacturing.py
+++ b/backend/app/models/manufacturing.py
@@ -4,7 +4,7 @@ Manufacturing Routes Models
 Work Centers, Resources, Routings, and Routing Operations.
 """
 from sqlalchemy import (
-    Column, Integer, String, Numeric, Boolean, DateTime, Text, Date, ForeignKey, UniqueConstraint
+    Column, Integer, String, Numeric, Boolean, DateTime, Text, Date, ForeignKey, UniqueConstraint, JSON
 )
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
@@ -162,6 +162,14 @@ class RoutingOperation(Base):
     operation_code = Column(String(50), nullable=True)  # 'PRINT', 'QC', 'ASSEMBLE'
     operation_name = Column(String(200), nullable=True)
     description = Column(Text, nullable=True)
+
+    # #876 PR-1: declared operation-type catalog code (e.g. 'FDM_PRINT',
+    # 'PACK_SHIP'). String type-code, NOT a FK to operation_types.id — see
+    # OperationType docstring below for why. NULL means "untyped": resolution
+    # falls through to the legacy operation_code map
+    # (operation_material_mapping.get_consume_stages_for_operation). Inert in
+    # this PR — no consumer reads it yet (that's #876 PR-2).
+    operation_type = Column(String(30), nullable=True)
 
     # Time (minutes)
     setup_time_minutes = Column(Numeric(10, 2), default=0, nullable=False)
@@ -340,19 +348,86 @@ class RoutingOperationMaterial(Base):
     def calculate_required_quantity(self, order_quantity: int) -> float:
         """
         Calculate total quantity required for a production order.
-        
+
         Args:
             order_quantity: Number of units being produced
-            
+
         Returns:
             Total quantity needed including scrap allowance
         """
         base_qty = float(self.quantity or 0)
         scrap = float(self.scrap_factor or 0) / 100
-        
+
         if self.quantity_per == 'unit':
             gross_qty = base_qty * order_quantity
         else:  # batch or order
             gross_qty = base_qty
-        
+
         return gross_qty * (1 + scrap)
+
+
+class OperationType(Base):
+    """
+    Canonical catalog of routing-operation types (#876 PR-1).
+
+    Every routing/production-order operation declares its Type, and the
+    Type's ``consume_stages`` decides WHEN the operation's materials count
+    as used (production completion vs. ship vs. never-automatic). This
+    replaces guessing timing from the free-text ``operation_code`` at
+    runtime.
+
+    ``routing_operations.operation_type`` / ``production_order_operations
+    .operation_type`` reference this catalog's ``code`` by STRING VALUE,
+    not by a foreign key to this table's ``id``. This is deliberate:
+
+    1. Production-order operations snapshot the type at release exactly
+       like they snapshot ``operation_code`` today — a plain string copies
+       with zero join cost and stays human-readable in raw SQL/exports.
+    2. Two ``ADD COLUMN`` + one ``CREATE TABLE`` avoids FK-ordering
+       constraints on the brownfield migration.
+    3. The PRO wheel writes ``RoutingOperation`` rows via lazy Core imports
+       and can set a string attribute behind a ``hasattr`` guard without
+       resolving an id against a table it may not know about yet.
+    4. Unknown/inactive codes at read time fall through to the legacy
+       ``operation_code`` map rather than raising — a routing edited after
+       its type was deactivated must never break historical resolution.
+
+    This PR ships the schema, the 9-row seed, and a resolver that nothing
+    calls yet (see ``operation_material_mapping.resolve_consume_stages``).
+    Zero behavior change until #876 PR-2 switches the consumers over.
+    """
+    __tablename__ = "operation_types"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    # Stored uppercase; the value referenced by operation_type columns above.
+    code = Column(String(30), unique=True, nullable=False, index=True)
+    label = Column(String(100), nullable=False)
+    description = Column(Text, nullable=True)
+
+    # UI grouping only (print/assembly/quality/finishing/shipping/other) —
+    # never consulted by any resolver; purely cosmetic categorization for
+    # the future editor picker.
+    category = Column(String(20), nullable=True)
+
+    # Verbatim legacy stage vocabulary — see the seed table in migration
+    # 101_operation_types.py for the exact values reused from
+    # OPERATION_CONSUME_STAGES so a typed op is byte-identical in behavior
+    # to its equivalent coded op.
+    consume_stages = Column(JSON, nullable=False)
+
+    # Drives QC-op resolution (record_qc_inspection fallback lookup, #876
+    # PR-2) — not consumed by anything in this PR.
+    is_qc = Column(Boolean, default=False, nullable=False)
+
+    # System rows (the 9 seeded types) are undeletable and have their
+    # consume_stages/is_qc locked in the admin CRUD shipped in #876 PR-3.
+    is_system = Column(Boolean, default=False, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    sort_order = Column(Integer, default=0, nullable=False)
+
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc), nullable=False)
+
+    def __repr__(self):
+        return f"<OperationType {self.code}: {self.label}>"

--- a/backend/app/models/production_order.py
+++ b/backend/app/models/production_order.py
@@ -223,6 +223,12 @@ class ProductionOrderOperation(Base):
     operation_code = Column(String(50), nullable=True)
     operation_name = Column(String(200), nullable=True)
 
+    # #876 PR-1: operation-type catalog code, snapshotted at release exactly
+    # like operation_code is today (production_order_service.py copy sites).
+    # NULL = untyped, falls through to the legacy operation_code map. Inert
+    # in this PR — see app/models/manufacturing.py:OperationType docstring.
+    operation_type = Column(String(30), nullable=True)
+
     # Status: pending, queued, running, complete, skipped
     status = Column(String(50), default='pending', nullable=False, index=True)
 

--- a/backend/app/schemas/operation_type.py
+++ b/backend/app/schemas/operation_type.py
@@ -1,0 +1,29 @@
+"""
+Operation Type Catalog Pydantic Schemas (#876 PR-1).
+
+Read-only response shape for GET /api/v1/operation-types. Admin CRUD
+(create/update/deactivate/classify) ships later in #876 PR-3.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class OperationTypeResponse(BaseModel):
+    """A single operation-type catalog row, for the future editor picker."""
+    id: int
+    code: str
+    label: str
+    description: Optional[str] = None
+    category: Optional[str] = None
+    consume_stages: List[str]
+    is_qc: bool
+    is_system: bool
+    is_active: bool
+    sort_order: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/operation_type.py
+++ b/backend/app/schemas/operation_type.py
@@ -7,11 +7,13 @@ Read-only response shape for GET /api/v1/operation-types. Admin CRUD
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class OperationTypeResponse(BaseModel):
     """A single operation-type catalog row, for the future editor picker."""
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     code: str
     label: str
@@ -24,6 +26,3 @@ class OperationTypeResponse(BaseModel):
     sort_order: int
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True

--- a/backend/app/services/operation_material_mapping.py
+++ b/backend/app/services/operation_material_mapping.py
@@ -3,7 +3,9 @@ Maps operation codes to BOM consume stages.
 
 This determines which materials are needed at each operation.
 """
-from typing import List, Set
+from typing import Dict, List, Optional, Set
+
+from sqlalchemy.orm import Session
 
 # Operation code to consume stage mapping
 # Multiple operation codes can map to the same consume stage
@@ -64,3 +66,72 @@ def get_all_consume_stages() -> Set[str]:
     for stage_list in OPERATION_CONSUME_STAGES.values():
         stages.update(stage_list)
     return stages
+
+
+# =============================================================================
+# #876 PR-1: operation-type catalog resolver (dormant — no consumer wired yet)
+#
+# Everything ABOVE this line (the legacy dict, DEFAULT_CONSUME_STAGES, and
+# get_consume_stages_for_operation) is UNTOUCHED and pinned by
+# tests/services/test_small_services.py::TestOperationMaterialMapping.
+#
+# The functions below are additive. #876 PR-2 will switch the three #875
+# stage resolvers (inventory_service.py) and get_bom_lines_for_operation
+# (operation_blocking.py) to call resolve_consume_stages() instead of
+# get_consume_stages_for_operation() directly. Until then, nothing calls
+# these — they ship dormant, proven correct by the predicate-equivalence
+# test in tests/services/test_operation_type_catalog.py.
+# =============================================================================
+
+def load_operation_type_stage_map(db: Session) -> Dict[str, List[str]]:
+    """
+    Load the operation-type catalog into a {code: consume_stages} map.
+
+    One query per consumer call (consumers call this once at entry, not
+    per-row). Includes INACTIVE rows deliberately — a routing operation
+    typed before its type was deactivated must still resolve exactly as it
+    always has; history must never break because a type was retired.
+
+    Returns an empty dict if the table doesn't exist yet or has no rows
+    (e.g. a Core-only checkout that hasn't run migration 101) — callers
+    fall through to the legacy code map via resolve_consume_stages().
+    """
+    from app.models.manufacturing import OperationType
+
+    try:
+        rows = db.query(OperationType.code, OperationType.consume_stages).all()
+    except Exception:
+        # Table not migrated yet on this DB — resolve entirely via legacy
+        # code map. This keeps the resolver safe to call speculatively
+        # during a rolling deploy where the migration hasn't landed.
+        return {}
+    return {code: list(stages or []) for code, stages in rows}
+
+
+def resolve_consume_stages(
+    type_map: Dict[str, List[str]],
+    operation_type: Optional[str],
+    operation_code: Optional[str],
+) -> List[str]:
+    """
+    Resolve the consume stages for an operation, type-first.
+
+    Precedence:
+      1. operation_type is set AND present in type_map -> its consume_stages.
+      2. Otherwise -> get_consume_stages_for_operation(operation_code), i.e.
+         the exact 18-key legacy dict, then DEFAULT_CONSUME_STAGES.
+
+    An unknown or inactive type code (not in type_map) falls through to
+    step 2 rather than raising — resolution must never crash on stale or
+    hand-edited data.
+
+    NULL type + NULL/unknown code -> ["production", "any"], honoring the
+    #875 docstring contract (inventory_service.py) and the pinned
+    default-stage tests. The stored type is the ONLY runtime semantic
+    carrier fed by this function — no name is ever consulted here.
+    """
+    if operation_type:
+        stages = type_map.get(operation_type)
+        if stages is not None:
+            return stages
+    return get_consume_stages_for_operation(operation_code)

--- a/backend/migrations/versions/101_operation_types.py
+++ b/backend/migrations/versions/101_operation_types.py
@@ -1,0 +1,248 @@
+"""operation-type catalog: schema + seed + backfill (#876 PR-1, inert)
+
+Revision ID: 101
+Revises: 100
+Create Date: 2026-07-04
+
+#876 PR-1 — every routing/production-order operation will eventually declare
+a Type, and the Type decides WHEN its materials count as used (production
+completion vs. ship vs. never-automatic), replacing the current runtime
+guess from the free-text operation_code (operation_material_mapping.
+OPERATION_CONSUME_STAGES). This migration ships the schema, the 9 system
+type rows, and an EXACT-code-only backfill. It is a NO-OP for behavior:
+no consumer reads operation_type yet (that's #876 PR-2), and the backfill
+only types rows whose operation_code is byte-identical to one of the 18
+legacy dict keys — proven behavior-neutral by the predicate-equivalence
+test in tests/services/test_operation_type_catalog.py.
+
+Steps:
+1. CREATE TABLE operation_types — inspector-guarded (has-table check).
+2. Seed the 9 system rows — INSERT-if-missing on unique code (mirrors
+   seed_routing_templates's skip-existing pattern, routing_service.py).
+3. ADD COLUMN operation_type VARCHAR(30) NULL on routing_operations and
+   production_order_operations — inspector-guarded (has-column check).
+4. Backfill: EXACT legacy-code matches ONLY (WHERE operation_type IS NULL,
+   re-runnable), on both tables, using the alias map below. FINISH and POST
+   get NO rule — deliberately excluded (live-ambiguous; see design §4a/§4d).
+5. NO name-based classification here. A brownfield `alembic upgrade` must
+   never auto-reclassify anyone's in-flight orders with only stdout as the
+   record — that ships later as a human-gated endpoint (#876 PR-3).
+
+Downgrade: drop the added columns + the operation_types table (never run on
+the live 129 brownfield).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "101"
+down_revision = "100"
+branch_labels = None
+depends_on = None
+
+
+# Verbatim from app.services.operation_material_mapping.OPERATION_CONSUME_STAGES
+# — reused so a typed op is byte-identical in behavior to its equivalent
+# coded op. See design doc #876 comment §2c.
+SEED_OPERATION_TYPES = [
+    # code, label, description, category, consume_stages, is_qc, sort_order
+    (
+        "FDM_PRINT", "FDM Print",
+        "Materials count when the production order completes.",
+        "print", ["production", "any"], False, 10,
+    ),
+    (
+        "RESIN_PRINT", "Resin Print",
+        "Materials count when the production order completes.",
+        "print", ["production", "any"], False, 20,
+    ),
+    (
+        "ASSEMBLY", "Assembly",
+        "Materials count when the production order completes.",
+        "assembly", ["assembly", "production", "any"], False, 30,
+    ),
+    (
+        "QUALITY_CONTROL", "Quality Control",
+        "Materials count for nothing automatically.",
+        "quality", ["any"], True, 40,
+    ),
+    (
+        "SUPPORT_REMOVAL", "Support Removal / Cleanup",
+        "Materials count for nothing automatically.",
+        "finishing", ["any"], False, 50,
+    ),
+    (
+        "SANDING", "Sanding",
+        "Materials count for nothing automatically.",
+        "finishing", ["any"], False, 60,
+    ),
+    (
+        "PAINTING", "Painting",
+        "Materials count for nothing automatically.",
+        "finishing", ["finishing", "any"], False, 70,
+    ),
+    (
+        "PACK_SHIP", "Pack / Ship",
+        "Materials count when the order ships.",
+        "shipping", ["shipping", "any"], False, 80,
+    ),
+    (
+        "GENERAL", "Other (consumes at production)",
+        "Materials count when the production order completes.",
+        "other", ["production", "any"], False, 90,
+    ),
+]
+
+# Exact operation_code -> operation_type alias map for the backfill.
+# FINISH and POST are deliberately excluded — the live census shows FINISH
+# spans shipping/quality/blank names, classifiable only per-row by name via
+# the human-gated classifier (#876 PR-3), never by a migration.
+BACKFILL_ALIAS_MAP = {
+    "PRINT": "FDM_PRINT",
+    "EXTRUDE": "GENERAL",
+    "MOLD": "GENERAL",
+    "CUT": "GENERAL",
+    "MACHINE": "GENERAL",
+    "ASSEMBLE": "ASSEMBLY",
+    "BUILD": "ASSEMBLY",
+    "WELD": "ASSEMBLY",
+    "QC": "QUALITY_CONTROL",
+    "INSPECT": "QUALITY_CONTROL",
+    "TEST": "QUALITY_CONTROL",
+    "CLEAN": "SUPPORT_REMOVAL",
+    "SAND": "SANDING",
+    "PAINT": "PAINTING",
+    "COAT": "PAINTING",
+    "PACK": "PACK_SHIP",
+    "SHIP": "PACK_SHIP",
+    "LABEL": "PACK_SHIP",
+}
+
+
+def _has_table(table: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return table in insp.get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = [c["name"] for c in insp.get_columns(table)]
+    return column in cols
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. CREATE TABLE operation_types
+    # ------------------------------------------------------------------
+    if not _has_table("operation_types"):
+        op.create_table(
+            "operation_types",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("code", sa.String(30), nullable=False),
+            sa.Column("label", sa.String(100), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("category", sa.String(20), nullable=True),
+            sa.Column("consume_stages", sa.JSON(), nullable=False),
+            sa.Column(
+                "is_qc", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            ),
+            sa.Column(
+                "is_system", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            ),
+            sa.Column(
+                "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+            ),
+            sa.Column(
+                "sort_order", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+            ),
+            sa.Column(
+                "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("code", name="uq_operation_types_code"),
+        )
+        op.create_index("ix_operation_types_code", "operation_types", ["code"])
+
+    # ------------------------------------------------------------------
+    # 2. Seed the 9 system rows — INSERT-if-missing on unique code
+    # ------------------------------------------------------------------
+    bind = op.get_bind()
+    operation_types_table = sa.table(
+        "operation_types",
+        sa.column("code", sa.String),
+        sa.column("label", sa.String),
+        sa.column("description", sa.Text),
+        sa.column("category", sa.String),
+        sa.column("consume_stages", sa.JSON),
+        sa.column("is_qc", sa.Boolean),
+        sa.column("is_system", sa.Boolean),
+        sa.column("is_active", sa.Boolean),
+        sa.column("sort_order", sa.Integer),
+    )
+
+    existing_codes = {
+        row[0]
+        for row in bind.execute(sa.text("SELECT code FROM operation_types")).fetchall()
+    }
+    for code, label, description, category, consume_stages, is_qc, sort_order in SEED_OPERATION_TYPES:
+        if code in existing_codes:
+            continue
+        bind.execute(
+            operation_types_table.insert().values(
+                code=code,
+                label=label,
+                description=description,
+                category=category,
+                consume_stages=consume_stages,
+                is_qc=is_qc,
+                is_system=True,
+                is_active=True,
+                sort_order=sort_order,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # 3. ADD COLUMN operation_type on both operation tables
+    # ------------------------------------------------------------------
+    for table in ("routing_operations", "production_order_operations"):
+        if not _has_column(table, "operation_type"):
+            op.add_column(
+                table,
+                sa.Column("operation_type", sa.String(30), nullable=True),
+            )
+
+    # ------------------------------------------------------------------
+    # 4. Backfill: EXACT legacy-code matches ONLY, re-runnable.
+    #    FINISH and POST get no rule (see module docstring).
+    # ------------------------------------------------------------------
+    for table in ("routing_operations", "production_order_operations"):
+        for legacy_code, type_code in BACKFILL_ALIAS_MAP.items():
+            bind.execute(
+                sa.text(
+                    f"""
+                    UPDATE {table}
+                    SET operation_type = :type_code
+                    WHERE operation_type IS NULL
+                      AND UPPER(operation_code) = :legacy_code
+                    """
+                ),
+                {"type_code": type_code, "legacy_code": legacy_code},
+            )
+
+    # 5. NO name-based classification here — deliberately. See docstring.
+
+
+def downgrade() -> None:
+    for table in ("routing_operations", "production_order_operations"):
+        if _has_column(table, "operation_type"):
+            op.drop_column(table, "operation_type")
+
+    if _has_table("operation_types"):
+        op.drop_index("ix_operation_types_code", table_name="operation_types", if_exists=True)
+        op.drop_table("operation_types")

--- a/backend/migrations/versions/101_operation_types.py
+++ b/backend/migrations/versions/101_operation_types.py
@@ -167,7 +167,6 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint("code", name="uq_operation_types_code"),
         )
-        op.create_index("ix_operation_types_code", "operation_types", ["code"])
 
     # ------------------------------------------------------------------
     # 2. Seed the 9 system rows — INSERT-if-missing on unique code
@@ -244,5 +243,4 @@ def downgrade() -> None:
             op.drop_column(table, "operation_type")
 
     if _has_table("operation_types"):
-        op.drop_index("ix_operation_types_code", table_name="operation_types", if_exists=True)
         op.drop_table("operation_types")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -369,6 +369,14 @@ def setup_database():
             END
             $$;
         """))
+        # #876 PR-1: operation-type catalog code (migration 101). create_all
+        # won't ALTER these pre-existing tables in the accumulated test DB.
+        conn.execute(text(
+            "ALTER TABLE routing_operations ADD COLUMN IF NOT EXISTS operation_type VARCHAR(30)"
+        ))
+        conn.execute(text(
+            "ALTER TABLE production_order_operations ADD COLUMN IF NOT EXISTS operation_type VARCHAR(30)"
+        ))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/services/test_operation_type_catalog.py
+++ b/backend/tests/services/test_operation_type_catalog.py
@@ -1,0 +1,489 @@
+"""
+Tests for #876 PR-1: operation-type catalog schema, seed, resolver.
+
+This PR is INERT — it ships schema + seed + a dormant resolver that no
+consumer calls yet. The load-bearing proof is predicate-equivalence: for
+every one of the 18 legacy operation_code dict keys, the seeded catalog
+type's consume_stages must produce IDENTICAL results through both live
+consumer predicate shapes as the legacy code path does, so the migration's
+exact-code backfill (migration 101) is provably behavior-neutral.
+
+Covers:
+- Predicate-equivalence proof (all 18 legacy keys x both predicate shapes)
+- Resolver precedence (type beats code; unknown/inactive type falls
+  through to code; NULL/unknown -> default)
+- Seed idempotency (running the seed helper twice = no change)
+- Backfill idempotency + exact-match-only scoping (OP10/FINISH stay NULL)
+- GET /api/v1/operation-types auth + shape
+"""
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+
+from app.models.manufacturing import OperationType, Routing, RoutingOperation
+from app.models.bom import BOMLine
+from app.services.operation_material_mapping import (
+    OPERATION_CONSUME_STAGES,
+    DEFAULT_CONSUME_STAGES,
+    get_consume_stages_for_operation,
+    load_operation_type_stage_map,
+    resolve_consume_stages,
+)
+
+# Mirrors migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES /
+# BACKFILL_ALIAS_MAP verbatim, so a drift between the migration and this test
+# fails loudly rather than silently.
+SEED_OPERATION_TYPES = [
+    ("FDM_PRINT", ["production", "any"], False),
+    ("RESIN_PRINT", ["production", "any"], False),
+    ("ASSEMBLY", ["assembly", "production", "any"], False),
+    ("QUALITY_CONTROL", ["any"], True),
+    ("SUPPORT_REMOVAL", ["any"], False),
+    ("SANDING", ["any"], False),
+    ("PAINTING", ["finishing", "any"], False),
+    ("PACK_SHIP", ["shipping", "any"], False),
+    ("GENERAL", ["production", "any"], False),
+]
+
+BACKFILL_ALIAS_MAP = {
+    "PRINT": "FDM_PRINT",
+    "EXTRUDE": "GENERAL",
+    "MOLD": "GENERAL",
+    "CUT": "GENERAL",
+    "MACHINE": "GENERAL",
+    "ASSEMBLE": "ASSEMBLY",
+    "BUILD": "ASSEMBLY",
+    "WELD": "ASSEMBLY",
+    "QC": "QUALITY_CONTROL",
+    "INSPECT": "QUALITY_CONTROL",
+    "TEST": "QUALITY_CONTROL",
+    "CLEAN": "SUPPORT_REMOVAL",
+    "SAND": "SANDING",
+    "PAINT": "PAINTING",
+    "COAT": "PAINTING",
+    "PACK": "PACK_SHIP",
+    "SHIP": "PACK_SHIP",
+    "LABEL": "PACK_SHIP",
+}
+
+
+def _seed_operation_types(db):
+    """Idempotent INSERT-if-missing seed helper, mirroring migration 101
+    step 2, for use directly against the test DB (no alembic run in tests)."""
+    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
+    seed_source = {
+        "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+        "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+        "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+        "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+        "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+        "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+        "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+        "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+        "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+    }
+    created = []
+    for code, (label, category, stages, is_qc, sort_order) in seed_source.items():
+        if code in existing_codes:
+            continue
+        row = OperationType(
+            code=code,
+            label=label,
+            category=category,
+            consume_stages=stages,
+            is_qc=is_qc,
+            is_system=True,
+            is_active=True,
+            sort_order=sort_order,
+        )
+        db.add(row)
+        created.append(code)
+    db.flush()
+    return created
+
+
+def _backfill_operation_types(db):
+    """Idempotent exact-match-only backfill helper, mirroring migration 101
+    step 4, for use directly against the test DB."""
+    total_updated = 0
+    for table in ("routing_operations", "production_order_operations"):
+        for legacy_code, type_code in BACKFILL_ALIAS_MAP.items():
+            result = db.execute(
+                text(
+                    f"""
+                    UPDATE {table}
+                    SET operation_type = :type_code
+                    WHERE operation_type IS NULL
+                      AND UPPER(operation_code) = :legacy_code
+                    """
+                ),
+                {"type_code": type_code, "legacy_code": legacy_code},
+            )
+            total_updated += result.rowcount or 0
+    db.commit()
+    return total_updated
+
+
+# =============================================================================
+# Predicate-equivalence proof — the load-bearing test
+# =============================================================================
+
+class TestPredicateEquivalence:
+    """
+    For every one of the 18 legacy OPERATION_CONSUME_STAGES keys, the seeded
+    type's consume_stages must be IDENTICAL to the legacy dict's stage list,
+    and must produce identical results through BOTH live consumer predicate
+    shapes:
+      - `stage in stages` (inventory_service._get_stage_op_materials /
+        _stage_has_consumed_op_materials / _get_stage_component_ids pattern)
+      - `BOMLine.consume_stage.in_(stages)` (operation_blocking
+        .get_bom_lines_for_operation pattern) for both 'production' and
+        'shipping' consume_stage values (the two live BOMLine values).
+
+    This proves the migration's exact-code backfill is behavior-neutral:
+    a row typed by exact-code match resolves identically to how it resolves
+    today via the untouched legacy code path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _seed(self, db):
+        _seed_operation_types(db)
+        db.commit()
+
+    def _type_for_code(self, db, legacy_code):
+        type_code = BACKFILL_ALIAS_MAP[legacy_code]
+        return db.query(OperationType).filter(OperationType.code == type_code).first()
+
+    @pytest.mark.parametrize("legacy_code", list(OPERATION_CONSUME_STAGES.keys()))
+    def test_seeded_type_stages_match_legacy_dict_exactly(self, db, legacy_code):
+        """alias(code) -> type.consume_stages == OPERATION_CONSUME_STAGES[code]."""
+        op_type = self._type_for_code(db, legacy_code)
+        assert op_type is not None, f"no seeded type for legacy code {legacy_code}"
+        assert list(op_type.consume_stages) == OPERATION_CONSUME_STAGES[legacy_code]
+
+    @pytest.mark.parametrize("legacy_code", list(OPERATION_CONSUME_STAGES.keys()))
+    @pytest.mark.parametrize("stage", ["production", "shipping", "assembly", "finishing", "any"])
+    def test_membership_predicate_equivalence(self, db, legacy_code, stage):
+        """`stage in stages` (inventory_service pattern) must agree between
+        the legacy code path and the seeded type's stored stages."""
+        op_type = self._type_for_code(db, legacy_code)
+        legacy_stages = get_consume_stages_for_operation(legacy_code)
+        typed_stages = list(op_type.consume_stages)
+
+        legacy_result = stage in legacy_stages
+        typed_result = stage in typed_stages
+        assert legacy_result == typed_result, (
+            f"stage={stage!r} legacy_code={legacy_code!r}: "
+            f"legacy={legacy_result} typed={typed_result}"
+        )
+
+    @pytest.mark.parametrize("legacy_code", list(OPERATION_CONSUME_STAGES.keys()))
+    @pytest.mark.parametrize("bom_consume_stage", ["production", "shipping"])
+    def test_bomline_predicate_equivalence(self, db, legacy_code, bom_consume_stage, make_product, make_bom):
+        """`BOMLine.consume_stage.in_(stages)` (operation_blocking pattern)
+        must agree between the legacy code path and the seeded type's
+        stored stages, for both live BOMLine.consume_stage values."""
+        op_type = self._type_for_code(db, legacy_code)
+        legacy_stages = get_consume_stages_for_operation(legacy_code)
+        typed_stages = list(op_type.consume_stages)
+
+        fg = make_product(item_type="finished_good")
+        raw = make_product(item_type="supply", is_raw_material=True)
+        bom = make_bom(
+            product_id=fg.id,
+            lines=[{"component_id": raw.id, "quantity": Decimal("1"), "unit": "EA"}],
+        )
+        line = bom.lines[0] if hasattr(bom, "lines") else db.query(BOMLine).filter(BOMLine.bom_id == bom.id).first()
+        line.consume_stage = bom_consume_stage
+        db.flush()
+
+        legacy_match = (
+            db.query(BOMLine)
+            .filter(BOMLine.id == line.id, BOMLine.consume_stage.in_(legacy_stages))
+            .first()
+            is not None
+        )
+        typed_match = (
+            db.query(BOMLine)
+            .filter(BOMLine.id == line.id, BOMLine.consume_stage.in_(typed_stages))
+            .first()
+            is not None
+        )
+        assert legacy_match == typed_match, (
+            f"bom_consume_stage={bom_consume_stage!r} legacy_code={legacy_code!r}: "
+            f"legacy={legacy_match} typed={typed_match}"
+        )
+
+
+# =============================================================================
+# Resolver precedence
+# =============================================================================
+
+class TestResolverPrecedence:
+    @pytest.fixture(autouse=True)
+    def _seed(self, db):
+        _seed_operation_types(db)
+        db.commit()
+
+    def test_type_beats_code(self, db):
+        """A typed op resolves via its type even when operation_code would
+        resolve to something different through the legacy map."""
+        type_map = load_operation_type_stage_map(db)
+        # PACK_SHIP type vs. a code ("PRINT") that would legacy-resolve to
+        # production-only — the stored type must win.
+        stages = resolve_consume_stages(type_map, "PACK_SHIP", "PRINT")
+        assert stages == ["shipping", "any"]
+
+    def test_unknown_type_falls_through_to_code(self, db):
+        """An operation_type not present in the catalog (stale/hand-edited
+        data) falls through to the legacy code resolution rather than
+        raising or silently defaulting."""
+        type_map = load_operation_type_stage_map(db)
+        stages = resolve_consume_stages(type_map, "NOT_A_REAL_TYPE", "PACK")
+        assert stages == get_consume_stages_for_operation("PACK")
+        assert "shipping" in stages
+
+    def test_inactive_type_falls_through_to_code(self, db):
+        """A deactivated type is excluded from the active-only map load
+        used elsewhere, but load_operation_type_stage_map includes inactive
+        rows so history never breaks. This test proves the fallback path
+        for when a type code isn't in the map at all (simulating a type
+        deleted outright, which the design forbids for system rows, but is
+        the fallback contract nonetheless)."""
+        type_map = {}  # simulates the type genuinely absent from the map
+        stages = resolve_consume_stages(type_map, "PACK_SHIP", "PACK")
+        assert stages == get_consume_stages_for_operation("PACK")
+
+    def test_null_type_uses_code(self, db):
+        type_map = load_operation_type_stage_map(db)
+        stages = resolve_consume_stages(type_map, None, "ASSEMBLE")
+        assert stages == get_consume_stages_for_operation("ASSEMBLE")
+        assert "assembly" in stages
+
+    def test_null_type_and_null_code_returns_default(self, db):
+        type_map = load_operation_type_stage_map(db)
+        stages = resolve_consume_stages(type_map, None, None)
+        assert stages == DEFAULT_CONSUME_STAGES
+        assert stages == ["production", "any"]
+
+    def test_null_type_and_unknown_code_returns_default(self, db):
+        type_map = load_operation_type_stage_map(db)
+        stages = resolve_consume_stages(type_map, None, "SOME_UNKNOWN_CODE")
+        assert stages == DEFAULT_CONSUME_STAGES
+
+    def test_empty_type_string_uses_code(self, db):
+        """Empty-string operation_type (falsy) must not attempt a type-map
+        lookup — falls straight through to code resolution."""
+        type_map = load_operation_type_stage_map(db)
+        stages = resolve_consume_stages(type_map, "", "PRINT")
+        assert stages == get_consume_stages_for_operation("PRINT")
+
+    def test_load_operation_type_stage_map_includes_inactive(self, db):
+        """load_operation_type_stage_map must include inactive rows so a
+        routing operation typed before its type was deactivated still
+        resolves — history must never break because a type was retired."""
+        op_type = db.query(OperationType).filter(OperationType.code == "PACK_SHIP").first()
+        op_type.is_active = False
+        db.flush()
+
+        type_map = load_operation_type_stage_map(db)
+        assert "PACK_SHIP" in type_map
+        assert type_map["PACK_SHIP"] == ["shipping", "any"]
+
+    def test_load_operation_type_stage_map_empty_when_table_missing(self, db, monkeypatch):
+        """If the OperationType query fails (e.g. table not migrated on an
+        older DB), the loader degrades to an empty map rather than raising,
+        so resolve_consume_stages falls through to the legacy code path for
+        every call."""
+        def _boom(*args, **kwargs):
+            raise Exception("relation \"operation_types\" does not exist")
+
+        monkeypatch.setattr(db, "query", _boom)
+        type_map = load_operation_type_stage_map(db)
+        assert type_map == {}
+
+
+# =============================================================================
+# Seed + backfill idempotency
+# =============================================================================
+
+class TestSeedIdempotency:
+    def test_seed_creates_nine_system_rows(self, db):
+        created = _seed_operation_types(db)
+        db.commit()
+        assert len(created) == 9
+        assert set(created) == {code for code, _, _ in SEED_OPERATION_TYPES}
+
+        rows = db.query(OperationType).filter(OperationType.is_system.is_(True)).all()
+        assert len(rows) == 9
+
+    def test_seed_running_twice_creates_nothing_new(self, db):
+        first_created = _seed_operation_types(db)
+        db.commit()
+        assert len(first_created) == 9
+
+        count_after_first = db.query(OperationType).count()
+
+        second_created = _seed_operation_types(db)
+        db.commit()
+        assert second_created == []
+
+        count_after_second = db.query(OperationType).count()
+        assert count_after_first == count_after_second
+
+    def test_seed_is_unique_on_code(self, db):
+        _seed_operation_types(db)
+        db.commit()
+        codes = [c for (c,) in db.query(OperationType.code).all()]
+        assert len(codes) == len(set(codes))
+
+
+class TestBackfillIdempotency:
+    def test_backfill_types_exact_matches_only(self, db, make_product):
+        """An OP10 row (no exact legacy-code match — routing editor
+        autofill) and a FINISH row (deliberately excluded) both stay NULL.
+        A PRINT row (exact match) gets typed FDM_PRINT."""
+        _seed_operation_types(db)
+        db.commit()
+
+        product = make_product(item_type="finished_good")
+        routing = Routing(product_id=product.id, code="RTG-TEST", is_template=False)
+        db.add(routing)
+        db.flush()
+
+        from app.models.work_center import WorkCenter
+        wc = db.query(WorkCenter).first()
+
+        op_op10 = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id, sequence=10,
+            operation_code="OP10", operation_name="3D Print",
+            run_time_minutes=Decimal("60"),
+        )
+        op_finish = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id, sequence=20,
+            operation_code="FINISH", operation_name="Pack/Ship",
+            run_time_minutes=Decimal("2"),
+        )
+        op_print = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id, sequence=30,
+            operation_code="PRINT", operation_name="Print",
+            run_time_minutes=Decimal("60"),
+        )
+        db.add_all([op_op10, op_finish, op_print])
+        db.commit()
+
+        _backfill_operation_types(db)
+
+        db.refresh(op_op10)
+        db.refresh(op_finish)
+        db.refresh(op_print)
+
+        assert op_op10.operation_type is None, "OP10 has no exact legacy-code match — must stay NULL"
+        assert op_finish.operation_type is None, "FINISH is deliberately excluded — must stay NULL"
+        assert op_print.operation_type == "FDM_PRINT", "PRINT is an exact legacy-code match"
+
+    def test_backfill_running_twice_is_a_no_op(self, db, make_product):
+        _seed_operation_types(db)
+        db.commit()
+
+        product = make_product(item_type="finished_good")
+        routing = Routing(product_id=product.id, code="RTG-TEST2", is_template=False)
+        db.add(routing)
+        db.flush()
+
+        from app.models.work_center import WorkCenter
+        wc = db.query(WorkCenter).first()
+
+        op = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id, sequence=10,
+            operation_code="ASSEMBLE", operation_name="Assembly",
+            run_time_minutes=Decimal("10"),
+        )
+        db.add(op)
+        db.commit()
+
+        first_updated = _backfill_operation_types(db)
+        db.refresh(op)
+        assert op.operation_type == "ASSEMBLY"
+        assert first_updated >= 1
+
+        second_updated = _backfill_operation_types(db)
+        db.refresh(op)
+        assert op.operation_type == "ASSEMBLY", "re-running must not change an already-typed row"
+        # WHERE operation_type IS NULL excludes every row typed by the first
+        # pass, so the second pass must be a complete no-op.
+        assert second_updated == 0, "second backfill pass must update zero rows"
+
+    def test_backfill_never_overwrites_a_human_set_type(self, db, make_product):
+        """A row a human already typed (even to something unexpected) must
+        never be overwritten — the WHERE operation_type IS NULL guard is
+        what makes this true; assert it holds."""
+        _seed_operation_types(db)
+        db.commit()
+
+        product = make_product(item_type="finished_good")
+        routing = Routing(product_id=product.id, code="RTG-TEST3", is_template=False)
+        db.add(routing)
+        db.flush()
+
+        from app.models.work_center import WorkCenter
+        wc = db.query(WorkCenter).first()
+
+        op = RoutingOperation(
+            routing_id=routing.id, work_center_id=wc.id, sequence=10,
+            operation_code="PRINT", operation_name="Print",
+            operation_type="QUALITY_CONTROL",  # deliberately "wrong" / human-set
+            run_time_minutes=Decimal("60"),
+        )
+        db.add(op)
+        db.commit()
+
+        _backfill_operation_types(db)
+        db.refresh(op)
+        assert op.operation_type == "QUALITY_CONTROL", "backfill must never overwrite a non-NULL type"
+
+
+# =============================================================================
+# GET /api/v1/operation-types
+# =============================================================================
+
+class TestOperationTypesEndpoint:
+    @pytest.fixture(autouse=True)
+    def _seed(self, db):
+        _seed_operation_types(db)
+        db.commit()
+
+    def test_requires_auth(self, unauthed_client):
+        response = unauthed_client.get("/api/v1/operation-types")
+        assert response.status_code == 401
+
+    def test_lists_active_types_ordered_by_sort_order(self, client, db):
+        response = client.get("/api/v1/operation-types")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 9
+
+        codes_in_order = [row["code"] for row in body]
+        sort_orders = [row["sort_order"] for row in body]
+        assert sort_orders == sorted(sort_orders)
+        assert "FDM_PRINT" in codes_in_order
+        assert "PACK_SHIP" in codes_in_order
+
+        pack_ship = next(row for row in body if row["code"] == "PACK_SHIP")
+        assert pack_ship["consume_stages"] == ["shipping", "any"]
+        assert pack_ship["is_qc"] is False
+
+        qc = next(row for row in body if row["code"] == "QUALITY_CONTROL")
+        assert qc["is_qc"] is True
+
+    def test_excludes_inactive_types(self, client, db):
+        op_type = db.query(OperationType).filter(OperationType.code == "SANDING").first()
+        op_type.is_active = False
+        db.commit()
+
+        response = client.get("/api/v1/operation-types")
+        assert response.status_code == 200
+        codes = [row["code"] for row in response.json()]
+        assert "SANDING" not in codes
+        assert len(codes) == 8

--- a/backend/tests/services/test_operation_type_catalog.py
+++ b/backend/tests/services/test_operation_type_catalog.py
@@ -33,18 +33,21 @@ from app.services.operation_material_mapping import (
 
 # Mirrors migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES /
 # BACKFILL_ALIAS_MAP verbatim, so a drift between the migration and this test
-# fails loudly rather than silently.
-SEED_OPERATION_TYPES = [
-    ("FDM_PRINT", ["production", "any"], False),
-    ("RESIN_PRINT", ["production", "any"], False),
-    ("ASSEMBLY", ["assembly", "production", "any"], False),
-    ("QUALITY_CONTROL", ["any"], True),
-    ("SUPPORT_REMOVAL", ["any"], False),
-    ("SANDING", ["any"], False),
-    ("PAINTING", ["finishing", "any"], False),
-    ("PACK_SHIP", ["shipping", "any"], False),
-    ("GENERAL", ["production", "any"], False),
-]
+# fails loudly rather than silently. This is the ONLY seed-data literal in
+# this file — _seed_operation_types() below consumes it directly rather than
+# maintaining a second, redundant copy.
+SEED_OPERATION_TYPES = {
+    # code: (label, category, consume_stages, is_qc, sort_order)
+    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+}
 
 BACKFILL_ALIAS_MAP = {
     "PRINT": "FDM_PRINT",
@@ -70,21 +73,12 @@ BACKFILL_ALIAS_MAP = {
 
 def _seed_operation_types(db):
     """Idempotent INSERT-if-missing seed helper, mirroring migration 101
-    step 2, for use directly against the test DB (no alembic run in tests)."""
+    step 2, for use directly against the test DB (no alembic run in tests).
+    Consumes the module-level SEED_OPERATION_TYPES constant above — no
+    separate inline copy of the seed data."""
     existing_codes = {code for (code,) in db.query(OperationType.code).all()}
-    seed_source = {
-        "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
-        "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
-        "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
-        "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
-        "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
-        "SANDING": ("Sanding", "finishing", ["any"], False, 60),
-        "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
-        "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
-        "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
-    }
     created = []
-    for code, (label, category, stages, is_qc, sort_order) in seed_source.items():
+    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
         if code in existing_codes:
             continue
         row = OperationType(
@@ -313,7 +307,7 @@ class TestSeedIdempotency:
         created = _seed_operation_types(db)
         db.commit()
         assert len(created) == 9
-        assert set(created) == {code for code, _, _ in SEED_OPERATION_TYPES}
+        assert set(created) == set(SEED_OPERATION_TYPES)
 
         rows = db.query(OperationType).filter(OperationType.is_system.is_(True)).all()
         assert len(rows) == 9


### PR DESCRIPTION
## What

First PR of the #876 operation-type catalog track (PR-1 of the approved plan). Ships the foundation only — **deploying this changes zero behavior**:

- **`operation_types` catalog table + `OperationType` model** (`backend/app/models/manufacturing.py`): code (unique, uppercase), label, description, category, `consume_stages` JSON (verbatim legacy stage vocabulary), `is_qc`, `is_system`/`is_active`/`sort_order`. String-code referenced, deliberately **not** an integer FK (snapshot-at-release copies as a plain string; no FK ordering on the brownfield migration; PRO wheel can set it behind a `hasattr` guard; unknown/inactive codes fall through to the legacy map instead of raising).
- **Nullable `operation_type VARCHAR(30)`** on both `routing_operations` and `production_order_operations`.
- **Migration `101_operation_types.py`**: inspector-guarded DDL (has-table / has-column checks, re-runnable); INSERT-if-missing seed of the 9 system type rows with `consume_stages` copied byte-for-byte from `OPERATION_CONSUME_STAGES`; **exact-legacy-code-only backfill** (`WHERE operation_type IS NULL`, both tables, the 18-key alias map). **FINISH and POST are deliberately excluded** — the live census shows FINISH spans shipping/quality/blank names and is classifiable only per-row by the human-gated classifier (#876 PR-3). **No name-based rules in the migration.** Downgrade drops columns + table.
- **Dormant resolver** in `operation_material_mapping.py`: `load_operation_type_stage_map(db)` + `resolve_consume_stages(type_map, operation_type, operation_code)` with type > code > default precedence. The legacy dict, `DEFAULT_CONSUME_STAGES`, and `get_consume_stages_for_operation` are **untouched** (pinned by `test_small_services.py`). Nothing calls the new resolver yet — the consumer switch is #876 PR-2.
- **`GET /api/v1/operation-types`** — authenticated read listing active types for the future routing-editor Type picker (#876 PR-4). Admin CRUD/audit/classifier ship in PR-3.

## Why

Material-consumption timing is currently guessed at runtime from free-text `operation_code` against a hardcoded 18-word dict; everything unrecognized (every `OP10`/`OP20` the routing editor autofills, every intake `FINISH` op) silently defaults to consume-at-production-completion. That is why Pack/Ship steps consumed boxes at print completion instead of at ship. The fix is a declared, stored Type per operation — this PR ships the catalog and columns so later PRs can switch the consumers, without guessing from names at runtime ever again.

## INERT guarantee

- No consumer reads `operation_type` yet — the three #875 stage resolvers and `operation_blocking` still resolve exclusively through the untouched legacy code map.
- The migration's backfill types only rows whose `operation_code` exactly matches one of the 18 legacy dict keys — **proven behavior-neutral by the predicate-equivalence test** in `tests/services/test_operation_type_catalog.py`, which asserts for all 18 keys that the seeded type's `consume_stages` produce identical results through BOTH live consumer predicate shapes (`stage in stages` and `BOMLine.consume_stage.in_(stages)`).
- NULL type + NULL/unknown code → `["production","any"]`, honoring the #875 docstring contract; pinned legacy tests pass unchanged.

## Tests

- `tests/services/test_operation_type_catalog.py` (new): predicate-equivalence proof (18 keys × both predicate shapes × 5 stage values), resolver precedence (type beats code, unknown/inactive type falls through, NULL/empty/unknown → default), seed idempotency, backfill idempotency + exact-match-only scoping (OP10/FINISH stay NULL) + never-overwrites-human-set, endpoint auth + shape + inactive exclusion.
- Combined run with pinned `tests/services/test_small_services.py`: **227 passed, 0 failed**.
- `ruff check` clean on all changed/new files (2 pre-existing F401s in `models/__init__.py` predate this PR and are reported separately).

## References

- Design: #876 (see the final design comment: https://github.com/BLB3DPrinting/filaops/issues/876#issuecomment-4880247733)
- Roadmap: #880 (combined 880/876 roadmap comment)
- Plan row: PR-1 — "Catalog schema + seed + resolver (inert)"; next: PR-2 consumer switch + snapshot propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Operation Types API endpoint to list active operation type entries, including labels, stages, ordering, and status flags.
  * Introduced operation type support in the system so routing and production operations can store and carry this classification.

* **Bug Fixes**
  * Backfilled existing records with operation type values where a direct legacy match was found, while leaving unmatched or already set values unchanged.
  * Added safer fallback behavior so existing operation-stage logic continues to work when no operation type is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->