### PR TITLE
fix(accounting): sales journal + Tax Center use shared anchor statuses — delivered orders stop vanishing (899)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/accounting.py
+++ b/backend/app/api/v1/endpoints/admin/accounting.py
@@ -696,7 +696,7 @@ async def get_sales_journal(
     query = db.query(SalesOrder).filter(
         SalesOrder.shipped_at >= start_date,
         SalesOrder.shipped_at <= end_date_eod,
-        SalesOrder.status.in_(["shipped", "completed"])
+        SalesOrder.status.in_(cogs_report_service.ANCHOR_STATUSES)
     )
 
     if status:
@@ -785,7 +785,7 @@ async def export_sales_journal_csv(
     orders = db.query(SalesOrder).filter(
         SalesOrder.shipped_at >= start_date,
         SalesOrder.shipped_at <= end_date_eod,
-        SalesOrder.status.in_(["shipped", "completed"])
+        SalesOrder.status.in_(cogs_report_service.ANCHOR_STATUSES)
     ).order_by(SalesOrder.shipped_at).all()
 
     output = io.StringIO()
@@ -868,12 +868,15 @@ async def get_tax_summary(
     # Tax liability is recognized when revenue is recognized (at shipment)
     orders = db.query(SalesOrder).filter(
         SalesOrder.shipped_at >= period_start,
-        SalesOrder.status.in_(["shipped", "completed"])
+        SalesOrder.status.in_(cogs_report_service.ANCHOR_STATUSES)
     ).all()
 
-    # Get pending orders (not yet shipped) to show future tax liability
+    # Get pending orders (not yet in an anchor/terminal state) to show future
+    # tax liability. Exclude the shared anchor set (#899) — not just the old
+    # shipped/completed pair — so a delivered order, now counted as *collected*
+    # above, can never also appear here (double-counted tax); plus cancelled.
     pending_orders = db.query(SalesOrder).filter(
-        SalesOrder.status.notin_(["shipped", "completed", "cancelled"]),
+        SalesOrder.status.notin_(cogs_report_service.ANCHOR_STATUSES + ("cancelled",)),
         SalesOrder.tax_amount > 0
     ).all()
 
@@ -998,7 +1001,7 @@ async def export_tax_summary_csv(
     # Use shipped_at for accrual accounting (tax liability at revenue recognition)
     orders = db.query(SalesOrder).filter(
         SalesOrder.shipped_at >= period_start,
-        SalesOrder.status.in_(["shipped", "completed"])
+        SalesOrder.status.in_(cogs_report_service.ANCHOR_STATUSES)
     ).order_by(SalesOrder.shipped_at).all()
 
     output = io.StringIO()

--- a/backend/tests/api/v1/test_admin_accounting.py
+++ b/backend/tests/api/v1/test_admin_accounting.py
@@ -1177,3 +1177,110 @@ class TestEdgeCases:
             assert resp.status_code == 200, (
                 f"Endpoint {endpoint} returned {resp.status_code}: {resp.text[:200]}"
             )
+
+
+# =============================================================================
+# TEST: Delivered orders anchor on the shared status set (#899)
+# =============================================================================
+
+class TestDeliveredOrderAnchorStatuses:
+    """Regression tests for #899: a 'delivered' sales order must surface on the
+    revenue/tax surfaces (sales journal, Tax Center, and both CSV exports) the
+    same way 'shipped'/'completed' orders do.
+
+    Epic #880 (PR #897) unified every COGS surface on
+    ``cogs_report_service.ANCHOR_STATUSES = ('shipped', 'completed', 'delivered')``,
+    but five inline status filters on these revenue/tax surfaces still used the
+    old ('shipped', 'completed') pair — so an order advancing to 'delivered'
+    silently vanished from the sales journal and Tax Center, understating tax
+    liability. These tests pin the widened behavior at every one of the five
+    sites (sales journal, its CSV, Tax Center collected, the pending complement,
+    and the tax CSV).
+
+    All assertions are delta-based: the shared test DB accumulates committed
+    rows across runs, so we never assert absolute counts (see MEMORY note).
+    """
+
+    def _make_delivered_taxed_order(self, make_sales_order, db):
+        """A 'delivered' order carrying tax, shipped in the current period."""
+        now = datetime.now(timezone.utc)
+        order = make_sales_order(
+            quantity=1,
+            unit_price=Decimal("100.00"),
+            status="delivered",
+            shipped_at=now,
+            tax_amount=Decimal("8.00"),
+            tax_rate=Decimal("0.08"),
+            is_taxable=True,
+        )
+        db.commit()
+        return order
+
+    def test_delivered_order_appears_in_sales_journal(self, client, db, make_sales_order):
+        """A 'delivered' order must show in the sales journal (excluded pre-#899)."""
+        order = self._make_delivered_taxed_order(make_sales_order, db)
+
+        params = {"start_date": "2020-01-01T00:00:00", "end_date": "2030-12-31T23:59:59"}
+        resp = client.get(f"{BASE}/sales-journal", params=params)
+        assert resp.status_code == 200
+        order_numbers = {e["order_number"] for e in resp.json()["entries"]}
+        assert order.order_number in order_numbers, (
+            "delivered order must appear in the sales journal"
+        )
+
+    def test_delivered_order_contributes_to_tax_collected(self, client, db, make_sales_order):
+        """Tax Center 'collected' totals must include a delivered order's tax."""
+        before = client.get(
+            f"{BASE}/tax-summary", params={"period": "year"}
+        ).json()["summary"]
+
+        self._make_delivered_taxed_order(make_sales_order, db)
+
+        after = client.get(
+            f"{BASE}/tax-summary", params={"period": "year"}
+        ).json()["summary"]
+
+        assert round(after["tax_collected"] - before["tax_collected"], 2) == 8.00, (
+            "delivered order's tax must be counted as collected"
+        )
+        assert after["order_count"] - before["order_count"] >= 1
+
+    def test_delivered_order_not_in_pending_tax(self, client, db, make_sales_order):
+        """A delivered order counted as collected must NOT also appear as pending
+        tax — otherwise the same liability is double-counted. This pins the
+        site-4 widening: notin_(anchor + cancelled), not the old pair."""
+        before = client.get(
+            f"{BASE}/tax-summary", params={"period": "year"}
+        ).json()["pending"]
+
+        self._make_delivered_taxed_order(make_sales_order, db)
+
+        after = client.get(
+            f"{BASE}/tax-summary", params={"period": "year"}
+        ).json()["pending"]
+
+        assert round(after["tax_amount"] - before["tax_amount"], 2) == 0.00, (
+            "delivered order's tax must not land in pending (already collected)"
+        )
+        assert after["order_count"] - before["order_count"] == 0
+
+    def test_delivered_order_in_sales_journal_csv(self, client, db, make_sales_order):
+        """The sales-journal CSV export must include a delivered order."""
+        order = self._make_delivered_taxed_order(make_sales_order, db)
+
+        params = {"start_date": "2020-01-01T00:00:00", "end_date": "2030-12-31T23:59:59"}
+        resp = client.get(f"{BASE}/sales-journal/export", params=params)
+        assert resp.status_code == 200
+        assert order.order_number in resp.text, (
+            "delivered order must appear in the sales-journal CSV export"
+        )
+
+    def test_delivered_order_in_tax_summary_csv(self, client, db, make_sales_order):
+        """The tax-summary CSV export must include a delivered order."""
+        order = self._make_delivered_taxed_order(make_sales_order, db)
+
+        resp = client.get(f"{BASE}/tax-summary/export", params={"period": "year"})
+        assert resp.status_code == 200
+        assert order.order_number in resp.text, (
+            "delivered order must appear in the tax-summary CSV export"
+        )


### PR DESCRIPTION
## What

Closes #899. The four revenue/tax surfaces in `admin/accounting.py` still filtered on inline `["shipped","completed"]` lists after #897 unified the COGS surfaces on `cogs_report_service.ANCHOR_STATUSES = ("shipped","completed","delivered")`. Once an order advanced to `delivered`, it silently vanished from the sales journal and — worse — from the Tax Center's liability numbers and CSV exports. Understated tax liability, same silent-books-wrong class #880 exists to kill.

## The five sites (not four — the issue undercounted by one)

| Site | Before | After |
|---|---|---|
| Sales journal (`get_sales_journal`) | `in_(["shipped","completed"])` | `in_(ANCHOR_STATUSES)` |
| Sales journal CSV | same | same |
| Tax Center summary (collected) | same | same |
| **Tax Center pending complement** | `notin_(["shipped","completed","cancelled"])` | `notin_(ANCHOR_STATUSES + ("cancelled",))` |
| Tax CSV export | `in_(["shipped","completed"])` | `in_(ANCHOR_STATUSES)` |

The complement matters: without it, a `delivered` order would count in **both** collected and pending tax after the widening — double-counted liability instead of missing liability.

## Tests (delta-based, per house convention)

New class `TestDeliveredOrderAnchorStatuses` (5 tests): a delivered+taxed order (1) appears in the sales journal, (2) contributes to Tax Center collected figures, (3) does **not** appear in the pending-tax complement, (4) appears in the sales-journal CSV, (5) appears in the tax-summary CSV.

`tests/api/v1/test_admin_accounting.py`: **98 passed** (93 pre-existing + 5 new), ruff clean on the touched file.

## Refs

#899 (issue), #897 (pattern + `ANCHOR_STATUSES` origin), #880 (epic), #850 (status-vocabulary fork — this is another instance of that drift class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounting reports now consistently include eligible delivered orders in sales journal and tax calculations.
  * Pending tax totals exclude orders that have reached a recognized fulfillment status.
  * CSV exports now reflect the same corrected sales and tax reporting logic.

* **Tests**
  * Added coverage confirming delivered orders appear in reports and exports and are excluded from pending tax totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->