### PR TITLE
feat(routing-ui): operation type picker + badges — stop minting semantically-empty OPn codes (876 PR-4)

### DIFF
--- a/frontend/src/components/routing/AddOperationForm.jsx
+++ b/frontend/src/components/routing/AddOperationForm.jsx
@@ -1,8 +1,17 @@
+import { useState } from "react";
+import {
+  CANONICAL_OPERATION_CODE,
+  categoryLabel,
+  groupOperationTypes,
+} from "./operationTypeDisplay";
+
 /**
  * AddOperationForm - Form for adding a new operation to a routing.
  *
  * Props:
  * - workCenters: array - Available work centers
+ * - operationTypes: array - Operation-type catalog (GET /operation-types),
+ *   fetched once by RoutingEditorContent and passed down.
  * - newOperation: object - The new operation state
  * - onOperationChange: (updatedOperation) => void
  * - onAdd: () => void - Called when the Add button is clicked
@@ -10,26 +19,92 @@
  */
 export default function AddOperationForm({
   workCenters,
+  operationTypes = [],
   newOperation,
   onOperationChange,
   onAdd,
   onCancel,
 }) {
+  // Tracks whether the user has hand-edited the (now secondary) operation
+  // code field, so picking/changing a type never clobbers a custom code —
+  // same "don't clobber a manual edit" contract as
+  // QualityPlanEditor's codeTouched (qualityPlanEditor.utils.js).
+  const [codeTouched, setCodeTouched] = useState(
+    Boolean(newOperation.operation_code)
+  );
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
   function updateField(field, value) {
     onOperationChange({ ...newOperation, [field]: value });
   }
+
+  function handleTypeChange(typeCode) {
+    const canonicalCode = CANONICAL_OPERATION_CODE[typeCode] ?? "";
+    onOperationChange({
+      ...newOperation,
+      operation_type: typeCode,
+      operation_code: codeTouched ? newOperation.operation_code : canonicalCode,
+    });
+  }
+
+  function handleCodeChange(value) {
+    setCodeTouched(true);
+    updateField("operation_code", value);
+  }
+
+  const groupedTypes = groupOperationTypes(operationTypes);
+  const selectedType = operationTypes.find(
+    (t) => t.code === newOperation.operation_type
+  );
 
   return (
     <div className="mb-6 p-4 bg-gray-800 rounded-lg border border-gray-700">
       <h4 className="font-semibold mb-3 text-white">
         Add Operation
       </h4>
+
+      <div className="mb-4">
+        <label
+          htmlFor="new-operation-type"
+          className="block text-sm font-medium mb-1 text-gray-300"
+        >
+          Operation Type *
+        </label>
+        <select
+          id="new-operation-type"
+          value={newOperation.operation_type || ""}
+          onChange={(e) => handleTypeChange(e.target.value)}
+          className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-white"
+          required
+        >
+          <option value="">Select operation type...</option>
+          {groupedTypes.map(([category, types]) => (
+            <optgroup key={category} label={categoryLabel(category)}>
+              {types.map((t) => (
+                <option key={t.code} value={t.code}>
+                  {t.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        {selectedType?.description && (
+          <p className="text-xs text-gray-400 mt-1">
+            {selectedType.description}
+          </p>
+        )}
+      </div>
+
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium mb-1 text-gray-300">
+          <label
+            htmlFor="new-operation-work-center"
+            className="block text-sm font-medium mb-1 text-gray-300"
+          >
             Work Center
           </label>
           <select
+            id="new-operation-work-center"
             value={newOperation.work_center_id}
             onChange={(e) => updateField("work_center_id", e.target.value)}
             className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-white"
@@ -43,27 +118,16 @@ export default function AddOperationForm({
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium mb-1">
+          <label htmlFor="new-operation-name" className="block text-sm font-medium mb-1">
             Operation Name
           </label>
           <input
+            id="new-operation-name"
             type="text"
             value={newOperation.operation_name}
             onChange={(e) => updateField("operation_name", e.target.value)}
             className="w-full px-3 py-2 border rounded-md"
             placeholder="e.g., 3D Print, Support Removal"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            Operation Code
-          </label>
-          <input
-            type="text"
-            value={newOperation.operation_code}
-            onChange={(e) => updateField("operation_code", e.target.value)}
-            className="w-full px-3 py-2 border rounded-md"
-            placeholder="e.g., OP10, OP20"
           />
         </div>
         <div>
@@ -106,10 +170,40 @@ export default function AddOperationForm({
           />
         </div>
       </div>
+
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((v) => !v)}
+          className="text-xs text-blue-400 hover:text-blue-300"
+        >
+          {showAdvanced ? "Hide" : "Show"} advanced: custom operation code
+        </button>
+        {showAdvanced && (
+          <div className="mt-2">
+            <label
+              htmlFor="new-operation-code"
+              className="block text-sm font-medium mb-1 text-gray-300"
+            >
+              Operation Code (optional)
+            </label>
+            <input
+              id="new-operation-code"
+              type="text"
+              value={newOperation.operation_code}
+              onChange={(e) => handleCodeChange(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md"
+              placeholder="Auto-filled from the selected type; edit for a custom code"
+            />
+          </div>
+        )}
+      </div>
+
       <div className="mt-3 flex gap-2">
         <button
           onClick={onAdd}
-          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+          disabled={!newOperation.operation_type}
+          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
         >
           Add
         </button>

--- a/frontend/src/components/routing/OperationRow.jsx
+++ b/frontend/src/components/routing/OperationRow.jsx
@@ -1,4 +1,11 @@
 import React from "react";
+import {
+  categoryLabel,
+  describeOperationType,
+  groupOperationTypes,
+  UNTYPED_DESCRIPTION,
+  UNTYPED_LABEL,
+} from "./operationTypeDisplay";
 
 /**
  * OperationRow - A single operation row in the routing operations table.
@@ -12,6 +19,8 @@ import React from "react";
  * - materials: array - Materials assigned to this operation
  * - isExpanded: boolean - Whether the materials sub-row is visible
  * - loading: boolean - Whether a save/delete is in progress
+ * - operationTypes: array - Operation-type catalog (GET /operation-types),
+ *   used to render the type badge/picker and its description
  * - onToggleExpand: (operationId) => void
  * - onUpdateOperation: (index, field, value) => void
  * - onRemoveOperation: (index) => void
@@ -25,6 +34,7 @@ export default function OperationRow({
   materials,
   isExpanded,
   loading,
+  operationTypes = [],
   onToggleExpand,
   onUpdateOperation,
   onRemoveOperation,
@@ -32,6 +42,15 @@ export default function OperationRow({
   onEditMaterial,
   operations,
 }) {
+  const typeInfo = describeOperationType(op.operation_type, operationTypes);
+  const groupedTypes = groupOperationTypes(operationTypes);
+  // Keep a currently-assigned type visible in the picker even if it's not
+  // in the fetched active-only catalog (e.g. a deactivated custom type
+  // still stamped on this operation) — never silently drop the selection.
+  const hasOrphanType =
+    op.operation_type &&
+    !operationTypes.some((t) => t.code === op.operation_type);
+
   return (
     <React.Fragment>
       <tr className="border-b border-gray-800 hover:bg-gray-800/50">
@@ -87,6 +106,40 @@ export default function OperationRow({
             {op.operation_code && (
               <div className="text-sm text-gray-400">{op.operation_code}</div>
             )}
+            <div className="mt-1">
+              <select
+                aria-label={`Operation type for ${op.operation_name || op.operation_code || `operation ${index + 1}`}`}
+                value={op.operation_type || ""}
+                onChange={(e) =>
+                  onUpdateOperation(index, "operation_type", e.target.value)
+                }
+                title={typeInfo?.description || UNTYPED_DESCRIPTION}
+                className={`text-xs px-1.5 py-0.5 rounded border ${
+                  op.operation_type
+                    ? "bg-blue-500/20 text-blue-400 border-blue-500/30"
+                    : "bg-yellow-500/20 text-yellow-400 border-yellow-500/30"
+                }`}
+              >
+                <option value="">{UNTYPED_LABEL}</option>
+                {groupedTypes.map(([category, types]) => (
+                  <optgroup key={category} label={categoryLabel(category)}>
+                    {types.map((t) => (
+                      <option key={t.code} value={t.code}>
+                        {t.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+                {hasOrphanType && (
+                  <option value={op.operation_type}>{typeInfo?.label}</option>
+                )}
+              </select>
+              <div className="text-xs text-gray-500 mt-0.5">
+                {typeInfo
+                  ? `${typeInfo.label} — ${typeInfo.description || ""}`
+                  : UNTYPED_DESCRIPTION}
+              </div>
+            </div>
             {materials.length > 0 && (
               <div className="text-xs text-blue-400 mt-1">
                 {materials.length} material{materials.length !== 1 ? 's' : ''}

--- a/frontend/src/components/routing/RoutingEditorContent.jsx
+++ b/frontend/src/components/routing/RoutingEditorContent.jsx
@@ -27,6 +27,7 @@ export default function RoutingEditorContent({
   const [operations, setOperations] = useState([]);
   const [workCenters, setWorkCenters] = useState([]);
   const [templates, setTemplates] = useState([]);
+  const [operationTypes, setOperationTypes] = useState([]);
   const [showAddOperation, setShowAddOperation] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState("");
   const [selectedProductId, setSelectedProductId] = useState(productId || "");
@@ -43,6 +44,7 @@ export default function RoutingEditorContent({
   const [newOperation, setNewOperation] = useState({
     work_center_id: "",
     sequence: 1,
+    operation_type: "",
     operation_code: "",
     operation_name: "",
     setup_time_minutes: 0,
@@ -120,6 +122,22 @@ export default function RoutingEditorContent({
     }
   }, []);
 
+  const fetchOperationTypes = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/v1/operation-types`, {
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setOperationTypes(data || []);
+      }
+    } catch {
+      // Operation-types fetch failure is non-critical — the picker falls
+      // back to showing just the bare code for any already-typed op
+      // (operationTypeDisplay.describeOperationType's fallback table).
+    }
+  }, []);
+
   const fetchOperationMaterials = useCallback(async (operationId) => {
     if (!operationId) return;
     try {
@@ -165,6 +183,7 @@ export default function RoutingEditorContent({
       }
       fetchWorkCenters();
       fetchTemplates();
+      fetchOperationTypes();
       setError(null);
       setOperationMaterials({});
       setExpandedOperations({});
@@ -177,6 +196,7 @@ export default function RoutingEditorContent({
     fetchRoutingByProduct,
     fetchWorkCenters,
     fetchTemplates,
+    fetchOperationTypes,
   ]);
 
   // Notify parent of routing data changes (used by BOM page for cost display)
@@ -250,7 +270,8 @@ export default function RoutingEditorContent({
           operations: operations.map((op, idx) => ({
             work_center_id: op.work_center_id,
             sequence: idx + 1,
-            operation_code: op.operation_code || `OP${idx + 1}`,
+            operation_type: op.operation_type || null,
+            operation_code: op.operation_code || "",
             operation_name: op.operation_name || "",
             setup_time_minutes: op.setup_time_minutes || 0,
             run_time_minutes: op.run_time_minutes || 0,
@@ -296,7 +317,8 @@ export default function RoutingEditorContent({
               body: JSON.stringify({
                 work_center_id: op.work_center_id,
                 sequence: i + 1,
-                operation_code: op.operation_code || `OP${i + 1}`,
+                operation_type: op.operation_type || null,
+                operation_code: op.operation_code || "",
                 operation_name: op.operation_name || "",
                 setup_time_minutes: op.setup_time_minutes || 0,
                 run_time_minutes: op.run_time_minutes || 0,
@@ -319,7 +341,8 @@ export default function RoutingEditorContent({
               body: JSON.stringify({
                 work_center_id: op.work_center_id,
                 sequence: i + 1,
-                operation_code: op.operation_code || `OP${i + 1}`,
+                operation_type: op.operation_type || null,
+                operation_code: op.operation_code || "",
                 operation_name: op.operation_name || "",
                 setup_time_minutes: op.setup_time_minutes || 0,
                 run_time_minutes: op.run_time_minutes || 0,
@@ -352,6 +375,11 @@ export default function RoutingEditorContent({
   };
 
   const addOperation = () => {
+    if (!newOperation.operation_type) {
+      setError("Please select an operation type");
+      return;
+    }
+
     const workCenter = workCenters.find(
       (wc) => wc.id === parseInt(newOperation.work_center_id)
     );
@@ -376,6 +404,7 @@ export default function RoutingEditorContent({
     setNewOperation({
       work_center_id: "",
       sequence: operations.length + 2,
+      operation_type: "",
       operation_code: "",
       operation_name: "",
       setup_time_minutes: 0,
@@ -690,6 +719,7 @@ export default function RoutingEditorContent({
                       }
                       isExpanded={op.id && expandedOperations[op.id]}
                       loading={loading}
+                      operationTypes={operationTypes}
                       operations={operations}
                       onToggleExpand={toggleOperationExpanded}
                       onUpdateOperation={updateOperation}
@@ -727,6 +757,7 @@ export default function RoutingEditorContent({
           {showAddOperation && (
             <AddOperationForm
               workCenters={workCenters}
+              operationTypes={operationTypes}
               newOperation={newOperation}
               onOperationChange={setNewOperation}
               onAdd={addOperation}

--- a/frontend/src/components/routing/__tests__/AddOperationForm.test.jsx
+++ b/frontend/src/components/routing/__tests__/AddOperationForm.test.jsx
@@ -1,0 +1,177 @@
+/**
+ * Tests for AddOperationForm (#876 PR-4 — operation type picker).
+ *
+ * Scenarios:
+ *  1. Operation Type renders as a required select, grouped by category.
+ *  2. Picking a type shows its plain-English description under the field.
+ *  3. Picking a type pre-fills the (collapsed/advanced) operation code with
+ *     the canonical short code, without touching the untouched field.
+ *  4. Manually editing the code (escape hatch) survives a later type change
+ *     — the auto-fill never clobbers a hand-typed code.
+ *  5. The Add button is disabled until a type is selected.
+ *  6. The killed "e.g., OP10, OP20" placeholder is gone.
+ */
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import AddOperationForm from "../AddOperationForm";
+
+const OPERATION_TYPES = [
+  {
+    id: 1,
+    code: "FDM_PRINT",
+    label: "FDM Print",
+    description: "Materials count when the production order completes.",
+    category: "print",
+    sort_order: 10,
+  },
+  {
+    id: 4,
+    code: "QUALITY_CONTROL",
+    label: "Quality Control",
+    description: "Materials count for nothing automatically.",
+    category: "quality",
+    sort_order: 40,
+  },
+  {
+    id: 8,
+    code: "PACK_SHIP",
+    label: "Pack / Ship",
+    description: "Materials count when the order ships.",
+    category: "shipping",
+    sort_order: 80,
+  },
+  {
+    id: 9,
+    code: "GENERAL",
+    label: "Other (consumes at production)",
+    description: "Materials count when the production order completes.",
+    category: "other",
+    sort_order: 90,
+  },
+];
+
+const WORK_CENTERS = [
+  { id: 1, code: "FDM-1", name: "FDM Printer 1", total_rate_per_hour: "10" },
+];
+
+const baseOperation = {
+  work_center_id: "",
+  sequence: 1,
+  operation_type: "",
+  operation_code: "",
+  operation_name: "",
+  setup_time_minutes: 0,
+  run_time_minutes: 0,
+  wait_time_minutes: 0,
+  move_time_minutes: 0,
+  units_per_cycle: 1,
+  scrap_rate_percent: 0,
+  is_active: true,
+};
+
+// Wraps AddOperationForm with the controlled-state contract its real
+// parent (RoutingEditorContent) provides, so onOperationChange updates
+// flow back in as props like they do in the app.
+function ControlledForm({ initial = baseOperation, onAdd = vi.fn(), onCancel = vi.fn() }) {
+  const [newOperation, setNewOperation] = useState(initial);
+  return (
+    <AddOperationForm
+      workCenters={WORK_CENTERS}
+      operationTypes={OPERATION_TYPES}
+      newOperation={newOperation}
+      onOperationChange={setNewOperation}
+      onAdd={() => onAdd(newOperation)}
+      onCancel={onCancel}
+    />
+  );
+}
+
+describe("AddOperationForm — operation type picker", () => {
+  it("renders the Operation Type select grouped by category", () => {
+    render(<ControlledForm />);
+    const select = screen.getByLabelText(/Operation Type/);
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Print" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Quality" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Shipping" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "FDM Print" })).toBeInTheDocument();
+  });
+
+  it("shows the selected type's plain-English description", () => {
+    render(<ControlledForm />);
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "PACK_SHIP" },
+    });
+    expect(
+      screen.getByText("Materials count when the order ships.")
+    ).toBeInTheDocument();
+  });
+
+  it("pre-fills the advanced operation code with the type's canonical code", () => {
+    render(<ControlledForm />);
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "QUALITY_CONTROL" },
+    });
+    fireEvent.click(
+      screen.getByText(/Show advanced: custom operation code/)
+    );
+    expect(screen.getByLabelText(/Operation Code/).value).toBe("QC");
+  });
+
+  it("does not clobber a manually entered code when the type changes again", () => {
+    render(<ControlledForm />);
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "FDM_PRINT" },
+    });
+    fireEvent.click(
+      screen.getByText(/Show advanced: custom operation code/)
+    );
+    expect(screen.getByLabelText(/Operation Code/).value).toBe("PRINT");
+
+    fireEvent.change(screen.getByLabelText(/Operation Code/), {
+      target: { value: "CUSTOM-1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "PACK_SHIP" },
+    });
+    expect(screen.getByLabelText(/Operation Code/).value).toBe("CUSTOM-1");
+  });
+
+  it("GENERAL pre-fills a blank code, not a placeholder OPn value", () => {
+    render(<ControlledForm />);
+    // Touch a different type first, then land on GENERAL — still untouched
+    // by hand, so the auto-fill follows the latest type (blank for GENERAL)
+    // rather than ever minting an OPn placeholder.
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "FDM_PRINT" },
+    });
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "GENERAL" },
+    });
+    fireEvent.click(
+      screen.getByText(/Show advanced: custom operation code/)
+    );
+    expect(screen.getByLabelText(/Operation Code/).value).toBe("");
+    expect(screen.queryByPlaceholderText(/OP10, OP20/)).not.toBeInTheDocument();
+  });
+
+  it("disables Add until an operation type is selected", () => {
+    const onAdd = vi.fn();
+    render(<ControlledForm onAdd={onAdd} />);
+    expect(screen.getByText("Add")).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "FDM_PRINT" },
+    });
+    expect(screen.getByText("Add")).not.toBeDisabled();
+  });
+
+  it("never renders the killed OP10/OP20 placeholder", () => {
+    render(<ControlledForm />);
+    fireEvent.click(
+      screen.getByText(/Show advanced: custom operation code/)
+    );
+    expect(screen.queryByPlaceholderText(/OP10, OP20/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/routing/__tests__/OperationRow.test.jsx
+++ b/frontend/src/components/routing/__tests__/OperationRow.test.jsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for OperationRow's operation-type badge/picker (#876 PR-4).
+ *
+ * Scenarios:
+ *  1. An untyped operation renders the "No type — treated as Production"
+ *     warning chip and its default-consumption description.
+ *  2. A typed operation renders its label as the badge and its catalog
+ *     description underneath.
+ *  3. Changing the select calls onUpdateOperation(index, "operation_type", value).
+ *  4. A type stamped on the op but absent from the fetched (active-only)
+ *     catalog still renders instead of silently disappearing.
+ */
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import OperationRow from "../OperationRow";
+
+const OPERATION_TYPES = [
+  {
+    id: 1,
+    code: "FDM_PRINT",
+    label: "FDM Print",
+    description: "Materials count when the production order completes.",
+    category: "print",
+    sort_order: 10,
+  },
+  {
+    id: 8,
+    code: "PACK_SHIP",
+    label: "Pack / Ship",
+    description: "Materials count when the order ships.",
+    category: "shipping",
+    sort_order: 80,
+  },
+];
+
+function makeOp(overrides = {}) {
+  return {
+    id: 1,
+    sequence: 1,
+    operation_name: "3D Print",
+    operation_code: "PRINT",
+    operation_type: null,
+    work_center_name: "FDM Printer 1",
+    setup_time_minutes: 5,
+    run_time_minutes: 60,
+    calculated_cost: 10,
+    ...overrides,
+  };
+}
+
+function renderRow(op, extraProps = {}) {
+  const onUpdateOperation = vi.fn();
+  const utils = render(
+    <table>
+      <tbody>
+        <OperationRow
+          op={op}
+          index={0}
+          materials={[]}
+          isExpanded={false}
+          loading={false}
+          operationTypes={OPERATION_TYPES}
+          operations={[op]}
+          onToggleExpand={vi.fn()}
+          onUpdateOperation={onUpdateOperation}
+          onRemoveOperation={vi.fn()}
+          onAddMaterial={vi.fn()}
+          onEditMaterial={vi.fn()}
+          {...extraProps}
+        />
+      </tbody>
+    </table>
+  );
+  return { ...utils, onUpdateOperation };
+}
+
+describe("OperationRow — operation type badge/picker", () => {
+  it("shows the untyped warning chip and default description", () => {
+    renderRow(makeOp({ operation_type: null }));
+    const select = screen.getByRole("combobox");
+    expect(select.value).toBe("");
+    expect(
+      within(select).getByRole("option", { name: "No type — treated as Production" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Materials count when the production order completes \(default/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the assigned type's label and description for a typed op", () => {
+    renderRow(makeOp({ operation_type: "PACK_SHIP" }));
+    const select = screen.getByRole("combobox");
+    expect(select.value).toBe("PACK_SHIP");
+    expect(
+      screen.getByText(/Pack \/ Ship.*Materials count when the order ships\./)
+    ).toBeInTheDocument();
+  });
+
+  it("calls onUpdateOperation with the new type when changed", () => {
+    const { onUpdateOperation } = renderRow(makeOp({ operation_type: null }));
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "FDM_PRINT" },
+    });
+    expect(onUpdateOperation).toHaveBeenCalledWith(0, "operation_type", "FDM_PRINT");
+  });
+
+  it("keeps an orphaned type (not in the active catalog) visible", () => {
+    renderRow(makeOp({ operation_type: "LEGACY_CUSTOM_TYPE" }));
+    const select = screen.getByRole("combobox");
+    expect(select.value).toBe("LEGACY_CUSTOM_TYPE");
+    expect(
+      within(select).getByRole("option", { name: "LEGACY_CUSTOM_TYPE" })
+    ).toBeInTheDocument();
+  });
+
+  it("applies warning styling when untyped and info styling when typed", () => {
+    const { rerender } = render(
+      <table>
+        <tbody>
+          <OperationRow
+            op={makeOp({ operation_type: null })}
+            index={0}
+            materials={[]}
+            isExpanded={false}
+            loading={false}
+            operationTypes={OPERATION_TYPES}
+            operations={[makeOp({ operation_type: null })]}
+            onToggleExpand={vi.fn()}
+            onUpdateOperation={vi.fn()}
+            onRemoveOperation={vi.fn()}
+            onAddMaterial={vi.fn()}
+            onEditMaterial={vi.fn()}
+          />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole("combobox").className).toMatch(/yellow/);
+
+    rerender(
+      <table>
+        <tbody>
+          <OperationRow
+            op={makeOp({ operation_type: "FDM_PRINT" })}
+            index={0}
+            materials={[]}
+            isExpanded={false}
+            loading={false}
+            operationTypes={OPERATION_TYPES}
+            operations={[makeOp({ operation_type: "FDM_PRINT" })]}
+            onToggleExpand={vi.fn()}
+            onUpdateOperation={vi.fn()}
+            onRemoveOperation={vi.fn()}
+            onAddMaterial={vi.fn()}
+            onEditMaterial={vi.fn()}
+          />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByRole("combobox").className).toMatch(/blue/);
+  });
+});

--- a/frontend/src/components/routing/__tests__/RoutingEditorContent.test.jsx
+++ b/frontend/src/components/routing/__tests__/RoutingEditorContent.test.jsx
@@ -1,0 +1,137 @@
+/**
+ * Integration test for RoutingEditorContent (#876 PR-4).
+ *
+ * Covers the end-to-end contract the design calls for: adding an operation
+ * through the new type picker sends operation_type on create, and no
+ * longer mints a placeholder OPn operation_code for a blank code.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RoutingEditorContent from "../RoutingEditorContent";
+
+const OPERATION_TYPES = [
+  {
+    id: 1,
+    code: "FDM_PRINT",
+    label: "FDM Print",
+    description: "Materials count when the production order completes.",
+    category: "print",
+    sort_order: 10,
+  },
+  {
+    id: 8,
+    code: "PACK_SHIP",
+    label: "Pack / Ship",
+    description: "Materials count when the order ships.",
+    category: "shipping",
+    sort_order: 80,
+  },
+];
+
+const WORK_CENTERS = [
+  { id: 1, code: "FDM-1", name: "FDM Printer 1", total_rate_per_hour: "10" },
+];
+
+function jsonResponse(data, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => data,
+  };
+}
+
+let capturedCreateBody = null;
+
+beforeEach(() => {
+  capturedCreateBody = null;
+  globalThis.fetch = vi.fn().mockImplementation(async (url, options = {}) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+
+    if (urlStr.includes("/routings/product/")) {
+      // No routing exists yet for this product — editor starts empty.
+      return jsonResponse({ detail: "not found" }, false, 404);
+    }
+    if (urlStr.includes("/work-centers")) {
+      return jsonResponse(WORK_CENTERS);
+    }
+    if (urlStr.includes("/operation-types")) {
+      return jsonResponse(OPERATION_TYPES);
+    }
+    if (urlStr.includes("/routings?templates_only=true")) {
+      return jsonResponse([]);
+    }
+    if (urlStr.includes("/routings/") && options.method === "POST") {
+      capturedCreateBody = JSON.parse(options.body);
+      return jsonResponse({ id: 99, operations: [] });
+    }
+    return jsonResponse({});
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RoutingEditorContent — operation type on create", () => {
+  it("sends operation_type and does not mint an OPn operation_code", async () => {
+    const onSuccess = vi.fn();
+    render(
+      <RoutingEditorContent
+        productId={5}
+        isActive={true}
+        embedded={true}
+        onSuccess={onSuccess}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Wait for the catalog fetches to resolve before opening the form.
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    fireEvent.click(await screen.findByText("+ Add Operation"));
+
+    // The <select>s only accept a value once their matching <option> has
+    // rendered (native select semantics) — wait for both fetched catalogs.
+    await screen.findByRole("option", { name: "FDM Print" });
+    await screen.findByRole("option", { name: "FDM-1 - FDM Printer 1" });
+
+    fireEvent.change(screen.getByLabelText(/Operation Type/), {
+      target: { value: "FDM_PRINT" },
+    });
+    fireEvent.change(screen.getByLabelText(/Work Center/), {
+      target: { value: "1" },
+    });
+    // Deliberately leave the (now-secondary) operation code untouched.
+    fireEvent.click(screen.getByText("Add"));
+
+    fireEvent.click(screen.getByText("Create Routing"));
+
+    await waitFor(() => expect(capturedCreateBody).not.toBeNull());
+    expect(capturedCreateBody.operations).toHaveLength(1);
+    const op = capturedCreateBody.operations[0];
+    expect(op.operation_type).toBe("FDM_PRINT");
+    // The old behavior minted `OP${idx + 1}` here — assert that's gone.
+    expect(op.operation_code).not.toMatch(/^OP\d+$/);
+    expect(op.operation_code).toBe("PRINT"); // canonical code for FDM_PRINT
+  });
+
+  it("blocks adding an operation with no type selected", async () => {
+    render(
+      <RoutingEditorContent
+        productId={5}
+        isActive={true}
+        embedded={true}
+        onSuccess={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    fireEvent.click(await screen.findByText("+ Add Operation"));
+
+    await screen.findByRole("option", { name: "FDM-1 - FDM Printer 1" });
+    fireEvent.change(screen.getByLabelText(/Work Center/), {
+      target: { value: "1" },
+    });
+    expect(screen.getByText("Add")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/routing/operationTypeDisplay.js
+++ b/frontend/src/components/routing/operationTypeDisplay.js
@@ -1,0 +1,144 @@
+/**
+ * Display helpers for the operation-type catalog (#876 PR-4).
+ *
+ * The catalog itself is fetched once by RoutingEditorContent from
+ * GET /api/v1/operation-types and passed down as a prop. This module is
+ * presentation-only: grouping for the picker's <optgroup>s, the canonical
+ * short operation_code each type pre-fills into the (now secondary/
+ * editable) Operation Code field, and a frozen fallback label/description
+ * table so an already-typed operation's badge never goes blank if its type
+ * isn't in the currently-fetched active-only catalog (e.g. a deactivated
+ * custom type still stamped on an existing operation).
+ */
+
+// Canonical short operation_code pre-filled when a type is picked. This is
+// a display convenience only — the backend drives all real semantics off
+// operation_type, not this code (see operation_material_mapping.py
+// resolve_consume_stages). GENERAL has no single canonical short code.
+export const CANONICAL_OPERATION_CODE = {
+  FDM_PRINT: "PRINT",
+  RESIN_PRINT: "PRINT",
+  ASSEMBLY: "ASSEMBLE",
+  QUALITY_CONTROL: "QC",
+  SUPPORT_REMOVAL: "CLEAN",
+  SANDING: "SAND",
+  PAINTING: "PAINT",
+  PACK_SHIP: "PACK",
+  GENERAL: "",
+};
+
+// Fallback label/description/category for the 9 system types, verbatim
+// from migrations/versions/101_operation_types.py SEED_OPERATION_TYPES.
+// Only consulted when a code isn't present in the fetched (active-only)
+// catalog prop.
+export const OPERATION_TYPE_FALLBACK = {
+  FDM_PRINT: {
+    label: "FDM Print",
+    description: "Materials count when the production order completes.",
+    category: "print",
+  },
+  RESIN_PRINT: {
+    label: "Resin Print",
+    description: "Materials count when the production order completes.",
+    category: "print",
+  },
+  ASSEMBLY: {
+    label: "Assembly",
+    description: "Materials count when the production order completes.",
+    category: "assembly",
+  },
+  QUALITY_CONTROL: {
+    label: "Quality Control",
+    description: "Materials count for nothing automatically.",
+    category: "quality",
+  },
+  SUPPORT_REMOVAL: {
+    label: "Support Removal / Cleanup",
+    description: "Materials count for nothing automatically.",
+    category: "finishing",
+  },
+  SANDING: {
+    label: "Sanding",
+    description: "Materials count for nothing automatically.",
+    category: "finishing",
+  },
+  PAINTING: {
+    label: "Painting",
+    description: "Materials count for nothing automatically.",
+    category: "finishing",
+  },
+  PACK_SHIP: {
+    label: "Pack / Ship",
+    description: "Materials count when the order ships.",
+    category: "shipping",
+  },
+  GENERAL: {
+    label: "Other (consumes at production)",
+    description: "Materials count when the production order completes.",
+    category: "other",
+  },
+};
+
+// Shown under/inside the picker for an operation with no type assigned —
+// mirrors resolve_consume_stages()'s NULL-type fallback
+// (["production", "any"]) in operation_material_mapping.py.
+export const UNTYPED_LABEL = "No type — treated as Production";
+export const UNTYPED_DESCRIPTION =
+  "Materials count when the production order completes (default — no type set).";
+
+const CATEGORY_LABELS = {
+  print: "Print",
+  assembly: "Assembly",
+  quality: "Quality",
+  finishing: "Finishing",
+  shipping: "Shipping",
+  other: "Other",
+};
+
+export function categoryLabel(category) {
+  if (!category) return "Other";
+  return (
+    CATEGORY_LABELS[category] ||
+    category.charAt(0).toUpperCase() + category.slice(1)
+  );
+}
+
+/**
+ * Group a flat operation-types catalog array into [category, types[]]
+ * entries, ordered by each group's lowest sort_order, for <optgroup>
+ * display. Falls back to a flat "other" group when categories are absent.
+ */
+export function groupOperationTypes(operationTypes) {
+  const groups = new Map();
+  for (const t of operationTypes || []) {
+    const key = t.category || "other";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(t);
+  }
+  return Array.from(groups.entries()).sort((a, b) => {
+    const aOrder = Math.min(...a[1].map((t) => t.sort_order ?? 0));
+    const bOrder = Math.min(...b[1].map((t) => t.sort_order ?? 0));
+    return aOrder - bOrder;
+  });
+}
+
+/**
+ * Resolve {label, description, category} for an operation_type code:
+ * prefer the live fetched catalog, then the frozen system-type fallback,
+ * then just the bare code with no description. Returns null for an empty
+ * code (caller decides how to render the untyped/warning state).
+ */
+export function describeOperationType(code, operationTypes) {
+  if (!code) return null;
+  const fromCatalog = (operationTypes || []).find((t) => t.code === code);
+  if (fromCatalog) {
+    return {
+      label: fromCatalog.label,
+      description: fromCatalog.description,
+      category: fromCatalog.category,
+    };
+  }
+  const fallback = OPERATION_TYPE_FALLBACK[code];
+  if (fallback) return fallback;
+  return { label: code, description: null, category: null };
+}


### PR DESCRIPTION
## What

- **AddOperationForm.jsx**: new **Operation Type** select is now the primary/required field, grouped by category (`<optgroup>`), populated from `GET /api/v1/operation-types`. The plain-English description of the selected type renders under the field.
- **Operation Code** is demoted to a collapsed "Show advanced: custom operation code" section — pre-filled with the type's canonical short code (`FDM_PRINT→PRINT`, `ASSEMBLY→ASSEMBLE`, `QUALITY_CONTROL→QC`, `PACK_SHIP→PACK`, `SUPPORT_REMOVAL→CLEAN`, `SANDING→SAND`, `PAINTING→PAINT`, `RESIN_PRINT→PRINT`, `GENERAL→""`), but freely editable (custom-code escape hatch that, once hand-edited, is never clobbered by a later type change). Killed the `"e.g., OP10, OP20"` placeholder.
- **RoutingEditorContent.jsx**: `operation_type` is now sent on both create (`POST /routings/`) and update (`PUT`/`POST` per-operation) payloads. Removed the `` op.operation_code || `OP${idx+1}` `` autofill at all three call sites — a blank `operation_code` is now sent as `""` rather than a minted placeholder. Added a client-side guard (`addOperation`) requiring a type before an operation can be added, mirroring the existing work-center guard.
- **OperationRow.jsx**: every operation row now renders a type badge that **is** the picker — a live `<select>` styled as a pill (blue when typed, amber/warning when not), showing the assigned type's label as its current value and the plain-English consume-timing description underneath. Untyped operations show `"No type — treated as Production"` as the pill text; clicking it opens the same select to assign one. A type that's stamped on an operation but missing from the (active-only) fetched catalog — e.g. a deactivated custom type — still renders instead of silently disappearing.
- **New `operationTypeDisplay.js`**: shared presentation helpers (canonical-code map, category grouping/labels, and a frozen fallback label/description table mirroring migration 101's seed data, used only when a type isn't in the live catalog).

## Why

`operation_code` free text (`OP10`, `OP20`, ...) never carried real semantics — the backend now drives consumption timing off `operation_type` (#876 PR-1/PR-2/PR-3, already on `main`). The editor was still steering users toward inventing meaningless codes and never surfaced the type at all. This PR makes the type the primary input, stops the autofill from manufacturing empty codes, and makes existing untyped operations visible (and one click away from being fixed) instead of silently defaulting to "Production" semantics.

## Backend

No backend changes were needed — `GET /api/v1/operation-types` (`OperationTypeResponse`, `#876` PR-1) already returns `description` and `category` on every row, which is everything the picker/badges need.

## Before / after

- **Before**: "Operation Code" was the only identity field (placeholder `"e.g., OP10, OP20"`); leaving it blank silently minted `OP1`, `OP2`, ... on save; there was no way to see or set an operation's type in the UI at all.
- **After**: "Operation Type" is required and primary; "Operation Code" is optional/secondary/collapsed and pre-filled sensibly; every row shows its type (or a warning if untyped) with a plain-English explanation of when its materials count as consumed.

## Manual test plan

CI runs `npm run test:unit` (vitest, `frontend/package.json`) — 66 files / 595 tests pass, including 3 new files / 14 new tests for this change (`AddOperationForm.test.jsx`, `OperationRow.test.jsx`, `RoutingEditorContent.test.jsx` — the last is an integration test asserting the create-routing POST body carries `operation_type` and never mints an `OPn` code). No Playwright/E2E spec exists for the routing editor, so nothing there to update. Manual verification (in addition to the automated tests above) on a real browser:

1. Items/Manufacturing → open a product's routing editor → "+ Add Operation".
2. Confirm "Operation Type" is required, grouped (Print / Assembly / Quality / Finishing / Shipping / Other), and the "Add" button is disabled until a type is picked.
3. Pick "FDM Print" → confirm the description ("Materials count when the production order completes.") appears, and expanding "Show advanced: custom operation code" shows the code pre-filled to `PRINT`.
4. Hand-edit the code to something custom, then change the type again → confirm the custom code is preserved (not overwritten).
5. Add the operation, Save/Create the routing → confirm the row shows a blue "FDM Print" badge/picker with its description underneath.
6. Re-open a routing with a legacy operation that has no `operation_type` set (e.g. one created before this PR / via the classifier's untouched rows) → confirm it shows the amber "No type — treated as Production" chip, and picking a type from it updates the row.
7. `npm run lint` on changed files: zero new errors (one pre-existing `react-hooks/set-state-in-effect` finding on `RoutingEditorContent.jsx:180` predates this PR — confirmed by linting `origin/main`'s copy of the file directly, unrelated to `fetchOperationTypes` which was added nearby). `npm run build` succeeds.

## Refs

- #876 design comment (§5b, PR-4 row)
- Session record: issuecomment-4912112893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operation type picker with grouped options and readable descriptions.
  * Existing operations now keep their selected type even if it’s not available in the current list.
  * The add-operation flow now waits for an operation type before allowing submission.

* **Bug Fixes**
  * Preserved manually entered operation codes when changing operation type.
  * Replaced placeholder-style operation codes with clearer canonical values or blank values where appropriate.
  * Improved labels and selection styling for typed vs. untyped operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->