### PR TITLE
feat(intake-ui): finishing-op type picker (876 PR-5b)

### DIFF
--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -12,6 +12,26 @@ import OperationMaterialModal from "../../components/OperationMaterialModal";
 import AssemblyIntakePanel from "./intake/AssemblyIntakePanel";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// 876 PR-5b: the finishing-op "Type" picker. Mirrors the wheel's
+// ALLOWED_FINISHING_OPERATION_TYPES (filaops-pro/filaops_pro/routes/intake.py)
+// and Core's operation_types catalog (#898) finishing-category rows. Stored
+// on RoutingOperation.operation_type when present — the picker prevents a
+// NEW ambiguous-FINISH population (see 876 §5a). "None" (empty value) keeps
+// the op untyped, resolving through the legacy operation_code map /
+// production default exactly like before this picker existed.
+const FINISHING_OPERATION_TYPES = [
+  { value: "", label: "None" },
+  { value: "SUPPORT_REMOVAL", label: "Support Removal" },
+  { value: "SANDING", label: "Sanding" },
+  { value: "PAINTING", label: "Painting" },
+  { value: "QUALITY_CONTROL", label: "Quality Control" },
+  { value: "PACK_SHIP", label: "Pack / Ship" },
+];
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1971,6 +1991,7 @@ export default function AdminIntakeStudio() {
           .map((o) => ({
             work_center_id: Number(o.work_center_id),
             operation_name: o.operation_name,
+            operation_type: o.operation_type || undefined,
             run_time_minutes: Number(o.run_time_minutes) || 0,
             setup_time_minutes: Number(o.setup_time_minutes) || 0,
             materials: (o.materials || []).map((m) => ({
@@ -2085,6 +2106,7 @@ export default function AdminIntakeStudio() {
           .map((o) => ({
             work_center_id: Number(o.work_center_id),
             operation_name: o.operation_name,
+            operation_type: o.operation_type || undefined,
             run_time_minutes: Number(o.run_time_minutes) || 0,
             setup_time_minutes: Number(o.setup_time_minutes) || 0,
             materials: (o.materials || []).map((m) => ({
@@ -2224,6 +2246,7 @@ export default function AdminIntakeStudio() {
       {
         work_center_id: "",
         operation_name: "",
+        operation_type: "",
         run_time_minutes: "",
         setup_time_minutes: "",
         materials: [],
@@ -3270,7 +3293,7 @@ export default function AdminIntakeStudio() {
                         className="bg-gray-800/50 rounded-lg p-4 space-y-3"
                       >
                         {/* Op fields row */}
-                        <div className="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+                        <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
                           <div>
                             <label className="block text-xs text-gray-400 mb-1">
                               Work center
@@ -3310,6 +3333,28 @@ export default function AdminIntakeStudio() {
                               placeholder="e.g. Support removal"
                               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
                             />
+                          </div>
+                          <div>
+                            <label className="block text-xs text-gray-400 mb-1">
+                              Type
+                            </label>
+                            <select
+                              value={op.operation_type || ""}
+                              onChange={(e) =>
+                                updateFinishingOp(
+                                  idx,
+                                  "operation_type",
+                                  e.target.value
+                                )
+                              }
+                              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm focus:outline-none focus:border-blue-500"
+                            >
+                              {FINISHING_OPERATION_TYPES.map((t) => (
+                                <option key={t.value} value={t.value}>
+                                  {t.label}
+                                </option>
+                              ))}
+                            </select>
                           </div>
                           <div>
                             <label className="block text-xs text-gray-400 mb-1">

--- a/frontend/src/pages/admin/AdminIntakeStudio.jsx
+++ b/frontend/src/pages/admin/AdminIntakeStudio.jsx
@@ -1986,22 +1986,7 @@ export default function AdminIntakeStudio() {
         item_type: itemType,
         category_id: categoryId ? Number(categoryId) : undefined,
         slots: buildSlotsPayload(),
-        finishing_ops: finishingOps
-          .filter((o) => o.work_center_id)
-          .map((o) => ({
-            work_center_id: Number(o.work_center_id),
-            operation_name: o.operation_name,
-            operation_type: o.operation_type || undefined,
-            run_time_minutes: Number(o.run_time_minutes) || 0,
-            setup_time_minutes: Number(o.setup_time_minutes) || 0,
-            materials: (o.materials || []).map((m) => ({
-              component_product_id: m.component_id,
-              quantity: Number(m.quantity) || 0,
-              unit: m.unit || "EA",
-              quantity_per: m.quantity_per || "unit",
-              scrap_factor: Number(m.scrap_factor) || 0,
-            })),
-          })),
+        finishing_ops: buildFinishingOpsPayload(finishingOps),
         packaging: [],
         persist_color_map: true,
       };
@@ -2071,7 +2056,7 @@ export default function AdminIntakeStudio() {
   };
 
   // ---------------------------------------------------------------------------
-  // Shared slot-payload builder (used by /preview and /sku)
+  // Shared slot / finishing-op payload builders (used by /preview and /sku)
   // ---------------------------------------------------------------------------
 
   const buildSlotsPayload = () =>
@@ -2082,6 +2067,24 @@ export default function AdminIntakeStudio() {
       used_g: s.used_g,
       spool_product_id: matchChoices[s.slot_id]?.product_id,
     }));
+
+  const buildFinishingOpsPayload = (ops) =>
+    ops
+      .filter((o) => o.work_center_id)
+      .map((o) => ({
+        work_center_id: Number(o.work_center_id),
+        operation_name: o.operation_name,
+        operation_type: o.operation_type || undefined,
+        run_time_minutes: Number(o.run_time_minutes) || 0,
+        setup_time_minutes: Number(o.setup_time_minutes) || 0,
+        materials: (o.materials || []).map((m) => ({
+          component_product_id: m.component_id,
+          quantity: Number(m.quantity) || 0,
+          unit: m.unit || "EA",
+          quantity_per: m.quantity_per || "unit",
+          scrap_factor: Number(m.scrap_factor) || 0,
+        })),
+      }));
 
   // ---------------------------------------------------------------------------
   // Step 4 — /preview (cost estimate before committing)
@@ -2101,22 +2104,7 @@ export default function AdminIntakeStudio() {
         print_time_seconds: parseResult.print_time_seconds,
         parts_on_plate: parts,
         slots: buildSlotsPayload(),
-        finishing_ops: ops
-          .filter((o) => o.work_center_id)
-          .map((o) => ({
-            work_center_id: Number(o.work_center_id),
-            operation_name: o.operation_name,
-            operation_type: o.operation_type || undefined,
-            run_time_minutes: Number(o.run_time_minutes) || 0,
-            setup_time_minutes: Number(o.setup_time_minutes) || 0,
-            materials: (o.materials || []).map((m) => ({
-              component_product_id: m.component_id,
-              quantity: Number(m.quantity) || 0,
-              unit: m.unit || "EA",
-              quantity_per: m.quantity_per || "unit",
-              scrap_factor: Number(m.scrap_factor) || 0,
-            })),
-          })),
+        finishing_ops: buildFinishingOpsPayload(ops),
         packaging: [],
       };
       const data = await api.post("/api/v1/pro/intake/preview", body);


### PR DESCRIPTION
## Summary

- Adds a per-finishing-op **Type** dropdown to Intake Studio's finishing-operations editor: Support Removal / Sanding / Painting / Quality Control / Pack-Ship / None — matching Core's `operation_types` catalog (#898) finishing-category rows.
- Sends `operation_type` in both the `/preview` and `/sku` request bodies when a type is picked; omitted when left at "None", so an untyped finishing op stays NULL — unchanged from today's behavior.
- No backend/Core changes — pure frontend addition to `frontend/src/pages/admin/AdminIntakeStudio.jsx`, matching the existing Studio component style (grid layout, `SearchableSelect`/`<select>` idioms, dark theme classes).

This is the UI half of 876 PR-5. The PRO wheel companion PR validates and stamps `operation_type` server-side and degrades gracefully when the field is absent (older/undeployed UI), so there is no hard dependency ordering between the two PRs:

- Wheel PR (filaops-ecosystem): BLB3DPrinting/filaops-ecosystem#191 — "feat(filaops-pro): intake stamps operation types + finishing-op type field + PRO type seeder (876 PR-5)"

Refs BLB3DPrinting/filaops#876 (design comment + session record issuecomment-4912112893).

## Test plan

- [x] `eslint` on the changed file: 0 errors, 0 warnings (verified via the main checkout's installed toolchain since this is a fresh worktree with no `node_modules`).
- [x] Manual code review: grid layout extended from 4 to 5 columns; `addFinishingOp` seeds `operation_type: ""`; both `runCreateSku` and `runPreview` payload builders send `operation_type: o.operation_type || undefined` (dropped from the JSON body when "None" is selected).
- [ ] Manual smoke test in a running Intake Studio instance (owner/CI to verify against a live Core+PRO stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Type** selector for finishing operations in Admin Intake Studio.
  * Included an optional finishing operation type in both the preview and SKU creation requests.
* **Bug Fixes**
  * Newly added finishing operations default to an empty type value to reduce unintended selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->