### PR TITLE
fix(accounting): shared item_type→inventory-account map — completion/op-consumption posters stop leaking across accounts (910)

### DIFF
--- a/backend/app/services/accounting_service.py
+++ b/backend/app/services/accounting_service.py
@@ -15,6 +15,7 @@ from app.logging_config import get_logger
 from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine, GLFiscalPeriod
 from app.models.inventory import Inventory
 from app.models.product import Product
+from app.services.gl_account_map import inventory_account_for
 
 logger = get_logger(__name__)
 
@@ -201,15 +202,16 @@ def get_inventory_valuation(db: Session, *, as_of_date: date | None = None) -> d
     if as_of_date is None:
         as_of_date = date.today()
 
-    # Define category mappings
-    # item_type -> (category_name, gl_account_code)
+    # Define category mappings: item_type -> (category_name, gl_account_code).
+    # Labels stay local; account codes come from the shared map (#910) so this
+    # valuation surface can never drift from what the posters actually book.
     # Valid inventory item_types: finished_good, component, packaging, supply.
     # WIP (1210) exists for journal entries, but has no corresponding item_type.
     category_map = {
-        "supply": ("Raw Materials", "1200"),
-        "component": ("Components", "1200"),
-        "packaging": ("Packaging", "1230"),
-        "finished_good": ("Finished Goods", "1220"),
+        "supply": ("Raw Materials", inventory_account_for("supply")),
+        "component": ("Components", inventory_account_for("component")),
+        "packaging": ("Packaging", inventory_account_for("packaging")),
+        "finished_good": ("Finished Goods", inventory_account_for("finished_good")),
     }
 
     categories = []

--- a/backend/app/services/gl_account_map.py
+++ b/backend/app/services/gl_account_map.py
@@ -1,0 +1,50 @@
+"""
+Single source of truth for the item_type -> inventory GL account map (#910).
+
+For years this 3-way map was hand-copied into every poster that touches
+inventory value. When one copy drifted the ledger corrupted silently: a
+manufactured ``component`` was received into Finished Goods (1220) by the
+production-completion poster while every downstream flow (cycle count,
+reconciliation, valuation) relieved/valued it at Raw Materials (1200), so
+1200 went negative for value it never held and 1220 stayed overstated
+forever (#894 item 4, #892).
+
+The canonical map — matching the four surfaces that were already correct
+(``receive_purchase_order``, ``cycle_count_adjustment``,
+``post_reconciliation_baseline``, ``get_inventory_valuation``):
+
+    packaging     -> 1230  Packaging Inventory
+    finished_good -> 1220  Finished Goods Inventory
+    everything else (component / material / supply / service / None)
+                  -> 1200  Raw Materials / Inventory
+
+Manufactured sub-assemblies are materials-in-waiting, not finished goods,
+so ``component`` deliberately maps to 1200.
+
+This helper is the ONLY place the map may live. Every poster that debits or
+credits an inventory account by item_type MUST call ``inventory_account_for``.
+"""
+from __future__ import annotations
+
+# Inventory GL account codes (asset side). Kept here so the map and the codes
+# it emits share one definition.
+RAW_MATERIALS_ACCOUNT = "1200"
+FINISHED_GOODS_ACCOUNT = "1220"
+PACKAGING_ACCOUNT = "1230"
+
+# item_type -> inventory account. Only the two non-default types are listed;
+# every other (or missing) item_type falls through to Raw Materials.
+_INVENTORY_ACCOUNT_BY_ITEM_TYPE = {
+    "packaging": PACKAGING_ACCOUNT,
+    "finished_good": FINISHED_GOODS_ACCOUNT,
+}
+
+
+def inventory_account_for(item_type: str | None) -> str:
+    """Return the inventory GL account code for a product's ``item_type``.
+
+    packaging -> 1230, finished_good -> 1220, everything else (component,
+    material, supply, service, unknown, or None) -> 1200. This is the single
+    source of truth referenced by every inventory-value poster (#910).
+    """
+    return _INVENTORY_ACCOUNT_BY_ITEM_TYPE.get(item_type or "", RAW_MATERIALS_ACCOUNT)

--- a/backend/app/services/production_gl_service.py
+++ b/backend/app/services/production_gl_service.py
@@ -13,12 +13,14 @@ material cost through WIP (1210) into Finished Goods (1220) at the
 receipt values, routing the difference to 5200 "COGS - Other" as a
 production variance:
 
-    DR 1210  total consumption (materials + packaging + labor)
-    CR 1200  non-packaging material consumption
-    CR 1230  packaging-component consumption
+    DR 1210  total consumption (materials + packaging + labor + FG inputs)
+    CR 1200  component / material / supply consumption
+    CR 1230  packaging consumption
+    CR 1220  purchased finished-good BOM-input consumption
     CR 5100  SVC- labor consumption
-    DR 1220  finished-goods receipts / CR 1210 same
-    V = FG + S - M   (S = this PO's already-posted scrap-JE 1210 credits)
+    DR acct  receipts by item_type (1200/1220/1230 per #910 map) / CR 1210 same
+    V = R + S - C   (R = receipts total; S = this PO's scrap-JE 1210 credits;
+                     C = total consumption)
       V > 0:  DR 1210 V / CR 5200 V
       V < 0:  DR 5200 |V| / CR 1210 |V|
 
@@ -54,6 +56,7 @@ from app.logging_config import get_logger
 from app.models.accounting import GLAccount, GLJournalEntry, GLJournalEntryLine
 from app.models.inventory import InventoryTransaction
 from app.models.production_order import ProductionOrder, ScrapRecord
+from app.services.gl_account_map import inventory_account_for
 
 logger = get_logger(__name__)
 
@@ -94,21 +97,45 @@ class CompletionGLPreview:
 
     Built by the same code the poster runs, so the backfill script's
     dry-run output can never drift from the real posting.
+
+    Consumption and receipts are held as account-keyed maps (#910) so a
+    manufactured component consumed/received routes to its own inventory
+    account instead of a hard-coded 1200/1220. The named scalar properties
+    (material_cost/packaging_cost/labor_cost/finished_goods_value) are kept
+    as views over those maps for the logging + backfill call sites.
     """
     production_order_id: int
     production_order_code: str
     transaction_ids: List[int]
-    material_cost: Decimal        # consumption, non-packaging, non-SVC → CR 1200
-    packaging_cost: Decimal       # consumption, packaging item_type → CR 1230
-    labor_cost: Decimal           # consumption, SVC- prefix → CR 5100
-    finished_goods_value: Decimal  # receipts → DR 1220 / CR 1210
+    consumption_by_account: dict[str, Decimal]  # CR side: account -> amount
+    receipt_by_account: dict[str, Decimal]      # DR side: account -> amount
     scrap_wip_credits: Decimal    # S: prior scrap-JE 1210 credits
-    variance: Decimal             # V = FG + S − (mat + pkg + labor)
+    variance: Decimal             # V = receipts + S − consumption
     lines: List[Tuple[str, Decimal, str]]
 
     @property
+    def material_cost(self) -> Decimal:
+        """Consumption credited to Raw Materials (1200)."""
+        return self.consumption_by_account.get(RAW_MATERIALS_ACCOUNT, Decimal("0.00"))
+
+    @property
+    def packaging_cost(self) -> Decimal:
+        """Consumption credited to Packaging (1230)."""
+        return self.consumption_by_account.get(PACKAGING_ACCOUNT, Decimal("0.00"))
+
+    @property
+    def labor_cost(self) -> Decimal:
+        """SVC- consumption credited to Direct Labor (5100)."""
+        return self.consumption_by_account.get(DIRECT_LABOR_ACCOUNT, Decimal("0.00"))
+
+    @property
+    def finished_goods_value(self) -> Decimal:
+        """Total production receipts (DR by item_type map, CR 1210)."""
+        return sum(self.receipt_by_account.values(), Decimal("0.00"))
+
+    @property
     def total_consumption(self) -> Decimal:
-        return self.material_cost + self.packaging_cost + self.labor_cost
+        return sum(self.consumption_by_account.values(), Decimal("0.00"))
 
 
 def _ensure_completion_gl_accounts(db: Session) -> None:
@@ -218,44 +245,52 @@ def _build_preview(
     production_order: ProductionOrder,
     txns: List[InventoryTransaction],
 ) -> CompletionGLPreview:
-    material = Decimal("0.00")
-    packaging = Decimal("0.00")
-    labor = Decimal("0.00")
-    finished_goods = Decimal("0.00")
+    # CR side (consumption) and DR side (receipts), each keyed by the account
+    # the shared item_type map (#910) routes the row to. A manufactured
+    # component consumed as a BOM input credits 1200; a purchased finished_good
+    # BOM input credits 1220; packaging credits 1230; SVC- labor credits 5100.
+    # Receipts debit their mapped inventory account (component->1200,
+    # packaging->1230, finished_good->1220) instead of a flat DR 1220.
+    consumption_by_account: dict[str, Decimal] = {}
+    receipt_by_account: dict[str, Decimal] = {}
 
     for txn in txns:
         cost = _txn_cost(txn)
-        if txn.transaction_type == "receipt":
-            # Includes overrun receipts — both rows receive FG at the
-            # product's effective cost frozen on the transaction.
-            finished_goods += cost
-            continue
         product = txn.product
-        sku = (product.sku if product else "") or ""
         item_type = (product.item_type if product else "") or ""
+        if txn.transaction_type == "receipt":
+            # Includes overrun receipts — both rows receive at the product's
+            # effective cost frozen on the transaction.
+            account = inventory_account_for(item_type)
+            receipt_by_account[account] = (
+                receipt_by_account.get(account, Decimal("0.00")) + cost
+            )
+            continue
+        sku = (product.sku if product else "") or ""
         if sku.startswith(LABOR_SKU_PREFIX):
-            labor += cost
-        elif item_type == "packaging":
-            packaging += cost
+            account = DIRECT_LABOR_ACCOUNT
         else:
-            material += cost
+            account = inventory_account_for(item_type)
+        consumption_by_account[account] = (
+            consumption_by_account.get(account, Decimal("0.00")) + cost
+        )
 
     scrap_credits = _scrap_wip_credits(db, production_order.id)
-    total_consumption = material + packaging + labor
-    variance = finished_goods + scrap_credits - total_consumption
+    total_consumption = sum(consumption_by_account.values(), Decimal("0.00"))
+    total_receipts = sum(receipt_by_account.values(), Decimal("0.00"))
+    variance = total_receipts + scrap_credits - total_consumption
 
     lines: List[Tuple[str, Decimal, str]] = []
     if total_consumption > 0:
         lines.append((WIP_ACCOUNT, total_consumption, "DR"))
-    if material > 0:
-        lines.append((RAW_MATERIALS_ACCOUNT, material, "CR"))
-    if packaging > 0:
-        lines.append((PACKAGING_ACCOUNT, packaging, "CR"))
-    if labor > 0:
-        lines.append((DIRECT_LABOR_ACCOUNT, labor, "CR"))
-    if finished_goods > 0:
-        lines.append((FINISHED_GOODS_ACCOUNT, finished_goods, "DR"))
-        lines.append((WIP_ACCOUNT, finished_goods, "CR"))
+    for account, amount in sorted(consumption_by_account.items()):
+        if amount > 0:
+            lines.append((account, amount, "CR"))
+    for account, amount in sorted(receipt_by_account.items()):
+        if amount > 0:
+            lines.append((account, amount, "DR"))
+    if total_receipts > 0:
+        lines.append((WIP_ACCOUNT, total_receipts, "CR"))
     # Variance so WIP nets to exactly zero per completed order — the S term
     # offsets scrap entries that already credited 1210 mid-order.
     if variance > 0:
@@ -269,10 +304,8 @@ def _build_preview(
         production_order_id=production_order.id,
         production_order_code=production_order.code,
         transaction_ids=[txn.id for txn in txns],
-        material_cost=material,
-        packaging_cost=packaging,
-        labor_cost=labor,
-        finished_goods_value=finished_goods,
+        consumption_by_account=consumption_by_account,
+        receipt_by_account=receipt_by_account,
         scrap_wip_credits=scrap_credits,
         variance=variance,
         lines=lines,

--- a/backend/app/services/reconciliation_service.py
+++ b/backend/app/services/reconciliation_service.py
@@ -87,6 +87,7 @@ from sqlalchemy.orm import Session
 
 from app.models.inventory import Inventory, InventoryTransaction
 from app.models.product import Product
+from app.services.gl_account_map import inventory_account_for
 from app.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -392,12 +393,8 @@ def post_reconciliation_baseline(
             )
             total_cost = abs(delta) * unit_cost
 
-            # Map product type to inventory account (mirrors cycle_count_adjustment)
-            inv_account = "1200"
-            if product.item_type == "finished_good":
-                inv_account = "1220"
-            elif product.item_type == "packaging":
-                inv_account = "1230"
+            # Shared item_type -> account map (#910).
+            inv_account = inventory_account_for(product.item_type)
 
             if total_cost > 0:
                 # overage (delta > 0): DR Inventory, CR Inv Adjustment

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -26,6 +26,7 @@ from app.models.production_order import ScrapRecord
 from app.models.product import Product
 from app.models.sales_order import SalesOrder
 from app.services import inventory_ledger
+from app.services.gl_account_map import inventory_account_for
 
 _JOURNAL_ENTRY_NUMBER_LOCK_NAMESPACE = 74002
 # Distinct namespace so ship-guard locks never collide with entry-number locks.
@@ -309,13 +310,27 @@ class TransactionService:
         Issue raw materials when production operation starts.
 
         Inventory: CONSUMPTION for each material (negative qty)
-        Accounting: DR WIP (1210), CR Raw Materials (1200)
+        Accounting: DR WIP (1210), CR inventory account by item_type (#910):
+            packaging -> 1230, finished_good BOM inputs -> 1220, else -> 1200.
 
         Returns:
             Tuple of (list of inventory transactions, journal entry)
         """
         inv_txns = []
         total_cost = Decimal("0")
+        cost_by_account: dict[str, Decimal] = {}
+
+        # Batch-load products so each consumption credits the SAME inventory
+        # account its purchase debited (#910). A flat CR 1200 here credited
+        # Raw Materials for packaging (PO debited 1230) and purchased
+        # finished-good BOM inputs (PO debited 1220), drifting those accounts
+        # permanently overstated — the consumption sibling of the receipt-side
+        # bug already fixed in receive_purchase_order.
+        product_ids = {mat.product_id for mat in materials}
+        products_by_id: dict[int, Product] = {
+            p.id: p
+            for p in self.db.query(Product).filter(Product.id.in_(product_ids))
+        } if product_ids else {}
 
         for mat in materials:
             inv_txn = self._post_inventory(
@@ -330,18 +345,30 @@ class TransactionService:
             )
             inv_txns.append(inv_txn)
 
-            total_cost += mat.quantity * mat.unit_cost
+            cost = mat.quantity * mat.unit_cost
+            total_cost += cost
+            product = products_by_id.get(mat.product_id)
+            cr_account = inventory_account_for(
+                product.item_type if product else None
+            )
+            cost_by_account[cr_account] = (
+                cost_by_account.get(cr_account, Decimal("0")) + cost
+            )
 
-        # Create journal entry: DR WIP, CR Raw Materials
+        # Create journal entry: DR WIP, CR inventory accounts by item_type.
         # Skip GL entry if total cost is zero (no monetary value to record)
         je = None
         if total_cost > 0:
+            je_lines: List[Tuple[str, Decimal, str]] = [
+                ("1210", total_cost, "DR"),  # WIP Inventory
+            ]
+            je_lines.extend(
+                (account, amount, "CR")
+                for account, amount in sorted(cost_by_account.items())
+            )
             je = self._create_journal_entry(
                 description=f"Material issue for PO#{production_order_id} op {operation_sequence}",
-                lines=[
-                    ("1210", total_cost, "DR"),  # WIP Inventory
-                    ("1200", total_cost, "CR"),  # Raw Materials Inventory
-                ],
+                lines=je_lines,
                 source_type="production_order",
                 source_id=production_order_id,
                 user_id=user_id,
@@ -754,15 +781,13 @@ class TransactionService:
             cost = item.quantity * item.unit_cost
             total_cost += cost
 
-            # Same item_type -> account map as cycle_count_adjustment (#880):
-            # a flat DR 1200 sends packaging purchases to Raw Materials while
-            # shipping credits 1230, driving Packaging Inventory negative.
+            # Shared item_type -> account map (#910): a flat DR 1200 would send
+            # packaging purchases to Raw Materials while shipping credits 1230,
+            # driving Packaging Inventory negative.
             product = products_by_id.get(item.product_id)
-            inv_account = "1200"  # Default: Raw Materials
-            if product and product.item_type == "finished_good":
-                inv_account = "1220"
-            elif product and product.item_type == "packaging":
-                inv_account = "1230"
+            inv_account = inventory_account_for(
+                product.item_type if product else None
+            )
             cost_by_account[inv_account] = (
                 cost_by_account.get(inv_account, Decimal("0")) + cost
             )
@@ -831,12 +856,8 @@ class TransactionService:
         if not product:
             raise ValueError(f"Product {product_id} not found")
 
-        # Map product type to inventory account
-        inv_account = "1200"  # Default: Raw Materials
-        if product.item_type == "finished_good":
-            inv_account = "1220"
-        elif product.item_type == "packaging":
-            inv_account = "1230"
+        # Shared item_type -> account map (#910).
+        inv_account = inventory_account_for(product.item_type)
 
         unit_cost = product.standard_cost or product.average_cost or Decimal("0")
         total_cost = abs(variance) * unit_cost

--- a/backend/tests/test_inventory_account_map.py
+++ b/backend/tests/test_inventory_account_map.py
@@ -1,0 +1,392 @@
+"""
+#910: one shared item_type -> inventory-account map, and the three posters
+that used to disagree with it.
+
+Canonical map (app.services.gl_account_map.inventory_account_for):
+    packaging -> 1230, finished_good -> 1220, everything else -> 1200.
+
+Behavior changes pinned here (the bugs #910 fixes):
+  (a) A manufactured `component` received by the production-completion sweep
+      lands in Raw Materials (1200), not Finished Goods (1220) — so cycle
+      count / reconciliation / valuation, which all relieve it at 1200, no
+      longer drive 1200 negative and 1220 overstated.
+  (b) issue_materials_for_operation credits the SAME account the purchase
+      debited: packaging -> 1230, purchased finished_good BOM input -> 1220.
+  (c) The completion-sweep consumption classifier sends a purchased
+      finished_good consumed as a BOM input to 1220, not 1200.
+
+Unchanged-behavior regressions (this is a refactor to the shared helper for
+the four already-correct surfaces — identical output asserted):
+  (d) receive_purchase_order and cycle_count_adjustment still book each
+      item_type to the same account as before.
+  (e) the #897 COGS identity (net 5000+5010+5030+5200 == material consumed)
+      still holds on a produce -> ship flow.
+
+Delta-based, per-run unique fixtures (filaops_test accumulates state), so
+every assertion looks at an INDIVIDUAL entry's per-account nets.
+"""
+from collections import defaultdict
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.models.accounting import GLAccount, GLJournalEntryLine
+from app.services import inventory_service
+from app.services.gl_account_map import inventory_account_for
+from app.services.production_gl_service import create_production_completion_gl_entry
+from app.services.transaction_service import (
+    MaterialConsumption,
+    ReceiptItem,
+    ShipmentItem,
+    TransactionService,
+)
+
+
+# =============================================================================
+# Helpers (mirror test_production_completion_gl / test_cogs_gl_derivation)
+# =============================================================================
+
+def _location(db):
+    return inventory_service.get_or_create_default_location(db)
+
+
+def _seed_stock(db, product, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="test_seed",
+        reference_id=0,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _consume(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="consumption",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _receive_production(db, product, po, qty, cost):
+    return inventory_service.create_inventory_transaction(
+        db=db,
+        product_id=product.id,
+        location_id=_location(db).id,
+        transaction_type="receipt",
+        quantity=Decimal(str(qty)),
+        reference_type="production_order",
+        reference_id=po.id,
+        cost_per_unit=Decimal(str(cost)),
+    )
+
+
+def _je_net(db, *jes):
+    """account_code -> net (DR - CR) aggregated across one or more entries."""
+    net = defaultdict(lambda: Decimal("0"))
+    je_ids = [je.id for je in jes]
+    rows = (
+        db.query(
+            GLAccount.account_code,
+            GLJournalEntryLine.debit_amount,
+            GLJournalEntryLine.credit_amount,
+        )
+        .join(GLJournalEntryLine, GLJournalEntryLine.account_id == GLAccount.id)
+        .filter(GLJournalEntryLine.journal_entry_id.in_(je_ids))
+        .all()
+    )
+    for code, debit, credit in rows:
+        net[code] += Decimal(str(debit or 0)) - Decimal(str(credit or 0))
+    return net
+
+
+# =============================================================================
+# The shared helper itself
+# =============================================================================
+
+class TestInventoryAccountForHelper:
+
+    @pytest.mark.parametrize(
+        "item_type,expected",
+        [
+            ("packaging", "1230"),
+            ("finished_good", "1220"),
+            ("component", "1200"),
+            ("material", "1200"),
+            ("supply", "1200"),
+            ("service", "1200"),
+            ("", "1200"),
+            (None, "1200"),
+            ("some_future_type", "1200"),
+        ],
+    )
+    def test_maps_item_type_to_account(self, item_type, expected):
+        assert inventory_account_for(item_type) == expected
+
+
+# =============================================================================
+# (a) Completion sweep: manufactured component receipt -> DR 1200, not 1220
+# =============================================================================
+
+class TestComponentCompletionReceipt:
+
+    def test_component_receipt_debits_raw_materials_not_finished_goods(
+        self, db, make_product, make_production_order
+    ):
+        """A production order that MAKES a `component` receives it into Raw
+        Materials (1200) — the account every downstream flow relieves it at —
+        instead of the flat DR 1220 that used to overstate Finished Goods."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        comp = make_product(item_type="component", average_cost=Decimal("2.00"))
+        po = make_production_order(
+            product_id=comp.id, status="in_progress", quantity=5
+        )
+
+        _seed_stock(db, raw, 100, "0.50")
+        _consume(db, raw, po, 8, "0.50")        # 4.00 material  -> CR 1200
+        _receive_production(db, comp, po, 5, "2.00")  # 10.00 component -> DR 1200
+
+        je = create_production_completion_gl_entry(db, po)
+        assert je is not None
+
+        net = _je_net(db, je)
+        # THE FIX: the manufactured component never touches Finished Goods.
+        assert net["1220"] == Decimal("0")
+        # Receipt (DR 10) minus consumption (CR 4) both net inside 1200.
+        assert net["1200"] == Decimal("6.00")
+        # WIP still nets to zero; variance = receipts(10) - consumption(4) = 6.
+        assert net["1210"] == Decimal("0")
+        assert net["5200"] == Decimal("-6.00")
+
+
+# =============================================================================
+# (c) Completion sweep: purchased finished_good BOM input -> CR 1220
+# =============================================================================
+
+class TestFinishedGoodConsumedAsBomInput:
+
+    def test_finished_good_bom_input_credits_finished_goods_not_raw(
+        self, db, make_product, make_production_order
+    ):
+        """A purchased `finished_good` consumed as a BOM input is relieved
+        from Finished Goods (1220) — where its PO receipt debited it — not
+        wrongly credited to Raw Materials (1200)."""
+        fg_input = make_product(item_type="finished_good", average_cost=Decimal("2.00"))
+        out_fg = make_product(item_type="finished_good", average_cost=Decimal("5.00"))
+        po = make_production_order(
+            product_id=out_fg.id, status="in_progress", quantity=2
+        )
+
+        _seed_stock(db, fg_input, 100, "2.00")
+        _consume(db, fg_input, po, 2, "2.00")      # 4.00 FG input -> CR 1220
+        _receive_production(db, out_fg, po, 2, "5.00")  # 10.00 out FG -> DR 1220
+
+        je = create_production_completion_gl_entry(db, po)
+        assert je is not None
+
+        net = _je_net(db, je)
+        # THE FIX: the finished_good BOM input is not miscredited to 1200.
+        assert net["1200"] == Decimal("0")
+        # Out-FG receipt (DR 10) minus FG-input consumption (CR 4) net in 1220.
+        assert net["1220"] == Decimal("6.00")
+        assert net["1210"] == Decimal("0")
+        assert net["5200"] == Decimal("-6.00")
+
+
+# =============================================================================
+# (b) issue_materials_for_operation credits by item_type
+# =============================================================================
+
+class TestIssueMaterialsAccountMap:
+
+    def _issue(self, db, product, po, qty, cost):
+        _seed_stock(db, product, qty * 10, cost)  # ensure on-hand
+        ts = TransactionService(db)
+        _txns, je = ts.issue_materials_for_operation(
+            production_order_id=po.id,
+            operation_sequence=10,
+            materials=[
+                MaterialConsumption(
+                    product_id=product.id,
+                    quantity=Decimal(str(qty)),
+                    unit_cost=Decimal(str(cost)),
+                )
+            ],
+        )
+        db.flush()
+        return je
+
+    def test_packaging_consumed_at_operation_credits_1230(
+        self, db, make_product, make_production_order
+    ):
+        """Packaging consumed at a production stage credits Packaging (1230),
+        matching the 1230 its PO receipt debited — not a flat CR 1200."""
+        pkg = make_product(item_type="packaging", average_cost=Decimal("2.50"))
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        je = self._issue(db, pkg, po, qty=4, cost="2.50")  # 10.00
+
+        net = _je_net(db, je)
+        assert net["1210"] == Decimal("10.00")   # DR WIP
+        assert net["1230"] == Decimal("-10.00")  # CR Packaging
+        assert net["1200"] == Decimal("0")       # NOT Raw Materials
+
+    def test_finished_good_bom_input_at_operation_credits_1220(
+        self, db, make_product, make_production_order
+    ):
+        """A purchased finished_good issued as a BOM input at an operation
+        credits Finished Goods (1220), not Raw Materials."""
+        fg_input = make_product(item_type="finished_good", average_cost=Decimal("3.00"))
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        je = self._issue(db, fg_input, po, qty=2, cost="3.00")  # 6.00
+
+        net = _je_net(db, je)
+        assert net["1210"] == Decimal("6.00")    # DR WIP
+        assert net["1220"] == Decimal("-6.00")   # CR Finished Goods
+        assert net["1200"] == Decimal("0")
+
+    def test_supply_at_operation_still_credits_1200(
+        self, db, make_product, make_production_order
+    ):
+        """Regression: the common raw-material case is unchanged (CR 1200)."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.02"))
+        fg = make_product(item_type="finished_good")
+        po = make_production_order(product_id=fg.id, status="in_progress", quantity=1)
+
+        je = self._issue(db, raw, po, qty=100, cost="0.02")  # 2.00
+
+        net = _je_net(db, je)
+        assert net["1210"] == Decimal("2.00")
+        assert net["1200"] == Decimal("-2.00")
+
+
+# =============================================================================
+# (d) Unchanged-behavior regressions for the already-correct posters
+# =============================================================================
+
+class TestPurchaseOrderReceiptRegression:
+
+    @pytest.mark.parametrize(
+        "item_type,expected_account",
+        [
+            ("supply", "1200"),
+            ("component", "1200"),
+            ("packaging", "1230"),
+            ("finished_good", "1220"),
+        ],
+    )
+    def test_receipt_debits_expected_inventory_account(
+        self, db, make_product, make_vendor, make_purchase_order,
+        item_type, expected_account,
+    ):
+        product = make_product(item_type=item_type, standard_cost=Decimal("4.00"))
+        po = make_purchase_order(vendor_id=make_vendor().id, status="approved")
+
+        ts = TransactionService(db)
+        _txns, je = ts.receive_purchase_order(
+            purchase_order_id=po.id,
+            items=[ReceiptItem(
+                product_id=product.id,
+                quantity=Decimal("3"),
+                unit_cost=Decimal("4.00"),
+            )],
+        )
+        db.flush()
+
+        net = _je_net(db, je)
+        assert net[expected_account] == Decimal("12.00")   # DR inventory
+        assert net["2000"] == Decimal("-12.00")            # CR Accounts Payable
+
+
+class TestCycleCountAdjustmentRegression:
+
+    @pytest.mark.parametrize(
+        "item_type,expected_account",
+        [
+            ("supply", "1200"),
+            ("component", "1200"),
+            ("packaging", "1230"),
+            ("finished_good", "1220"),
+        ],
+    )
+    def test_shortage_credits_expected_inventory_account(
+        self, db, make_product, item_type, expected_account,
+    ):
+        product = make_product(item_type=item_type, standard_cost=Decimal("5.00"))
+        _seed_stock(db, product, 10, "5.00")
+
+        ts = TransactionService(db)
+        _txn, je = ts.cycle_count_adjustment(
+            product_id=product.id,
+            expected_qty=Decimal("10"),
+            actual_qty=Decimal("8"),      # shortage of 2 -> 10.00
+            reason="regression",
+        )
+        db.flush()
+
+        net = _je_net(db, je)
+        # Shortage: DR 5030 Inventory Adjustment, CR the inventory account.
+        assert net["5030"] == Decimal("10.00")
+        assert net[expected_account] == Decimal("-10.00")
+
+
+# =============================================================================
+# (e) #897 identity still holds on a produce -> ship flow
+# =============================================================================
+
+class TestProduceShipCogsIdentity:
+
+    def test_net_cogs_accounts_equal_material_consumed(
+        self, db, make_product, make_sales_order, make_production_order
+    ):
+        """#897: across a produce->ship cycle the net of the COGS/expense
+        accounts (5000 ship-COGS + 5010 packaging + 5030 adjustment + 5200
+        completion-variance, DR-CR) collapses to exactly the out-of-pocket
+        material actually consumed. The item_type->account refactor must not
+        disturb this — a normal finished_good still receipts to 1220."""
+        raw = make_product(item_type="supply", average_cost=Decimal("0.50"))
+        fg = make_product(item_type="finished_good", average_cost=Decimal("12.00"))
+
+        so = make_sales_order(
+            product_id=fg.id, quantity=1, unit_price=Decimal("24.00"),
+            status="shipped", shipped_at=datetime.now(timezone.utc),
+        )
+        po = make_production_order(
+            product_id=fg.id, status="completed", quantity=1, sales_order_id=so.id,
+        )
+
+        _seed_stock(db, raw, 1000, "0.50")
+        _consume(db, raw, po, 10, "0.50")            # 5.00 material consumed
+        _receive_production(db, fg, po, 1, "12.00")  # 12.00 FG -> DR 1220
+
+        completion_je = create_production_completion_gl_entry(db, po)
+        db.flush()
+
+        _seed_stock(db, fg, 1, "12.00")  # FG on-hand so ship isn't held
+        ts = TransactionService(db)
+        _inv, ship_je = ts.ship_order(
+            sales_order_id=so.id,
+            items=[ShipmentItem(
+                product_id=fg.id, quantity=Decimal("1"), unit_cost=Decimal("12.00"),
+            )],
+        )
+        db.flush()
+
+        net = _je_net(db, completion_je, ship_je)
+        identity = net["5000"] + net["5010"] + net["5030"] + net["5200"]
+        assert identity == Decimal("5.00")  # == material consumed (out of pocket)
+        # Sanity on the individual legs.
+        assert net["5000"] == Decimal("12.00")   # ship COGS
+        assert net["5200"] == Decimal("-7.00")   # completion variance credit


### PR DESCRIPTION
Resolves #910. Implements #894 (item 4); closes the poster-origin gap from the #880 surface pass.

## Problem

The 3-way `item_type -> inventory-account` map (packaging → 1230, finished_good → 1220, everything else → 1200) was hand-copied into four already-correct surfaces, and **three posters disagreed with it** — booking value into one account that every downstream flow relieved/valued at another. A manufactured `component` entered Finished Goods (1220) on completion but was relieved at Raw Materials (1200) by cycle count / reconciliation / valuation, so 1200 went negative for value it never held and 1220 stayed overstated forever. Path-dependence made it worse: whichever poster reached a consumption txn first decided its account permanently (#892).

## Fix

One source of truth: `backend/app/services/gl_account_map.py::inventory_account_for(item_type)`, wired into **all six** call sites.

| Call site | Before | After |
|---|---|---|
| `receive_purchase_order` | map (correct) | helper — **no behavior change** |
| `cycle_count_adjustment` | map (correct) | helper — **no behavior change** |
| `post_reconciliation_baseline` | map (correct) | helper — **no behavior change** |
| `get_inventory_valuation.category_map` | map (correct) | helper (labels kept, codes derived) — **no behavior change** |
| production completion **receipt** | flat DR 1220 for every item_type | **DR by map** (component→1200, packaging→1230, finished_good→1220); CR 1210 unchanged |
| completion-sweep **consumption** classifier | packaging→1230, else→1200; SVC→5100 | **finished_good BOM input→1220**; packaging→1230, else→1200; SVC→5100 unchanged |
| `issue_materials_for_operation` | flat CR 1200 for every material | **CR by map** (packaging→1230, finished_good→1220, else→1200) |

WIP (1210) still nets to exactly zero per completed order — the receipt DR side now splits across accounts by map, but the receipt total (which drives CR 1210 and the 5200 variance) is unchanged, so the #897 COGS identity is preserved (pinned by test).

## Behavior changes (exactly these three)

1. Production-completion receipt of a non-finished_good lands in its mapped account (component→1200, packaging→1230).
2. `issue_materials_for_operation` credits the mapped account (packaging→1230, finished_good→1220).
3. Completion-sweep consumption classifier credits finished_good→1220.

PO receipt / cycle count / reconciliation / valuation output is unchanged (asserted by regression tests).

## Books impact — forward-only safe

No reclass JE is needed: the 2026-07-04 correction left 1220 at $0.00 and all live POs are terminal, so there is no historical balance to migrate — the map only governs entries posted from here forward. Re-verify 1220 = $0.00 and PO terminality at merge time.

## Test evidence

- **New** `backend/tests/test_inventory_account_map.py`: **23 passed in 1.92s** (delta-based, per-run unique fixtures)
  - `TestInventoryAccountForHelper::test_maps_item_type_to_account` (9 params: packaging/finished_good/component/material/supply/service/empty/None/unknown)
  - `TestComponentCompletionReceipt::test_component_receipt_debits_raw_materials_not_finished_goods`
  - `TestFinishedGoodConsumedAsBomInput::test_finished_good_bom_input_credits_finished_goods_not_raw`
  - `TestIssueMaterialsAccountMap::test_packaging_consumed_at_operation_credits_1230`, `test_finished_good_bom_input_at_operation_credits_1220`, `test_supply_at_operation_still_credits_1200`
  - `TestPurchaseOrderReceiptRegression::test_receipt_debits_expected_inventory_account` (4 item_types)
  - `TestCycleCountAdjustmentRegression::test_shortage_credits_expected_inventory_account` (4 item_types)
  - `TestProduceShipCogsIdentity::test_net_cogs_accounts_equal_material_consumed` (#897 identity)
- **Regression**: `tests/test_production_completion_gl.py` + `tests/services/test_transaction_service.py`: **62 passed in 6.81s**
- `ruff check app/ --select E712`: clean

Refs #880, #894 (item 4), #892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)