### PR TITLE
chore: gitignore docs/DEMO_* working docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,10 @@ docs/T-REX-Implementation-Report.md
 docs/T-REX-Implementation-Report.pdf
 docs/AI_Agent_Governance_Gap_Analysis.pdf
 docs/BLIND_TEST_RECOVERY.md
+
+# Demo-instance working docs (live in the private filaops-demo-deploy repo)
+docs/DEMO_*
+
 .worktrees/
 
 # Documentation assets (screenshots, logos) must be tracked despite *.png above


### PR DESCRIPTION
## Summary

Adds `docs/DEMO_*` to `.gitignore`. Working docs for the demo-instance project are kept in the private `filaops-demo-deploy` ops repo; this is a backstop so stray local copies can never land in a public commit.

Verified before this PR: `git ls-files docs/` and `git log --all` show no `docs/DEMO_*` path has ever been tracked in this repo.

## Test plan

- [x] `git check-ignore docs/DEMO_ANYTHING.md` matches the new pattern
- [x] No functional change; docs-hygiene only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file handling to exclude demo-instance working documentation from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->