### PR TITLE
feat(invoices): void endpoint with mirrored GL reversal + PATCH status whitelist (894 PR-A)

### DIFF
--- a/backend/app/api/v1/endpoints/invoices.py
+++ b/backend/app/api/v1/endpoints/invoices.py
@@ -1,5 +1,5 @@
 """Invoice API endpoints."""
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from typing import Optional
@@ -8,7 +8,13 @@ from app.db.session import get_db
 from app.api.v1.deps import get_current_staff_user
 from app.models.user import User
 from app.models.sales_order import SalesOrder
-from app.schemas.invoice import InvoiceCreate, InvoiceUpdate, InvoiceResponse, InvoiceListResponse
+from app.schemas.invoice import (
+    InvoiceCreate,
+    InvoiceUpdate,
+    InvoiceResponse,
+    InvoiceListResponse,
+    InvoiceVoidRequest,
+)
 from app.services import invoice_service
 
 router = APIRouter(prefix="/invoices", tags=["Invoices"])
@@ -122,10 +128,24 @@ def update_invoice(
         )
     else:
         invoice = invoice_service.get_invoice(db, invoice_id)
-        if data.status:
-            invoice.status = data.status
-            db.commit()
-            db.refresh(invoice)
+        if data.status is not None:
+            # Status whitelist (#894): PATCH may only perform the draft -> sent
+            # transition. It used to write ANY string straight to the row —
+            # PATCH {status:'voided'} / {status:'paid'} silently forked the
+            # books from the ledger (same class as #838). Every other status
+            # change must go through its dedicated GL-aware endpoint.
+            if data.status == "sent" and invoice.status == "draft":
+                invoice = invoice_service.mark_sent(db, invoice_id)
+            else:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Invoice status cannot be set to '{data.status}' via "
+                        "PATCH. Use POST /invoices/{id}/send to send, "
+                        "POST /invoices/{id}/void to void, or record a payment "
+                        "to mark it paid."
+                    ),
+                )
     return _build_invoice_response(invoice, db)
 
 
@@ -153,4 +173,23 @@ def send_invoice(
     current_user: User = Depends(get_current_staff_user),
 ):
     invoice = invoice_service.mark_sent(db, invoice_id)
+    return _build_invoice_response(invoice, db)
+
+
+@router.post("/{invoice_id}/void", response_model=InvoiceResponse)
+def void_invoice(
+    invoice_id: int,
+    data: InvoiceVoidRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_staff_user),
+):
+    """Void an invoice, posting a mirror GL reversal of its posted receivable.
+
+    404 unknown; 400 already voided/cancelled; 409 if it has attributed
+    completed payments (void/refund those first). A draft with no posted JE
+    is a status-only void.
+    """
+    invoice = invoice_service.void_invoice(
+        db, invoice_id, reason=data.reason, voided_by_id=current_user.id
+    )
     return _build_invoice_response(invoice, db)

--- a/backend/app/models/invoice.py
+++ b/backend/app/models/invoice.py
@@ -50,6 +50,13 @@ class Invoice(Base):
     external_invoice_url = Column(String(500), nullable=True)
     external_provider = Column(String(20), nullable=True)
 
+    # Void audit trail (set when an invoice is voided via POST /invoices/{id}/void).
+    # A voided invoice is terminal and out of the AR picture; if it had a posted
+    # receivable JE, a mirror reversal (source_type='invoice_void') is posted.
+    voided_at = Column(DateTime(timezone=True), nullable=True)
+    voided_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    void_reason = Column(String(255), nullable=True)
+
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/backend/app/schemas/invoice.py
+++ b/backend/app/schemas/invoice.py
@@ -1,5 +1,5 @@
 """Invoice Pydantic schemas."""
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional, List
 from datetime import date, datetime
 from decimal import Decimal
@@ -29,6 +29,11 @@ class InvoiceUpdate(BaseModel):
     amount_paid: Optional[Decimal] = None
     payment_method: Optional[str] = None
     payment_reference: Optional[str] = None
+
+
+class InvoiceVoidRequest(BaseModel):
+    """Body for POST /invoices/{id}/void — a non-empty reason is required."""
+    reason: str = Field(..., min_length=1, max_length=255)
 
 
 class InvoiceResponse(BaseModel):
@@ -62,6 +67,9 @@ class InvoiceResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     sent_at: Optional[datetime] = None
+    voided_at: Optional[datetime] = None
+    voided_by_id: Optional[int] = None
+    void_reason: Optional[str] = None
     pdf_path: Optional[str] = None
     lines: List[InvoiceLineResponse] = []
     order_number: Optional[str] = None

--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -16,8 +16,10 @@ from app.models.product import Product
 from app.models.sales_order import SalesOrder, SalesOrderLine
 from app.models.user import User
 from app.services.payment_service import (
+    _money,
     post_invoice_receivable,
     record_payment_and_reconcile,
+    reverse_invoice_receivable,
     update_order_payment_status,
 )
 
@@ -444,6 +446,65 @@ def mark_sent(db: Session, invoice_id: int) -> Invoice:
     invoice.status = "sent"
     invoice.sent_at = datetime.now(timezone.utc)
     post_invoice_receivable(db, invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def void_invoice(
+    db: Session,
+    invoice_id: int,
+    reason: str,
+    voided_by_id: Optional[int] = None,
+) -> Invoice:
+    """Void an invoice: reverse its posted receivable GL and mark it voided.
+
+    Guards:
+      - 422 if ``reason`` is missing/blank (also enforced by the request schema).
+      - 404 if the invoice does not exist.
+      - 400 if it is already ``voided``/``cancelled`` (idempotent-safe: no
+        second reversal JE is ever posted).
+      - 409 if the invoice has attributed completed payments
+        (``amount_paid`` != 0). Those must be voided/refunded first so each
+        reversal stays a clean 1:1 mirror (matches how the ledger unwinds a
+        payment before the invoice).
+
+    GL: if a non-voided invoice-receivable JE exists, post a mirror reversal
+    (``source_type='invoice_void'``, idempotent). A draft invoice with no
+    posted JE is a status-only void — no JE. Sets status='voided',
+    voided_at, voided_by_id, void_reason. Commits.
+    """
+    reason = (reason or "").strip()
+    if not reason:
+        raise HTTPException(status_code=422, detail="Void reason is required")
+
+    invoice = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    if invoice.status in ("voided", "cancelled"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invoice is already {invoice.status}",
+        )
+
+    if _money(invoice.amount_paid) != 0:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Invoice has attributed payments; void or refund the payments "
+                "first, then void the invoice"
+            ),
+        )
+
+    # Mirror-reverse the posted receivable (no-op for a draft with no JE).
+    reverse_invoice_receivable(db, invoice, user_id=voided_by_id, reason=reason)
+
+    invoice.status = "voided"
+    invoice.voided_at = datetime.now(timezone.utc)
+    invoice.voided_by_id = voided_by_id
+    invoice.void_reason = reason
+
     db.commit()
     db.refresh(invoice)
     return invoice

--- a/backend/app/services/payment_service.py
+++ b/backend/app/services/payment_service.py
@@ -101,6 +101,71 @@ def post_invoice_receivable(db: Session, invoice, user_id: int | None = None) ->
     )
 
 
+def reverse_invoice_receivable(
+    db: Session,
+    invoice,
+    user_id: int | None = None,
+    reason: str | None = None,
+) -> GLJournalEntry | None:
+    """Post a one-time mirror reversal of an invoice's posted receivable JE.
+
+    Mirrors the ACTUAL posted lines with DR/CR swapped — it reads the lines
+    off the posted entry rather than recomputing from current invoice fields,
+    so a post-posting edit to the invoice still fully unwinds (a partial
+    reversal would leave the ledger unbalanced against reality). Idempotent on
+    (source_type='invoice_void', source_id=invoice.id).
+
+    Returns the reversal JE, or None when there is nothing to reverse:
+      - the invoice has no non-voided posted receivable JE (e.g. a draft), or
+      - the reversal was already posted.
+
+    entry_date defaults to today (create_journal_entry) — a void is never
+    backdated. Does NOT commit.
+    """
+    if not invoice or not invoice.id:
+        return None
+
+    posted = db.query(GLJournalEntry).filter(
+        GLJournalEntry.source_type == "invoice",
+        GLJournalEntry.source_id == invoice.id,
+        GLJournalEntry.status != "voided",
+    ).first()
+    if posted is None:
+        # No posted receivable (draft invoice) -> caller does a status-only void.
+        return None
+
+    if _posted_entry_exists(db, source_type="invoice_void", source_id=invoice.id):
+        return None
+
+    # Mirror the posted lines with DR/CR swapped. Fetch the actual lines and
+    # map account_id -> account_code (create_journal_entry works in codes).
+    reversal_lines: list[tuple[str, Decimal, str]] = []
+    for line in posted.lines:
+        account = db.get(GLAccount, line.account_id)
+        if account is None:
+            continue
+        debit = _money(line.debit_amount)
+        credit = _money(line.credit_amount)
+        if debit > 0:
+            reversal_lines.append((account.account_code, debit, "CR"))
+        if credit > 0:
+            reversal_lines.append((account.account_code, credit, "DR"))
+    if not reversal_lines:
+        return None
+
+    _ensure_core_sales_accounts(db)
+    description = f"Void invoice {invoice.invoice_number}"
+    if reason:
+        description = f"{description}: {reason}"
+    return TransactionService(db).create_journal_entry(
+        description=description[:255],
+        lines=reversal_lines,
+        source_type="invoice_void",
+        source_id=invoice.id,
+        user_id=user_id,
+    )
+
+
 def post_payment_receipt(db: Session, payment: Payment) -> GLJournalEntry | None:
     """Post a completed payment or refund to cash and AR once."""
     if not payment or not payment.id or payment.status != "completed":

--- a/backend/migrations/versions/102_invoice_void_audit.py
+++ b/backend/migrations/versions/102_invoice_void_audit.py
@@ -1,0 +1,77 @@
+"""invoice void audit columns: voided_at, voided_by_id, void_reason (#894 PR-A)
+
+Revision ID: 102
+Revises: 101
+Create Date: 2026-07-12
+
+#894 PR-A — adds the void audit trail to invoices so POST /invoices/{id}/void
+can record who voided an invoice, when, and why. A voided invoice is terminal
+and out of the AR picture; if it had a posted receivable JE, the void posts a
+mirror reversal (source_type='invoice_void') — that ledger work needs no schema
+change, only these three metadata columns.
+
+ADD COLUMN only (all nullable) — no table rewrite, safe on the live brownfield.
+Inspector-guarded so a re-run (or an accumulated create_all() test DB that
+already has the columns) is a no-op.
+
+Downgrade: drop the three columns (never run on the live DB).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "102"
+down_revision = "101"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = [c["name"] for c in insp.get_columns(table)]
+    return column in cols
+
+
+def _has_fk(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    names = {fk.get("name") for fk in insp.get_foreign_keys(table)}
+    return name in names
+
+
+def upgrade() -> None:
+    if not _has_column("invoices", "voided_at"):
+        op.add_column(
+            "invoices",
+            sa.Column("voided_at", sa.DateTime(timezone=True), nullable=True),
+        )
+    if not _has_column("invoices", "voided_by_id"):
+        op.add_column(
+            "invoices",
+            sa.Column("voided_by_id", sa.Integer(), nullable=True),
+        )
+        if not _has_fk("invoices", "fk_invoices_voided_by_id_users"):
+            op.create_foreign_key(
+                "fk_invoices_voided_by_id_users",
+                "invoices",
+                "users",
+                ["voided_by_id"],
+                ["id"],
+            )
+    if not _has_column("invoices", "void_reason"):
+        op.add_column(
+            "invoices",
+            sa.Column("void_reason", sa.String(length=255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_fk("invoices", "fk_invoices_voided_by_id_users"):
+        op.drop_constraint(
+            "fk_invoices_voided_by_id_users", "invoices", type_="foreignkey"
+        )
+    for column in ("void_reason", "voided_by_id", "voided_at"):
+        if _has_column("invoices", column):
+            op.drop_column("invoices", column)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -377,6 +377,17 @@ def setup_database():
         conn.execute(text(
             "ALTER TABLE production_order_operations ADD COLUMN IF NOT EXISTS operation_type VARCHAR(30)"
         ))
+        # #894 PR-A: invoice void audit trail (migration 102). create_all won't
+        # ALTER the pre-existing invoices table in the accumulated test DB.
+        conn.execute(text(
+            "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS voided_at TIMESTAMPTZ"
+        ))
+        conn.execute(text(
+            "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS voided_by_id INTEGER"
+        ))
+        conn.execute(text(
+            "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS void_reason VARCHAR(255)"
+        ))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -536,3 +536,303 @@ class TestInvoiceAPI:
         assert resp.status_code == 200
         assert resp.json()["status"] == "paid"
         assert float(resp.json()["amount_paid"]) == 50.00
+
+
+# ============================================================================
+# Void invoice (#894 PR-A)
+# ============================================================================
+#
+# GL assertions are scoped to each invoice's own source_id, so they are
+# delta-based by construction — the accumulated test DB's other rows never
+# enter the query.
+
+
+def _count_je(db, source_type, source_id):
+    from app.models.accounting import GLJournalEntry
+
+    return (
+        db.query(GLJournalEntry)
+        .filter(
+            GLJournalEntry.source_type == source_type,
+            GLJournalEntry.source_id == source_id,
+        )
+        .count()
+    )
+
+
+def _je_net_by_account(db, invoice_id):
+    """Net (debit - credit) per account across the invoice + invoice_void JEs
+    for this invoice. After a mirror void, every touched account nets to 0."""
+    from decimal import Decimal as _D
+
+    from sqlalchemy import func as _func
+
+    from app.models.accounting import (
+        GLAccount,
+        GLJournalEntry,
+        GLJournalEntryLine,
+    )
+
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            _func.coalesce(_func.sum(GLJournalEntryLine.debit_amount), 0),
+            _func.coalesce(_func.sum(GLJournalEntryLine.credit_amount), 0),
+        )
+        .join(GLJournalEntryLine, GLJournalEntryLine.account_id == GLAccount.id)
+        .join(
+            GLJournalEntry,
+            GLJournalEntry.id == GLJournalEntryLine.journal_entry_id,
+        )
+        .filter(
+            GLJournalEntry.source_type.in_(["invoice", "invoice_void"]),
+            GLJournalEntry.source_id == invoice_id,
+        )
+        .group_by(GLAccount.account_code)
+        .all()
+    )
+    return {code: _D(str(dr)) - _D(str(cr)) for code, dr, cr in rows}
+
+
+class TestVoidInvoice:
+    """Service-level void behavior (guards + mirrored GL reversal)."""
+
+    def test_void_posted_invoice_posts_mirror_reversal(
+        self, db, make_product, make_sales_order
+    ):
+        from app.services.invoice_service import (
+            create_invoice,
+            mark_sent,
+            void_invoice,
+        )
+
+        product = make_product(selling_price=Decimal("40.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("40.00"),
+            status="confirmed",
+        )
+        invoice = create_invoice(db, so.id)
+        mark_sent(db, invoice.id)  # posts DR 1100 AR / CR 4000 Revenue
+
+        assert _count_je(db, "invoice", invoice.id) == 1
+        assert _count_je(db, "invoice_void", invoice.id) == 0
+
+        voided = void_invoice(
+            db, invoice.id, reason="customer cancelled", voided_by_id=1
+        )
+        assert voided.status == "voided"
+        assert voided.voided_at is not None
+        assert voided.voided_by_id == 1
+        assert voided.void_reason == "customer cancelled"
+
+        # Exactly one reversal JE, and the pair nets every account to 0.
+        assert _count_je(db, "invoice_void", invoice.id) == 1
+        net = _je_net_by_account(db, invoice.id)
+        assert net, "expected GL lines for a posted invoice"
+        for code, value in net.items():
+            assert value == Decimal("0"), (
+                f"account {code} did not net to 0 across the void pair: {value}"
+            )
+
+    def test_void_draft_invoice_creates_no_je(
+        self, db, make_product, make_sales_order
+    ):
+        from app.services.invoice_service import create_invoice, void_invoice
+
+        product = make_product(selling_price=Decimal("15.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("15.00"),
+            status="confirmed",
+        )
+        invoice = create_invoice(db, so.id)
+        assert invoice.status == "draft"
+        # A draft has never posted a receivable JE.
+        assert _count_je(db, "invoice", invoice.id) == 0
+
+        voided = void_invoice(db, invoice.id, reason="created in error", voided_by_id=1)
+        assert voided.status == "voided"
+        # Status-only void: no invoice JE and no reversal JE.
+        assert _count_je(db, "invoice", invoice.id) == 0
+        assert _count_je(db, "invoice_void", invoice.id) == 0
+
+    def test_double_void_returns_400_and_single_reversal(
+        self, db, make_product, make_sales_order
+    ):
+        from fastapi import HTTPException
+
+        from app.services.invoice_service import (
+            create_invoice,
+            mark_sent,
+            void_invoice,
+        )
+
+        product = make_product(selling_price=Decimal("22.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("22.00"),
+            status="confirmed",
+        )
+        invoice = create_invoice(db, so.id)
+        mark_sent(db, invoice.id)
+        void_invoice(db, invoice.id, reason="first void", voided_by_id=1)
+        assert _count_je(db, "invoice_void", invoice.id) == 1
+
+        with pytest.raises(HTTPException) as exc_info:
+            void_invoice(db, invoice.id, reason="second void", voided_by_id=1)
+        assert exc_info.value.status_code == 400
+        # Still exactly one reversal JE — no double reversal.
+        assert _count_je(db, "invoice_void", invoice.id) == 1
+
+    def test_void_with_completed_payment_returns_409(
+        self, db, make_product, make_sales_order
+    ):
+        from fastapi import HTTPException
+
+        from app.services.invoice_service import (
+            create_invoice,
+            record_payment,
+            void_invoice,
+        )
+
+        product = make_product(selling_price=Decimal("60.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("60.00"),
+            status="confirmed",
+        )
+        invoice = create_invoice(db, so.id)
+        record_payment(db, invoice.id, Decimal("60.00"), "card")
+        db.refresh(invoice)
+        assert invoice.amount_paid == Decimal("60.00")
+
+        with pytest.raises(HTTPException) as exc_info:
+            void_invoice(db, invoice.id, reason="cannot void a paid invoice", voided_by_id=1)
+        assert exc_info.value.status_code == 409
+
+    def test_void_blank_reason_returns_422(self, db, make_product, make_sales_order):
+        from fastapi import HTTPException
+
+        from app.services.invoice_service import create_invoice, void_invoice
+
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal("10.00"),
+            status="confirmed",
+        )
+        invoice = create_invoice(db, so.id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            void_invoice(db, invoice.id, reason="   ", voided_by_id=1)
+        assert exc_info.value.status_code == 422
+
+
+class TestVoidInvoiceAPI:
+    """Endpoint-level void behavior + PATCH status whitelist (#894 PR-A)."""
+
+    def _make_invoice(self, client, make_product, make_sales_order, price="10.00"):
+        product = make_product(selling_price=Decimal(price))
+        so = make_sales_order(
+            product_id=product.id,
+            quantity=1,
+            unit_price=Decimal(price),
+            status="confirmed",
+        )
+        resp = client.post("/api/v1/invoices", json={"sales_order_id": so.id})
+        assert resp.status_code == 200
+        return resp.json()["id"]
+
+    def test_void_endpoint_marks_voided(
+        self, client, db, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        # Send first so a receivable JE is posted, exercising the reversal path.
+        assert client.post(f"/api/v1/invoices/{invoice_id}/send").status_code == 200
+
+        resp = client.post(
+            f"/api/v1/invoices/{invoice_id}/void",
+            json={"reason": "duplicate invoice"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "voided"
+        assert body["void_reason"] == "duplicate invoice"
+        assert body["voided_at"] is not None
+        # A mirror reversal JE was posted for this invoice.
+        assert _count_je(db, "invoice_void", invoice_id) == 1
+
+    def test_void_nonexistent_invoice_404(self, client):
+        resp = client.post("/api/v1/invoices/999999/void", json={"reason": "x"})
+        assert resp.status_code == 404
+
+    def test_void_missing_reason_422(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        resp = client.post(f"/api/v1/invoices/{invoice_id}/void", json={})
+        assert resp.status_code == 422
+
+    def test_void_empty_reason_422(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        resp = client.post(
+            f"/api/v1/invoices/{invoice_id}/void", json={"reason": ""}
+        )
+        assert resp.status_code == 422
+
+    def test_patch_status_voided_rejected_422(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        resp = client.patch(
+            f"/api/v1/invoices/{invoice_id}", json={"status": "voided"}
+        )
+        assert resp.status_code == 422
+        # The invoice must not have been forked to voided by the bypass.
+        get_resp = client.get(f"/api/v1/invoices/{invoice_id}")
+        assert get_resp.json()["status"] == "draft"
+
+    def test_patch_status_paid_rejected_422(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        resp = client.patch(
+            f"/api/v1/invoices/{invoice_id}", json={"status": "paid"}
+        )
+        assert resp.status_code == 422
+
+    def test_patch_status_sent_from_draft_ok_200(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        resp = client.patch(
+            f"/api/v1/invoices/{invoice_id}", json={"status": "sent"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "sent"
+        assert resp.json()["sent_at"] is not None
+
+    def test_patch_status_sent_from_non_draft_rejected_422(
+        self, client, make_product, make_sales_order
+    ):
+        invoice_id = self._make_invoice(client, make_product, make_sales_order)
+        # Move to sent once (allowed) ...
+        assert (
+            client.patch(
+                f"/api/v1/invoices/{invoice_id}", json={"status": "sent"}
+            ).status_code
+            == 200
+        )
+        # ... a second sent (from non-draft) is not a valid PATCH transition.
+        resp = client.patch(
+            f"/api/v1/invoices/{invoice_id}", json={"status": "sent"}
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## What

Implements **#894 PR-A** per the architect design in
https://github.com/BLB3DPrinting/filaops/issues/894#issuecomment-4952670760:

### 1. `POST /invoices/{invoice_id}/void` (staff-gated)
- Body `{reason: str}` — required, non-empty (schema `min_length=1` + service-side blank check → 422).
- Guards: **404** unknown invoice; **400** already `voided`/`cancelled`; **409** when `_money(invoice.amount_paid) != 0` — payments must be voided/refunded first so every reversal stays a clean 1:1 mirror.
- **GL**: locates the posted JE by `(source_type='invoice', source_id)` (same predicate as `_posted_entry_exists`). If a non-voided JE exists, posts a reversal that **mirrors the posted JE's actual lines with DR/CR swapped** — lines are read off the posted entry, never recomputed from current invoice fields, so post-posting edits still fully unwind. `source_type='invoice_void'`, idempotent on that pair, description `Void invoice {number}: {reason}`, posted via `TransactionService(db).create_journal_entry` with default `entry_date` = today (never backdated). Draft with no posted JE → status-only void, no JE.
- Service layer: `void_invoice()` in `invoice_service.py` (standalone function, `db` first param — same idiom as `mark_sent`); GL mirror in `reverse_invoice_receivable()` in `payment_service.py` next to `post_invoice_receivable` / `reverse_payment_receipt`. Endpoint stays thin.
- Sets `invoice.status='voided'`, `voided_at`, `voided_by_id`, `void_reason`.

### 2. Model + migration
- `Invoice.voided_at` (tz-aware DateTime), `voided_by_id` (FK `users.id`), `void_reason` (String(255)) — all nullable.
- Alembic revision **102** (`down_revision='101'`, the verified single head). ADD COLUMN only, inspector-guarded, no table rewrite. Conftest gets the matching `ADD COLUMN IF NOT EXISTS` patch for accumulated test DBs (repo idiom).

### 3. PATCH status bypass fix (new finding in #894)
`PATCH /invoices/{id}` previously wrote **any** `data.status` string straight to the row — `PATCH {status:'voided'}` / `{'paid'}` silently forked the books from the ledger (same class as #838). Now whitelisted: only `draft → sent` is allowed (delegates to `mark_sent`, which posts the receivable JE — previously PATCH-sent skipped GL entirely). Everything else → **422** pointing at `/send`, `/void`, and payment recording. The `amount_paid+payment_method` branch is untouched.

## Why

Voiding an invoice today requires manual ledger surgery; the PATCH hole let status flip with no GL at all. This gives ops a safe, auditable void with a guaranteed-balanced ledger pair, and closes the bypass.

## Tests (`backend/tests/test_invoice_service.py`, delta-based — GL assertions scoped to each invoice's own `source_id`)

| Test | Asserts |
|---|---|
| `test_void_posted_invoice_posts_mirror_reversal` | reversal JE exists; invoice+invoice_void pair nets **every** account to 0; audit fields set |
| `test_void_draft_invoice_creates_no_je` | status-only void; zero JEs for the invoice |
| `test_double_void_returns_400_and_single_reversal` | 400; still exactly one `invoice_void` JE |
| `test_void_with_completed_payment_returns_409` | 409 with attributed completed payment |
| `test_void_blank_reason_returns_422` | service rejects whitespace-only reason |
| `test_void_endpoint_marks_voided` | endpoint 200; voided + reversal JE posted |
| `test_void_nonexistent_invoice_404` | 404 |
| `test_void_missing_reason_422` / `test_void_empty_reason_422` | schema-level 422 |
| `test_patch_status_voided_rejected_422` | bypass closed; invoice stays `draft` |
| `test_patch_status_paid_rejected_422` | bypass closed |
| `test_patch_status_sent_from_draft_ok_200` | whitelisted transition still works (now GL-aware) |
| `test_patch_status_sent_from_non_draft_rejected_422` | `sent` only valid from `draft` |

`ruff check app/ --select E712`: clean.

Refs #894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to void invoices with a required reason.
  * Invoice responses now include voiding details, including timestamp, staff member, and reason.
  * Voiding unpaid invoices automatically reverses associated accounting entries.

* **Bug Fixes**
  * Restricted invoice status updates to supported transitions.
  * Prevented voiding paid, already voided, or cancelled invoices.
  * Added validation and clearer errors for invalid invoice status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->