### PR TITLE
feat(mrp): op-type audit + human-gated classifier + admin CRUD (876 PR-3)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -5,7 +5,8 @@ from fastapi import APIRouter
 from . import (
     bom, dashboard, fulfillment_queue, fulfillment_shipping, audit, accounting, traceability,
     customers, inventory_transactions, analytics, export, data_import, orders,
-    users, uom, locations, system, uploads, pro_install, reconciliation, reservations
+    users, uom, locations, system, uploads, pro_install, reconciliation, reservations,
+    operation_types,
 )
 
 router = APIRouter()
@@ -46,6 +47,9 @@ router.include_router(reconciliation.router)
 
 # Reservation Reconciliation + Stranded Allocation Repair (HARD-5)
 router.include_router(reservations.router)
+
+# Operation Type Catalog: audit + human-gated classifier + hardened CRUD (876 PR-3)
+router.include_router(operation_types.router)
 
 # Export/Import
 router.include_router(export.router)

--- a/backend/app/api/v1/endpoints/admin/operation_types.py
+++ b/backend/app/api/v1/endpoints/admin/operation_types.py
@@ -1,0 +1,278 @@
+"""
+Admin: Operation Type Catalog — audit, human-gated classifier, hardened CRUD
+(#876 PR-3).
+
+GET  /api/v1/admin/operation-types/audit
+  Read-only, re-runnable audit of every distinct (operation_code,
+  operation_name) pair across routing_operations AND
+  production_order_operations: per-table counts, stored type, resolved
+  consume stages, match source, old-vs-new stage projection, a
+  behavior_changed flag, and an in-flight (non-terminal PO) exposure
+  rollup.
+
+POST /api/v1/admin/operation-types/classify
+  Human-gated classifier. dry_run=true (default) returns the proposal
+  report and WRITES NOTHING. dry_run=false applies NULL-operation_type ->
+  proposed type ONLY — never overwrites a human-set type, and a
+  material-bearing op that would otherwise match a no-consume type
+  (QUALITY_CONTROL/SANDING/SUPPORT_REMOVAL) is always surfaced as "needs
+  manual decision" instead of auto-applied. Idempotent: re-running after
+  an apply finds no NULL rows left to act on.
+
+POST/PUT/POST .../{code}/deactivate  /api/v1/admin/operation-types
+  Hardened CRUD. is_system rows are undeletable and have consume_stages/
+  is_qc LOCKED (only label/description/category/sort_order/is_active are
+  editable). Editing consume_stages on ANY type (system or custom) that is
+  referenced by an operation belonging to a NON-terminal production order
+  is rejected with 409 ("create a new type instead"). Custom types support
+  deactivate only (no hard delete).
+
+Staff-gated: uses the same router-level dependency as reconciliation.py /
+mrp.py (post-#683).
+"""
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.api.v1.deps import get_current_staff_user
+from app.models.manufacturing import OperationType
+from app.models.production_order import ProductionOrder, ProductionOrderOperation
+from app.models.user import User
+from app.schemas.operation_type import (
+    OperationTypeResponse,
+    OperationTypeCreate,
+    OperationTypeUpdate,
+    OperationTypeAuditResponse,
+    OperationTypeAuditRow,
+    ClassifyRequest,
+    ClassifyResponse,
+    ClassifyProposalRow,
+)
+from app.services.operation_type_classifier import (
+    PO_TERMINAL_STATUSES,
+    build_audit,
+    run_classifier,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/operation-types",
+    tags=["Admin - Operation Types"],
+    dependencies=[Depends(get_current_staff_user)],
+)
+
+
+# =============================================================================
+# Audit
+# =============================================================================
+
+@router.get("/audit", response_model=OperationTypeAuditResponse)
+def get_operation_type_audit(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """Read-only, re-runnable audit — see module docstring."""
+    rows = build_audit(db)
+    return OperationTypeAuditResponse(
+        rows=[OperationTypeAuditRow(**row.__dict__) for row in rows],
+        total_pairs=len(rows),
+        total_in_flight_exposure=sum(r.in_flight_non_terminal_po_count for r in rows),
+    )
+
+
+# =============================================================================
+# Human-gated classifier
+# =============================================================================
+
+@router.post("/classify", response_model=ClassifyResponse)
+def classify_operation_types(
+    request: ClassifyRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """dry_run=true (default): proposal report, no writes. dry_run=false:
+    apply NULL-only, never overwrite, idempotent. See module docstring."""
+    result = run_classifier(db, dry_run=request.dry_run)
+
+    applied_by = None
+    applied_at = None
+    if not request.dry_run and result.applied_count:
+        applied_by = current_user.email
+        applied_at = datetime.now(timezone.utc)
+        logger.info(
+            "operation-type classifier applied %d rows (skipped_manual=%d "
+            "skipped_no_match=%d) by %s",
+            result.applied_count,
+            result.skipped_manual_decision_count,
+            result.skipped_no_match_count,
+            current_user.email,
+        )
+
+    return ClassifyResponse(
+        dry_run=result.dry_run,
+        proposals=[ClassifyProposalRow(**p.__dict__) for p in result.proposals],
+        applied_count=result.applied_count,
+        skipped_manual_decision_count=result.skipped_manual_decision_count,
+        skipped_no_match_count=result.skipped_no_match_count,
+        non_terminal_exposure_count=result.non_terminal_exposure_count,
+        applied_by=applied_by,
+        applied_at=applied_at,
+    )
+
+
+# =============================================================================
+# Hardened admin CRUD
+# =============================================================================
+
+def _get_or_404(db: Session, code: str) -> OperationType:
+    op_type = db.query(OperationType).filter(OperationType.code == code).first()
+    if not op_type:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Operation type not found: {code}")
+    return op_type
+
+
+def _referenced_by_non_terminal_po(db: Session, code: str) -> bool:
+    """True if `code` is the operation_type of any operation belonging to
+    a NON-terminal production order. See operation_type_classifier.py for
+    the PO_TERMINAL_STATUSES rationale (the #850 fork)."""
+    exists = (
+        db.query(ProductionOrderOperation.id)
+        .join(ProductionOrder, ProductionOrder.id == ProductionOrderOperation.production_order_id)
+        .filter(
+            ProductionOrderOperation.operation_type == code,
+            ProductionOrder.status.notin_(PO_TERMINAL_STATUSES),
+        )
+        .first()
+    )
+    return exists is not None
+
+
+@router.post("", response_model=OperationTypeResponse, status_code=status.HTTP_201_CREATED)
+def create_operation_type(
+    request: OperationTypeCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """Create a new custom (non-system) operation type."""
+    code = request.code.upper()
+    existing = db.query(OperationType).filter(OperationType.code == code).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Operation type with code '{code}' already exists",
+        )
+
+    op_type = OperationType(
+        code=code,
+        label=request.label,
+        description=request.description,
+        category=request.category,
+        consume_stages=list(request.consume_stages),
+        is_qc=request.is_qc,
+        is_system=False,
+        is_active=True,
+        sort_order=request.sort_order,
+    )
+    db.add(op_type)
+    db.commit()
+    db.refresh(op_type)
+
+    logger.info("Created operation type: %s (%s) by %s", op_type.code, op_type.label, current_user.email)
+    return op_type
+
+
+@router.put("/{code}", response_model=OperationTypeResponse)
+def update_operation_type(
+    code: str,
+    request: OperationTypeUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """
+    Update an operation type.
+
+    is_system rows: consume_stages/is_qc are LOCKED — any attempt to
+    change them (to a different value than currently stored) is rejected
+    with 400. label/description/category/sort_order/is_active remain
+    editable on system rows.
+
+    Any row (system or custom): changing consume_stages while the type is
+    referenced by an operation of a NON-terminal production order is
+    rejected with 409 ("create a new type instead").
+    """
+    op_type = _get_or_404(db, code.upper())
+    update_dict = request.model_dump(exclude_unset=True)
+
+    if op_type.is_system:
+        locked_fields = {"consume_stages", "is_qc"}
+        for field_name in locked_fields:
+            if field_name in update_dict:
+                new_value = update_dict[field_name]
+                current_value = list(op_type.consume_stages) if field_name == "consume_stages" else op_type.is_qc
+                if new_value != current_value:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            f"'{field_name}' is locked on system operation type '{op_type.code}'. "
+                            "Only label/description/category/sort_order/is_active are editable on system types."
+                        ),
+                    )
+
+    if "consume_stages" in update_dict:
+        new_stages = update_dict["consume_stages"]
+        if list(new_stages) != list(op_type.consume_stages) and _referenced_by_non_terminal_po(db, op_type.code):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Operation type '{op_type.code}' is referenced by an operation of a "
+                    "non-terminal production order — create a new type instead of editing "
+                    "consume_stages on one already in flight."
+                ),
+            )
+        op_type.consume_stages = list(new_stages)
+
+    if "label" in update_dict:
+        op_type.label = update_dict["label"]
+    if "description" in update_dict:
+        op_type.description = update_dict["description"]
+    if "category" in update_dict:
+        op_type.category = update_dict["category"]
+    if "sort_order" in update_dict:
+        op_type.sort_order = update_dict["sort_order"]
+    if "is_active" in update_dict:
+        op_type.is_active = update_dict["is_active"]
+    if "is_qc" in update_dict and not op_type.is_system:
+        op_type.is_qc = update_dict["is_qc"]
+
+    db.commit()
+    db.refresh(op_type)
+
+    logger.info("Updated operation type: %s by %s", op_type.code, current_user.email)
+    return op_type
+
+
+@router.post("/{code}/deactivate", response_model=OperationTypeResponse)
+def deactivate_operation_type(
+    code: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """
+    Deactivate an operation type (soft delete). Both system and custom
+    types support deactivate-only — there is no hard-delete endpoint.
+    is_system rows are undeletable in the sense that they can never be
+    hard-removed; deactivation just hides them from the active picker
+    while historical resolution (load_operation_type_stage_map includes
+    inactive rows) continues to work.
+    """
+    op_type = _get_or_404(db, code.upper())
+    op_type.is_active = False
+    db.commit()
+    db.refresh(op_type)
+
+    logger.info("Deactivated operation type: %s by %s", op_type.code, current_user.email)
+    return op_type

--- a/backend/app/schemas/operation_type.py
+++ b/backend/app/schemas/operation_type.py
@@ -1,13 +1,14 @@
 """
-Operation Type Catalog Pydantic Schemas (#876 PR-1).
+Operation Type Catalog Pydantic Schemas (#876 PR-1, extended in PR-3).
 
-Read-only response shape for GET /api/v1/operation-types. Admin CRUD
-(create/update/deactivate/classify) ships later in #876 PR-3.
+Read-only response shape for GET /api/v1/operation-types (PR-1), plus the
+admin CRUD request/response shapes and the audit/classifier report shapes
+added in #876 PR-3 (app/api/v1/endpoints/admin/operation_types.py).
 """
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class OperationTypeResponse(BaseModel):
@@ -26,3 +27,96 @@ class OperationTypeResponse(BaseModel):
     sort_order: int
     created_at: datetime
     updated_at: datetime
+
+
+# =============================================================================
+# #876 PR-3: Admin CRUD
+# =============================================================================
+
+class OperationTypeCreate(BaseModel):
+    """Create a new (custom, non-system) operation type."""
+    code: str = Field(..., min_length=1, max_length=30)
+    label: str = Field(..., min_length=1, max_length=100)
+    description: Optional[str] = None
+    category: Optional[str] = Field(None, max_length=20)
+    consume_stages: List[str] = Field(..., min_length=1)
+    is_qc: bool = False
+    sort_order: int = 0
+
+
+class OperationTypeUpdate(BaseModel):
+    """
+    Update an existing operation type.
+
+    For is_system rows, only label/description/category/sort_order/
+    is_active are honored — consume_stages/is_qc are LOCKED and any
+    attempt to change them is rejected with 400. For custom (non-system)
+    rows, editing consume_stages on a type referenced by an operation of a
+    NON-terminal production order is rejected with 409.
+    """
+    label: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = None
+    category: Optional[str] = Field(None, max_length=20)
+    consume_stages: Optional[List[str]] = Field(None, min_length=1)
+    is_qc: Optional[bool] = None
+    sort_order: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+# =============================================================================
+# #876 PR-3: Audit
+# =============================================================================
+
+class OperationTypeAuditRow(BaseModel):
+    operation_code: Optional[str] = None
+    operation_name: Optional[str] = None
+    routing_op_count: int
+    po_op_count: int
+    stored_operation_type: Optional[str] = None
+    match_source: str
+    current_consume_stages: List[str]
+    proposed_type: Optional[str] = None
+    proposed_consume_stages: Optional[List[str]] = None
+    behavior_changed: bool
+    material_bearing: bool
+    classification_reason: Optional[str] = None
+    in_flight_non_terminal_po_count: int
+
+
+class OperationTypeAuditResponse(BaseModel):
+    rows: List[OperationTypeAuditRow]
+    total_pairs: int
+    total_in_flight_exposure: int
+
+
+# =============================================================================
+# #876 PR-3: Human-gated classifier
+# =============================================================================
+
+class ClassifyRequest(BaseModel):
+    dry_run: bool = True
+
+
+class ClassifyProposalRow(BaseModel):
+    table: str
+    row_id: int
+    operation_code: Optional[str] = None
+    operation_name: Optional[str] = None
+    proposed_type: Optional[str] = None
+    reason: Optional[str] = None
+    material_bearing: bool
+    before_stages: List[str]
+    after_stages: Optional[List[str]] = None
+    production_order_id: Optional[int] = None
+    production_order_status: Optional[str] = None
+
+
+class ClassifyResponse(BaseModel):
+    dry_run: bool
+    proposals: List[ClassifyProposalRow]
+    applied_count: int
+    skipped_manual_decision_count: int
+    skipped_no_match_count: int
+    non_terminal_exposure_count: int
+    applied_by: Optional[str] = None
+    applied_at: Optional[datetime] = None

--- a/backend/app/schemas/operation_type.py
+++ b/backend/app/schemas/operation_type.py
@@ -6,9 +6,9 @@ admin CRUD request/response shapes and the audit/classifier report shapes
 added in #876 PR-3 (app/api/v1/endpoints/admin/operation_types.py).
 """
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class OperationTypeResponse(BaseModel):
@@ -44,6 +44,16 @@ class OperationTypeCreate(BaseModel):
     sort_order: int = 0
 
 
+# NOT NULL-backed columns on OperationType. A field left out of an update
+# request body is fine (means "don't touch it"), but an explicit JSON
+# `null` for any of these is rejected with 422 rather than being allowed
+# through to reach the ORM as a null write (e.g. `list(None)` on
+# consume_stages). Module-level (not a class attribute on
+# OperationTypeUpdate) because Pydantic v2 wraps an underscore-prefixed
+# class attribute in ModelPrivateAttr, which isn't iterable as plain data.
+_UPDATE_NOT_NULLABLE_FIELDS = ("label", "consume_stages", "is_qc", "sort_order", "is_active")
+
+
 class OperationTypeUpdate(BaseModel):
     """
     Update an existing operation type.
@@ -53,6 +63,14 @@ class OperationTypeUpdate(BaseModel):
     attempt to change them is rejected with 400. For custom (non-system)
     rows, editing consume_stages on a type referenced by an operation of a
     NON-terminal production order is rejected with 409.
+
+    label/consume_stages/is_qc/sort_order/is_active are NOT NULL-backed
+    columns on OperationType: a field left out of the request body is
+    fine (means "don't touch it"), but an explicit JSON `null` for any of
+    these is rejected with 422 rather than being allowed through to reach
+    the ORM as a null write (e.g. `list(None)` on consume_stages).
+    description/category are genuinely nullable columns, so explicit null
+    is accepted for those.
     """
     label: Optional[str] = Field(None, min_length=1, max_length=100)
     description: Optional[str] = None
@@ -61,6 +79,25 @@ class OperationTypeUpdate(BaseModel):
     is_qc: Optional[bool] = None
     sort_order: Optional[int] = None
     is_active: Optional[bool] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_explicit_null_for_not_nullable_fields(cls, data: Any) -> Any:
+        """Distinguish "omitted" (fine — means don't touch it) from an
+        explicit JSON `null` (rejected) for the NOT-NULL-backed columns.
+        Pydantic's Optional[...] = None default can't tell these apart on
+        its own, since both an omitted key and an explicit null produce
+        None after validation — this runs before that collapse happens."""
+        if isinstance(data, dict):
+            nulled = [
+                f for f in _UPDATE_NOT_NULLABLE_FIELDS if f in data and data[f] is None
+            ]
+            if nulled:
+                raise ValueError(
+                    "field(s) cannot be explicitly set to null (omit them instead "
+                    f"to leave unchanged): {', '.join(nulled)}"
+                )
+        return data
 
 
 # =============================================================================
@@ -81,6 +118,7 @@ class OperationTypeAuditRow(BaseModel):
     material_bearing: bool
     classification_reason: Optional[str] = None
     in_flight_non_terminal_po_count: int
+    conflicting_stored_types: Optional[List[str]] = None
 
 
 class OperationTypeAuditResponse(BaseModel):

--- a/backend/app/services/operation_type_classifier.py
+++ b/backend/app/services/operation_type_classifier.py
@@ -137,10 +137,25 @@ class AuditRow:
     material_bearing: bool
     classification_reason: Optional[str]
     in_flight_non_terminal_po_count: int
+    conflicting_stored_types: Optional[List[str]] = None
 
 
-def _match_source(operation_type: Optional[str], operation_code: Optional[str]) -> str:
-    if operation_type:
+def _match_source(
+    type_map: Dict[str, List[str]],
+    operation_type: Optional[str],
+    operation_code: Optional[str],
+) -> str:
+    """
+    Report the source that ``resolve_consume_stages`` actually used, not
+    merely whether ``operation_type`` is truthy. Mirrors
+    ``resolve_consume_stages``'s own precedence exactly: an unknown or
+    inactive type (not in ``type_map``) falls through to the legacy dict
+    or default, and the reported source must say so — otherwise a stored
+    type that silently failed to resolve would be mislabeled
+    "stored-type" when the runtime behavior is actually legacy-dict or
+    default.
+    """
+    if operation_type and operation_type in type_map:
         return "stored-type"
     from app.services.operation_material_mapping import OPERATION_CONSUME_STAGES
 
@@ -153,9 +168,19 @@ def _distinct_pairs_with_counts(db: Session):
     """
     Every distinct (operation_code, operation_name) pair across BOTH
     routing_operations and production_order_operations, with per-table
-    counts and one representative stored operation_type per pair (routing
-    table wins ties; falls back to the PO-op table if the pair only exists
-    there).
+    counts and a deterministic representative stored operation_type per
+    pair.
+
+    A pair can legitimately have MORE THAN ONE distinct non-NULL
+    operation_type across its rows (e.g. typed differently on different
+    routing operations, or typed on some rows and NULL on others) — this
+    is a real conflict, not merely a NULL-vs-typed split, and must be
+    surfaced rather than silently resolved by picking whichever type the
+    database happened to return first. All distinct non-NULL types seen
+    for the pair are collected; the representative is the
+    lexicographically-first one (deterministic regardless of DB row
+    order), and every distinct type beyond the representative is exposed
+    via ``conflicting_stored_types`` in the audit row.
     """
     routing_rows = (
         db.query(
@@ -187,9 +212,10 @@ def _distinct_pairs_with_counts(db: Session):
     )
 
     # key = (operation_code, operation_name) — the pair identity for the
-    # audit. Aggregate multiple stored-type rows for the same pair (e.g. a
-    # pair typed on some rows and NULL on others) by preferring any non-NULL
-    # type over NULL, routing table first.
+    # audit. Track EVERY distinct non-NULL operation_type seen for the
+    # pair (in a set) rather than keeping only the first-seen one, so a
+    # genuine conflict (the same pair typed two different ways across its
+    # rows) is detected instead of hidden by DB-return-order luck.
     pairs: Dict[Tuple[Optional[str], Optional[str]], dict] = {}
 
     def _ingest(rows, table_key):
@@ -197,14 +223,21 @@ def _distinct_pairs_with_counts(db: Session):
             key = (code, name)
             entry = pairs.setdefault(
                 key,
-                {"routing_op_count": 0, "po_op_count": 0, "operation_type": None},
+                {"routing_op_count": 0, "po_op_count": 0, "operation_types": set()},
             )
             entry[table_key] += count
-            if op_type and not entry["operation_type"]:
-                entry["operation_type"] = op_type
+            if op_type:
+                entry["operation_types"].add(op_type)
 
     _ingest(routing_rows, "routing_op_count")
     _ingest(po_rows, "po_op_count")
+
+    # Collapse the distinct-types set into a deterministic representative
+    # (sorted-first) plus the remaining conflicting types, if any.
+    for entry in pairs.values():
+        distinct_types = sorted(entry.pop("operation_types"))
+        entry["operation_type"] = distinct_types[0] if distinct_types else None
+        entry["conflicting_stored_types"] = distinct_types[1:] if len(distinct_types) > 1 else None
 
     return pairs
 
@@ -281,7 +314,7 @@ def build_audit(db: Session) -> List[AuditRow]:
     for (code, name), info in sorted(pairs.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or "")):
         stored_type = info["operation_type"]
         current_stages = resolve_consume_stages(type_map, stored_type, code)
-        source = _match_source(stored_type, code)
+        source = _match_source(type_map, stored_type, code)
         is_material_bearing = (code, name) in material_bearing_pairs
 
         name_result = classify_name(name)
@@ -294,9 +327,21 @@ def build_audit(db: Session) -> List[AuditRow]:
             proposed_type = None
             reason = MANUAL_DECISION_REASON
 
+        # Proposals are for NULL-typed rows only — the classifier
+        # (run_classifier) never touches a row that already has a stored
+        # type, so a proposal for an already-typed row is not actionable
+        # and must not be shown as if it were. Clearing proposed_type here
+        # (rather than merely leaving proposed_consume_stages/
+        # behavior_changed at their no-op defaults) keeps proposed_type
+        # and proposed_consume_stages consistent with each other: either
+        # both are populated (an actionable NULL-row proposal) or both are
+        # None, never a proposed_type with no stage projection behind it.
         proposed_stages = None
         behavior_changed = False
-        if proposed_type is not None and stored_type is None:
+        if stored_type is not None:
+            proposed_type = None
+            reason = None
+        elif proposed_type is not None:
             proposed_stages = resolve_consume_stages(type_map, proposed_type, code)
             behavior_changed = list(proposed_stages) != list(current_stages)
 
@@ -315,6 +360,7 @@ def build_audit(db: Session) -> List[AuditRow]:
                 material_bearing=is_material_bearing,
                 classification_reason=reason,
                 in_flight_non_terminal_po_count=in_flight.get((code, name), 0),
+                conflicting_stored_types=info.get("conflicting_stored_types"),
             )
         )
 
@@ -376,10 +422,15 @@ def run_classifier(db: Session, dry_run: bool = True) -> ClassifyResult:
 
     dry_run=False: applies NULL -> proposed_type ONLY where a safe
     unambiguous proposal exists. Never overwrites a non-NULL
-    operation_type (the WHERE clause guarantees this — rows are only
-    selected because operation_type IS NULL). Idempotent: running again
-    after an apply finds zero NULL rows left to propose for, so it is a
-    no-op.
+    operation_type — enforced twice: the initial SELECT only reads rows
+    where operation_type IS NULL, and the write itself is a conditional
+    UPDATE ... WHERE id = :id AND operation_type IS NULL (not an ORM
+    read-then-mutate-then-commit), so a concurrent write to the same row
+    between our read and our write cannot be silently clobbered — our
+    UPDATE simply matches zero rows for that id, and applied_count is
+    derived purely from each UPDATE's rowcount, never assumed. Idempotent:
+    running again after an apply finds zero NULL rows left to propose
+    for, so it is a no-op.
 
     Material-bearing rows that would otherwise match a no-consume type
     (QUALITY_CONTROL / SANDING / SUPPORT_REMOVAL) are never auto-applied —
@@ -453,9 +504,23 @@ def run_classifier(db: Session, dry_run: bool = True) -> ClassifyResult:
             result.non_terminal_exposure_count += 1
 
         if not dry_run:
-            row.operation_type = proposed_type
-            db.add(row)
-            result.applied_count += 1
+            # Conditional bulk UPDATE rather than an ORM read-then-mutate:
+            # the WHERE clause re-checks operation_type IS NULL at write
+            # time (not just at the earlier SELECT in
+            # _iter_null_typed_*_ops), so a concurrent request that typed
+            # this exact row between our read and our write loses the
+            # race safely — our UPDATE matches zero rows instead of
+            # clobbering the other request's write. rowcount is the only
+            # source of truth for whether this row was actually applied;
+            # the model class is resolved per table_name since the two
+            # tables share this helper.
+            model = RoutingOperation if table_name == "routing_operations" else ProductionOrderOperation
+            update_result = (
+                db.query(model)
+                .filter(model.id == row.id, model.operation_type.is_(None))
+                .update({model.operation_type: proposed_type}, synchronize_session=False)
+            )
+            result.applied_count += update_result
 
     for row in _iter_null_typed_routing_ops(db):
         _process(row, "routing_operations")

--- a/backend/app/services/operation_type_classifier.py
+++ b/backend/app/services/operation_type_classifier.py
@@ -1,0 +1,469 @@
+"""
+Operation-type audit + human-gated classifier (#876 PR-3).
+
+This module NEVER auto-reclassifies anything on its own. It only:
+  1. Produces a read-only, re-runnable audit of every distinct
+     (operation_code, operation_name) pair seen across
+     ``routing_operations`` and ``production_order_operations``, with the
+     resolved consume stages (via the #898 resolver), a name-rule
+     classification proposal, and an in-flight exposure rollup.
+  2. Proposes NULL-only type assignments from a name-matching rule set —
+     writes nothing unless explicitly told to apply, and even then only
+     touches rows where ``operation_type IS NULL``.
+
+Nothing in Core calls this automatically. It is reached only through the
+staff-gated admin endpoints in
+``app/api/v1/endpoints/admin/operation_types.py``.
+"""
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.manufacturing import (
+    RoutingOperation,
+    RoutingOperationMaterial,
+)
+from app.models.production_order import (
+    ProductionOrder,
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
+from app.services.operation_material_mapping import (
+    load_operation_type_stage_map,
+    resolve_consume_stages,
+)
+
+# ---------------------------------------------------------------------------
+# PO-level terminal statuses.
+#
+# NOTE the #850 fork: the ProductionOrder.status docstring describes an
+# aspirational lifecycle ending in "completed" / "closed" / "scrapped", but
+# every place in the codebase that actually WRITES or FILTERS on terminal
+# status uses "complete" (production_order_service.py get_schedule_summary
+# and its siblings: `ProductionOrder.status.notin_(["complete",
+# "cancelled"])`). We mirror that exact, live convention here rather than
+# the docstring's aspirational vocabulary, so "non-terminal" in this audit
+# means precisely what it means everywhere else in the running system.
+# ---------------------------------------------------------------------------
+PO_TERMINAL_STATUSES = ("complete", "cancelled")
+
+# Types that mean "materials count for nothing automatically" — an op
+# carrying material rows may NEVER be auto-proposed one of these (the
+# material-bearing safety rule).
+NO_CONSUME_TYPE_CODES = ("QUALITY_CONTROL", "SANDING", "SUPPORT_REMOVAL")
+
+MANUAL_DECISION_REASON = (
+    "needs manual decision — op carries material rows but matched a "
+    "no-consume type"
+)
+NO_MATCH_REASON = "no rule matched — blank or unrecognized name"
+MIXED_NAME_REASON = "mixed-name — priority applied"
+
+
+# ---------------------------------------------------------------------------
+# Name-classification rules, in priority order. First match wins. Matching
+# is case-insensitive against operation_name. A name matching more than one
+# rule is "mixed-name"; the first (highest-priority) match is applied and
+# flagged.
+# ---------------------------------------------------------------------------
+_NAME_RULES: List[Tuple[str, str]] = [
+    (r"pack|ship|label|packag|box|mail", "PACK_SHIP"),
+    (r"\bqc\b|quality|inspect", "QUALITY_CONTROL"),
+    (r"assembl", "ASSEMBLY"),
+    (r"print", "FDM_PRINT"),
+    (r"sand", "SANDING"),
+    (r"paint", "PAINTING"),
+    (r"support|clean|post.?process", "SUPPORT_REMOVAL"),
+]
+_COMPILED_NAME_RULES: List[Tuple[re.Pattern, str]] = [
+    (re.compile(pattern, re.IGNORECASE), type_code) for pattern, type_code in _NAME_RULES
+]
+
+
+@dataclass
+class NameClassification:
+    """Result of running the name rules against an operation_name."""
+    proposed_type: Optional[str]
+    matched_rule_count: int
+    reason: Optional[str] = None
+    mixed: bool = False
+
+
+def classify_name(operation_name: Optional[str]) -> NameClassification:
+    """
+    Run the priority-ordered name rules against ``operation_name``.
+
+    Blank/whitespace-only names propose nothing. A name matching more than
+    one rule's pattern is "mixed" — the highest-priority match is proposed,
+    flagged with MIXED_NAME_REASON. A name matching no rule proposes
+    nothing (NO_MATCH_REASON).
+    """
+    if not operation_name or not operation_name.strip():
+        return NameClassification(proposed_type=None, matched_rule_count=0, reason=NO_MATCH_REASON)
+
+    matches = [type_code for pattern, type_code in _COMPILED_NAME_RULES if pattern.search(operation_name)]
+    if not matches:
+        return NameClassification(proposed_type=None, matched_rule_count=0, reason=NO_MATCH_REASON)
+
+    proposed = matches[0]
+    mixed = len(matches) > 1
+    return NameClassification(
+        proposed_type=proposed,
+        matched_rule_count=len(matches),
+        reason=MIXED_NAME_REASON if mixed else None,
+        mixed=mixed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AuditRow:
+    operation_code: Optional[str]
+    operation_name: Optional[str]
+    routing_op_count: int
+    po_op_count: int
+    stored_operation_type: Optional[str]
+    match_source: str  # "stored-type" | "legacy-dict" | "default"
+    current_consume_stages: List[str]
+    proposed_type: Optional[str]
+    proposed_consume_stages: Optional[List[str]]
+    behavior_changed: bool
+    material_bearing: bool
+    classification_reason: Optional[str]
+    in_flight_non_terminal_po_count: int
+
+
+def _match_source(operation_type: Optional[str], operation_code: Optional[str]) -> str:
+    if operation_type:
+        return "stored-type"
+    from app.services.operation_material_mapping import OPERATION_CONSUME_STAGES
+
+    if operation_code and operation_code.upper() in OPERATION_CONSUME_STAGES:
+        return "legacy-dict"
+    return "default"
+
+
+def _distinct_pairs_with_counts(db: Session):
+    """
+    Every distinct (operation_code, operation_name) pair across BOTH
+    routing_operations and production_order_operations, with per-table
+    counts and one representative stored operation_type per pair (routing
+    table wins ties; falls back to the PO-op table if the pair only exists
+    there).
+    """
+    routing_rows = (
+        db.query(
+            RoutingOperation.operation_code,
+            RoutingOperation.operation_name,
+            RoutingOperation.operation_type,
+            func.count(RoutingOperation.id),
+        )
+        .group_by(
+            RoutingOperation.operation_code,
+            RoutingOperation.operation_name,
+            RoutingOperation.operation_type,
+        )
+        .all()
+    )
+    po_rows = (
+        db.query(
+            ProductionOrderOperation.operation_code,
+            ProductionOrderOperation.operation_name,
+            ProductionOrderOperation.operation_type,
+            func.count(ProductionOrderOperation.id),
+        )
+        .group_by(
+            ProductionOrderOperation.operation_code,
+            ProductionOrderOperation.operation_name,
+            ProductionOrderOperation.operation_type,
+        )
+        .all()
+    )
+
+    # key = (operation_code, operation_name) — the pair identity for the
+    # audit. Aggregate multiple stored-type rows for the same pair (e.g. a
+    # pair typed on some rows and NULL on others) by preferring any non-NULL
+    # type over NULL, routing table first.
+    pairs: Dict[Tuple[Optional[str], Optional[str]], dict] = {}
+
+    def _ingest(rows, table_key):
+        for code, name, op_type, count in rows:
+            key = (code, name)
+            entry = pairs.setdefault(
+                key,
+                {"routing_op_count": 0, "po_op_count": 0, "operation_type": None},
+            )
+            entry[table_key] += count
+            if op_type and not entry["operation_type"]:
+                entry["operation_type"] = op_type
+
+    _ingest(routing_rows, "routing_op_count")
+    _ingest(po_rows, "po_op_count")
+
+    return pairs
+
+
+def _material_bearing_codes(db: Session) -> set:
+    """
+    Set of (operation_code, operation_name) pairs that have at least one
+    material row attached, on EITHER the routing template
+    (RoutingOperationMaterial) or the production-order instance
+    (ProductionOrderOperationMaterial) side.
+    """
+    bearing = set()
+
+    routing_bearing = (
+        db.query(RoutingOperation.operation_code, RoutingOperation.operation_name)
+        .join(
+            RoutingOperationMaterial,
+            RoutingOperationMaterial.routing_operation_id == RoutingOperation.id,
+        )
+        .distinct()
+        .all()
+    )
+    bearing.update(routing_bearing)
+
+    po_bearing = (
+        db.query(ProductionOrderOperation.operation_code, ProductionOrderOperation.operation_name)
+        .join(
+            ProductionOrderOperationMaterial,
+            ProductionOrderOperationMaterial.production_order_operation_id == ProductionOrderOperation.id,
+        )
+        .distinct()
+        .all()
+    )
+    bearing.update(po_bearing)
+
+    return bearing
+
+
+def _in_flight_counts(db: Session) -> Dict[Tuple[Optional[str], Optional[str]], int]:
+    """
+    Count of DISTINCT non-terminal ProductionOrders whose operations carry
+    each (operation_code, operation_name) pair. "Non-terminal" = PO.status
+    NOT IN PO_TERMINAL_STATUSES (see module docstring re: #850 fork).
+    """
+    rows = (
+        db.query(
+            ProductionOrderOperation.operation_code,
+            ProductionOrderOperation.operation_name,
+            func.count(func.distinct(ProductionOrderOperation.production_order_id)),
+        )
+        .join(ProductionOrder, ProductionOrder.id == ProductionOrderOperation.production_order_id)
+        .filter(ProductionOrder.status.notin_(PO_TERMINAL_STATUSES))
+        .group_by(
+            ProductionOrderOperation.operation_code,
+            ProductionOrderOperation.operation_name,
+        )
+        .all()
+    )
+    return {(code, name): count for code, name, count in rows}
+
+
+def build_audit(db: Session) -> List[AuditRow]:
+    """
+    Build the full, read-only audit of every distinct (operation_code,
+    operation_name) pair across both operation tables. Re-runnable —
+    queries only, no writes.
+    """
+    type_map = load_operation_type_stage_map(db)
+    pairs = _distinct_pairs_with_counts(db)
+    material_bearing_pairs = _material_bearing_codes(db)
+    in_flight = _in_flight_counts(db)
+
+    rows: List[AuditRow] = []
+    for (code, name), info in sorted(pairs.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or "")):
+        stored_type = info["operation_type"]
+        current_stages = resolve_consume_stages(type_map, stored_type, code)
+        source = _match_source(stored_type, code)
+        is_material_bearing = (code, name) in material_bearing_pairs
+
+        name_result = classify_name(name)
+        proposed_type = name_result.proposed_type
+        reason = name_result.reason
+
+        # Material-bearing safety rule: never auto-propose a no-consume
+        # type for an op that carries material rows.
+        if proposed_type in NO_CONSUME_TYPE_CODES and is_material_bearing:
+            proposed_type = None
+            reason = MANUAL_DECISION_REASON
+
+        proposed_stages = None
+        behavior_changed = False
+        if proposed_type is not None and stored_type is None:
+            proposed_stages = resolve_consume_stages(type_map, proposed_type, code)
+            behavior_changed = list(proposed_stages) != list(current_stages)
+
+        rows.append(
+            AuditRow(
+                operation_code=code,
+                operation_name=name,
+                routing_op_count=info["routing_op_count"],
+                po_op_count=info["po_op_count"],
+                stored_operation_type=stored_type,
+                match_source=source,
+                current_consume_stages=current_stages,
+                proposed_type=proposed_type,
+                proposed_consume_stages=proposed_stages,
+                behavior_changed=behavior_changed,
+                material_bearing=is_material_bearing,
+                classification_reason=reason,
+                in_flight_non_terminal_po_count=in_flight.get((code, name), 0),
+            )
+        )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Classifier apply / dry-run
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProposalRow:
+    table: str  # "routing_operations" | "production_order_operations"
+    row_id: int
+    operation_code: Optional[str]
+    operation_name: Optional[str]
+    proposed_type: Optional[str]
+    reason: Optional[str]
+    material_bearing: bool
+    before_stages: List[str]
+    after_stages: Optional[List[str]]
+    production_order_id: Optional[int] = None
+    production_order_status: Optional[str] = None
+
+
+@dataclass
+class ClassifyResult:
+    dry_run: bool
+    proposals: List[ProposalRow] = field(default_factory=list)
+    applied_count: int = 0
+    skipped_manual_decision_count: int = 0
+    skipped_no_match_count: int = 0
+    non_terminal_exposure_count: int = 0
+
+
+def _iter_null_typed_routing_ops(db: Session):
+    return (
+        db.query(RoutingOperation)
+        .filter(RoutingOperation.operation_type.is_(None))
+        .all()
+    )
+
+
+def _iter_null_typed_po_ops(db: Session):
+    return (
+        db.query(ProductionOrderOperation)
+        .filter(ProductionOrderOperation.operation_type.is_(None))
+        .all()
+    )
+
+
+def run_classifier(db: Session, dry_run: bool = True) -> ClassifyResult:
+    """
+    Human-gated classifier over NULL-``operation_type`` rows in BOTH
+    ``routing_operations`` and ``production_order_operations``.
+
+    dry_run=True (default): builds and returns the full proposal report —
+    WRITES NOTHING.
+
+    dry_run=False: applies NULL -> proposed_type ONLY where a safe
+    unambiguous proposal exists. Never overwrites a non-NULL
+    operation_type (the WHERE clause guarantees this — rows are only
+    selected because operation_type IS NULL). Idempotent: running again
+    after an apply finds zero NULL rows left to propose for, so it is a
+    no-op.
+
+    Material-bearing rows that would otherwise match a no-consume type
+    (QUALITY_CONTROL / SANDING / SUPPORT_REMOVAL) are never auto-applied —
+    they are surfaced as "needs manual decision" and skipped in both
+    dry-run and apply.
+
+    Recording WHO applied a run and WHEN is the caller's responsibility
+    (the admin endpoint stamps the authenticated staff user's email +
+    current UTC time onto the response) — this function only knows about
+    rows and proposals, not the requesting identity.
+    """
+    type_map = load_operation_type_stage_map(db)
+    material_bearing_pairs = _material_bearing_codes(db)
+
+    # PO id -> status, for stamping production_order_status onto PO-op
+    # proposal rows and for the row-level non-terminal-exposure count,
+    # without a per-row query.
+    po_status_by_id: Dict[int, str] = dict(db.query(ProductionOrder.id, ProductionOrder.status).all())
+
+    result = ClassifyResult(dry_run=dry_run)
+
+    def _process(row, table_name: str):
+        code = row.operation_code
+        name = row.operation_name
+        is_material_bearing = (code, name) in material_bearing_pairs
+
+        name_result = classify_name(name)
+        proposed_type = name_result.proposed_type
+        reason = name_result.reason
+
+        if proposed_type in NO_CONSUME_TYPE_CODES and is_material_bearing:
+            proposed_type = None
+            reason = MANUAL_DECISION_REASON
+
+        before_stages = resolve_consume_stages(type_map, None, code)
+        after_stages = None
+        if proposed_type is not None:
+            after_stages = resolve_consume_stages(type_map, proposed_type, code)
+
+        po_id = None
+        po_status = None
+        row_is_non_terminal_po = False
+        if table_name == "production_order_operations":
+            po_id = row.production_order_id
+            po_status = po_status_by_id.get(po_id)
+            row_is_non_terminal_po = po_status is not None and po_status not in PO_TERMINAL_STATUSES
+
+        proposal = ProposalRow(
+            table=table_name,
+            row_id=row.id,
+            operation_code=code,
+            operation_name=name,
+            proposed_type=proposed_type,
+            reason=reason,
+            material_bearing=is_material_bearing,
+            before_stages=before_stages,
+            after_stages=after_stages,
+            production_order_id=po_id,
+            production_order_status=po_status,
+        )
+        result.proposals.append(proposal)
+
+        if proposed_type is None:
+            if reason == MANUAL_DECISION_REASON:
+                result.skipped_manual_decision_count += 1
+            else:
+                result.skipped_no_match_count += 1
+            return
+
+        if row_is_non_terminal_po:
+            result.non_terminal_exposure_count += 1
+
+        if not dry_run:
+            row.operation_type = proposed_type
+            db.add(row)
+            result.applied_count += 1
+
+    for row in _iter_null_typed_routing_ops(db):
+        _process(row, "routing_operations")
+
+    for row in _iter_null_typed_po_ops(db):
+        _process(row, "production_order_operations")
+
+    if not dry_run and result.applied_count:
+        db.commit()
+
+    return result

--- a/backend/tests/services/_operation_type_seed.py
+++ b/backend/tests/services/_operation_type_seed.py
@@ -1,0 +1,58 @@
+"""
+Shared operation-type seed data/helper for tests, mirroring
+migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES verbatim.
+
+Imported by BOTH test_operation_type_catalog.py (#876 PR-1's
+predicate-equivalence proof) and test_operation_type_classifier.py (#876
+PR-3's audit/classifier/CRUD tests) so a drift between the migration seed
+and the tests fails loudly in ONE place rather than silently in whichever
+file didn't get updated.
+
+This is deliberately a SEPARATE literal from migration 101's own
+SEED_OPERATION_TYPES — the migration keeps its own frozen copy on purpose
+(see test_operation_type_catalog.py's predicate-equivalence tests), so
+that a migration edit and a test-side edit must independently agree,
+proving the migration's exact-code backfill is behavior-neutral. Only the
+test-to-test duplication (this file vs. having two independent copies in
+each test module) is being eliminated here.
+"""
+from app.models.manufacturing import OperationType
+
+# code: (label, category, consume_stages, is_qc, sort_order)
+SEED_OPERATION_TYPES = {
+    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+}
+
+
+def seed_operation_types(db):
+    """Idempotent INSERT-if-missing seed helper, mirroring migration 101
+    step 2, for use directly against the test DB (no alembic run in
+    tests). Consumes the module-level SEED_OPERATION_TYPES constant above
+    — no separate inline copy of the seed data in either caller."""
+    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
+    created = []
+    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
+        if code in existing_codes:
+            continue
+        row = OperationType(
+            code=code,
+            label=label,
+            category=category,
+            consume_stages=stages,
+            is_qc=is_qc,
+            is_system=True,
+            is_active=True,
+            sort_order=sort_order,
+        )
+        db.add(row)
+        created.append(code)
+    db.flush()
+    return created

--- a/backend/tests/services/test_operation_type_catalog.py
+++ b/backend/tests/services/test_operation_type_catalog.py
@@ -30,25 +30,19 @@ from app.services.operation_material_mapping import (
     load_operation_type_stage_map,
     resolve_consume_stages,
 )
+from tests.services._operation_type_seed import (
+    SEED_OPERATION_TYPES,
+    seed_operation_types,
+)
 
-# Mirrors migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES /
-# BACKFILL_ALIAS_MAP verbatim, so a drift between the migration and this test
-# fails loudly rather than silently. This is the ONLY seed-data literal in
-# this file — _seed_operation_types() below consumes it directly rather than
-# maintaining a second, redundant copy.
-SEED_OPERATION_TYPES = {
-    # code: (label, category, consume_stages, is_qc, sort_order)
-    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
-    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
-    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
-    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
-    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
-    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
-    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
-    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
-    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
-}
-
+# Mirrors migrations/versions/101_operation_types.py::BACKFILL_ALIAS_MAP
+# verbatim, so a drift between the migration and this test fails loudly
+# rather than silently. SEED_OPERATION_TYPES itself now lives in the
+# shared _operation_type_seed module (imported above) so
+# test_operation_type_classifier.py doesn't carry an independent copy —
+# see that module's docstring for why the migration's OWN frozen copy is
+# a deliberate, separate equivalence-proof literal, not something to
+# unify away.
 BACKFILL_ALIAS_MAP = {
     "PRINT": "FDM_PRINT",
     "EXTRUDE": "GENERAL",
@@ -69,32 +63,6 @@ BACKFILL_ALIAS_MAP = {
     "SHIP": "PACK_SHIP",
     "LABEL": "PACK_SHIP",
 }
-
-
-def _seed_operation_types(db):
-    """Idempotent INSERT-if-missing seed helper, mirroring migration 101
-    step 2, for use directly against the test DB (no alembic run in tests).
-    Consumes the module-level SEED_OPERATION_TYPES constant above — no
-    separate inline copy of the seed data."""
-    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
-    created = []
-    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
-        if code in existing_codes:
-            continue
-        row = OperationType(
-            code=code,
-            label=label,
-            category=category,
-            consume_stages=stages,
-            is_qc=is_qc,
-            is_system=True,
-            is_active=True,
-            sort_order=sort_order,
-        )
-        db.add(row)
-        created.append(code)
-    db.flush()
-    return created
 
 
 def _backfill_operation_types(db):
@@ -142,7 +110,7 @@ class TestPredicateEquivalence:
 
     @pytest.fixture(autouse=True)
     def _seed(self, db):
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
     def _type_for_code(self, db, legacy_code):
@@ -217,7 +185,7 @@ class TestPredicateEquivalence:
 class TestResolverPrecedence:
     @pytest.fixture(autouse=True)
     def _seed(self, db):
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
     def test_type_beats_code(self, db):
@@ -304,7 +272,7 @@ class TestResolverPrecedence:
 
 class TestSeedIdempotency:
     def test_seed_creates_nine_system_rows(self, db):
-        created = _seed_operation_types(db)
+        created = seed_operation_types(db)
         db.commit()
         assert len(created) == 9
         assert set(created) == set(SEED_OPERATION_TYPES)
@@ -313,13 +281,13 @@ class TestSeedIdempotency:
         assert len(rows) == 9
 
     def test_seed_running_twice_creates_nothing_new(self, db):
-        first_created = _seed_operation_types(db)
+        first_created = seed_operation_types(db)
         db.commit()
         assert len(first_created) == 9
 
         count_after_first = db.query(OperationType).count()
 
-        second_created = _seed_operation_types(db)
+        second_created = seed_operation_types(db)
         db.commit()
         assert second_created == []
 
@@ -327,7 +295,7 @@ class TestSeedIdempotency:
         assert count_after_first == count_after_second
 
     def test_seed_is_unique_on_code(self, db):
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
         codes = [c for (c,) in db.query(OperationType.code).all()]
         assert len(codes) == len(set(codes))
@@ -338,7 +306,7 @@ class TestBackfillIdempotency:
         """An OP10 row (no exact legacy-code match — routing editor
         autofill) and a FINISH row (deliberately excluded) both stay NULL.
         A PRINT row (exact match) gets typed FDM_PRINT."""
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
         product = make_product(item_type="finished_good")
@@ -378,7 +346,7 @@ class TestBackfillIdempotency:
         assert op_print.operation_type == "FDM_PRINT", "PRINT is an exact legacy-code match"
 
     def test_backfill_running_twice_is_a_no_op(self, db, make_product):
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
         product = make_product(item_type="finished_good")
@@ -413,7 +381,7 @@ class TestBackfillIdempotency:
         """A row a human already typed (even to something unexpected) must
         never be overwritten — the WHERE operation_type IS NULL guard is
         what makes this true; assert it holds."""
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
         product = make_product(item_type="finished_good")
@@ -445,7 +413,7 @@ class TestBackfillIdempotency:
 class TestOperationTypesEndpoint:
     @pytest.fixture(autouse=True)
     def _seed(self, db):
-        _seed_operation_types(db)
+        seed_operation_types(db)
         db.commit()
 
     def test_requires_auth(self, unauthed_client):

--- a/backend/tests/services/test_operation_type_classifier.py
+++ b/backend/tests/services/test_operation_type_classifier.py
@@ -34,47 +34,12 @@ from app.services.operation_type_classifier import (
     classify_name,
     run_classifier,
 )
-
-# Mirrors migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES,
-# same approach as test_operation_type_catalog.py's seed helper.
-SEED_OPERATION_TYPES = {
-    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
-    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
-    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
-    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
-    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
-    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
-    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
-    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
-    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
-}
-
-
-def _seed_operation_types(db):
-    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
-    created = []
-    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
-        if code in existing_codes:
-            continue
-        row = OperationType(
-            code=code,
-            label=label,
-            category=category,
-            consume_stages=stages,
-            is_qc=is_qc,
-            is_system=True,
-            is_active=True,
-            sort_order=sort_order,
-        )
-        db.add(row)
-        created.append(code)
-    db.flush()
-    return created
+from tests.services._operation_type_seed import seed_operation_types
 
 
 @pytest.fixture(autouse=True)
 def _seed(db):
-    _seed_operation_types(db)
+    seed_operation_types(db)
     db.commit()
 
 
@@ -267,6 +232,94 @@ class TestAudit:
         untouched = db.query(RoutingOperation).filter(RoutingOperation.operation_code == "PRINT").first()
         assert untouched.operation_type is None
 
+    def test_audit_match_source_unknown_stored_type_falls_through_to_legacy_dict(
+        self, db, make_product, make_work_center
+    ):
+        """A stored operation_type that ISN'T in the catalog (unknown/
+        inactive/stale hand-edited data) must not be reported as
+        "stored-type" — resolve_consume_stages() actually falls through to
+        the legacy dict for this row, so match_source must say
+        "legacy-dict", matching runtime behavior exactly (CodeRabbit
+        finding: _match_source must reflect the REAL resolution path)."""
+        _make_routing_op(
+            db, make_product, make_work_center, "3D Print",
+            operation_code="PRINT", operation_type="NOT_A_REAL_TYPE_CODE",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "3D Print")
+        assert row.stored_operation_type == "NOT_A_REAL_TYPE_CODE"
+        assert row.match_source == "legacy-dict"
+        assert row.current_consume_stages == ["production", "any"]
+
+    def test_audit_match_source_unknown_stored_type_and_unknown_code_falls_through_to_default(
+        self, db, make_product, make_work_center
+    ):
+        """Same as above, but with no legacy-dict code match either ->
+        "default", not "stored-type"."""
+        _make_routing_op(
+            db, make_product, make_work_center, "Widget Frobnicate",
+            operation_code=None, operation_type="NOT_A_REAL_TYPE_CODE",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Widget Frobnicate")
+        assert row.match_source == "default"
+        assert row.current_consume_stages == ["production", "any"]
+
+    def test_audit_stored_type_row_gets_no_proposed_type(self, db, make_product, make_work_center):
+        """Proposals are for NULL-typed rows only — run_classifier() never
+        touches a row that already carries a stored type, so build_audit()
+        must not show an unactionable proposed_type (previously: a
+        stored-type row's name could still match a rule and populate
+        proposed_type with no proposed_consume_stages behind it)."""
+        _make_routing_op(
+            db, make_product, make_work_center, "Pack it up",
+            operation_code=None, operation_type="QUALITY_CONTROL",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Pack it up")
+        assert row.stored_operation_type == "QUALITY_CONTROL"
+        assert row.proposed_type is None
+        assert row.proposed_consume_stages is None
+        assert row.behavior_changed is False
+        assert row.classification_reason is None
+
+    def test_audit_conflicting_stored_types_across_rows_surfaced(
+        self, db, make_product, make_work_center
+    ):
+        """Two rows sharing the same (operation_code, operation_name) pair
+        but stored with DIFFERENT operation_type values is a genuine
+        conflict, not just a NULL-vs-typed split — the representative
+        stored_operation_type must be deterministic (sorted-first)
+        regardless of DB row order, and the other type(s) must be exposed
+        via conflicting_stored_types rather than silently dropped."""
+        _make_routing_op(
+            db, make_product, make_work_center, "Ambiguous Op",
+            operation_code="AMBIG", operation_type="QUALITY_CONTROL",
+        )
+        _make_routing_op(
+            db, make_product, make_work_center, "Ambiguous Op",
+            operation_code="AMBIG", operation_type="ASSEMBLY",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Ambiguous Op")
+        # Deterministic representative: lexicographically first of the
+        # distinct types ("ASSEMBLY" < "QUALITY_CONTROL").
+        assert row.stored_operation_type == "ASSEMBLY"
+        assert row.conflicting_stored_types == ["QUALITY_CONTROL"]
+        assert row.routing_op_count == 2
+
+    def test_audit_single_stored_type_has_no_conflict(self, db, make_product, make_work_center):
+        """A pair with only one distinct non-NULL stored type (the common
+        case) reports conflicting_stored_types = None, not an empty list
+        or the type itself."""
+        _make_routing_op(
+            db, make_product, make_work_center, "Pack it up",
+            operation_code=None, operation_type="PACK_SHIP",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Pack it up")
+        assert row.conflicting_stored_types is None
+
 
 # =============================================================================
 # Classifier: dry-run / apply / idempotency / safety rules
@@ -324,6 +377,67 @@ class TestClassifierApply:
         run_classifier(db, dry_run=False)
         db.refresh(op)
         assert op.operation_type == "QUALITY_CONTROL", "apply must never touch a non-NULL operation_type"
+
+    def test_apply_writes_via_conditional_update_not_orm_mutate(
+        self, db, make_product, make_work_center
+    ):
+        """The apply path must be a conditional UPDATE ... WHERE
+        operation_type IS NULL (re-checked at write time), not an ORM
+        read-then-mutate-then-commit — closing the TOCTOU window where a
+        concurrent request could type the row between the initial SELECT
+        and this function's write. Simulated in-process by setting the
+        row's operation_type to non-NULL AFTER the row objects have
+        already been read via _iter_null_typed_routing_ops (which
+        run_classifier calls internally): if the write were still
+        row.operation_type = proposed_type; db.add(row), the stale ORM
+        object would silently clobber the concurrent value on commit.
+        With the conditional UPDATE, the write matches zero rows for this
+        id and the concurrently-set value survives."""
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+
+        from app.services import operation_type_classifier as classifier_module
+
+        real_iter = classifier_module._iter_null_typed_routing_ops
+
+        def _iter_then_concurrently_type(db_):
+            rows = real_iter(db_)
+            # Simulate a concurrent request setting operation_type between
+            # our read and our write, via a raw UPDATE so it doesn't go
+            # through this same ORM session's identity map trickery.
+            db_.execute(
+                classifier_module.RoutingOperation.__table__.update()
+                .where(classifier_module.RoutingOperation.id == op.id)
+                .values(operation_type="QUALITY_CONTROL")
+            )
+            db_.commit()
+            return rows
+
+        original = classifier_module._iter_null_typed_routing_ops
+        classifier_module._iter_null_typed_routing_ops = _iter_then_concurrently_type
+        try:
+            result = run_classifier(db, dry_run=False)
+        finally:
+            classifier_module._iter_null_typed_routing_ops = original
+
+        # Our conditional UPDATE matched zero rows for this id (the
+        # concurrent write already changed operation_type away from NULL),
+        # so applied_count reflects that -- not a stale in-memory count.
+        assert result.applied_count == 0
+        db.refresh(op)
+        assert op.operation_type == "QUALITY_CONTROL", (
+            "the concurrently-set value must survive; the classifier's "
+            "conditional UPDATE must not clobber it"
+        )
+
+    def test_apply_second_run_reports_zero_from_rowcount(self, db, make_product, make_work_center):
+        """applied_count on a second run must come from actual UPDATE
+        rowcount (zero matching rows), not from re-counting proposals."""
+        _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        first = run_classifier(db, dry_run=False)
+        assert first.applied_count == 1
+
+        second = run_classifier(db, dry_run=False)
+        assert second.applied_count == 0
 
     def test_apply_only_touches_null_rows_both_tables(
         self, db, make_product, make_work_center, make_production_order
@@ -412,7 +526,7 @@ class TestClassifierApply:
     def test_non_terminal_exposure_count(
         self, db, make_product, make_work_center, make_production_order
     ):
-        _po_op, _po = _make_po_op(
+        _make_po_op(
             db, make_product, make_work_center, make_production_order,
             "Pack items", operation_code=None, po_status="in_progress",
         )
@@ -590,6 +704,36 @@ class TestAdminCRUD:
         response = client.put(
             "/api/v1/admin/operation-types/GENERAL",
             json={"consume_stages": ["production", "any"]},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("field,value", [
+        ("label", None),
+        ("consume_stages", None),
+        ("is_qc", None),
+        ("sort_order", None),
+        ("is_active", None),
+    ])
+    def test_explicit_null_rejected_for_not_nullable_fields(self, client, db, field, value):
+        """An explicit JSON null for a NOT NULL-backed column (label,
+        consume_stages, is_qc, sort_order, is_active) is rejected with 422
+        rather than reaching the ORM as a null write (e.g. list(None) on
+        consume_stages). Omitting the field entirely remains fine (covered
+        by test_system_row_label_and_sort_order_editable etc., which never
+        sends the other fields)."""
+        response = client.put(
+            "/api/v1/admin/operation-types/GENERAL",
+            json={field: value},
+        )
+        assert response.status_code == 422
+
+    def test_explicit_null_still_accepted_for_nullable_fields(self, client, db):
+        """description/category are genuinely nullable columns — explicit
+        null must still be accepted for these (only the NOT NULL-backed
+        fields are rejected)."""
+        response = client.put(
+            "/api/v1/admin/operation-types/GENERAL",
+            json={"description": None, "category": None},
         )
         assert response.status_code == 200
 

--- a/backend/tests/services/test_operation_type_classifier.py
+++ b/backend/tests/services/test_operation_type_classifier.py
@@ -1,0 +1,643 @@
+"""
+Tests for #876 PR-3: op-type audit endpoint, human-gated classifier, and
+hardened admin CRUD.
+
+Covers:
+- Non-staff-403 on every admin endpoint (PRO-leak-audit lesson)
+- Dry-run writes nothing
+- Apply is idempotent, NULL-only, never overwrites a human-set type
+- Material-bearing safety rule (never auto-propose a no-consume type)
+- Mixed-name priority flagging
+- Audit shape + in-flight (non-terminal PO) exposure rollup
+- is_system CRUD locks (consume_stages/is_qc locked; undeletable)
+- 409 in-use guard on consume_stages edits referenced by a non-terminal PO
+"""
+from decimal import Decimal
+
+import pytest
+
+from app.models.manufacturing import (
+    OperationType,
+    Routing,
+    RoutingOperation,
+    RoutingOperationMaterial,
+)
+from app.models.production_order import (
+    ProductionOrderOperation,
+    ProductionOrderOperationMaterial,
+)
+from app.services.operation_type_classifier import (
+    MANUAL_DECISION_REASON,
+    MIXED_NAME_REASON,
+    NO_MATCH_REASON,
+    build_audit,
+    classify_name,
+    run_classifier,
+)
+
+# Mirrors migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES,
+# same approach as test_operation_type_catalog.py's seed helper.
+SEED_OPERATION_TYPES = {
+    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+}
+
+
+def _seed_operation_types(db):
+    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
+    created = []
+    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
+        if code in existing_codes:
+            continue
+        row = OperationType(
+            code=code,
+            label=label,
+            category=category,
+            consume_stages=stages,
+            is_qc=is_qc,
+            is_system=True,
+            is_active=True,
+            sort_order=sort_order,
+        )
+        db.add(row)
+        created.append(code)
+    db.flush()
+    return created
+
+
+@pytest.fixture(autouse=True)
+def _seed(db):
+    _seed_operation_types(db)
+    db.commit()
+
+
+def _make_routing_op(db, make_product, make_work_center, operation_name, operation_code=None, operation_type=None):
+    product = make_product(item_type="finished_good")
+    routing = Routing(product_id=product.id, code=f"RTG-{operation_name}-{product.id}", is_template=False)
+    db.add(routing)
+    db.flush()
+    wc = make_work_center()
+    op = RoutingOperation(
+        routing_id=routing.id,
+        work_center_id=wc.id,
+        sequence=10,
+        operation_code=operation_code,
+        operation_name=operation_name,
+        operation_type=operation_type,
+        run_time_minutes=Decimal("10"),
+    )
+    db.add(op)
+    db.commit()
+    db.refresh(op)
+    return op
+
+
+def _make_po_op(db, make_product, make_work_center, make_production_order, operation_name,
+                 operation_code=None, operation_type=None, po_status="released"):
+    product = make_product(item_type="finished_good")
+    po = make_production_order(product_id=product.id, status=po_status)
+    wc = make_work_center()
+    op = ProductionOrderOperation(
+        production_order_id=po.id,
+        work_center_id=wc.id,
+        sequence=10,
+        operation_code=operation_code,
+        operation_name=operation_name,
+        operation_type=operation_type,
+        planned_run_minutes=Decimal("10"),
+    )
+    db.add(op)
+    db.commit()
+    db.refresh(op)
+    return op, po
+
+
+# =============================================================================
+# classify_name — pure name-rule unit tests
+# =============================================================================
+
+class TestClassifyName:
+    def test_blank_name_no_proposal(self):
+        result = classify_name("")
+        assert result.proposed_type is None
+        assert result.reason == NO_MATCH_REASON
+
+    def test_none_name_no_proposal(self):
+        result = classify_name(None)
+        assert result.proposed_type is None
+        assert result.reason == NO_MATCH_REASON
+
+    def test_no_match_name(self):
+        result = classify_name("Widget Frobnicate")
+        assert result.proposed_type is None
+        assert result.reason == NO_MATCH_REASON
+
+    @pytest.mark.parametrize("name,expected", [
+        ("Pack items", "PACK_SHIP"),
+        ("Ship to customer", "PACK_SHIP"),
+        ("Apply label", "PACK_SHIP"),
+        ("Packaging step", "PACK_SHIP"),
+        ("Box up", "PACK_SHIP"),
+        ("Mail order", "PACK_SHIP"),
+        ("QC inspection", "QUALITY_CONTROL"),
+        ("Quality check", "QUALITY_CONTROL"),
+        ("Inspect part", "QUALITY_CONTROL"),
+        ("Assembly step", "ASSEMBLY"),
+        ("3D Print base", "FDM_PRINT"),
+        ("Sand the surface", "SANDING"),
+        ("Paint finish", "PAINTING"),
+        ("Support removal", "SUPPORT_REMOVAL"),
+        ("Clean up", "SUPPORT_REMOVAL"),
+        ("Post processing", "SUPPORT_REMOVAL"),
+        ("Post-process", "SUPPORT_REMOVAL"),
+    ])
+    def test_single_rule_matches(self, name, expected):
+        result = classify_name(name)
+        assert result.proposed_type == expected
+        assert result.reason is None
+        assert result.mixed is False
+
+    def test_mixed_name_priority_qc_plus_pack(self):
+        """'QC + Pack' matches both the pack rule and the qc rule; PACK_SHIP
+        (rule #1, higher priority) wins, flagged as mixed-name."""
+        result = classify_name("QC + Pack")
+        assert result.proposed_type == "PACK_SHIP"
+        assert result.mixed is True
+        assert result.reason == MIXED_NAME_REASON
+
+    def test_case_insensitive(self):
+        result = classify_name("PACK AND SHIP")
+        assert result.proposed_type == "PACK_SHIP"
+
+
+# =============================================================================
+# Audit
+# =============================================================================
+
+class TestAudit:
+    def test_audit_shape_and_pair_grouping(self, db, make_product, make_work_center):
+        _make_routing_op(db, make_product, make_work_center, "Print", operation_code="PRINT")
+        rows = build_audit(db)
+        assert len(rows) >= 1
+        row = next(r for r in rows if r.operation_code == "PRINT" and r.operation_name == "Print")
+        assert row.routing_op_count == 1
+        assert row.po_op_count == 0
+        assert row.match_source == "legacy-dict"
+        assert row.current_consume_stages == ["production", "any"]
+
+    def test_audit_match_source_stored_type(self, db, make_product, make_work_center):
+        _make_routing_op(
+            db, make_product, make_work_center, "Pack it up",
+            operation_code=None, operation_type="PACK_SHIP",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Pack it up")
+        assert row.match_source == "stored-type"
+        assert row.stored_operation_type == "PACK_SHIP"
+        assert row.current_consume_stages == ["shipping", "any"]
+
+    def test_audit_match_source_default(self, db, make_product, make_work_center):
+        _make_routing_op(db, make_product, make_work_center, "Widget Frobnicate", operation_code=None)
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Widget Frobnicate")
+        assert row.match_source == "default"
+        assert row.current_consume_stages == ["production", "any"]
+
+    def test_audit_proposes_type_and_flags_behavior_changed(self, db, make_product, make_work_center):
+        """An untyped op named 'Pack items' with legacy code None (so
+        current resolution is the default ["production","any"]) proposes
+        PACK_SHIP, whose stages differ -> behavior_changed True."""
+        _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Pack items")
+        assert row.proposed_type == "PACK_SHIP"
+        assert row.proposed_consume_stages == ["shipping", "any"]
+        assert row.behavior_changed is True
+
+    def test_audit_in_flight_rollup_one_non_terminal_po(
+        self, db, make_product, make_work_center, make_production_order
+    ):
+        """One non-terminal PO with a generic-coded op appears in the
+        in-flight rollup; a terminal one does not."""
+        _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "3D Print", operation_code="PRINT", po_status="in_progress",
+        )
+        _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "3D Print", operation_code="PRINT", po_status="complete",
+        )
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_code == "PRINT" and r.operation_name == "3D Print")
+        assert row.in_flight_non_terminal_po_count == 1
+        assert row.po_op_count == 2
+
+    def test_audit_material_bearing_flag(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Sand surface", operation_code=None)
+        component = make_product(item_type="supply")
+        db.add(RoutingOperationMaterial(
+            routing_operation_id=op.id,
+            component_id=component.id,
+            quantity=Decimal("1"),
+            quantity_per="unit",
+            unit="EA",
+        ))
+        db.commit()
+
+        rows = build_audit(db)
+        row = next(r for r in rows if r.operation_name == "Sand surface")
+        assert row.material_bearing is True
+        # SANDING is a no-consume type; material-bearing safety rule fires.
+        assert row.proposed_type is None
+        assert row.classification_reason == MANUAL_DECISION_REASON
+
+    def test_audit_is_re_runnable_read_only(self, db, make_product, make_work_center):
+        _make_routing_op(db, make_product, make_work_center, "Print", operation_code="PRINT")
+        rows_first = build_audit(db)
+        rows_second = build_audit(db)
+        assert len(rows_first) == len(rows_second)
+        # No operation_type rows were mutated by merely running the audit.
+        untouched = db.query(RoutingOperation).filter(RoutingOperation.operation_code == "PRINT").first()
+        assert untouched.operation_type is None
+
+
+# =============================================================================
+# Classifier: dry-run / apply / idempotency / safety rules
+# =============================================================================
+
+class TestClassifierDryRun:
+    def test_dry_run_writes_nothing(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        result = run_classifier(db, dry_run=True)
+        assert result.dry_run is True
+        assert result.applied_count == 0
+
+        db.refresh(op)
+        assert op.operation_type is None
+
+        proposal = next(p for p in result.proposals if p.row_id == op.id)
+        assert proposal.proposed_type == "PACK_SHIP"
+
+    def test_dry_run_reports_before_after_stages(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Assembly step", operation_code=None)
+        result = run_classifier(db, dry_run=True)
+        proposal = next(p for p in result.proposals if p.row_id == op.id)
+        assert proposal.before_stages == ["production", "any"]
+        assert proposal.after_stages == ["assembly", "production", "any"]
+
+
+class TestClassifierApply:
+    def test_apply_sets_null_to_type(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        result = run_classifier(db, dry_run=False)
+        assert result.applied_count == 1
+
+        db.refresh(op)
+        assert op.operation_type == "PACK_SHIP"
+
+    def test_apply_is_idempotent(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        first = run_classifier(db, dry_run=False)
+        assert first.applied_count == 1
+
+        db.refresh(op)
+        assert op.operation_type == "PACK_SHIP"
+
+        second = run_classifier(db, dry_run=False)
+        assert second.applied_count == 0, "re-running apply must find zero NULL rows left"
+
+        db.refresh(op)
+        assert op.operation_type == "PACK_SHIP"
+
+    def test_apply_never_overwrites_a_human_set_type(self, db, make_product, make_work_center):
+        op = _make_routing_op(
+            db, make_product, make_work_center, "Pack items",
+            operation_code=None, operation_type="QUALITY_CONTROL",
+        )
+        run_classifier(db, dry_run=False)
+        db.refresh(op)
+        assert op.operation_type == "QUALITY_CONTROL", "apply must never touch a non-NULL operation_type"
+
+    def test_apply_only_touches_null_rows_both_tables(
+        self, db, make_product, make_work_center, make_production_order
+    ):
+        routing_op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        po_op, _po = _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "Assembly", operation_code=None,
+        )
+        result = run_classifier(db, dry_run=False)
+        assert result.applied_count == 2
+
+        db.refresh(routing_op)
+        db.refresh(po_op)
+        assert routing_op.operation_type == "PACK_SHIP"
+        assert po_op.operation_type == "ASSEMBLY"
+
+    def test_material_bearing_refused_no_consume_needs_manual(self, db, make_product, make_work_center):
+        """An op named 'Sand and inspect' matching a no-consume rule but
+        carrying material rows must never be auto-applied — surfaced as
+        needs-manual-decision, left NULL."""
+        op = _make_routing_op(db, make_product, make_work_center, "Sanding", operation_code=None)
+        component = make_product(item_type="supply")
+        db.add(RoutingOperationMaterial(
+            routing_operation_id=op.id,
+            component_id=component.id,
+            quantity=Decimal("1"),
+            quantity_per="unit",
+            unit="EA",
+        ))
+        db.commit()
+
+        result = run_classifier(db, dry_run=False)
+        assert result.applied_count == 0
+        assert result.skipped_manual_decision_count == 1
+
+        db.refresh(op)
+        assert op.operation_type is None
+
+        proposal = next(p for p in result.proposals if p.row_id == op.id)
+        assert proposal.proposed_type is None
+        assert proposal.reason == MANUAL_DECISION_REASON
+        assert proposal.material_bearing is True
+
+    def test_material_bearing_po_op_material_also_refused(
+        self, db, make_product, make_work_center, make_production_order
+    ):
+        po_op, _po = _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "Quality Control", operation_code=None,
+        )
+        component = make_product(item_type="supply")
+        db.add(ProductionOrderOperationMaterial(
+            production_order_operation_id=po_op.id,
+            component_id=component.id,
+            quantity_required=Decimal("1"),
+            unit="EA",
+            status="pending",
+        ))
+        db.commit()
+
+        result = run_classifier(db, dry_run=False)
+        assert result.applied_count == 0
+        assert result.skipped_manual_decision_count == 1
+        db.refresh(po_op)
+        assert po_op.operation_type is None
+
+    def test_blank_name_no_proposal_not_applied(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "", operation_code=None)
+        result = run_classifier(db, dry_run=False)
+        assert result.applied_count == 0
+        assert result.skipped_no_match_count >= 1
+        db.refresh(op)
+        assert op.operation_type is None
+
+    def test_mixed_name_flagged_qc_plus_pack(self, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "QC + Pack", operation_code=None)
+        result = run_classifier(db, dry_run=False)
+        proposal = next(p for p in result.proposals if p.row_id == op.id)
+        assert proposal.proposed_type == "PACK_SHIP"
+        assert proposal.reason == MIXED_NAME_REASON
+
+        db.refresh(op)
+        assert op.operation_type == "PACK_SHIP"
+
+    def test_non_terminal_exposure_count(
+        self, db, make_product, make_work_center, make_production_order
+    ):
+        _po_op, _po = _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "Pack items", operation_code=None, po_status="in_progress",
+        )
+        result = run_classifier(db, dry_run=True)
+        assert result.non_terminal_exposure_count >= 1
+
+
+# =============================================================================
+# Admin endpoints: auth
+# =============================================================================
+
+ADMIN_ENDPOINTS = [
+    ("get", "/api/v1/admin/operation-types/audit"),
+    ("post", "/api/v1/admin/operation-types/classify"),
+    ("post", "/api/v1/admin/operation-types"),
+    ("put", "/api/v1/admin/operation-types/GENERAL"),
+    ("post", "/api/v1/admin/operation-types/GENERAL/deactivate"),
+]
+
+
+@pytest.fixture
+def customer_client(db):
+    """TestClient authenticated as a NON-STAFF (account_type='customer')
+    user — mirrors tests/endpoints/test_inventory_auth.py's fixture."""
+    from fastapi.testclient import TestClient
+    from app.main import app
+    from app.db.session import get_db
+    from app.models.user import User
+    from app.core.security import create_access_token
+
+    customer = User(
+        email=f"buyer-{id(db)}@example.com",
+        password_hash="not-a-real-hash",
+        account_type="customer",
+        status="active",
+    )
+    db.add(customer)
+    db.flush()
+    token = create_access_token(user_id=customer.id)
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = f"Bearer {token}"
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+class TestAdminEndpointsUnauthenticated:
+    @pytest.mark.parametrize("method,path", ADMIN_ENDPOINTS)
+    def test_requires_auth(self, unauthed_client, method, path):
+        kwargs = {"json": {}} if method in ("post", "put") else {}
+        resp = getattr(unauthed_client, method)(path, **kwargs)
+        assert resp.status_code == 401
+
+
+class TestAdminEndpointsNonStaffForbidden:
+    """PRO-leak-audit lesson: every admin endpoint must reject an
+    authenticated non-staff (customer) account with 403."""
+
+    @pytest.mark.parametrize("method,path", ADMIN_ENDPOINTS)
+    def test_non_staff_forbidden(self, customer_client, method, path):
+        kwargs = {}
+        if method in ("post", "put"):
+            kwargs["json"] = {}
+        resp = getattr(customer_client, method)(path, **kwargs)
+        assert resp.status_code == 403
+
+
+# =============================================================================
+# Admin endpoints: audit + classify (via HTTP, staff-authed `client`)
+# =============================================================================
+
+class TestAuditEndpoint:
+    def test_audit_endpoint_shape(self, client, db, make_product, make_work_center):
+        _make_routing_op(db, make_product, make_work_center, "Print", operation_code="PRINT")
+        response = client.get("/api/v1/admin/operation-types/audit")
+        assert response.status_code == 200
+        body = response.json()
+        assert "rows" in body
+        assert "total_pairs" in body
+        assert "total_in_flight_exposure" in body
+        assert body["total_pairs"] >= 1
+
+
+class TestClassifyEndpoint:
+    def test_classify_dry_run_default_writes_nothing(self, client, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        response = client.post("/api/v1/admin/operation-types/classify", json={})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["dry_run"] is True
+        assert body["applied_count"] == 0
+
+        db.refresh(op)
+        assert op.operation_type is None
+
+    def test_classify_apply_sets_type_and_stamps_applied_by(self, client, db, make_product, make_work_center):
+        op = _make_routing_op(db, make_product, make_work_center, "Pack items", operation_code=None)
+        response = client.post("/api/v1/admin/operation-types/classify", json={"dry_run": False})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["applied_count"] == 1
+        assert body["applied_by"] is not None
+        assert body["applied_at"] is not None
+
+        db.refresh(op)
+        assert op.operation_type == "PACK_SHIP"
+
+
+# =============================================================================
+# Admin CRUD: is_system locks + 409 in-use guard
+# =============================================================================
+
+class TestAdminCRUD:
+    def test_create_custom_type(self, client, db):
+        response = client.post(
+            "/api/v1/admin/operation-types",
+            json={
+                "code": "CUSTOM_TEST",
+                "label": "Custom Test Type",
+                "consume_stages": ["production", "any"],
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["code"] == "CUSTOM_TEST"
+        assert body["is_system"] is False
+
+    def test_create_duplicate_code_rejected(self, client, db):
+        client.post(
+            "/api/v1/admin/operation-types",
+            json={"code": "DUPE_TEST", "label": "Dupe", "consume_stages": ["any"]},
+        )
+        response = client.post(
+            "/api/v1/admin/operation-types",
+            json={"code": "DUPE_TEST", "label": "Dupe Again", "consume_stages": ["any"]},
+        )
+        assert response.status_code == 400
+
+    def test_system_row_label_and_sort_order_editable(self, client, db):
+        response = client.put(
+            "/api/v1/admin/operation-types/GENERAL",
+            json={"label": "Other (renamed)", "sort_order": 95},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["label"] == "Other (renamed)"
+        assert body["sort_order"] == 95
+
+    def test_system_row_consume_stages_locked(self, client, db):
+        response = client.put(
+            "/api/v1/admin/operation-types/GENERAL",
+            json={"consume_stages": ["shipping"]},
+        )
+        assert response.status_code == 400
+
+    def test_system_row_is_qc_locked(self, client, db):
+        response = client.put(
+            "/api/v1/admin/operation-types/QUALITY_CONTROL",
+            json={"is_qc": False},
+        )
+        assert response.status_code == 400
+
+    def test_system_row_same_value_consume_stages_not_locked(self, client, db):
+        """Submitting the SAME consume_stages value as already stored is not
+        a change and must not be rejected as a lock violation."""
+        response = client.put(
+            "/api/v1/admin/operation-types/GENERAL",
+            json={"consume_stages": ["production", "any"]},
+        )
+        assert response.status_code == 200
+
+    def test_deactivate_is_system_row_soft_only(self, client, db):
+        response = client.post("/api/v1/admin/operation-types/SANDING/deactivate")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["is_active"] is False
+
+        op_type = db.query(OperationType).filter(OperationType.code == "SANDING").first()
+        assert op_type is not None, "is_system row must never be hard-deleted"
+
+    def test_consume_stages_edit_referenced_by_non_terminal_po_returns_409(
+        self, client, db, make_product, make_work_center, make_production_order
+    ):
+        # consume_stages is LOCKED on system types (asserted separately
+        # above), so the in-use 409 guard is exercised via a custom type.
+        create_resp = client.post(
+            "/api/v1/admin/operation-types",
+            json={"code": "CUSTOM_INUSE", "label": "Custom In Use", "consume_stages": ["production", "any"]},
+        )
+        assert create_resp.status_code == 201
+
+        _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "Custom op", operation_code=None, operation_type="CUSTOM_INUSE", po_status="in_progress",
+        )
+        response = client.put(
+            "/api/v1/admin/operation-types/CUSTOM_INUSE",
+            json={"consume_stages": ["shipping"]},
+        )
+        assert response.status_code == 409
+
+    def test_consume_stages_edit_referenced_only_by_terminal_po_allowed(
+        self, client, db, make_product, make_work_center, make_production_order
+    ):
+        create_resp = client.post(
+            "/api/v1/admin/operation-types",
+            json={"code": "CUSTOM_TERMINAL", "label": "Custom Terminal", "consume_stages": ["production", "any"]},
+        )
+        assert create_resp.status_code == 201
+
+        _make_po_op(
+            db, make_product, make_work_center, make_production_order,
+            "Custom op", operation_code=None, operation_type="CUSTOM_TERMINAL", po_status="complete",
+        )
+        response = client.put(
+            "/api/v1/admin/operation-types/CUSTOM_TERMINAL",
+            json={"consume_stages": ["shipping", "any", "production"]},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## What

Staff-gated admin surface for the #876 operation-type catalog (schema/seed/resolver shipped inert in #898):

1. **`GET /api/v1/admin/operation-types/audit`** — read-only, re-runnable audit of every distinct `(operation_code, operation_name)` pair across `routing_operations` AND `production_order_operations`: per-table counts, stored `operation_type`, resolved consume stages (via the #898 resolver), match source (`stored-type` / `legacy-dict` / `default`), old-vs-new stage projection + `behavior_changed` flag, material-bearing flag, and an in-flight exposure rollup (count of non-terminal POs whose ops carry the pair).
2. **`POST /api/v1/admin/operation-types/classify {dry_run}`** — human-gated classifier over NULL-`operation_type` rows in both tables. Priority-ordered, case-insensitive name rules (pack/ship/label/packag/box/mail → PACK_SHIP; `\bqc\b`/quality/inspect → QUALITY_CONTROL; assembl → ASSEMBLY; print → FDM_PRINT; sand → SANDING; paint → PAINTING; support/clean/post-process → SUPPORT_REMOVAL). Mixed-name matches are flagged "mixed-name — priority applied". Blank names propose nothing.
3. **Hardened admin CRUD** (`POST` / `PUT` / `POST .../{code}/deactivate` under `/api/v1/admin/operation-types`) — `is_system` rows are undeletable with `consume_stages`/`is_qc` LOCKED (only label/description/category/sort_order/is_active editable); editing `consume_stages` on a type referenced by an operation of a **non-terminal** production order returns 409 ("create a new type instead"); custom types are deactivate-only.

## Why

#876/#880 (roadmap seq 11, owner green-light [issuecomment-4880356641](https://github.com/BLB3DPrinting/filaops/issues/880#issuecomment-4880356641)) needs a durable, staff-reviewable path from the dormant catalog (#898) to real classification — replacing ad-hoc deploy-stdout reporting with a re-runnable audit and putting a human in the loop before anything is reclassified.

## The never-auto-reclassify guarantee

Nothing in this PR writes an `operation_type` automatically:

- The audit endpoint is **read-only** — proven by a dedicated test that re-runs it and asserts no row was touched.
- The classifier's `dry_run=true` (the default) returns the full proposal report and **writes nothing**.
- Apply (`dry_run=false`) only ever does `NULL -> proposed_type`; it **never overwrites** a human-set type (enforced by the `operation_type IS NULL` selection, not just a check), and is **idempotent** — re-running after an apply finds zero NULL rows left to act on.
- **Material-bearing safety rule**: an operation carrying `RoutingOperationMaterial` or `ProductionOrderOperationMaterial` rows can never be auto-proposed a no-consume type (`QUALITY_CONTROL` / `SANDING` / `SUPPORT_REMOVAL`) — it is always surfaced as *"needs manual decision"* instead, in both the audit and the classifier.

### The #850 status-vocabulary fork

`ProductionOrder.status`'s docstring describes an aspirational `draft → released → scheduled → in_progress → completed → closed` lifecycle, but every live write/filter in the codebase (`production_order_service.py`'s `get_schedule_summary` and siblings) uses `.notin_(["complete", "cancelled"])`. This PR's `PO_TERMINAL_STATUSES = ("complete", "cancelled")` mirrors that **live** convention, not the docstring, so "non-terminal" in the audit/classifier/409-guard means exactly what it means everywhere else in the running system.

## Scope

This PR does **not** touch `inventory_service.py`, `operation_blocking.py`, `production_order_service.py`, `routing_service.py`, or `schemas/manufacturing.py` — the consumer switch (#876 PR-2) is being built in parallel on another branch. Only new files plus the admin router registration (`admin/__init__.py`) and additive schema classes (`schemas/operation_type.py`) were touched.

## Tests

62 new tests in `tests/services/test_operation_type_classifier.py`:
- Non-staff-403 on every admin endpoint (PRO-leak-audit lesson) + 401-unauthenticated
- Dry-run writes nothing
- Apply: NULL-only, idempotent, never overwrites a human-set type
- Material-bearing rows refused a no-consume type -> "needs manual decision" (both routing and PO-op materials)
- Mixed-name priority ("QC + Pack" -> PACK_SHIP, flagged)
- Audit shape, match-source variants, behavior_changed, in-flight non-terminal-PO rollup
- `is_system` locks (consume_stages/is_qc locked; same-value edits allowed; label/sort_order editable; undeletable)
- 409 in-use guard on a custom type referenced by a non-terminal PO; 200 when only referenced by a terminal PO

Plus the existing 162-test `test_operation_type_catalog.py` PR-1 suite — all green, no regressions.

```
224 passed in 8.92s  (test_operation_type_catalog.py + test_operation_type_classifier.py)
```

`ruff check` clean on all changed/new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin tools to review operation types, including an audit view and a guided classification flow with safe default preview mode.
  * Expanded admin management for operation types: create, update, and deactivate entries from the interface/API.
* **Bug Fixes**
  * Improved safeguards to prevent risky edits to operation types that are already in use.
  * Added protections so system-defined values can’t be changed in unsupported ways, and deactivations are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->