### PR TITLE
feat(mrp): consumers resolve operation semantics by stored type (876 PR-2)

### DIFF
--- a/backend/app/api/v1/endpoints/routings.py
+++ b/backend/app/api/v1/endpoints/routings.py
@@ -410,6 +410,7 @@ def _build_operation_response(op: RoutingOperation) -> RoutingOperationResponse:
         work_center_name=op.work_center.name if op.work_center else None,
         sequence=op.sequence,
         operation_code=op.operation_code,
+        operation_type=op.operation_type,
         operation_name=op.operation_name,
         description=op.description,
         setup_time_minutes=op.setup_time_minutes,

--- a/backend/app/schemas/manufacturing.py
+++ b/backend/app/schemas/manufacturing.py
@@ -189,6 +189,13 @@ class RoutingOperationBase(BaseModel):
     work_center_id: int
     sequence: int = Field(..., ge=1)
     operation_code: Optional[str] = Field(None, max_length=50)
+    # #876 PR-2: declared Type — the ONLY runtime semantic carrier for
+    # consume-stage resolution (see operation_material_mapping.
+    # resolve_consume_stages). operation_code stays a plain free-text label.
+    # Write-time validated against the operation_types catalog (400 on an
+    # unknown, case-normalized-upper code) and write-time alias-assisted
+    # from operation_code when absent — see routing_service.py.
+    operation_type: Optional[str] = Field(None, max_length=30)
     operation_name: Optional[str] = Field(None, max_length=200)
     description: Optional[str] = None
 
@@ -226,6 +233,7 @@ class RoutingOperationUpdate(BaseModel):
     work_center_id: Optional[int] = None
     sequence: Optional[int] = None
     operation_code: Optional[str] = None
+    operation_type: Optional[str] = None
     operation_name: Optional[str] = None
     description: Optional[str] = None
     setup_time_minutes: Optional[Decimal] = None

--- a/backend/app/schemas/production_order.py
+++ b/backend/app/schemas/production_order.py
@@ -76,6 +76,12 @@ class ProductionOrderOperationBase(BaseModel):
     resource_id: Optional[int] = None
     sequence: int = Field(..., ge=1)
     operation_code: Optional[str] = Field(None, max_length=50)
+    # #876 PR-2: snapshot of the routing operation's declared Type at
+    # release time — copied alongside operation_code (see
+    # production_order_service.copy_routing_to_operations and the other
+    # release-time copy sites). Drives QC-op resolution and stage
+    # resolution for this specific production-order operation.
+    operation_type: Optional[str] = Field(None, max_length=30)
     operation_name: Optional[str] = Field(None, max_length=200)
     planned_setup_minutes: Decimal = Field(0, ge=0, le=99999)
     planned_run_minutes: Decimal = Field(..., ge=0, le=99999)
@@ -119,6 +125,7 @@ class ProductionOrderOperationResponse(BaseModel):
 
     sequence: int
     operation_code: Optional[str] = None
+    operation_type: Optional[str] = None
     operation_name: Optional[str] = None
     status: str
 

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -1458,6 +1458,7 @@ def _get_stage_op_materials(
     db: Session,
     production_order_id: int,
     stage: str,
+    type_map: Optional[Dict[str, List[str]]] = None,
 ) -> Tuple[List["ProductionOrderOperationMaterial"], bool]:
     """
     Shared routing-first + stage-filter + idempotency resolver for material
@@ -1491,6 +1492,13 @@ def _get_stage_op_materials(
         db: Database session
         production_order_id: The production order
         stage: The consume stage to filter to ("production" or "shipping")
+        type_map: Pre-loaded {code: consume_stages} map (see
+            load_operation_type_stage_map). Callers that need this resolved
+            for multiple stages/POs in one flow should load it ONCE and
+            pass it through here instead of letting each helper re-query
+            the operation_types table. Defaults to a fresh load when the
+            caller has no map to share (keeps this helper safe to call
+            standalone).
 
     Returns:
         Tuple of:
@@ -1506,7 +1514,8 @@ def _get_stage_op_materials(
 
     has_any_op_rows = len(all_op_rows) > 0
 
-    type_map = load_operation_type_stage_map(db)
+    if type_map is None:
+        type_map = load_operation_type_stage_map(db)
 
     stage_rows = []
     for row in all_op_rows:
@@ -1528,6 +1537,7 @@ def _stage_has_consumed_op_materials(
     db: Session,
     production_order_id: int,
     stage: str,
+    type_map: Optional[Dict[str, List[str]]] = None,
 ) -> bool:
     """Return True if this order has AT LEAST ONE ProductionOrderOperationMaterial
     row for `stage` that is already status=='consumed'.
@@ -1539,8 +1549,13 @@ def _stage_has_consumed_op_materials(
     which posts the consumption + marks the row 'consumed' but does NOT
     release the reservation)". The latter is a correctly-completed order
     finalizing through the bulk/auto-complete path — it must NOT false-raise
-    merely because the still-open reservation makes had_reservation True."""
-    type_map = load_operation_type_stage_map(db)
+    merely because the still-open reservation makes had_reservation True.
+
+    type_map: optional pre-loaded {code: consume_stages} map, threaded
+    through by callers that already loaded one for this flow (see
+    _get_stage_op_materials). Defaults to a fresh load when omitted."""
+    if type_map is None:
+        type_map = load_operation_type_stage_map(db)
     for row in _get_all_op_material_rows(db, production_order_id):
         if row.status != "consumed":
             continue
@@ -1587,6 +1602,7 @@ def _get_stage_component_ids(
     db: Session,
     production_order: ProductionOrder,
     stage: str,
+    type_map: Optional[Dict[str, List[str]]] = None,
 ) -> set:
     """
     Return the set of component_ids that belong to `stage` for this
@@ -1606,11 +1622,16 @@ def _get_stage_component_ids(
     BOM fallback: only consulted when the order has ZERO op-material rows,
     matching the "op rows replace the BOM walk entirely" rule used
     everywhere else in this module.
+
+    type_map: optional pre-loaded {code: consume_stages} map, threaded
+    through by callers that already loaded one for this flow. Defaults to
+    a fresh load when omitted.
     """
     all_op_rows = _get_all_op_material_rows(db, production_order.id)
 
     if all_op_rows:
-        type_map = load_operation_type_stage_map(db)
+        if type_map is None:
+            type_map = load_operation_type_stage_map(db)
         component_ids = set()
         for row in all_op_rows:
             op = row.operation
@@ -1715,12 +1736,20 @@ def consume_production_materials(
     Returns:
         List of created inventory transactions
     """
+    # Loaded ONCE and threaded through every stage helper call below
+    # (_get_stage_component_ids / _get_stage_op_materials /
+    # _stage_has_consumed_op_materials) instead of each one re-querying the
+    # operation_types table independently.
+    type_map = load_operation_type_stage_map(db)
+
     # Resolve which components belong to the PRODUCTION stage for this order
     # (routing-first, BOM-fallback-only-if-no-op-rows — see
     # _get_stage_component_ids) so both the reservation snapshot and the
     # release below are scoped to THIS stage and never touch shipping-stage
     # reservations (e.g. a box reserved for a PACK op).
-    stage_component_ids = _get_stage_component_ids(db, production_order, "production")
+    stage_component_ids = _get_stage_component_ids(
+        db, production_order, "production", type_map
+    )
 
     # Snapshot whether this order had any net production-stage reservation
     # BEFORE releasing it, so the FIX-3 guardrail can tell "nothing to
@@ -1747,7 +1776,7 @@ def consume_production_materials(
 
     # FIX-1: routing-first resolution, production stage only.
     stage_rows, has_any_op_rows = _get_stage_op_materials(
-        db, production_order.id, "production"
+        db, production_order.id, "production", type_map
     )
 
     if stage_rows:
@@ -1784,7 +1813,9 @@ def consume_production_materials(
         if (
             had_reservation
             and not transactions
-            and not _stage_has_consumed_op_materials(db, production_order.id, "production")
+            and not _stage_has_consumed_op_materials(
+                db, production_order.id, "production", type_map
+            )
         ):
             logger.error(
                 "Production-stage reservation existed for PO %s (product %s) "
@@ -1816,7 +1847,7 @@ def consume_production_materials(
         # order finalizing, NOT a missing-source bug. The lingering
         # reservation was already released above; return quietly.
         if had_reservation and not _stage_has_consumed_op_materials(
-            db, production_order.id, "production"
+            db, production_order.id, "production", type_map
         ):
             logger.error(
                 "Production-stage reservation existed for PO %s (product %s) "
@@ -2144,6 +2175,11 @@ def consume_shipping_materials(
     transactions = []
     location = get_or_create_default_location(db)
 
+    # Loaded ONCE for the whole call and threaded through every stage helper
+    # below (potentially multiple products x multiple production orders)
+    # instead of each PO's helper calls re-querying operation_types.
+    type_map = load_operation_type_stage_map(db)
+
     # Get products to ship - either from lines or legacy single-product format
     products_to_ship = []
 
@@ -2171,7 +2207,7 @@ def consume_shipping_materials(
         )
 
         for po in production_orders:
-            stage_component_ids = _get_stage_component_ids(db, po, "shipping")
+            stage_component_ids = _get_stage_component_ids(db, po, "shipping", type_map)
 
             net_reserved = _get_net_reserved_by_component(db, po.id)
             po_had_reservation = any(
@@ -2187,7 +2223,7 @@ def consume_shipping_materials(
             # consume_operation_material posts + marks 'consumed' but does NOT
             # release the reservation, so a fully-consumed shipping stage on a
             # finalizing call still shows had_reservation=True).
-            if _stage_has_consumed_op_materials(db, po.id, "shipping"):
+            if _stage_has_consumed_op_materials(db, po.id, "shipping", type_map):
                 product_stage_already_consumed = True
 
             # Release SHIPPING-stage reservations for this PO only —
@@ -2197,7 +2233,9 @@ def consume_shipping_materials(
                 db, po, created_by, component_ids=stage_component_ids
             )
 
-            stage_rows, _has_any_op_rows = _get_stage_op_materials(db, po.id, "shipping")
+            stage_rows, _has_any_op_rows = _get_stage_op_materials(
+                db, po.id, "shipping", type_map
+            )
             for row in stage_rows:
                 component = db.query(Product).filter(Product.id == row.component_id).first()
                 if not component:

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -25,7 +25,10 @@ from app.services.uom_service import (
     convert_cost_for_unit,
 )
 from app.services.reservation_reconciliation_service import check_allocation_guard
-from app.services.operation_material_mapping import get_consume_stages_for_operation
+from app.services.operation_material_mapping import (
+    load_operation_type_stage_map,
+    resolve_consume_stages,
+)
 
 logger = get_logger(__name__)
 
@@ -1468,13 +1471,15 @@ def _get_stage_op_materials(
     as reservation already does) — this is what keeps reserve and consume
     from diverging again.
 
-    Filters to rows whose parent operation's operation_code resolves (via
-    get_consume_stages_for_operation) to include `stage` — e.g. only
-    PRINT/EXTRUDE/etc-coded operations are returned for stage="production",
-    only PACK/SHIP/LABEL-coded operations for stage="shipping". Operations
-    with no operation_code use DEFAULT_CONSUME_STAGES (production + any),
-    matching the mapping module's own default and existing test fixtures
-    that don't set operation_code.
+    Filters to rows whose parent operation resolves (via
+    resolve_consume_stages — stored operation_type first, falling back to
+    get_consume_stages_for_operation on operation_code) to include `stage`
+    — e.g. only PRINT/EXTRUDE/etc-coded (or FDM_PRINT/ASSEMBLY-typed)
+    operations are returned for stage="production", only PACK/SHIP/LABEL-
+    coded (or PACK_SHIP-typed) operations for stage="shipping". Operations
+    with no operation_type and no operation_code use DEFAULT_CONSUME_STAGES
+    (production + any), matching the mapping module's own default and
+    existing test fixtures that don't set either.
 
     IDEMPOTENCY: rows already status=='consumed' are excluded — the
     per-operation path (complete_operation -> consume_operation_materials
@@ -1501,12 +1506,18 @@ def _get_stage_op_materials(
 
     has_any_op_rows = len(all_op_rows) > 0
 
+    type_map = load_operation_type_stage_map(db)
+
     stage_rows = []
     for row in all_op_rows:
         if row.status == "consumed":
             continue
         op = row.operation
-        stages = get_consume_stages_for_operation(op.operation_code if op else None)
+        stages = resolve_consume_stages(
+            type_map,
+            getattr(op, "operation_type", None),
+            op.operation_code if op else None,
+        )
         if stage in stages:
             stage_rows.append(row)
 
@@ -1529,11 +1540,16 @@ def _stage_has_consumed_op_materials(
     release the reservation)". The latter is a correctly-completed order
     finalizing through the bulk/auto-complete path — it must NOT false-raise
     merely because the still-open reservation makes had_reservation True."""
+    type_map = load_operation_type_stage_map(db)
     for row in _get_all_op_material_rows(db, production_order_id):
         if row.status != "consumed":
             continue
         op = row.operation
-        stages = get_consume_stages_for_operation(op.operation_code if op else None)
+        stages = resolve_consume_stages(
+            type_map,
+            getattr(op, "operation_type", None),
+            op.operation_code if op else None,
+        )
         if stage in stages:
             return True
     return False
@@ -1594,10 +1610,15 @@ def _get_stage_component_ids(
     all_op_rows = _get_all_op_material_rows(db, production_order.id)
 
     if all_op_rows:
+        type_map = load_operation_type_stage_map(db)
         component_ids = set()
         for row in all_op_rows:
             op = row.operation
-            stages = get_consume_stages_for_operation(op.operation_code if op else None)
+            stages = resolve_consume_stages(
+                type_map,
+                getattr(op, "operation_type", None),
+                op.operation_code if op else None,
+            )
             if stage in stages:
                 component_ids.add(row.component_id)
         return component_ids
@@ -1649,10 +1670,11 @@ def consume_production_materials(
     FIX-1 (routing-first consumption): mirrors the reservation side's
     routing-first resolution (_get_reservation_requirements / RESERVE-1).
     PRIMARY source is materialized ProductionOrderOperationMaterial rows for
-    this order's PRODUCTION-stage operations (resolved via
-    get_consume_stages_for_operation through the shared
-    _get_stage_op_materials helper) — this is the normal case for
-    routing-driven / Intake-Studio products that have NO active BOM at all.
+    this order's PRODUCTION-stage operations (resolved type-first via
+    resolve_consume_stages, falling back to get_consume_stages_for_operation,
+    through the shared _get_stage_op_materials helper) — this is the normal
+    case for routing-driven / Intake-Studio products that have NO active BOM
+    at all.
     FALLBACK — legacy BOM walk (consume_stage='production'): only runs when
     the order has ZERO op-material rows whatsoever (not just zero for this
     stage), matching reservation's "op rows REPLACE the BOM walk entirely"

--- a/backend/app/services/item_duplicate_service.py
+++ b/backend/app/services/item_duplicate_service.py
@@ -179,6 +179,7 @@ def duplicate_item(
                 work_center_id=op.work_center_id,
                 sequence=op.sequence,
                 operation_code=op.operation_code,
+                operation_type=getattr(op, "operation_type", None),
                 operation_name=op.operation_name,
                 description=op.description,
                 setup_time_minutes=op.setup_time_minutes,

--- a/backend/app/services/operation_blocking.py
+++ b/backend/app/services/operation_blocking.py
@@ -4,7 +4,7 @@ Service layer for operation-level blocking checks.
 Checks material availability for a specific operation, not the entire PO.
 """
 from decimal import Decimal
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -17,7 +17,10 @@ from app.models.production_order import (
 )
 from app.models.inventory import Inventory
 from app.models.purchase_order import PurchaseOrder, PurchaseOrderLine
-from app.services.operation_material_mapping import get_consume_stages_for_operation
+from app.services.operation_material_mapping import (
+    load_operation_type_stage_map,
+    resolve_consume_stages,
+)
 
 
 class OperationBlockingError(Exception):
@@ -76,7 +79,8 @@ def get_material_available(db: Session, product_id: int) -> Decimal:
 def get_bom_lines_for_operation(
     db: Session,
     bom_id: int,
-    operation_code: str
+    operation_code: str,
+    operation_type: Optional[str] = None,
 ) -> List[BOMLine]:
     """
     Get BOM lines that should be checked for a specific operation.
@@ -85,15 +89,22 @@ def get_bom_lines_for_operation(
     - consume_stage matches operation's stages
     - is_cost_only = False (cost-only lines don't consume inventory)
 
+    Resolution is type-first: when `operation_type` is set and known to the
+    operation-type catalog, its consume_stages win; otherwise falls back to
+    the legacy operation_code map (see resolve_consume_stages).
+
     Args:
         db: Database session
         bom_id: BOM ID
         operation_code: Operation code (e.g., "PRINT", "PACK")
+        operation_type: Stored operation type code (e.g., "FDM_PRINT",
+            "PACK_SHIP"), if the operation has one
 
     Returns:
         List of BOMLine objects to check
     """
-    consume_stages = get_consume_stages_for_operation(operation_code)
+    type_map = load_operation_type_stage_map(db)
+    consume_stages = resolve_consume_stages(type_map, operation_type, operation_code)
 
     lines = db.query(BOMLine).filter(
         BOMLine.bom_id == bom_id,
@@ -247,7 +258,9 @@ def check_operation_blocking(
     if not po.bom_id:
         return result
 
-    bom_lines = get_bom_lines_for_operation(db, po.bom_id, op.operation_code)
+    bom_lines = get_bom_lines_for_operation(
+        db, po.bom_id, op.operation_code, getattr(op, "operation_type", None)
+    )
 
     if not bom_lines:
         return result

--- a/backend/app/services/operation_generation.py
+++ b/backend/app/services/operation_generation.py
@@ -86,6 +86,7 @@ def generate_operations_from_routing(
             routing_operation_id=routing_op.id,
             sequence=routing_op.sequence,
             operation_code=routing_op.operation_code,
+            operation_type=getattr(routing_op, "operation_type", None),
             operation_name=routing_op.operation_name,
             work_center_id=routing_op.work_center_id,
             planned_setup_minutes=routing_op.setup_time_minutes or 0,

--- a/backend/app/services/operation_material_mapping.py
+++ b/backend/app/services/operation_material_mapping.py
@@ -69,6 +69,63 @@ def get_all_consume_stages() -> Set[str]:
 
 
 # =============================================================================
+# #876 PR-2: write-time alias assist — the ONE shared importable copy.
+#
+# NOTE ON DUPLICATION: migrations/versions/101_operation_types.py and
+# tests/services/test_operation_type_catalog.py each keep their OWN frozen
+# literal copy of this same code->type mapping, deliberately — a migration
+# must never import live application code (it has to keep working exactly
+# as written even after this module changes in the future), and its pinned
+# test asserts the migration's frozen copy byte-for-byte. This module's copy
+# is the single source other RUNTIME code (routing_service.py's write-time
+# alias assist) is meant to import. If you change the aliasing rule here,
+# the migration and its test are NOT automatically updated — that is correct
+# and intentional; a shipped migration is immutable history.
+#
+# FINISH and POST are deliberately excluded (see migration 101 docstring):
+# the live census shows FINISH spans shipping/quality/blank names, so it is
+# classifiable only per-row by name via the human-gated classifier, never
+# by a blanket alias.
+# =============================================================================
+
+OPERATION_CODE_TYPE_ALIASES: Dict[str, str] = {
+    "PRINT": "FDM_PRINT",
+    "EXTRUDE": "GENERAL",
+    "MOLD": "GENERAL",
+    "CUT": "GENERAL",
+    "MACHINE": "GENERAL",
+    "ASSEMBLE": "ASSEMBLY",
+    "BUILD": "ASSEMBLY",
+    "WELD": "ASSEMBLY",
+    "QC": "QUALITY_CONTROL",
+    "INSPECT": "QUALITY_CONTROL",
+    "TEST": "QUALITY_CONTROL",
+    "CLEAN": "SUPPORT_REMOVAL",
+    "SAND": "SANDING",
+    "PAINT": "PAINTING",
+    "COAT": "PAINTING",
+    "PACK": "PACK_SHIP",
+    "SHIP": "PACK_SHIP",
+    "LABEL": "PACK_SHIP",
+}
+
+
+def alias_operation_type_for_code(operation_code: Optional[str]) -> Optional[str]:
+    """
+    Write-time alias assist: given a legacy operation_code, return the
+    canonical operation_type it should be auto-assigned when the caller
+    didn't supply one explicitly.
+
+    Returns None when the code is empty/None or doesn't match one of the 18
+    legacy canonical keys (case-insensitive) — most notably FINISH and POST,
+    which get NO alias, deliberately (see module docstring above).
+    """
+    if not operation_code:
+        return None
+    return OPERATION_CODE_TYPE_ALIASES.get(operation_code.upper())
+
+
+# =============================================================================
 # #876 PR-1: operation-type catalog resolver (dormant — no consumer wired yet)
 #
 # Everything ABOVE this line (the legacy dict, DEFAULT_CONSUME_STAGES, and

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -22,7 +22,7 @@ from app.models import (
 )
 from app.models.bom import BOMLine
 from app.models.inventory import Inventory
-from app.models.manufacturing import Routing, RoutingOperation, Resource
+from app.models.manufacturing import OperationType, Routing, RoutingOperation, Resource
 from app.models.production_order import ProductionOrderOperationMaterial, ScrapRecord, QCInspection
 from app.models.work_center import WorkCenter
 from app.models.material_spool import MaterialSpool, ProductionOrderSpool
@@ -84,6 +84,7 @@ def copy_routing_to_operations(
             resource_id=None,
             sequence=rop.sequence,
             operation_code=rop.operation_code,
+            operation_type=getattr(rop, "operation_type", None),
             operation_name=rop.operation_name,
             planned_setup_minutes=rop.setup_time_minutes or 0,
             planned_run_minutes=float(rop.run_time_minutes or 0) * float(order.quantity_ordered),
@@ -774,17 +775,38 @@ def record_qc_inspection(
 
     inspected_at = datetime.now(timezone.utc)
 
-    # Resolve the operation this inspection completes: the explicit target when
-    # the caller gave one, else the first QC-coded op (legacy heuristic, kept for
-    # callers that don't pass an operation_id).
-    qc_op = target_op or (
-        db.query(ProductionOrderOperation)
-        .filter(
-            ProductionOrderOperation.production_order_id == order_id,
-            ProductionOrderOperation.operation_code.ilike("%QC%")
+    # Resolve the operation this inspection completes (#876 PR-2 typed
+    # lookup): the explicit target when the caller gave one; else the first
+    # op whose STORED operation_type is flagged is_qc in the catalog (typed
+    # lookup — beats the old code-substring heuristic because ops coded
+    # OP20/OP30/FINISH per the live census never matched "%QC%" at all);
+    # else the legacy operation_code ilike("%QC%") fallback, kept for ONE
+    # release to cover untyped data, then removed (see design #876 comment
+    # §3 / PR-2 row).
+    qc_op = target_op
+    if qc_op is None:
+        qc_type_codes = [
+            code for (code,) in
+            db.query(OperationType.code).filter(OperationType.is_qc.is_(True)).all()
+        ]
+        if qc_type_codes:
+            qc_op = (
+                db.query(ProductionOrderOperation)
+                .filter(
+                    ProductionOrderOperation.production_order_id == order_id,
+                    ProductionOrderOperation.operation_type.in_(qc_type_codes),
+                )
+                .first()
+            )
+    if qc_op is None:
+        qc_op = (
+            db.query(ProductionOrderOperation)
+            .filter(
+                ProductionOrderOperation.production_order_id == order_id,
+                ProductionOrderOperation.operation_code.ilike("%QC%")
+            )
+            .first()
         )
-        .first()
-    )
 
     if qc_op:
         qc_op.status = "complete"

--- a/backend/app/services/production_order_service.py
+++ b/backend/app/services/production_order_service.py
@@ -787,7 +787,12 @@ def record_qc_inspection(
     if qc_op is None:
         qc_type_codes = [
             code for (code,) in
-            db.query(OperationType.code).filter(OperationType.is_qc.is_(True)).all()
+            db.query(OperationType.code)
+            .filter(
+                OperationType.is_qc.is_(True),
+                OperationType.is_active.is_(True),
+            )
+            .all()
         ]
         if qc_type_codes:
             qc_op = (
@@ -796,6 +801,10 @@ def record_qc_inspection(
                     ProductionOrderOperation.production_order_id == order_id,
                     ProductionOrderOperation.operation_type.in_(qc_type_codes),
                 )
+                # Deterministic pick when multiple untargeted QC ops exist:
+                # earliest in the routing sequence wins, rather than
+                # whatever order the DB happens to return rows in.
+                .order_by(ProductionOrderOperation.sequence)
                 .first()
             )
     if qc_op is None:
@@ -805,6 +814,8 @@ def record_qc_inspection(
                 ProductionOrderOperation.production_order_id == order_id,
                 ProductionOrderOperation.operation_code.ilike("%QC%")
             )
+            # Same determinism guarantee as the typed lookup above.
+            .order_by(ProductionOrderOperation.sequence)
             .first()
         )
 

--- a/backend/app/services/routing_service.py
+++ b/backend/app/services/routing_service.py
@@ -31,22 +31,42 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _type_exists_in_catalog(db: Session, code: str) -> bool:
+    """
+    Shared catalog-existence check used by both write-time validation and
+    alias assist, so the two paths can never drift on what counts as a
+    "real" type. Deliberately excludes deactivated rows — deactivation
+    blocks future assignability (PR-3 semantics): a retired type must
+    neither pass validation for new/updated rows nor be proposed by alias
+    assist, even though it still resolves fine for historical rows already
+    carrying it (that read-time leniency lives in resolve_consume_stages,
+    not here).
+    """
+    return (
+        db.query(OperationType.id)
+        .filter(
+            OperationType.code == code,
+            OperationType.is_active.is_(True),
+        )
+        .first()
+        is not None
+    )
+
+
 def _validate_operation_type(db: Session, operation_type) -> None:
     """
     Write-time validation: a non-null operation_type must be a known,
-    case-normalized (upper) code in the operation_types catalog, else 400.
+    ACTIVE, case-normalized (upper) code in the operation_types catalog,
+    else 400. A deactivated type is treated the same as an unknown one —
+    deactivation blocks future assignability even though historical rows
+    already carrying it keep resolving normally at read time.
 
     Silently allows None/empty — operation_type stays optional; untyped ops
     behave exactly as before (legacy code-map resolution).
     """
-    if not operation_type:
+    if not operation_type or not operation_type.strip():
         return
-    exists = (
-        db.query(OperationType.id)
-        .filter(OperationType.code == operation_type.upper())
-        .first()
-    )
-    if not exists:
+    if not _type_exists_in_catalog(db, operation_type.upper()):
         raise HTTPException(
             status_code=400,
             detail=f"Unknown operation_type '{operation_type}'",
@@ -62,29 +82,33 @@ def _apply_operation_type_alias_assist(db: Session, op_data: dict) -> dict:
     operation_type. FINISH/POST get no alias (see
     operation_material_mapping.alias_operation_type_for_code).
 
-    The proposed alias is only applied if that type code actually exists in
-    the operation_types catalog — on a DB where migration 101 hasn't run
-    (or in an isolated test transaction that never seeded the catalog),
-    this degrades to a no-op exactly like an unrecognized code would,
-    rather than assigning a type that then 400s on write-time validation.
+    A blank/whitespace-only operation_type ("", "  ") is treated as ABSENT,
+    not as an explicit value — it falls through to the alias path exactly
+    like a missing/None key, and never leaks back out as an empty string in
+    the returned op_data (the caller would otherwise persist "" onto the
+    row instead of NULL or a real code).
+
+    The proposed alias is only applied if that type code actually exists
+    (and is active) in the operation_types catalog — on a DB where
+    migration 101 hasn't run (or in an isolated test transaction that never
+    seeded the catalog), this degrades to a no-op exactly like an
+    unrecognized code would, rather than assigning a type that then 400s on
+    write-time validation.
 
     Also case-normalizes an explicitly-provided operation_type to upper,
     matching the catalog's stored-uppercase convention.
     """
     op_data = dict(op_data)
     provided_type = op_data.get("operation_type")
-    if provided_type:
+    if provided_type and provided_type.strip():
         op_data["operation_type"] = provided_type.upper()
-    elif "operation_type" not in op_data or op_data.get("operation_type") is None:
+    else:
+        if provided_type is not None:
+            # Blank/whitespace-only — never let "" or "  " leak through.
+            op_data.pop("operation_type", None)
         alias = alias_operation_type_for_code(op_data.get("operation_code"))
-        if alias:
-            exists = (
-                db.query(OperationType.id)
-                .filter(OperationType.code == alias)
-                .first()
-            )
-            if exists:
-                op_data["operation_type"] = alias
+        if alias and _type_exists_in_catalog(db, alias):
+            op_data["operation_type"] = alias
     return op_data
 
 
@@ -516,24 +540,25 @@ def update_operation(db: Session, operation_id: int, *, data: dict) -> RoutingOp
         if not db.query(WorkCenter).filter(WorkCenter.id == wc_id).first():
             raise HTTPException(status_code=400, detail=f"Work center {wc_id} not found")
 
-    if "operation_type" in data and data["operation_type"]:
+    provided_type = data.get("operation_type")
+    if "operation_type" in data and provided_type and provided_type.strip():
         # Explicit type in the payload wins outright — case-normalize only.
-        data["operation_type"] = data["operation_type"].upper()
-    elif data.get("operation_code") and not operation.operation_type:
-        # Write-time alias assist: operation_code is being (re)set, no type
-        # was explicitly provided, and the row has no type yet — auto-assign
-        # from the legacy canonical alias if the new code matches one and
-        # that type actually exists in the catalog (degrades to a no-op on
-        # a DB where migration 101 hasn't run). Never overwrites an
-        # already-typed operation.
-        alias = alias_operation_type_for_code(data["operation_code"])
-        if alias:
-            exists = (
-                db.query(OperationType.id)
-                .filter(OperationType.code == alias)
-                .first()
-            )
-            if exists:
+        data["operation_type"] = provided_type.upper()
+    else:
+        if "operation_type" in data and provided_type is not None:
+            # Blank/whitespace-only ("", "  ") is treated as absent, not as
+            # an explicit value — drop it so it never overwrites the row
+            # with an empty string below.
+            data.pop("operation_type")
+        if data.get("operation_code") and not operation.operation_type:
+            # Write-time alias assist: operation_code is being (re)set, no
+            # type was explicitly provided, and the row has no type yet —
+            # auto-assign from the legacy canonical alias if the new code
+            # matches one and that type actually exists (and is active) in
+            # the catalog (degrades to a no-op on a DB where migration 101
+            # hasn't run). Never overwrites an already-typed operation.
+            alias = alias_operation_type_for_code(data["operation_code"])
+            if alias and _type_exists_in_catalog(db, alias):
                 data["operation_type"] = alias
 
     _validate_operation_type(db, data.get("operation_type"))

--- a/backend/app/services/routing_service.py
+++ b/backend/app/services/routing_service.py
@@ -12,12 +12,80 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from app.logging_config import get_logger
-from app.models.manufacturing import Routing, RoutingOperation, RoutingOperationMaterial
+from app.models.manufacturing import (
+    OperationType,
+    Routing,
+    RoutingOperation,
+    RoutingOperationMaterial,
+)
 from app.models.work_center import WorkCenter
 from app.models.product import Product
 from app.core.utils import get_or_404
+from app.services.operation_material_mapping import alias_operation_type_for_code
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# #876 PR-2: operation_type write-time helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_operation_type(db: Session, operation_type) -> None:
+    """
+    Write-time validation: a non-null operation_type must be a known,
+    case-normalized (upper) code in the operation_types catalog, else 400.
+
+    Silently allows None/empty — operation_type stays optional; untyped ops
+    behave exactly as before (legacy code-map resolution).
+    """
+    if not operation_type:
+        return
+    exists = (
+        db.query(OperationType.id)
+        .filter(OperationType.code == operation_type.upper())
+        .first()
+    )
+    if not exists:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown operation_type '{operation_type}'",
+        )
+
+
+def _apply_operation_type_alias_assist(db: Session, op_data: dict) -> dict:
+    """
+    Write-time alias assist (#876 PR-2): when operation_type is absent but
+    operation_code matches a legacy canonical code, auto-assign the type
+    server-side so old wheels/API producers emitting PRINT/PACK/ASSEMBLE
+    etc. get typed rows for free. Never overwrites an explicitly-provided
+    operation_type. FINISH/POST get no alias (see
+    operation_material_mapping.alias_operation_type_for_code).
+
+    The proposed alias is only applied if that type code actually exists in
+    the operation_types catalog — on a DB where migration 101 hasn't run
+    (or in an isolated test transaction that never seeded the catalog),
+    this degrades to a no-op exactly like an unrecognized code would,
+    rather than assigning a type that then 400s on write-time validation.
+
+    Also case-normalizes an explicitly-provided operation_type to upper,
+    matching the catalog's stored-uppercase convention.
+    """
+    op_data = dict(op_data)
+    provided_type = op_data.get("operation_type")
+    if provided_type:
+        op_data["operation_type"] = provided_type.upper()
+    elif "operation_type" not in op_data or op_data.get("operation_type") is None:
+        alias = alias_operation_type_for_code(op_data.get("operation_code"))
+        if alias:
+            exists = (
+                db.query(OperationType.id)
+                .filter(OperationType.code == alias)
+                .first()
+            )
+            if exists:
+                op_data["operation_type"] = alias
+    return op_data
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +201,12 @@ def create_routing(db: Session, *, data: dict, operations: list[dict] | None = N
             if not db.query(WorkCenter).filter(WorkCenter.id == wc_id).first():
                 db.rollback()  # Rollback flushed routing before raising
                 raise HTTPException(status_code=400, detail=f"Work center {wc_id} not found")
+            op_data = _apply_operation_type_alias_assist(db, op_data)
+            try:
+                _validate_operation_type(db, op_data.get("operation_type"))
+            except HTTPException:
+                db.rollback()  # Rollback flushed routing before raising
+                raise
             operation = RoutingOperation(routing_id=routing.id, **op_data)
             db.add(operation)
 
@@ -184,10 +258,10 @@ ROUTING_TEMPLATES = [
         "name": "Standard Flow",
         "notes": "Standard routing: Print → QC → Pack → Ship",
         "operations": [
-            {"sequence": 10, "operation_code": "PRINT", "operation_name": "3D Print", "work_center_code": "FDM-POOL", "setup_time_minutes": Decimal("7"), "run_time_minutes": Decimal("60"), "runtime_source": "slicer"},
-            {"sequence": 20, "operation_code": "QC", "operation_name": "Quality Check", "work_center_code": "QC", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("2")},
-            {"sequence": 30, "operation_code": "PACK", "operation_name": "Pack", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("1"), "run_time_minutes": Decimal("2")},
-            {"sequence": 40, "operation_code": "SHIP", "operation_name": "Ship", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("3")},
+            {"sequence": 10, "operation_code": "PRINT", "operation_type": "FDM_PRINT", "operation_name": "3D Print", "work_center_code": "FDM-POOL", "setup_time_minutes": Decimal("7"), "run_time_minutes": Decimal("60"), "runtime_source": "slicer"},
+            {"sequence": 20, "operation_code": "QC", "operation_type": "QUALITY_CONTROL", "operation_name": "Quality Check", "work_center_code": "QC", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("2")},
+            {"sequence": 30, "operation_code": "PACK", "operation_type": "PACK_SHIP", "operation_name": "Pack", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("1"), "run_time_minutes": Decimal("2")},
+            {"sequence": 40, "operation_code": "SHIP", "operation_type": "PACK_SHIP", "operation_name": "Ship", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("3")},
         ],
     },
     {
@@ -195,11 +269,11 @@ ROUTING_TEMPLATES = [
         "name": "Assembly Flow",
         "notes": "Assembly routing: Print → QC → Assemble → Pack → Ship",
         "operations": [
-            {"sequence": 10, "operation_code": "PRINT", "operation_name": "3D Print", "work_center_code": "FDM-POOL", "setup_time_minutes": Decimal("7"), "run_time_minutes": Decimal("60"), "runtime_source": "slicer"},
-            {"sequence": 20, "operation_code": "QC", "operation_name": "Quality Check", "work_center_code": "QC", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("2")},
-            {"sequence": 30, "operation_code": "ASSEMBLE", "operation_name": "Assembly", "work_center_code": "ASSEMBLY", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("5")},
-            {"sequence": 40, "operation_code": "PACK", "operation_name": "Pack", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("1"), "run_time_minutes": Decimal("2")},
-            {"sequence": 50, "operation_code": "SHIP", "operation_name": "Ship", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("3")},
+            {"sequence": 10, "operation_code": "PRINT", "operation_type": "FDM_PRINT", "operation_name": "3D Print", "work_center_code": "FDM-POOL", "setup_time_minutes": Decimal("7"), "run_time_minutes": Decimal("60"), "runtime_source": "slicer"},
+            {"sequence": 20, "operation_code": "QC", "operation_type": "QUALITY_CONTROL", "operation_name": "Quality Check", "work_center_code": "QC", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("2")},
+            {"sequence": 30, "operation_code": "ASSEMBLE", "operation_type": "ASSEMBLY", "operation_name": "Assembly", "work_center_code": "ASSEMBLY", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("5")},
+            {"sequence": 40, "operation_code": "PACK", "operation_type": "PACK_SHIP", "operation_name": "Pack", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("1"), "run_time_minutes": Decimal("2")},
+            {"sequence": 50, "operation_code": "SHIP", "operation_type": "PACK_SHIP", "operation_name": "Ship", "work_center_code": "SHIPPING", "setup_time_minutes": Decimal("0"), "run_time_minutes": Decimal("3")},
         ],
     },
 ]
@@ -252,6 +326,7 @@ def seed_routing_templates(db: Session) -> dict:
                 work_center_id=wc.id,
                 sequence=op_data["sequence"],
                 operation_code=op_data["operation_code"],
+                operation_type=op_data.get("operation_type"),
                 operation_name=op_data["operation_name"],
                 setup_time_minutes=op_data["setup_time_minutes"],
                 run_time_minutes=op_data["run_time_minutes"],
@@ -344,6 +419,7 @@ def apply_template_to_product(
             work_center_id=tpl_op.work_center_id,
             sequence=tpl_op.sequence,
             operation_code=tpl_op.operation_code,
+            operation_type=getattr(tpl_op, "operation_type", None),
             operation_name=tpl_op.operation_name,
             description=tpl_op.description,
             setup_time_minutes=setup_time,
@@ -400,6 +476,9 @@ def add_operation(db: Session, routing_id: int, *, data: dict) -> RoutingOperati
     if "runtime_source" in data and hasattr(data["runtime_source"], "value"):
         data["runtime_source"] = data["runtime_source"].value
 
+    data = _apply_operation_type_alias_assist(db, data)
+    _validate_operation_type(db, data.get("operation_type"))
+
     operation = RoutingOperation(routing_id=routing_id, **data)
     db.add(operation)
     db.flush()
@@ -436,6 +515,28 @@ def update_operation(db: Session, operation_id: int, *, data: dict) -> RoutingOp
         wc_id = data["work_center_id"]
         if not db.query(WorkCenter).filter(WorkCenter.id == wc_id).first():
             raise HTTPException(status_code=400, detail=f"Work center {wc_id} not found")
+
+    if "operation_type" in data and data["operation_type"]:
+        # Explicit type in the payload wins outright — case-normalize only.
+        data["operation_type"] = data["operation_type"].upper()
+    elif data.get("operation_code") and not operation.operation_type:
+        # Write-time alias assist: operation_code is being (re)set, no type
+        # was explicitly provided, and the row has no type yet — auto-assign
+        # from the legacy canonical alias if the new code matches one and
+        # that type actually exists in the catalog (degrades to a no-op on
+        # a DB where migration 101 hasn't run). Never overwrites an
+        # already-typed operation.
+        alias = alias_operation_type_for_code(data["operation_code"])
+        if alias:
+            exists = (
+                db.query(OperationType.id)
+                .filter(OperationType.code == alias)
+                .first()
+            )
+            if exists:
+                data["operation_type"] = alias
+
+    _validate_operation_type(db, data.get("operation_type"))
 
     for field, value in data.items():
         if field == "runtime_source" and value and hasattr(value, "value"):

--- a/backend/app/services/sales_order_production_service.py
+++ b/backend/app/services/sales_order_production_service.py
@@ -84,6 +84,7 @@ def copy_routing_to_operations(
             resource_id=None,  # Resource assigned during scheduling
             sequence=rop.sequence,
             operation_code=rop.operation_code,
+            operation_type=getattr(rop, "operation_type", None),
             operation_name=rop.operation_name,
             planned_setup_minutes=rop.setup_time_minutes or 0,
             planned_run_minutes=float(rop.run_time_minutes or 0) * float(production_order.quantity_ordered),

--- a/backend/app/services/sales_order_requirements_service.py
+++ b/backend/app/services/sales_order_requirements_service.py
@@ -202,7 +202,8 @@ def get_material_requirements(
         qty_required: Decimal,
         unit: str,
         operation_code: Optional[str],
-        material_source: str
+        material_source: str,
+        operation_type: Optional[str] = None,
     ):
         """Add a material requirement, aggregating duplicates."""
         key = component.id
@@ -270,6 +271,7 @@ def get_material_requirements(
                 "quantity_short_now": float(qty_short_now),
                 "covered_by_incoming": covered_by_incoming,
                 "operation_code": operation_code,
+                "operation_type": operation_type,
                 "material_source": material_source,
                 "has_incoming_supply": has_incoming,
                 "incoming_supply_details": incoming_details,
@@ -289,13 +291,17 @@ def get_material_requirements(
             # when a routing was found, "bom" otherwise — the canonical function
             # already applied routing-first precedence so we just tag accordingly.
             # The operation_code is unavailable at this aggregation layer because
-            # explode_requirements flattens multi-operation materials; tag as None.
+            # explode_requirements flattens multi-operation materials; tag as
+            # None. operation_type is explicitly None for the same reason
+            # (#876 PR-2 snapshot-propagation site) — there is no single
+            # operation this flattened requirement can be attributed to.
             add_requirement(
                 component=component,
                 qty_required=req.gross_quantity,
                 unit=component.unit or "EA",
                 operation_code=None,
                 material_source="routing_or_bom",
+                operation_type=None,
             )
 
     # Process based on order type

--- a/backend/app/services/variant_service.py
+++ b/backend/app/services/variant_service.py
@@ -498,6 +498,7 @@ def sync_routing_to_variants(db: Session, template_id: int) -> dict:
                     routing_id=variant_routing.id,
                     sequence=t_op.sequence,
                     operation_code=t_op.operation_code,
+                    operation_type=getattr(t_op, "operation_type", None),
                     operation_name=t_op.operation_name,
                     description=t_op.description,
                     work_center_id=t_op.work_center_id,

--- a/backend/tests/api/v1/test_routings.py
+++ b/backend/tests/api/v1/test_routings.py
@@ -13,6 +13,8 @@ Covers:
 import pytest
 from decimal import Decimal
 
+from tests.services._operation_type_seed import seed_operation_types as _seed_operation_types
+
 
 BASE_URL = "/api/v1/routings"
 
@@ -1183,36 +1185,6 @@ class TestManufacturingBOM:
 # #876 PR-2 — operation_type write-time alias assist + validation
 # =============================================================================
 
-def _seed_operation_types(db):
-    """Idempotent INSERT-if-missing seed of the 9 system operation types,
-    mirroring migration 101 / test_operation_type_catalog.py's helper. Kept
-    local to this file (each test file seeds its own catalog rows rather
-    than importing another test module's helper)."""
-    from app.models.manufacturing import OperationType
-
-    seed = {
-        "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
-        "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
-        "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
-        "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
-        "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
-        "SANDING": ("Sanding", "finishing", ["any"], False, 60),
-        "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
-        "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
-        "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
-    }
-    existing = {code for (code,) in db.query(OperationType.code).all()}
-    for code, (label, category, stages, is_qc, sort_order) in seed.items():
-        if code in existing:
-            continue
-        db.add(OperationType(
-            code=code, label=label, category=category, consume_stages=stages,
-            is_qc=is_qc, is_system=True, is_active=True, sort_order=sort_order,
-        ))
-    db.flush()
-    db.commit()
-
-
 class TestOperationTypeAliasAssist:
     """Write-time alias assist (#876 PR-2 design §3): when operation_type is
     absent but operation_code matches one of the 18 legacy canonical codes,
@@ -1279,6 +1251,30 @@ class TestOperationTypeAliasAssist:
         op = _create_operation(client, routing["id"], operation_code="OP10")
         assert op["operation_type"] is None
 
+    def test_alias_target_deactivated_gets_no_alias(self, db, client, make_product):
+        """CodeRabbit #4630789865 finding 4: the shared catalog-existence
+        check used by alias assist excludes deactivated types, exactly like
+        write-time validation — a code that would normally alias to a now-
+        deactivated type degrades to a no-op instead of assigning a type
+        that write-time validation would then reject."""
+        _seed_operation_types(db)
+        from app.models.manufacturing import OperationType
+
+        deactivated_type = db.query(OperationType).filter(
+            OperationType.code == "FDM_PRINT"
+        ).first()
+        deactivated_type.is_active = False
+        db.flush()
+
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="PRINT")
+        assert op["operation_type"] is None, (
+            "PRINT would normally alias to FDM_PRINT, but that type is "
+            "deactivated — alias assist must degrade to a no-op"
+        )
+
     def test_explicit_type_is_never_overridden_by_alias(self, db, client, make_product):
         """An explicitly-provided operation_type always wins, even when the
         code would alias to something else."""
@@ -1341,6 +1337,58 @@ class TestOperationTypeAliasAssist:
             "Alias assist must never overwrite an already-typed operation"
         )
 
+    def test_blank_operation_type_treated_as_absent_on_create(
+        self, db, client, make_product
+    ):
+        """CodeRabbit #4630789865 finding 2: an empty-string operation_type
+        must be treated as ABSENT (falls to alias assist), not as an
+        explicit value that leaks through unchanged."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(
+            client, routing["id"], operation_code="PRINT", operation_type="",
+        )
+        assert op["operation_type"] == "FDM_PRINT", (
+            "A blank operation_type must fall through to alias assist "
+            "exactly like an absent one, never persist as ''"
+        )
+
+    def test_whitespace_operation_type_treated_as_absent_on_create(
+        self, db, client, make_product
+    ):
+        """Same as above, for a whitespace-only value — must not be
+        treated as an explicit provided type either."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(
+            client, routing["id"], operation_code="PRINT", operation_type="   ",
+        )
+        assert op["operation_type"] == "FDM_PRINT"
+
+    def test_blank_operation_type_treated_as_absent_on_update(
+        self, db, client, make_product
+    ):
+        """Same blank-is-absent rule on the update_operation path."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+        op = _create_operation(client, routing["id"], operation_code="OP10")
+        assert op["operation_type"] is None
+
+        response = client.put(
+            f"{BASE_URL}/operations/{op['id']}",
+            json={"operation_code": "PACK", "operation_type": ""},
+        )
+        assert response.status_code == 200
+        assert response.json()["operation_type"] == "PACK_SHIP", (
+            "A blank operation_type on update must fall through to alias "
+            "assist rather than persisting as ''"
+        )
+
 
 class TestOperationTypeValidation:
     """Write-time validation (#876 PR-2 design §5): a non-null operation_type
@@ -1392,6 +1440,31 @@ class TestOperationTypeValidation:
 
         op = _create_operation(client, routing["id"], operation_code="OP99")
         assert op["operation_type"] is None
+
+    def test_deactivated_operation_type_returns_400(self, db, client, make_product):
+        """CodeRabbit #4630789865 finding 3: a deactivated type must be
+        rejected on write exactly like an unknown one — deactivation blocks
+        future assignability even though it still exists in the catalog."""
+        _seed_operation_types(db)
+        from app.models.manufacturing import OperationType
+
+        deactivated_type = db.query(OperationType).filter(
+            OperationType.code == "PAINTING"
+        ).first()
+        deactivated_type.is_active = False
+        db.flush()
+
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        response = client.post(f"{BASE_URL}/{routing['id']}/operations", json={
+            "work_center_id": 1,
+            "sequence": 10,
+            "operation_code": "OP10",
+            "operation_type": "PAINTING",
+            "run_time_minutes": "5.0",
+        })
+        assert response.status_code == 400
 
 
 class TestOperationTypeSnapshotPropagation:

--- a/backend/tests/api/v1/test_routings.py
+++ b/backend/tests/api/v1/test_routings.py
@@ -1177,3 +1177,248 @@ class TestManufacturingBOM:
         data = response.json()
         assert len(data["operations"]) == 2
         assert data["operations"][0]["sequence"] < data["operations"][1]["sequence"]
+
+
+# =============================================================================
+# #876 PR-2 — operation_type write-time alias assist + validation
+# =============================================================================
+
+def _seed_operation_types(db):
+    """Idempotent INSERT-if-missing seed of the 9 system operation types,
+    mirroring migration 101 / test_operation_type_catalog.py's helper. Kept
+    local to this file (each test file seeds its own catalog rows rather
+    than importing another test module's helper)."""
+    from app.models.manufacturing import OperationType
+
+    seed = {
+        "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+        "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+        "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+        "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+        "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+        "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+        "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+        "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+        "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+    }
+    existing = {code for (code,) in db.query(OperationType.code).all()}
+    for code, (label, category, stages, is_qc, sort_order) in seed.items():
+        if code in existing:
+            continue
+        db.add(OperationType(
+            code=code, label=label, category=category, consume_stages=stages,
+            is_qc=is_qc, is_system=True, is_active=True, sort_order=sort_order,
+        ))
+    db.flush()
+    db.commit()
+
+
+class TestOperationTypeAliasAssist:
+    """Write-time alias assist (#876 PR-2 design §3): when operation_type is
+    absent but operation_code matches one of the 18 legacy canonical codes,
+    the server auto-assigns the type. FINISH/POST get NO alias."""
+
+    def test_print_code_gets_fdm_print_alias(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="PRINT")
+        assert op["operation_type"] == "FDM_PRINT"
+
+    def test_pack_code_gets_pack_ship_alias(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="PACK")
+        assert op["operation_type"] == "PACK_SHIP"
+
+    def test_qc_code_gets_quality_control_alias(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="QC")
+        assert op["operation_type"] == "QUALITY_CONTROL"
+
+    def test_assemble_code_gets_assembly_alias(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="ASSEMBLE")
+        assert op["operation_type"] == "ASSEMBLY"
+
+    def test_finish_code_gets_no_alias(self, db, client, make_product):
+        """FINISH is deliberately excluded from the alias map — the live
+        census shows it spans shipping/quality/blank names."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="FINISH")
+        assert op["operation_type"] is None
+
+    def test_post_code_gets_no_alias(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="POST")
+        assert op["operation_type"] is None
+
+    def test_unrecognized_code_gets_no_alias(self, db, client, make_product):
+        """OP10/OP20-style autofilled codes (not in the legacy 18) get no
+        alias — they stay untyped, exactly like today, until a human or the
+        classifier (#876 PR-3) types them."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="OP10")
+        assert op["operation_type"] is None
+
+    def test_explicit_type_is_never_overridden_by_alias(self, db, client, make_product):
+        """An explicitly-provided operation_type always wins, even when the
+        code would alias to something else."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(
+            client, routing["id"],
+            operation_code="PRINT", operation_type="QUALITY_CONTROL",
+        )
+        assert op["operation_type"] == "QUALITY_CONTROL"
+
+    def test_explicit_type_is_case_normalized_upper(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(
+            client, routing["id"],
+            operation_code="PRINT", operation_type="fdm_print",
+        )
+        assert op["operation_type"] == "FDM_PRINT"
+
+    def test_update_operation_alias_assist_on_code_change(self, db, client, make_product):
+        """Changing operation_code on an untyped op via PUT also gets the
+        alias-assist treatment (op CRUD path, not just create)."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+        op = _create_operation(client, routing["id"], operation_code="OP10")
+        assert op["operation_type"] is None
+
+        response = client.put(
+            f"{BASE_URL}/operations/{op['id']}",
+            json={"operation_code": "PACK"},
+        )
+        assert response.status_code == 200
+        assert response.json()["operation_type"] == "PACK_SHIP"
+
+    def test_update_operation_alias_assist_never_overwrites_existing_type(
+        self, db, client, make_product
+    ):
+        """If the operation already has a type, changing operation_code
+        alone must NOT silently retype it via alias assist."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+        op = _create_operation(
+            client, routing["id"], operation_code="OP10", operation_type="QUALITY_CONTROL",
+        )
+        assert op["operation_type"] == "QUALITY_CONTROL"
+
+        response = client.put(
+            f"{BASE_URL}/operations/{op['id']}",
+            json={"operation_code": "PACK"},
+        )
+        assert response.status_code == 200
+        assert response.json()["operation_type"] == "QUALITY_CONTROL", (
+            "Alias assist must never overwrite an already-typed operation"
+        )
+
+
+class TestOperationTypeValidation:
+    """Write-time validation (#876 PR-2 design §5): a non-null operation_type
+    must be a known, case-normalized-upper code in the operation_types
+    catalog, else 400."""
+
+    def test_unknown_operation_type_returns_400(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        response = client.post(f"{BASE_URL}/{routing['id']}/operations", json={
+            "work_center_id": 1,
+            "sequence": 10,
+            "operation_code": "OP10",
+            "operation_type": "NOT_A_REAL_TYPE",
+            "run_time_minutes": "5.0",
+        })
+        assert response.status_code == 400
+
+    def test_unknown_operation_type_on_update_returns_400(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+        op = _create_operation(client, routing["id"], operation_code="OP10")
+
+        response = client.put(
+            f"{BASE_URL}/operations/{op['id']}",
+            json={"operation_type": "NOT_A_REAL_TYPE"},
+        )
+        assert response.status_code == 400
+
+    def test_known_type_case_insensitive_passes(self, db, client, make_product):
+        """A lowercase-but-otherwise-known type code is case-normalized and
+        accepted, not rejected."""
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(
+            client, routing["id"], operation_code="OP10", operation_type="pack_ship",
+        )
+        assert op["operation_type"] == "PACK_SHIP"
+
+    def test_null_operation_type_always_allowed(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+        routing = _create_routing(client, product_id=product.id)
+
+        op = _create_operation(client, routing["id"], operation_code="OP99")
+        assert op["operation_type"] is None
+
+
+class TestOperationTypeSnapshotPropagation:
+    """Type propagation at copy sites (#876 PR-2 design §4): template seeds
+    carry operation_type, and apply-template copies it onto the new
+    per-product routing."""
+
+    def test_apply_template_propagates_operation_type(self, db, client, make_product):
+        _seed_operation_types(db)
+        product = make_product(item_type="finished_good", procurement_type="make")
+
+        template = _create_routing(
+            client, is_template=True,
+            code="TPL-TYPE-PROPAGATION", name="Type Propagation Template",
+        )
+        _create_operation(
+            client, template["id"],
+            operation_code="PRINT", operation_type="FDM_PRINT",
+            operation_name="3D Print", run_time_minutes="60.0",
+        )
+
+        response = client.post(f"{BASE_URL}/apply-template", json={
+            "template_id": template["id"],
+            "product_id": product.id,
+        })
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["operations"][0]["operation_code"] == "PRINT"
+        assert data["operations"][0]["operation_type"] == "FDM_PRINT"

--- a/backend/tests/services/_operation_type_seed.py
+++ b/backend/tests/services/_operation_type_seed.py
@@ -1,0 +1,58 @@
+"""
+Shared operation-type seed data/helper for tests, mirroring
+migrations/versions/101_operation_types.py::SEED_OPERATION_TYPES verbatim.
+
+Imported by BOTH test_operation_type_catalog.py (#876 PR-1's
+predicate-equivalence proof) and test_operation_type_classifier.py (#876
+PR-3's audit/classifier/CRUD tests) so a drift between the migration seed
+and the tests fails loudly in ONE place rather than silently in whichever
+file didn't get updated.
+
+This is deliberately a SEPARATE literal from migration 101's own
+SEED_OPERATION_TYPES — the migration keeps its own frozen copy on purpose
+(see test_operation_type_catalog.py's predicate-equivalence tests), so
+that a migration edit and a test-side edit must independently agree,
+proving the migration's exact-code backfill is behavior-neutral. Only the
+test-to-test duplication (this file vs. having two independent copies in
+each test module) is being eliminated here.
+"""
+from app.models.manufacturing import OperationType
+
+# code: (label, category, consume_stages, is_qc, sort_order)
+SEED_OPERATION_TYPES = {
+    "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+    "RESIN_PRINT": ("Resin Print", "print", ["production", "any"], False, 20),
+    "ASSEMBLY": ("Assembly", "assembly", ["assembly", "production", "any"], False, 30),
+    "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+    "SUPPORT_REMOVAL": ("Support Removal / Cleanup", "finishing", ["any"], False, 50),
+    "SANDING": ("Sanding", "finishing", ["any"], False, 60),
+    "PAINTING": ("Painting", "finishing", ["finishing", "any"], False, 70),
+    "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+    "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+}
+
+
+def seed_operation_types(db):
+    """Idempotent INSERT-if-missing seed helper, mirroring migration 101
+    step 2, for use directly against the test DB (no alembic run in
+    tests). Consumes the module-level SEED_OPERATION_TYPES constant above
+    — no separate inline copy of the seed data in either caller."""
+    existing_codes = {code for (code,) in db.query(OperationType.code).all()}
+    created = []
+    for code, (label, category, stages, is_qc, sort_order) in SEED_OPERATION_TYPES.items():
+        if code in existing_codes:
+            continue
+        row = OperationType(
+            code=code,
+            label=label,
+            category=category,
+            consume_stages=stages,
+            is_qc=is_qc,
+            is_system=True,
+            is_active=True,
+            sort_order=sort_order,
+        )
+        db.add(row)
+        created.append(code)
+    db.flush()
+    return created

--- a/backend/tests/services/test_inventory_extra.py
+++ b/backend/tests/services/test_inventory_extra.py
@@ -2495,3 +2495,335 @@ class TestCogsSelfHealsAfterRoutingFirstFix:
             "transactions for a routing-only completed order"
         )
         assert data["cogs"]["total"] > 0.0
+
+
+# =============================================================================
+# #876 PR-2: consumer switch to stored operation_type — mandatory load-bearing
+# test: mid-flight reclassification through BOTH completion paths, then ship.
+# =============================================================================
+
+def _seed_operation_types_876(db):
+    """Idempotent INSERT-if-missing seed of the operation types this test
+    module needs (subset of the 9 system rows), mirroring migration 101."""
+    from app.models.manufacturing import OperationType
+
+    seed = {
+        "GENERAL": ("Other (consumes at production)", "other", ["production", "any"], False, 90),
+        "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+    }
+    existing = {code for (code,) in db.query(OperationType.code).all()}
+    for code, (label, category, stages, is_qc, sort_order) in seed.items():
+        if code in existing:
+            continue
+        db.add(OperationType(
+            code=code, label=label, category=category, consume_stages=stages,
+            is_qc=is_qc, is_system=True, is_active=True, sort_order=sort_order,
+        ))
+    db.flush()
+
+
+class TestMidFlightReclassificationBothCompletionPaths:
+    """LOAD-BEARING TEST (#876 PR-2 design §6 / PR-plan PR-2 row).
+
+    Setup shared by both completion-path variants — TWO generic-coded ops
+    (neither code is one of the 18 legacy alias keys, so both start life
+    resolving via the untyped DEFAULT_CONSUME_STAGES path exactly like
+    today):
+    - op1 ("OP10", typed GENERAL == production-consuming) carries the
+      filament. It is consumed per-op WHILE still GENERAL-typed — "consume
+      SOME per-op" before the reclassification happens — and marked
+      complete, simulating a real per-op-driven shop floor flow.
+    - op2 ("OP20") carries the box, LEFT PENDING. It is THEN retyped
+      GENERAL -> PACK_SHIP (production -> shipping) mid-flight — its
+      op-material row, still unconsumed, now resolves to the shipping
+      stage instead of production.
+    - Production is finalized through the completion path under test
+      (completing op2, the last op, triggers update_po_status ->
+      process_production_completion's bulk stage-sweep). The box must NOT
+      consume at production completion (it's shipping-staged now) and the
+      filament must NOT double-consume (already consumed per-op). No FIX-3
+      false raise (a reservation exists via reserve_production_materials,
+      so the guardrail is live and must stay quiet).
+    - Ship then consumes the box. No double-consumption anywhere.
+
+    Both variants assert on POSTED ROWS (InventoryTransaction / on_hand),
+    never on op/PO status alone — operation_status.py's broad
+    `except Exception` around process_production_completion (~line 218)
+    would otherwise make a regression in this path silent.
+    """
+
+    def _setup(self, db, make_product):
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        filament = make_product(unit="G", cost_method="average", average_cost=Decimal("0.02"))
+        box = make_product(
+            item_type="packaging", unit="EA", cost_method="average",
+            average_cost=Decimal("1.50"),
+        )
+
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, filament.id, location.id, Decimal("1000"))
+        _make_inventory(db, box.id, location.id, Decimal("100"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+
+        op1 = _make_operation(db, po.id, wc.id, sequence=10)
+        op1.operation_code = "OP10"  # generic — not one of the 18 legacy keys
+        op1.operation_type = "GENERAL"  # production-consuming, stored type
+        filament_mat = _make_op_material(db, op1.id, filament.id, Decimal("370"), unit="G")
+
+        op2 = _make_operation(db, po.id, wc.id, sequence=20)
+        op2.operation_code = "OP20"  # generic — not one of the 18 legacy keys
+        op2.operation_type = "GENERAL"  # still production-consuming at reserve time
+        box_mat = _make_op_material(db, op2.id, box.id, Decimal("1"), unit="EA")
+        db.flush()
+
+        # Reserve (routing-first) — posts real 'reservation' ledger rows for
+        # BOTH materials while both ops are still production-typed. This
+        # makes the FIX-3 guardrail live: if resolution regresses and finds
+        # nothing consumable behind an existing reservation, it must raise.
+        reservations = inventory_service.reserve_production_materials(db, po)
+        assert len(reservations) == 2, "Both materials must reserve while ops are production-typed"
+        db.flush()
+
+        # Consume SOME per-op: op1's filament only, while op1 is still
+        # GENERAL (production-consuming). op1 is completed via the
+        # per-operation path; op2 (the box) stays pending/unconsumed.
+        op1.status = "running"
+        db.flush()
+        from app.services import operation_status
+        operation_status.complete_operation(
+            db, po.id, op1.id,
+            quantity_completed=Decimal("1"), quantity_scrapped=Decimal("0"),
+        )
+        db.refresh(filament_mat)
+        assert filament_mat.status == "consumed"
+        db.refresh(box_mat)
+        assert box_mat.status != "consumed"
+
+        # Mid-flight reclassification: production -> shipping, on op2 only.
+        op2.operation_type = "PACK_SHIP"
+        db.flush()
+
+        return fg, filament, box, location, po, op2, filament_mat, box_mat
+
+    def test_bulk_completion_path_defers_box_no_double_consume_no_false_raise(
+        self, db, make_product, make_sales_order
+    ):
+        _seed_operation_types_876(db)
+        fg, filament, box, location, po, op, filament_mat, box_mat = self._setup(db, make_product)
+
+        # Drive the BULK completion path directly (what process_production_
+        # completion calls). Must NOT raise MaterialConsumptionError despite
+        # an open reservation existing for the (now shipping-typed) box.
+        bulk_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=True
+        )
+
+        # The box must NOT consume at production completion (PACK_SHIP
+        # resolves to the shipping stage now) — bulk posts ZERO new rows
+        # (filament already consumed per-op, box deferred to ship).
+        assert bulk_txns == [], (
+            "Bulk completion must post nothing: filament already consumed "
+            "per-op, box deferred to ship by its new PACK_SHIP type"
+        )
+
+        # Posted-rows assertion (not status): exactly one filament
+        # consumption row total, zero box consumption rows.
+        filament_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(filament_rows) == 1, "Filament must not double-consume"
+
+        box_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows) == 0, "Box must not consume at production completion post-retype"
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id, Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("100"), "Box on_hand untouched pre-ship"
+
+        # Now ship: the box (PACK_SHIP-typed) must consume at ship.
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po.sales_order_id = so.id
+        db.flush()
+
+        ship_txns = inventory_service.consume_shipping_materials(db, so)
+        assert len(ship_txns) == 1
+        assert ship_txns[0].product_id == box.id
+
+        box_rows_after_ship = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows_after_ship) == 1, "Box must consume exactly once, at ship"
+
+        box_inv_after_ship = db.query(Inventory).filter(
+            Inventory.product_id == box.id, Inventory.location_id == location.id,
+        ).first()
+        assert box_inv_after_ship.on_hand_quantity == Decimal("99")
+
+        # Idempotency: a second ship call must not double-consume the box.
+        second_ship_txns = inventory_service.consume_shipping_materials(db, so)
+        assert second_ship_txns == []
+
+        # Filament still only ever consumed once, throughout the whole flow.
+        filament_rows_final = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(filament_rows_final) == 1
+
+    def test_per_op_auto_complete_path_defers_box_no_double_consume_no_false_raise(
+        self, db, make_product, make_sales_order
+    ):
+        """Same scenario, but production finalizes through the
+        PER-OPERATION auto-complete path rather than a direct bulk call.
+
+        _setup() already completed op1 (filament) via
+        operation_status.complete_operation — that alone does not finalize
+        the PO because op2 (box, now retyped PACK_SHIP) is still pending.
+        This test finalizes via operation_status.skip_operation(op2) — a
+        legitimate real shop-floor action (nothing to physically do for a
+        shipping-stage op at production time) that is ITSELF part of the
+        per-operation status machinery: it flips op2 to 'skipped' and calls
+        update_po_status, which (now that every op is complete/skipped)
+        triggers process_production_completion -> consume_production_
+        materials (the STAGE-resolving bulk sweep this PR's fix targets)
+        under operation_status.py's broad try/except swallow (~line 218)
+        that would otherwise hide a regression here silently."""
+        from app.services import operation_status
+
+        _seed_operation_types_876(db)
+        fg, filament, box, location, po, op2, filament_mat, box_mat = self._setup(db, make_product)
+
+        skipped_op = operation_status.skip_operation(
+            db, po.id, op2.id, reason="Shipping-stage op — nothing to do at production time",
+        )
+        assert skipped_op.status == "skipped"
+
+        # Posted-rows assertions — the whole point of this test. Assert on
+        # ledger rows, not on op/po status, since a silent regression inside
+        # the swallowed try/except would otherwise still show status
+        # fields looking "fine".
+        filament_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(filament_rows) == 1, "Filament must not double-consume via the per-op path"
+
+        box_rows = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows) == 0, (
+            "Box must NOT consume when the per-op path finalizes the PO — "
+            "its PACK_SHIP type defers it to ship (if it doesn't, this "
+            "assertion catches what the swallowed try/except in "
+            "operation_status.py would otherwise hide)"
+        )
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id, Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("100"), "Box on_hand untouched pre-ship"
+
+        # Now ship: the box must consume at ship, exactly once.
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po.sales_order_id = so.id
+        db.flush()
+
+        ship_txns = inventory_service.consume_shipping_materials(db, so)
+        assert len(ship_txns) == 1
+        assert ship_txns[0].product_id == box.id
+
+        box_rows_after_ship = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == box.id,
+        ).all()
+        assert len(box_rows_after_ship) == 1, "Box must consume exactly once, at ship"
+
+        box_inv_after_ship = db.query(Inventory).filter(
+            Inventory.product_id == box.id, Inventory.location_id == location.id,
+        ).first()
+        assert box_inv_after_ship.on_hand_quantity == Decimal("99")
+
+        second_ship_txns = inventory_service.consume_shipping_materials(db, so)
+        assert second_ship_txns == [], "Second ship call must be idempotent"
+
+        filament_rows_final = db.query(InventoryTransaction).filter(
+            InventoryTransaction.reference_type == "production_order",
+            InventoryTransaction.reference_id == po.id,
+            InventoryTransaction.transaction_type == "consumption",
+            InventoryTransaction.product_id == filament.id,
+        ).all()
+        assert len(filament_rows_final) == 1
+
+
+class TestTypedPackShipDefersToShip:
+    """Typed PACK_SHIP (not just legacy PACK/SHIP codes) defers packaging
+    consumption to ship — proves the type-first resolver switch actually
+    drives real consumption behavior, not just resolver unit tests."""
+
+    def test_typed_pack_ship_op_defers_packaging_with_generic_code(
+        self, db, make_product, make_sales_order
+    ):
+        """An op coded generically ("OP30" — not in the legacy 18-key map at
+        all) but TYPED PACK_SHIP must defer its packaging to ship — this is
+        exactly the live-bug shape the type catalog exists to fix (routing
+        editor autofilled OP-codes never resolved via the legacy dict)."""
+        _seed_operation_types_876(db)
+        fg = make_product(item_type="finished_good", cost_method="standard", standard_cost=Decimal("5.00"))
+        box = make_product(
+            item_type="packaging", unit="EA", cost_method="average",
+            average_cost=Decimal("1.50"),
+        )
+        location = inventory_service.get_or_create_default_location(db)
+        _make_inventory(db, box.id, location.id, Decimal("50"))
+
+        po = _make_production_order(db, fg.id, qty_ordered=1)
+        wc = _make_work_center(db)
+        op = _make_operation(db, po.id, wc.id, sequence=30)
+        op.operation_code = "OP30"  # NOT one of the 18 legacy keys
+        op.operation_type = "PACK_SHIP"
+        box_mat = _make_op_material(db, op.id, box.id, Decimal("1"), unit="EA")
+        db.flush()
+
+        # Production completion must NOT consume the box (typed shipping).
+        prod_txns = inventory_service.consume_production_materials(
+            db, po, Decimal("1"), release_reservations=False
+        )
+        assert prod_txns == []
+        db.refresh(box_mat)
+        assert box_mat.status != "consumed"
+
+        so = make_sales_order(product_id=fg.id, quantity=1, status="ready_to_ship")
+        po.sales_order_id = so.id
+        db.flush()
+
+        ship_txns = inventory_service.consume_shipping_materials(db, so)
+        assert len(ship_txns) == 1
+        assert ship_txns[0].product_id == box.id
+
+        box_inv = db.query(Inventory).filter(
+            Inventory.product_id == box.id, Inventory.location_id == location.id,
+        ).first()
+        assert box_inv.on_hand_quantity == Decimal("49")

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -2997,6 +2997,203 @@ class TestRecordQCInspection:
         assert exc_info.value.status_code == 404
 
 
+class TestQCTypedLookup:
+    """#876 PR-2: record_qc_inspection's QC-op fallback resolution order —
+    explicit target_op -> first op whose STORED operation_type is in the
+    catalog's is_qc set -> legacy operation_code ilike('%QC%') (kept for one
+    release, then removed). Typed lookup beats the code-substring heuristic
+    because live ops are coded OP20/OP30/FINISH and never match '%QC%' at
+    all — this is the actual bug the type catalog fixes."""
+
+    def _seed_operation_types(self, db):
+        from app.models.manufacturing import OperationType
+
+        seed = {
+            "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
+            "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
+            "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
+        }
+        existing = {code for (code,) in db.query(OperationType.code).all()}
+        for code, (label, category, stages, is_qc, sort_order) in seed.items():
+            if code in existing:
+                continue
+            db.add(OperationType(
+                code=code, label=label, category=category, consume_stages=stages,
+                is_qc=is_qc, is_system=True, is_active=True, sort_order=sort_order,
+            ))
+        db.flush()
+
+    def test_typed_qc_op_found_even_with_non_qc_code(self, db, finished_good):
+        """The live-census bug case: an op coded OP20 (no 'QC' substring at
+        all) but TYPED QUALITY_CONTROL must still be found and completed —
+        the old ilike('%QC%') fallback would have missed this entirely."""
+        self._seed_operation_types(db)
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="OP20",
+            operation_type="QUALITY_CONTROL",
+            operation_name="Assembly",
+            planned_setup_minutes=0,
+            planned_run_minutes=10,
+            status="running",
+        )
+        db.add(qc_op)
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Typed",
+            qc_status="passed",
+            quantity_passed=10,
+        )
+
+        op = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == qc_op.id
+        ).first()
+        assert op.status == "complete", (
+            "Typed QUALITY_CONTROL op must be found and completed even "
+            "though its code (OP20) doesn't match '%QC%'"
+        )
+        assert op.operator_name == "Inspector Typed"
+
+    def test_typed_lookup_beats_ilike_when_both_present(self, db, finished_good):
+        """When one op is typed QUALITY_CONTROL and a DIFFERENT op merely has
+        'QC' in its code, the typed op wins (typed lookup runs first)."""
+        self._seed_operation_types(db)
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+
+        # A print op that happens to have "QC" in a free-text code — must
+        # NOT be picked over the properly-typed QC op.
+        decoy_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="PRINT-QC-STATION-3",
+            operation_type="FDM_PRINT",
+            operation_name="Print",
+            planned_setup_minutes=0,
+            planned_run_minutes=60,
+            status="complete",
+        )
+        typed_qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="OP20",
+            operation_type="QUALITY_CONTROL",
+            operation_name="Inspection",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        db.add_all([decoy_op, typed_qc_op])
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Precedence",
+            qc_status="passed",
+            quantity_passed=10,
+        )
+
+        decoy = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == decoy_op.id
+        ).first()
+        typed = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == typed_qc_op.id
+        ).first()
+        assert typed.status == "complete", "The typed QUALITY_CONTROL op must be completed"
+        assert typed.operator_name == "Inspector Precedence"
+        # Decoy was already 'complete' before the call and must be untouched
+        # (no operator_name stamped onto it by this inspection).
+        assert decoy.operator_name is None
+
+    def test_ilike_fallback_still_works_for_untyped_op(self, db, finished_good):
+        """An op with NO operation_type but a code containing 'QC' must
+        still be found via the legacy ilike fallback — kept for one release
+        to cover untyped data (see design #876 comment §3)."""
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="QC-CHECK",
+            operation_name="Quality Check",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        db.add(qc_op)
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Legacy",
+            qc_status="passed",
+            quantity_passed=10,
+        )
+
+        op = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == qc_op.id
+        ).first()
+        assert op.status == "complete"
+        assert op.operator_name == "Inspector Legacy"
+
+    def test_explicit_operation_id_beats_both_typed_and_ilike(self, db, finished_good):
+        """An explicit operation_id target always wins over both the typed
+        lookup and the ilike fallback."""
+        self._seed_operation_types(db)
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+
+        typed_qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=10,
+            operation_code="OP10",
+            operation_type="QUALITY_CONTROL",
+            operation_name="In-process QC",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        explicit_target_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="FINISH",
+            operation_type="QUALITY_CONTROL",
+            operation_name="Final QC",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        db.add_all([typed_qc_op, explicit_target_op])
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Explicit",
+            qc_status="passed",
+            quantity_passed=10,
+            operation_id=explicit_target_op.id,
+        )
+
+        explicit = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == explicit_target_op.id
+        ).first()
+        first_typed = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == typed_qc_op.id
+        ).first()
+        assert explicit.status == "complete"
+        assert explicit.operator_name == "Inspector Explicit"
+        assert first_typed.status == "running", (
+            "The non-targeted typed QC op must be left untouched"
+        )
+
+
 class TestQCInspectionRecords:
     """#783: append-only qc_inspections history behind the qc_* cache."""
 

--- a/backend/tests/services/test_production_order_service.py
+++ b/backend/tests/services/test_production_order_service.py
@@ -41,6 +41,7 @@ from app.models.scrap_reason import ScrapReason
 from app.models.work_center import WorkCenter
 from app.models.inventory import Inventory
 from app.services import production_order_service as svc
+from tests.services._operation_type_seed import seed_operation_types as _seed_operation_types
 
 
 # =============================================================================
@@ -3005,29 +3006,11 @@ class TestQCTypedLookup:
     because live ops are coded OP20/OP30/FINISH and never match '%QC%' at
     all — this is the actual bug the type catalog fixes."""
 
-    def _seed_operation_types(self, db):
-        from app.models.manufacturing import OperationType
-
-        seed = {
-            "FDM_PRINT": ("FDM Print", "print", ["production", "any"], False, 10),
-            "QUALITY_CONTROL": ("Quality Control", "quality", ["any"], True, 40),
-            "PACK_SHIP": ("Pack / Ship", "shipping", ["shipping", "any"], False, 80),
-        }
-        existing = {code for (code,) in db.query(OperationType.code).all()}
-        for code, (label, category, stages, is_qc, sort_order) in seed.items():
-            if code in existing:
-                continue
-            db.add(OperationType(
-                code=code, label=label, category=category, consume_stages=stages,
-                is_qc=is_qc, is_system=True, is_active=True, sort_order=sort_order,
-            ))
-        db.flush()
-
     def test_typed_qc_op_found_even_with_non_qc_code(self, db, finished_good):
         """The live-census bug case: an op coded OP20 (no 'QC' substring at
         all) but TYPED QUALITY_CONTROL must still be found and completed —
         the old ilike('%QC%') fallback would have missed this entirely."""
-        self._seed_operation_types(db)
+        _seed_operation_types(db)
         order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
         qc_op = ProductionOrderOperation(
             production_order_id=order.id,
@@ -3062,7 +3045,7 @@ class TestQCTypedLookup:
     def test_typed_lookup_beats_ilike_when_both_present(self, db, finished_good):
         """When one op is typed QUALITY_CONTROL and a DIFFERENT op merely has
         'QC' in its code, the typed op wins (typed lookup runs first)."""
-        self._seed_operation_types(db)
+        _seed_operation_types(db)
         order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
 
         # A print op that happens to have "QC" in a free-text code — must
@@ -3145,7 +3128,7 @@ class TestQCTypedLookup:
     def test_explicit_operation_id_beats_both_typed_and_ilike(self, db, finished_good):
         """An explicit operation_id target always wins over both the typed
         lookup and the ilike fallback."""
-        self._seed_operation_types(db)
+        _seed_operation_types(db)
         order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
 
         typed_qc_op = ProductionOrderOperation(
@@ -3192,6 +3175,111 @@ class TestQCTypedLookup:
         assert first_typed.status == "running", (
             "The non-targeted typed QC op must be left untouched"
         )
+
+    def test_typed_qc_tie_break_picks_earliest_sequence(self, db, finished_good):
+        """CodeRabbit #4630789865 finding 1/7: when two untargeted ops are
+        BOTH typed QUALITY_CONTROL, the fallback query must deterministically
+        pick the earliest in routing sequence, not whatever order the DB
+        happens to return rows in."""
+        _seed_operation_types(db)
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+
+        later_qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=30,
+            operation_code="OP30",
+            operation_type="QUALITY_CONTROL",
+            operation_name="Final Inspection",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        earlier_qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=15,
+            operation_code="OP15",
+            operation_type="QUALITY_CONTROL",
+            operation_name="In-process Inspection",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        # Inserted in DB-row order later_qc_op, earlier_qc_op (sequence 30
+        # THEN 15) so a passing test can only be explained by an explicit
+        # ORDER BY sequence, not insertion/PK order.
+        db.add_all([later_qc_op, earlier_qc_op])
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Tiebreak",
+            qc_status="passed",
+            quantity_passed=10,
+        )
+
+        earlier = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == earlier_qc_op.id
+        ).first()
+        later = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == later_qc_op.id
+        ).first()
+        assert earlier.status == "complete", (
+            "The sequence-earliest typed QC op (15) must be picked over "
+            "the later one (30)"
+        )
+        assert earlier.operator_name == "Inspector Tiebreak"
+        assert later.status == "running", (
+            "The non-earliest typed QC op must be left untouched"
+        )
+
+    def test_deactivated_qc_type_is_not_matched(self, db, finished_good):
+        """CodeRabbit #4630789865 finding 1/7 (nitpick): the qc_type_codes
+        lookup must filter to is_active types — an op typed with a
+        DEACTIVATED is_qc type must fall through to the legacy ilike
+        fallback (or nothing at all if the code doesn't match either),
+        not be matched via the typed lookup."""
+        _seed_operation_types(db)
+        from app.models.manufacturing import OperationType
+
+        deactivated_type = db.query(OperationType).filter(
+            OperationType.code == "QUALITY_CONTROL"
+        ).first()
+        deactivated_type.is_active = False
+        db.flush()
+
+        order = _make_production_order(db, finished_good, status="in_progress", quantity=10)
+        qc_op = ProductionOrderOperation(
+            production_order_id=order.id,
+            work_center_id=1,
+            sequence=20,
+            operation_code="OP20",
+            operation_type="QUALITY_CONTROL",
+            operation_name="Inspection",
+            planned_setup_minutes=0,
+            planned_run_minutes=5,
+            status="running",
+        )
+        db.add(qc_op)
+        db.flush()
+
+        svc.record_qc_inspection(
+            db, order.id,
+            inspector="Inspector Deactivated",
+            qc_status="passed",
+            quantity_passed=10,
+        )
+
+        op = db.query(ProductionOrderOperation).filter(
+            ProductionOrderOperation.id == qc_op.id
+        ).first()
+        assert op.status == "running", (
+            "An op typed with a DEACTIVATED is_qc type must not be matched "
+            "by the typed lookup — its code (OP20) also doesn't match the "
+            "legacy ilike('%QC%') fallback, so nothing should be completed"
+        )
+        assert op.operator_name is None
 
 
 class TestQCInspectionRecords:


### PR DESCRIPTION
## What

Switches the live consume-stage / QC-op-resolution consumers to read the
stored `operation_type` catalog code first, falling back to the legacy
`operation_code` map (#876 PR-1's `resolve_consume_stages`, shipped inert
in #898):

1. **The three #875 stage resolvers** (`inventory_service.py`:
   `_get_stage_op_materials`, `_stage_has_consumed_op_materials`,
   `_get_stage_component_ids`) each load the type map once at entry and
   resolve type-first via `resolve_consume_stages`.
2. **`get_bom_lines_for_operation`** (`operation_blocking.py`) gains an
   optional `operation_type` param; `check_operation_blocking` passes it
   through.
3. **QC typed lookup** (`production_order_service.record_qc_inspection`):
   new resolution order — explicit `target_op` → first op whose
   `operation_type` is in the catalog's `is_qc` set → legacy
   `operation_code.ilike("%QC%")` fallback, kept **one release** for
   untyped data, then removed.
4. **Snapshot propagation** — `operation_type` now copied at every site
   `operation_code` is copied: PO release (`production_order_service.py`,
   `sales_order_production_service.py`, `operation_generation.py`),
   routing duplication (`variant_service.py`, `item_duplicate_service.py`,
   apply-template in `routing_service.py`), and the `ROUTING_TEMPLATES`
   seed data (PRINT→FDM_PRINT, QC→QUALITY_CONTROL, PACK/SHIP→PACK_SHIP,
   ASSEMBLE→ASSEMBLY). `sales_order_requirements_service.py`'s flattened
   per-component aggregation gets an explicit `operation_type=None` (no
   single operation to attribute a flattened requirement to).
5. **Schemas**: optional `operation_type` alongside `operation_code` on
   routing-op create/update/response (`schemas/manufacturing.py`) and
   PO-op create/response (`schemas/production_order.py`); write-time
   validation — an unknown, case-normalized-upper type → **400**.
6. **Write-time alias assist**: `routing_service.create_routing`,
   `add_operation`, and `update_operation` auto-assign a canonical type
   when `operation_type` is absent but `UPPER(operation_code)` matches one
   of the 18 legacy keys (PRINT→FDM_PRINT; EXTRUDE/MOLD/CUT/MACHINE→GENERAL;
   ASSEMBLE/BUILD/WELD→ASSEMBLY; QC/INSPECT/TEST→QUALITY_CONTROL;
   CLEAN→SUPPORT_REMOVAL; SAND→SANDING; PAINT/COAT→PAINTING;
   PACK/SHIP/LABEL→PACK_SHIP). **FINISH/POST get no alias**, deliberately.
   The alias map now has one shared importable copy
   (`operation_material_mapping.OPERATION_CODE_TYPE_ALIASES` /
   `alias_operation_type_for_code`) — migration 101 and its test keep
   their own frozen literal copies (a shipped migration must never import
   live app code); this is noted in both.

## Why

Today, whether a routing step's materials leave inventory at production
completion or at ship is guessed at runtime from an 18-word hardcoded dict
matched against free-text `operation_code`. Anything the routing editor
autofills (`OP10`/`OP20`) or intake emits (`FINISH`) silently defaults to
"consume at production" — this is why Pack/Ship steps were consuming
packaging at print completion instead of ship. PR-1 shipped the catalog
schema + a dormant resolver; this PR wires it into every live consumer so
a declared Type becomes the actual runtime semantic carrier, while leaving
every untyped op behaving exactly as it does today.

## Untyped-behavior-identical guarantee

An operation with no `operation_type` resolves through the exact same
code path as before this PR: `get_consume_stages_for_operation(operation_code)`
→ the unchanged 18-key `OPERATION_CONSUME_STAGES` dict → `["production","any"]`
default. The #875 guardrail docstring contract and the pinned legacy test
suites (`test_small_services.py::TestOperationMaterialMapping`,
`test_operation_type_catalog.py`) are untouched — verified green.

## Mandatory regression coverage

- **Mid-flight reclassification** (`TestMidFlightReclassificationBothCompletionPaths`
  in `test_inventory_extra.py`): a shipping-typed op retyped
  production→PACK_SHIP mid-flight, with some materials already consumed
  per-op, is driven through **both** the bulk completion path and the
  per-operation auto-complete path (`operation_status.skip_operation` →
  `update_po_status` → `process_production_completion`, under the module's
  swallowed `try/except`). Assertions are on **posted `InventoryTransaction`
  rows**, not status, since that swallow would otherwise hide a regression
  silently. Then ships — box consumes exactly once, at ship; filament never
  double-consumes; no `MaterialConsumptionError` false-raise.
- Typed `PACK_SHIP` (on a generic, non-legacy-coded op) defers packaging to
  ship (`TestTypedPackShipDefersToShip`).
- QC typed-lookup matrix: typed beats a decoy `ilike` match; typed lookup
  finds an op the old code-substring heuristic would have missed entirely
  (the actual live bug shape); explicit `operation_id` beats both; legacy
  `ilike` still works for untyped ops (`TestQCTypedLookup` in
  `test_production_order_service.py`).
- Write-time alias assist + 400-on-unknown-type + snapshot propagation
  through apply-template (`test_routings.py`).

## Refs

- #876 design comment (issuecomment-4880247733) §3
- #880 roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routing operations and production-order steps now preserve an operation type alongside the existing code label.
  * Routing templates and copied variants now carry this type through to newly created records.
  * QC inspections can now identify the correct operation using the typed classification first, with older matching still supported.

* **Bug Fixes**
  * Inventory consumption and BOM stage checks now resolve stages more accurately for typed operations.
  * Operation types are validated during save, and legacy codes can be mapped automatically where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->